### PR TITLE
fix for latest rust

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::os::errno;
-use std::num::from_int;
+use std::num::from_uint;
 use libc::c_int;
 
 pub use self::consts::*;
@@ -14,7 +14,7 @@ pub struct SysError {
 
 impl SysError {
     pub fn last() -> SysError {
-        match from_int(errno()) {
+        match from_uint(errno()) {
             Some(no) => SysError::new(no),
             _ => SysError::new(UnknownErrno)
         }


### PR DESCRIPTION
Latest rust compiler changed errno to uint.
