### PR TITLE
Update to last Rust

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -8,7 +8,7 @@ pub use self::consts::Errno::*;
 
 pub type SysResult<T> = Result<T, SysError>;
 
-#[deriving(Clone, PartialEq)]
+#[deriving(Clone, PartialEq, Copy)]
 pub struct SysError {
     pub kind: Errno,
 }
@@ -420,7 +420,7 @@ pub fn from_ffi(res: c_int) -> SysResult<()> {
 
 #[cfg(target_os = "linux")]
 mod consts {
-    #[deriving(Show, Clone, PartialEq, FromPrimitive)]
+    #[deriving(Show, Clone, PartialEq, FromPrimitive, Copy)]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = 1,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -18,6 +18,7 @@ mod ffi {
         use libc::{c_int, c_short, off_t, pid_t};
 
         #[repr(C)]
+        #[deriving(Copy)]
         pub struct flock {
             pub l_type: c_short,
             pub l_whence: c_short,
@@ -122,6 +123,7 @@ mod consts {
     use libc::c_int;
 
     bitflags!(
+        #[deriving(Copy)]
         flags OFlag: c_int {
             const O_ACCMODE   = 0o00000003,
             const O_RDONLY    = 0o00000000,
@@ -148,6 +150,7 @@ mod consts {
     )
 
     bitflags!(
+        #[deriving(Copy)]
         flags FdFlag: c_int {
             const FD_CLOEXEC = 1
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![feature(globs)]
 #![feature(linkage)]
-#![feature(if_let)]
 #![allow(non_camel_case_types)]
 
 extern crate libc;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -4,6 +4,7 @@ use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
 
 bitflags!(
+    #[deriving(Copy)]
     flags MsFlags: c_ulong {
         const MS_RDONLY      = 1 << 0,  // Mount read-only
         const MS_NOSUID      = 1 << 1,  // Ignore suid and sgid bits
@@ -43,6 +44,7 @@ bitflags!(
 )
 
 bitflags!(
+    #[deriving(Copy)]
     flags MntFlags: c_int {
         const MNT_FORCE   = 1 << 0,
         const MNT_DETATCH = 1 << 1,

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -69,6 +69,7 @@ pub type CpuMask = c_ulong;
 
 // Structure representing the CPU set to apply
 #[repr(C)]
+#[deriving(Copy)]
 pub struct CpuSet {
     cpu_mask: [CpuMask, ..cpuset_attribs::CPU_SETSIZE/cpuset_attribs::CPU_MASK_BITS]
 }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -16,6 +16,7 @@ mod ffi {
 
 bitflags!(
     #[repr(C)]
+    #[deriving(Copy)]
     flags EpollEventKind: u32 {
         const EPOLLIN = 0x001,
         const EPOLLPRI = 0x002,
@@ -69,6 +70,7 @@ impl fmt::Show for EpollEventKind {
     }
 }
 
+#[deriving(Copy)]
 #[repr(C)]
 pub enum EpollOp {
     EpollCtlAdd = 1,
@@ -76,6 +78,7 @@ pub enum EpollOp {
     EpollCtlMod = 3
 }
 
+#[deriving(Copy)]
 #[repr(C, packed)]
 pub struct EpollEvent {
     pub events: EpollEventKind,

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -4,6 +4,7 @@ use fcntl::Fd;
 use errno::{SysResult, SysError};
 
 bitflags!(
+    #[deriving(Copy)]
     flags EventFdFlag: c_int {
         const EFD_CLOEXEC   = 0o2000000, // Since Linux 2.6.27
         const EFD_NONBLOCK  = 0o0004000, // Since Linux 2.6.27

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -56,6 +56,7 @@ pub mod signal {
     use libc;
 
     bitflags!(
+        #[deriving(Copy)]
         flags SockFlag: libc::c_ulong {
             const SA_NOCLDSTOP = 0x00000001,
             const SA_NOCLDWAIT = 0x00000002,
@@ -95,6 +96,7 @@ pub mod signal {
     // actually a giant union. Currently we're only interested in these fields,
     // however.
     #[repr(C)]
+    #[deriving(Copy)]
     pub struct siginfo {
         si_signo: libc::c_int,
         si_errno: libc::c_int,
@@ -105,6 +107,7 @@ pub mod signal {
     }
 
     #[repr(C)]
+    #[allow(missing_copy_implementations)]
     pub struct sigaction {
         pub sa_handler: extern fn(libc::c_int),
         pub sa_mask: sigset_t,
@@ -114,12 +117,14 @@ pub mod signal {
 
     #[repr(C)]
     #[cfg(target_word_size = "32")]
+    #[deriving(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong, ..32],
     }
 
     #[repr(C)]
     #[cfg(target_word_size = "64")]
+    #[deriving(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong, ..16],
     }
@@ -290,6 +295,7 @@ mod ffi {
     }
 }
 
+#[deriving(Copy)]
 pub struct SigSet {
     sigset: sigset_t
 }

--- a/src/sys/socket.rs
+++ b/src/sys/socket.rs
@@ -25,12 +25,14 @@ mod ffi {
 
 // Extra flags - Supported by Linux 2.6.27, normalized on other platforms
 bitflags!(
+    #[deriving(Copy)]
     flags SockFlag: c_int {
         const SOCK_NONBLOCK = 0o0004000,
         const SOCK_CLOEXEC  = 0o2000000
     }
 )
 
+#[deriving(Copy)]
 pub enum SockAddr {
     SockIpV4(sockaddr_in),
     SockIpV6(sockaddr_in6),
@@ -443,6 +445,7 @@ pub fn sendto(sockfd: Fd, buf: &[u8], addr: &SockAddr, flags: SockMessageFlags) 
 }
 
 #[repr(C)]
+#[deriving(Copy)]
 pub struct linger {
     pub l_onoff: c_int,
     pub l_linger: c_int

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -20,6 +20,7 @@ mod ffi {
 }
 
 bitflags!(
+    #[deriving(Copy)]
     flags SFlag: mode_t {
         const S_IFREG  = 0o100000,
         const S_IFCHR  = 0o020000,

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -15,6 +15,7 @@ mod ffi {
 const UTSNAME_LEN: uint = 65;
 
 #[repr(C)]
+#[deriving(Copy)]
 pub struct UtsName {
     sysname: [c_char, ..UTSNAME_LEN],
     nodename: [c_char, ..UTSNAME_LEN],

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -10,11 +10,13 @@ mod ffi {
 }
 
 bitflags!(
+    #[deriving(Copy)]
     flags WaitPidFlag: c_int {
         const WNOHANG = 0x00000001,
     }
 )
 
+#[deriving(Copy)]
 pub enum WaitStatus {
     Exited(pid_t),
     StillAlive

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -53,6 +53,7 @@ mod ffi {
     }
 }
 
+#[deriving(Copy)]
 pub enum Fork {
     Parent(pid_t),
     Child
@@ -101,7 +102,9 @@ pub fn fork() -> SysResult<Fork> {
 type IovecR = Iovec<ToRead>;
 type IovecW = Iovec<ToWrite>;
 
+#[deriving(Copy)]
 pub struct ToRead;
+#[deriving(Copy)]
 pub struct ToWrite;
 
 #[repr(C)]


### PR DESCRIPTION
This PR is an attempt to fix errors and warnings introduced by last Rust changes.

It only covers `#[cfg(target_os = "linux")]` (because I don't have any other platform to test on).

There are two main changes:
- fixing errors about `improper_ctypes` in ffi (first commit)
- `Copy` is now opt-in (second commit)

About Copy, I simply marked as `#[deriving(Copy)]` all types the compiler suggested could be. But probably some of them can be not copyable (with `#[allow(missing_copy_implementations)]`), but I don't think I'm able to choose which should and which should not.
