### PR TITLE
Rust update : macro bitflags require a ';'

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -147,13 +147,13 @@ mod consts {
             const O_TMPFILE   = 0o20000000,
             const O_NDELAY    = O_NONBLOCK.bits
         }
-    )
+    );
 
     bitflags!(
         flags FdFlag: c_int {
             const FD_CLOEXEC = 1
         }
-    )
+    );
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -180,11 +180,11 @@ mod consts {
             const O_NDELAY    = O_NONBLOCK.bits,
             const O_FSYNC     = O_SYNC.bits
         }
-    )
+    );
 
     bitflags!(
         flags FdFlag: c_int {
             const FD_CLOEXEC = 1
         }
-    )
+    );
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -40,7 +40,7 @@ bitflags!(
         const MS_MGC_VAL     = 0xC0ED0000,
         const MS_MGC_MSK     = 0xffff0000
     }
-)
+);
 
 bitflags!(
     flags MntFlags: c_int {
@@ -48,7 +48,7 @@ bitflags!(
         const MNT_DETATCH = 1 << 1,
         const MNT_EXPIRE  = 1 << 2
     }
-)
+);
 
 mod ffi {
     use libc::{c_char, c_int, c_void, c_ulong};

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -32,7 +32,7 @@ bitflags!(
         const EPOLLONESHOT = 1 << 30,
         const EPOLLET = 1 << 31
     }
-)
+);
 
 impl fmt::Show for EpollEventKind {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -72,7 +72,7 @@ bitflags!(
         const EV_EOF       = 0x8000,
         const EV_ERROR     = 0x4000
     }
-)
+);
 
 impl fmt::Show for EventFlag {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -153,7 +153,7 @@ bitflags!(
         const NOTE_TRACKERR                        = 0x00000002,
         const NOTE_CHILD                           = 0x00000004
     }
-)
+);
 
 pub const EV_POLL: EventFlag = EV_FLAG0;
 pub const EV_OOBAND: EventFlag = EV_FLAG1;

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -9,7 +9,7 @@ bitflags!(
         const EFD_NONBLOCK  = 0o0004000, // Since Linux 2.6.27
         const EFD_SEMAPHORE = 0o0000001, // Since Linux 2.6.30
     }
-)
+);
 
 pub fn eventfd(initval: uint, flags: EventFdFlag) -> SysResult<Fd> {
     type F = unsafe extern "C" fn(initval: c_uint, flags: c_int) -> c_int;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -65,7 +65,7 @@ pub mod signal {
             const SA_RESTART   = 0x10000000,
             const SA_SIGINFO   = 0x00000004,
         }
-    )
+    );
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;
@@ -144,7 +144,7 @@ pub mod signal {
             const SA_RESTART   = 0x10000000,
             const SA_SIGINFO   = 0x00000008,
         }
-    )
+    );
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;
@@ -214,7 +214,7 @@ pub mod signal {
             const SA_RESTART   = 0x0002,
             const SA_SIGINFO   = 0x0040,
         }
-    )
+    );
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;

--- a/src/sys/socket.rs
+++ b/src/sys/socket.rs
@@ -29,7 +29,7 @@ bitflags!(
         const SOCK_NONBLOCK = 0o0004000,
         const SOCK_CLOEXEC  = 0o2000000
     }
-)
+);
 
 #[deriving(Copy)]
 pub enum SockAddr {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -27,7 +27,7 @@ bitflags!(
         const S_IFIFO  = 0o010000,
         const S_IFSOCK = 0o140000
     }
-)
+);
 
 impl fmt::Show for SFlag {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -13,7 +13,7 @@ bitflags!(
     flags WaitPidFlag: c_int {
         const WNOHANG = 0x00000001,
     }
-)
+);
 
 #[deriving(Copy)]
 pub enum WaitStatus {


### PR DESCRIPTION
Fallout of https://github.com/rust-lang/rust/pull/19984 .
