### PR TITLE
Use braces for macros which require them.

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -123,7 +123,7 @@ pub fn fcntl(fd: Fd, arg: FcntlArg) -> SysResult<()> {
 mod consts {
     use libc::c_int;
 
-    bitflags!(
+    bitflags! {
         flags OFlag: c_int {
             const O_ACCMODE   = 0o00000003,
             const O_RDONLY    = 0o00000000,
@@ -147,20 +147,20 @@ mod consts {
             const O_TMPFILE   = 0o20000000,
             const O_NDELAY    = O_NONBLOCK.bits
         }
-    )
+    }
 
-    bitflags!(
+    bitflags! {
         flags FdFlag: c_int {
             const FD_CLOEXEC = 1
         }
-    )
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod consts {
     use libc::c_int;
 
-    bitflags!(
+    bitflags! {
         flags OFlag: c_int {
             const O_ACCMODE   = 0x0000003,
             const O_RDONLY    = 0x0000000,
@@ -180,11 +180,11 @@ mod consts {
             const O_NDELAY    = O_NONBLOCK.bits,
             const O_FSYNC     = O_SYNC.bits
         }
-    )
+    }
 
-    bitflags!(
+    bitflags! {
         flags FdFlag: c_int {
             const FD_CLOEXEC = 1
         }
-    )
+    }
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
 
-bitflags!(
+bitflags! {
     flags MsFlags: c_ulong {
         const MS_RDONLY      = 1 << 0,  // Mount read-only
         const MS_NOSUID      = 1 << 1,  // Ignore suid and sgid bits
@@ -40,15 +40,15 @@ bitflags!(
         const MS_MGC_VAL     = 0xC0ED0000,
         const MS_MGC_MSK     = 0xffff0000
     }
-)
+}
 
-bitflags!(
+bitflags! {
     flags MntFlags: c_int {
         const MNT_FORCE   = 1 << 0,
         const MNT_DETATCH = 1 << 1,
         const MNT_EXPIRE  = 1 << 2
     }
-)
+}
 
 mod ffi {
     use libc::{c_char, c_int, c_void, c_ulong};

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -14,7 +14,7 @@ mod ffi {
     }
 }
 
-bitflags!(
+bitflags! {
     #[repr(C)]
     flags EpollEventKind: u32 {
         const EPOLLIN = 0x001,
@@ -32,7 +32,7 @@ bitflags!(
         const EPOLLONESHOT = 1 << 30,
         const EPOLLET = 1 << 31
     }
-)
+}
 
 impl fmt::Show for EpollEventKind {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -56,7 +56,7 @@ pub enum EventFilter {
     EVFILT_SYSCOUNT = 13
 }
 
-bitflags!(
+bitflags! {
     flags EventFlag: u16 {
         const EV_ADD       = 0x0001,
         const EV_DELETE    = 0x0002,
@@ -72,7 +72,7 @@ bitflags!(
         const EV_EOF       = 0x8000,
         const EV_ERROR     = 0x4000
     }
-)
+}
 
 impl fmt::Show for EventFlag {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -108,7 +108,7 @@ impl fmt::Show for EventFlag {
     }
 }
 
-bitflags!(
+bitflags! {
     flags FilterFlag: u32 {
         const NOTE_TRIGGER                         = 0x01000000,
         const NOTE_FFNOP                           = 0x00000000,
@@ -153,7 +153,7 @@ bitflags!(
         const NOTE_TRACKERR                        = 0x00000002,
         const NOTE_CHILD                           = 0x00000004
     }
-)
+}
 
 pub const EV_POLL: EventFlag = EV_FLAG0;
 pub const EV_OOBAND: EventFlag = EV_FLAG1;

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -3,13 +3,13 @@ use libc::{c_int, c_uint};
 use fcntl::Fd;
 use errno::{SysResult, SysError};
 
-bitflags!(
+bitflags! {
     flags EventFdFlag: c_int {
         const EFD_CLOEXEC   = 0o2000000, // Since Linux 2.6.27
         const EFD_NONBLOCK  = 0o0004000, // Since Linux 2.6.27
         const EFD_SEMAPHORE = 0o0000001, // Since Linux 2.6.30
     }
-)
+}
 
 pub fn eventfd(initval: uint, flags: EventFdFlag) -> SysResult<Fd> {
     type F = unsafe extern "C" fn(initval: c_uint, flags: c_int) -> c_int;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -55,7 +55,7 @@ pub const SIGEMT: libc::c_int = 7;
 pub mod signal {
     use libc;
 
-    bitflags!(
+    bitflags! {
         flags SockFlag: libc::c_ulong {
             const SA_NOCLDSTOP = 0x00000001,
             const SA_NOCLDWAIT = 0x00000002,
@@ -65,7 +65,7 @@ pub mod signal {
             const SA_RESTART   = 0x10000000,
             const SA_SIGINFO   = 0x00000004,
         }
-    )
+    }
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;
@@ -134,7 +134,7 @@ pub mod signal {
 pub mod signal {
     use libc;
 
-    bitflags!(
+    bitflags! {
         flags SockFlag: libc::c_uint {
             const SA_NOCLDSTOP = 0x00000001,
             const SA_NOCLDWAIT = 0x00001000,
@@ -144,7 +144,7 @@ pub mod signal {
             const SA_RESTART   = 0x10000000,
             const SA_SIGINFO   = 0x00000008,
         }
-    )
+    }
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;
@@ -204,7 +204,7 @@ pub mod signal {
 pub mod signal {
     use libc;
 
-    bitflags!(
+    bitflags! {
         flags SockFlag: libc::c_int {
             const SA_NOCLDSTOP = 0x0008,
             const SA_NOCLDWAIT = 0x0020,
@@ -214,7 +214,7 @@ pub mod signal {
             const SA_RESTART   = 0x0002,
             const SA_SIGINFO   = 0x0040,
         }
-    )
+    }
 
     pub const SIGTRAP:      libc::c_int = 5;
     pub const SIGIOT:       libc::c_int = 6;

--- a/src/sys/socket.rs
+++ b/src/sys/socket.rs
@@ -24,12 +24,12 @@ mod ffi {
 }
 
 // Extra flags - Supported by Linux 2.6.27, normalized on other platforms
-bitflags!(
+bitflags! {
     flags SockFlag: c_int {
         const SOCK_NONBLOCK = 0o0004000,
         const SOCK_CLOEXEC  = 0o2000000
     }
-)
+}
 
 #[deriving(Copy)]
 pub enum SockAddr {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -19,7 +19,7 @@ mod ffi {
     }
 }
 
-bitflags!(
+bitflags! {
     flags SFlag: mode_t {
         const S_IFREG  = 0o100000,
         const S_IFCHR  = 0o020000,
@@ -27,7 +27,7 @@ bitflags!(
         const S_IFIFO  = 0o010000,
         const S_IFSOCK = 0o140000
     }
-)
+}
 
 impl fmt::Show for SFlag {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -9,11 +9,11 @@ mod ffi {
     }
 }
 
-bitflags!(
+bitflags! {
     flags WaitPidFlag: c_int {
         const WNOHANG = 0x00000001,
     }
-)
+}
 
 #[deriving(Copy)]
 pub enum WaitStatus {


### PR DESCRIPTION
This fixes _all_ invocations of bitflags, for all targets.
