### PR TITLE
Bumped bitflags version to 0.4 and removed warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ signalfd = []
 
 [dependencies]
 libc     = "0.2.7"
-bitflags = "0.3.3"
+bitflags = "0.4"
 
 [dev-dependencies]
 rand = "0.3.8"


### PR DESCRIPTION
Bumped bitflags version to 0.4 and removed warning about derive with raw pointer