### PR TITLE
Make crate libc import public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 #[macro_use]
 extern crate bitflags;
 
-extern crate libc;
+pub extern crate libc;
 
 #[cfg(test)]
 extern crate nix_test as nixtest;


### PR DESCRIPTION
On currently nightly I got an error regarding the public export of libc in sys::ioctl. It now requires us to import the extern crate publicly.