### PR TITLE
libc: re-export libc properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,17 @@ extern crate bitflags;
 #[macro_use]
 extern crate cfg_if;
 
-pub extern crate libc;
-
 #[cfg(test)]
 extern crate nix_test as nixtest;
 
-// Re-exports
+// In rust 1.8+ this should be `pub extern crate libc` but prior
+// to https://github.com/rust-lang/rust/issues/26775 being resolved
+// it is necessary to get a little creative.
+pub mod libc {
+    extern crate libc;
+    pub use self::libc::*;
+}
+
 pub use libc::{c_int, c_void};
 pub use errno::Errno;
 


### PR DESCRIPTION
With rust 1.7, the following warning was being emitted by the compiler:

    warning: `pub extern crate` does not work as expected and should
    not be used. Likely to become an error. Prefer `extern crate` and
    `pub use`.

Based on https://github.com/rust-lang/rust/issues/26775 it appears that
this change is the current best approach for properly exporting the
libc dependency so it may be used outside of nix.

Signed-off-by: Paul Osborne <osbpau@gmail.com>