### PR TITLE
testing: increase stability by removing thread parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ os:
   - osx
 
 env:
-  - ARCH=x86_64
-  - ARCH=i686
+  - RUST_TEST_THREADS=1 ARCH=x86_64
+  - RUST_TEST_THREADS=1 ARCH=i686
 
 script:
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | RUST_TEST_THREADS=1 bash


### PR DESCRIPTION
Currently, several of the tests are failing intermittently.  After
some research it appears that these failures only occur when thread
parallelism is enabled (as is the case by default).  To test, I just
ran the failing tests over and over.  I would consistently see errors
when running the following:

    $ while true; do target/debug/test-7ec4d9681e812f6a; done

When I forced single threaded execution, I no longer saw failures:

    $ while true; do RUST_TEST_THREADS=1 target/debug/test-7ec4d9681e812f6a; done

I was mostly looking at the test_unistd failures which make calls out
to fork() and then make subsequent calls to wait().  In that case there
is one parent and the wait() called could (and frequently does) get some
random child pid back because it just happened to terminate.  That is
why when one of the test fails so does the other one.

I couldn't think of an obvious fix other than preventing thread
parallelism in the short term.  The tests still run very quickly.

https://github.com/nix-rust/nix/issues/251

Signed-off-by: Paul Osborne <osbpau@gmail.com>