### PR TITLE
Add gettid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc     = "0.2.7"
+libc     = "0.2.8"
 bitflags = "0.4"
 cfg-if = "0.1.0"
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -56,6 +56,12 @@ pub fn setpgid(pid: pid_t, pgid: pid_t) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[inline]
+pub fn gettid() -> pid_t {
+    unsafe { libc::syscall(libc::SYS_gettid) as pid_t }    // no error handling, according to man page: "These functions are always successful."
+}
+
 #[inline]
 pub fn dup(oldfd: RawFd) -> Result<RawFd> {
     let res = unsafe { libc::dup(oldfd) };

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -54,6 +54,17 @@ fn test_getpid() {
     assert!(ppid > 0);
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod linux_android {
+    use nix::unistd::gettid;
+
+    #[test]
+    fn test_gettid() {
+        let tid = gettid();
+        assert!(tid > 0);
+    }
+}
+
 macro_rules! execve_test_factory(
     ($test_name:ident, $syscall:ident, $unix_sh:expr, $android_sh:expr) => (
     #[test]


### PR DESCRIPTION
I tested this under linux, and I noticed that this seems to also be built for OSX. It would be appreciated if someone could test this under OSX.

I'm not familiar enough with rust to know if there is a way of integrating this without creating a sub-crate.