### PR TITLE
Docker cross test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,35 @@
----
+language: rust
 sudo: required
+dist: trusty
 services:
   - docker
-language: rust
+
 rust:
   - 1.1.0  # Oldest supported version
-  - 1.2.0
-  - 1.3.0
-  - 1.4.0
-  - 1.5.0
-  - 1.6.0
-  - 1.7.0
   - stable
   - beta
   - nightly
 
 script:
-  - sh ci/run-travis.sh
+  - bash ci/run-travis.sh
+
+env:
+  - ARCH=x86_64
 
 os:
   - linux
   - osx
 
-env:
-  - ARCH=x86_64
-  - ARCH=i686
-
 # Failures on nightly shouldn't fail the overall build.
 matrix:
   fast_finish: true
   include:
+    - os: linux
+      env: ARCH=i686
+      rust: stable
+    - os: osx
+      env: ARCH=i686
+      rust: stable
     - os: linux
       env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm
       rust: 1.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
-sudo: false
+sudo: required
+services:
+  - docker
 language: rust
 rust:
   - 1.1.0  # Oldest supported version
@@ -7,31 +9,49 @@ rust:
   - 1.3.0
   - 1.4.0
   - 1.5.0
+  - 1.6.0
+  - 1.7.0
   - stable
   - beta
   - nightly
 
-# Failures on nightly shouldn't fail the overall build.
-matrix:
-  allow_failures:
-    - rust: nightly
+script:
+  - sh ci/run-travis.sh
 
 os:
   - linux
   - osx
 
 env:
-  - RUST_TEST_THREADS=1 ARCH=x86_64
-  - RUST_TEST_THREADS=1 ARCH=i686
+  - ARCH=x86_64
+  - ARCH=i686
 
-script:
-  - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | RUST_TEST_THREADS=1 bash
-  - cargo doc --no-deps
-
-addons:
-  apt:
-    packages:
-      - gcc-multilib
+# Failures on nightly shouldn't fail the overall build.
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm
+      rust: 1.7.0
+    - os: linux
+      env: TARGET=arm-unknown-linux-gnueabihf DOCKER_IMAGE=posborne/rust-cross:arm
+      rust: 1.7.0
+    - os: linux
+      env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
+      rust: 1.7.0
+    - os: linux
+      env: TARGET=mipsel-unknwon-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
+      rust: 1.7.0
+    - os: linux
+      env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android
+      rust: 1.7.0
+  allow_failures:
+    - rust: nightly
+    - env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm
+    - env: TARGET=arm-unknown-linux-gnueabihf DOCKER_IMAGE=posborne/rust-cross:arm
+    - env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
+    - env: TARGET=mipsel-unknwon-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
+    - env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android
 
 # Deploy documentation to S3 for specific branches. At some
 # point, it would be nice to also support building docs for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,11 @@ environment. We also have [continuous integration set up on
 Travis-CI][travis-ci], which might find some issues on other platforms. The CI
 will run once you open a pull request.
 
-[travis-ci]: https://travis-ci.org/nix-rust/nix
+There is also infrastructure for running tests for other targets
+locally.  More information is available in the [CI Readme][ci-readme].
 
+[travis-ci]: https://travis-ci.org/nix-rust/nix
+[ci-readme]: ci/README.md
 
 ## Homu, the bot who merges all the PRs
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc     = "0.2.8"
+libc     = { git = "https://github.com/rust-lang/libc.git" }
 bitflags = "0.4"
 cfg-if = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc     = { git = "https://github.com/rust-lang/libc.git" }
+libc     = "0.2.8"
 bitflags = "0.4"
 cfg-if = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use `nix`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nix = "*"
+nix = "0.5.0"
 ```
 
 Then, add this to your crate root:

--- a/ci/README.md
+++ b/ci/README.md
@@ -31,12 +31,18 @@ The list of versions and architectures tested by this can be
 determined by looking at the contents of the script.  The docker image
 used is [posborne/rust-cross][posborne/rust-cross].
 
+[posborne/rust-cross]: https://github.com/rust-embedded/docker-rust-cross
+
 Running Test for Specific Architectures/Versions
 ------------------------------------------------
 
-Suppose we have a failing test with Rust 1.6/1.7 on the raspberry pi.  In
+Suppose we have a failing test with Rust 1.7 on the raspberry pi.  In
 that case, we can run the following:
 
-    $ RUST_VERSIONS="1.6.0 1.7.0" RUST_TARGETS="arm-unknown-linux-gnueabihf" ci/run-all.sh
+    $ DOCKER_IMAGE=posborne/rust-cross:arm \
+          RUST_VERSION=1.7.0 \
+          RUST_TARGET=arm-unknown-linux-gnueabihf ci/run-docker.sh
 
-[posborne/rust-cross]: https://github.com/posborne/docker-rust-cross
+Currently, the docker images only support Rust 1.7.  To get a better
+idea of combinations that might work, look at the contents of the
+[travis configuration](../.travis.yml) or [run-all.sh](run-all.sh).

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,42 @@
+Test Infrastructure
+===================
+
+The ci directory contains scripts that aid in the testing of nix both
+in our continuous integration environment (Travis CI) but also for
+developers working locally.
+
+Nix interfaces very directly with the underlying platform (usually via
+libc) and changes need to be tested on a large number of platforms to
+avoid problems.
+
+Running Tests For Host Architecture
+-----------------------------------
+
+Running the tests for one's host architecture can be done by simply
+doing the following:
+
+    $ cargo test
+
+Running Tests Against All Architectures/Versions
+------------------------------------------------
+
+Testing for other architectures is more involved.  Currently,
+developers may run tests against several architectures and versions of
+rust by running the `ci/run-all.sh` script.  This scripts requires
+that docker be set up.  This will take some time:
+
+    $ ci/run-all.sh
+
+The list of versions and architectures tested by this can be
+determined by looking at the contents of the script.  The docker image
+used is [posborne/rust-cross][posborne/rust-cross].
+
+Running Test for Specific Architectures/Versions
+------------------------------------------------
+
+Suppose we have a failing test with Rust 1.6/1.7 on the raspberry pi.  In
+that case, we can run the following:
+
+    $ RUST_VERSIONS="1.6.0 1.7.0" RUST_TARGETS="arm-unknown-linux-gnueabihf" ci/run-all.sh
+
+[posborne/rust-cross]: https://github.com/posborne/docker-rust-cross

--- a/ci/cargo-config
+++ b/ci/cargo-config
@@ -1,0 +1,13 @@
+# Configuration of which linkers to call on Travis for various architectures
+
+[target.arm-linux-androideabi]
+linker = "arm-linux-androideabi-gcc"
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc-4.7"
+
+[target.mips-unknown-linux-gnu]
+linker = "mips-linux-gnu-gcc-5"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/ci/cargo-config
+++ b/ci/cargo-config
@@ -1,13 +1,25 @@
 # Configuration of which linkers to call on Travis for various architectures
 
+[target.x86_64-unknown-linux-gnu]
+linker = "gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker = "gcc"
+
+[target.i686-unknown-linux-gnu]
+linker = "gcc"
+
+[target.i686-unknown-linux-musl]
+linker = "gcc"
+
 [target.arm-linux-androideabi]
 linker = "arm-linux-androideabi-gcc"
 
 [target.arm-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc-4.7"
+linker = "arm-linux-gnueabihf-gcc"
 
 [target.mips-unknown-linux-gnu]
-linker = "mips-linux-gnu-gcc-5"
+linker = "mips-linux-gnu-gcc"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/ci/cargo-config
+++ b/ci/cargo-config
@@ -16,10 +16,16 @@ linker = "gcc"
 linker = "arm-linux-androideabi-gcc"
 
 [target.arm-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
+linker = "arm-linux-gnueabihf-gcc-4.7"
 
 [target.mips-unknown-linux-gnu]
-linker = "mips-linux-gnu-gcc"
+linker = "mips-linux-gnu-gcc-5"
+
+[target.mipsel-unknown-linux-gnu]
+linker = "mipsel-linux-gnu-gcc-5"
 
 [target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
+linker = "aarch64-linux-gnu-gcc-4.8"
+
+[target.powerpc-unknown-linux-gnu]
+linker = "powerpc-linux-gnu-gcc-4.8"

--- a/ci/cargo-config
+++ b/ci/cargo-config
@@ -1,17 +1,4 @@
 # Configuration of which linkers to call on Travis for various architectures
-
-[target.x86_64-unknown-linux-gnu]
-linker = "gcc"
-
-[target.x86_64-unknown-linux-musl]
-linker = "gcc"
-
-[target.i686-unknown-linux-gnu]
-linker = "gcc"
-
-[target.i686-unknown-linux-musl]
-linker = "gcc"
-
 [target.arm-linux-androideabi]
 linker = "arm-linux-androideabi-gcc"
 

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -6,49 +6,23 @@
 
 set -e
 
-RUST_VERSIONS=${RUST_VERSIONS:-"\
-    1.6.0 \
-    1.7.0 \
-    beta \
-    nightly"}
-
-# Disabled (not working presently) but with some support in the target
-# image:
-# - i686-apple-darwin
-# - x86_64-apple-darwin
-
-RUST_TARGETS=${RUST_TARGETS:-"\
-    aarch64-unknown-linux-gnu \
-    arm-linux-androideabi \
-    arm-unknown-linux-gnueabi \
-    arm-unknown-linux-gnueabihf \
-    i686-unknown-linux-gnu \
-    mips-unknown-linux-gnu \
-    mipsel-unknown-linux-gnu \
-    x86_64-unknown-linux-gnu \
-    x86_64-unknown-linux-musl"}
-
-DOCKER_IMAGE=${DOCKER_IMAGE:-"posborne/rust-cross"}
-
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_DOCKER="${BASE_DIR}/ci/run-docker.sh"
 
-test_nix() {
-    version=$1
-    target=$2
+export RUST_VERSION=1.7.0
 
-    docker run -i -t \
-           -v ${BASE_DIR}:/source \
-           -e CARGO_TARGET_DIR=/build \
-           ${DOCKER_IMAGE} \
-           /source/ci/run.sh ${version} ${target}
-}
+export DOCKER_IMAGE=posborne/rust-cross:base
+RUST_TARGET=x86_64-unknown-linux-gnu ${RUN_DOCKER}
+RUST_TARGET=x86_64-unknown-linux-musl ${RUN_DOCKER}
 
-# Ensure up to date (short compared to everything else)
-docker pull ${DOCKER_IMAGE}
+export DOCKER_IMAGE=posborne/rust-cross:arm
+RUST_TARGET=aarch64-unknown-linux-gnu ${RUN_DOCKER}
+RUST_TARGET=arm-linux-gnueabi test_nix ${RUN_DOCKER}
+RUST_TARGET=arm-linux-gnueabihf test_nix ${RUN_DOCKER}
 
-# Run tests for each version/target combination
-for version in ${RUST_VERSIONS}; do
-    for target in ${RUST_TARGETS}; do
-        test_nix $version $target || true
-    done
-done
+export DOCKER_IMAGE=posborne/rust-cross:mips
+RUST_TARGET=mips-unknown-linux-gnu test_nix ${RUN_DOCKER}
+RUST_TARGET=mipsel-unknown-linux-gnu test_nix ${RUN_DOCKER}
+
+export DOCKER_IMAGE=posborne/rust-cross:android ${RUN_DOCKER}
+RUST_TARGET=arm-linux-androideabi test_nix ${RUN_DOCKER}

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# This is **not** meant to be run on CI, but rather locally instead. If you're
+# on a Linux machine you'll be able to run most of these, but otherwise this'll
+# just attempt to run as many platforms as possible!
+
+set -e
+
+RUST_VERSIONS=${RUST_VERSIONS:-"\
+    1.6.0 \
+    1.7.0 \
+    stable \
+    beta \
+    nightly"}
+
+RUST_TARGETS=${RUST_TARGETS:-"\
+    aarch64-unknown-linux-gnu \
+    arm-linux-androideabi \
+    arm-unknown-linux-gnueabi \
+    arm-unknown-linux-gnueabihf \
+    i686-apple-darwin \
+    i686-unknown-linux-gnu \
+    mips-unknown-linux-gnu \
+    mipsel-unknown-linux-gnu \
+    x86_64-apple-darwin \
+    x86_64-unknown-linux-gnu \
+    x86_64-unknown-linux-musl"}
+
+DOCKER_IMAGE="rust-crossbuilder"
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+test_nix() {
+    version=$1
+    target=$2
+
+    docker run -i -t \
+           -v ${BASE_DIR}:/source \
+           -e CARGO_TARGET_DIR=/build \
+           ${DOCKER_IMAGE} \
+           /source/ci/run.sh ${version} ${target}
+}
+
+for version in ${RUST_VERSIONS}; do
+    for target in ${RUST_TARGETS}; do
+        test_nix $version $target
+    done
+done

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -9,20 +9,22 @@ set -e
 RUST_VERSIONS=${RUST_VERSIONS:-"\
     1.6.0 \
     1.7.0 \
-    stable \
     beta \
     nightly"}
+
+# Disabled (not working presently) but with some support in the target
+# image:
+# - i686-apple-darwin
+# - x86_64-apple-darwin
 
 RUST_TARGETS=${RUST_TARGETS:-"\
     aarch64-unknown-linux-gnu \
     arm-linux-androideabi \
     arm-unknown-linux-gnueabi \
     arm-unknown-linux-gnueabihf \
-    i686-apple-darwin \
     i686-unknown-linux-gnu \
     mips-unknown-linux-gnu \
     mipsel-unknown-linux-gnu \
-    x86_64-apple-darwin \
     x86_64-unknown-linux-gnu \
     x86_64-unknown-linux-musl"}
 
@@ -47,6 +49,6 @@ docker pull ${DOCKER_IMAGE}
 # Run tests for each version/target combination
 for version in ${RUST_VERSIONS}; do
     for target in ${RUST_TARGETS}; do
-        test_nix $version $target
+        test_nix $version $target || true
     done
 done

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -26,7 +26,7 @@ RUST_TARGETS=${RUST_TARGETS:-"\
     x86_64-unknown-linux-gnu \
     x86_64-unknown-linux-musl"}
 
-DOCKER_IMAGE="posborne/rust-cross"
+DOCKER_IMAGE=${DOCKER_IMAGE:-"posborne/rust-cross"}
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# This is **not** meant to be run on CI, but rather locally instead. If you're
-# on a Linux machine you'll be able to run most of these, but otherwise this'll
-# just attempt to run as many platforms as possible!
+# Build nix and all tests for as many versions and platforms as can be
+# managed.  This requires docker.
+#
 
 set -e
 
@@ -26,7 +26,7 @@ RUST_TARGETS=${RUST_TARGETS:-"\
     x86_64-unknown-linux-gnu \
     x86_64-unknown-linux-musl"}
 
-DOCKER_IMAGE="rust-crossbuilder"
+DOCKER_IMAGE="posborne/rust-cross"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -41,6 +41,10 @@ test_nix() {
            /source/ci/run.sh ${version} ${target}
 }
 
+# Ensure up to date (short compared to everything else)
+docker pull ${DOCKER_IMAGE}
+
+# Run tests for each version/target combination
 for version in ${RUST_VERSIONS}; do
     for target in ${RUST_TARGETS}; do
         test_nix $version $target

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Run the nix tests in a docker container.  This script expects the following
+# environment variables to be set:
+# - DOCKER_IMAGE : Docker image to use for testing (e.g. posborne/rust-cross:arm)
+# - RUST_VERSION : Rust Version to test against (e.g. 1.7.0)
+# - RUST_TARGET  : Target Triple to test
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+docker run -i -t \
+       -v ${BASE_DIR}:/source \
+       -e CARGO_TARGET_DIR=/build \
+       ${DOCKER_IMAGE} \
+       /source/ci/run.sh ${RUST_VERSION} ${RUST_TARGET}

--- a/ci/run-travis.sh
+++ b/ci/run-travis.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Entry point for all travis builds, this will set up the Travis environment by
+# downloading any dependencies. It will then execute the `run.sh` script to
+# build and execute all tests.
+#
+# Much of this script was liberally stolen from rust-lang/libc
+#
+# Key variables that may be set from Travis:
+# - TRAVIS_RUST_VERSION: 1.1.0 ... stable/nightly/beta
+# - TRAVIS_OS_NAME: linux/osx
+# - DOCKER_IMAGE: posborne/rust-cross:arm
+# - TARGET: e.g. arm-unknown-linux-gnueabihf
+
+set -ex
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+  OS=unknown-linux-gnu
+else
+  OS=apple-darwin
+fi
+
+export HOST=$ARCH-$OS
+if [ "$TARGET" = "" ]; then
+  TARGET=$HOST
+fi
+
+if [ "$DOCKER_IMAGE" = "" ]; then
+  RUST_TEST_THREADS=1 cargo test
+else
+  export RUST_VERSION=${TRAVIS_RUST_VERSION}
+  export RUST_TARGET=${TARGET}
+  export DOCKER_IMAGE=${DOCKER_IMAGE}
+  ${BASE_DIR}/ci/run-docker.sh
+fi

--- a/ci/run-travis.sh
+++ b/ci/run-travis.sh
@@ -18,8 +18,11 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
   OS=unknown-linux-gnu
-else
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
   OS=apple-darwin
+else
+  echo "Unexpected TRAVIS_OS_NAME: $TRAVIS_OS_NAME"
+  exit 1
 fi
 
 export HOST=$ARCH-$OS

--- a/ci/run-travis.sh
+++ b/ci/run-travis.sh
@@ -27,8 +27,15 @@ if [ "$TARGET" = "" ]; then
   TARGET=$HOST
 fi
 
+if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
+    sudo apt-get -y update
+    sudo apt-get install -y gcc-multilib
+fi
+
 if [ "$DOCKER_IMAGE" = "" ]; then
-  RUST_TEST_THREADS=1 cargo test
+  export RUST_TEST_THREADS=1
+  curl -sSL "https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test" | bash
+  cargo doc --no-deps
 else
   export RUST_VERSION=${TRAVIS_RUST_VERSION}
   export RUST_TARGET=${TARGET}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,6 +12,8 @@ BUILD_DIR="."
 VERSION="$1"
 TARGET="$2"
 
+export RUST_TEST_THREADS=1
+
 echo "======================================================="
 echo "TESTING VERSION: ${VERSION}, TARGET: ${TARGET}"
 echo "======================================================="

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -27,6 +27,17 @@ configure_cargo() {
   cp "${BASE_DIR}/ci/cargo-config" .cargo/config
 }
 
+#
+# We need to export CC for the tests to build properly (some C code is
+# compiled) to work.  We already tell Cargo about the compiler in the
+# cargo config, so we just parse that info out of the cargo config
+#
+cc_for_target() {
+  awk "/\[target\.${TARGET}\]/{getline; print}" .cargo/config |
+      cut -d '=' -f2 | \
+      tr -d '"' | tr -d ' '
+}
+
 cross_compile_tests() {
   case "$TARGET" in
     *-apple-ios)
@@ -98,6 +109,8 @@ test_binary() {
 }
 
 configure_cargo
+
+export CC="$(cc_for_target)"
 
 # select the proper version
 multirust override ${VERSION}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Builds and runs tests for a particular target passed as an argument to this
+# script.
+
+set -e
+set -x
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST_PATH="${BASE_DIR}/Cargo.toml"
+
+VERSION="$1"
+TARGET="$2"
+
+echo "======================================================="
+echo "TESTING VERSION: ${VERSION}, TARGET: ${TARGET}"
+echo "======================================================="
+
+cross_compile_tests() {
+  case "$TARGET" in
+    *-apple-ios)
+      cargo test --no-run --manifest-path="${MANIFEST_PATH}" --target "$TARGET" -- \
+            -C link-args=-mios-simulator-version-min=7.0
+      ;;
+
+    *)
+      cargo test --no-run --verbose \
+            --manifest-path="${MANIFEST_PATH}" \
+            --target "$TARGET"
+      ;;
+  esac
+}
+
+# This is a hack as we cannot currently
+# ask cargo what test files it generated:
+# https://github.com/rust-lang/cargo/issues/1924
+find_binaries() {
+  target_base_dir="target/${TARGET}/debug"
+
+  # find [[test]] sections and print the first line and
+  # hack it to what we want from there.  Also "nix" for
+  # tests that are implicitly prsent
+  for test_base in $( awk '/\[\[test\]\]/{getline; print}' Cargo.toml | \
+                          cut -d '='  -f2 | \
+                          tr -d '"' | \
+                          tr '-' '_' | \
+                          tr -d ' '; echo "nix" ); do
+    for path in ${target_base_dir}/${test_base}-* ; do
+      echo "${path} "
+    done
+  done
+}
+
+test_binary() {
+  binary=$1
+
+  case "$TARGET" in
+    arm-linux-gnueabi-gcc)
+      qemu-arm -L /usr/arm-linux-gnueabihf "$binary"
+      ;;
+
+    arm-unknown-linux-gnueabihf)
+      qemu-arm -L /usr/arm-linux-gnueabihf "$binary"
+      ;;
+
+    mips-unknown-linux-gnu)
+      qemu-mips -L /usr/mips-linux-gnu "$binary"
+      ;;
+
+    aarch64-unknown-linux-gnu)
+      qemu-aarch64 -L /usr/aarch64-linux-gnu "$binary"
+      ;;
+
+    *-rumprun-netbsd)
+      rumprun-bake hw_virtio /tmp/nix-test.img "${binary}"
+      qemu-system-x86_64 -nographic -vga none -m 64 \
+                         -kernel /tmp/nix-test.img 2>&1 | tee /tmp/out &
+      sleep 5
+      grep "^PASSED .* tests" /tmp/out
+      ;;
+
+    *)
+      echo "Running binary: ${binary}"
+      ${binary}
+      ;;
+  esac
+}
+
+# select the proper version
+multirust override ${VERSION}
+
+# build the tests
+cross_compile_tests
+
+# and run the tests
+for bin in $(find_binaries); do
+  test_binary "${bin}"
+done

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,6 +7,7 @@ set -e
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST_PATH="${BASE_DIR}/Cargo.toml"
+BUILD_DIR="."
 
 VERSION="$1"
 TARGET="$2"
@@ -43,12 +44,12 @@ cross_compile_tests() {
 # ask cargo what test files it generated:
 # https://github.com/rust-lang/cargo/issues/1924
 find_binaries() {
-  target_base_dir="target/${TARGET}/debug"
+  target_base_dir="${BUILD_DIR}/${TARGET}/debug"
 
   # find [[test]] sections and print the first line and
   # hack it to what we want from there.  Also "nix" for
   # tests that are implicitly prsent
-  for test_base in $( awk '/\[\[test\]\]/{getline; print}' Cargo.toml | \
+  for test_base in $( awk '/\[\[test\]\]/{getline; print}' "${MANIFEST_PATH}" | \
                           cut -d '='  -f2 | \
                           tr -d '"' | \
                           tr '-' '_' | \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -16,6 +16,15 @@ echo "======================================================="
 echo "TESTING VERSION: ${VERSION}, TARGET: ${TARGET}"
 echo "======================================================="
 
+#
+# Tell cargo what linker to use and whatever else is required
+#
+configure_cargo() {
+  rm -rf .cargo
+  mkdir .cargo
+  cp "${BASE_DIR}/ci/cargo-config" .cargo/config
+}
+
 cross_compile_tests() {
   case "$TARGET" in
     *-apple-ios)
@@ -85,6 +94,8 @@ test_binary() {
       ;;
   esac
 }
+
+configure_cargo
 
 # select the proper version
 multirust override ${VERSION}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,6 +5,16 @@
 
 set -e
 
+# This should only be run in a docker container, so verify that
+if [ ! -f /.dockerinit ]; then
+    echo "run.sh should only be executed in a docker container"
+    echo "and that does not appear to be the case.  Maybe you meant"
+    echo "to execute the tests via run-all.sh or run-docker.sh."
+    echo ""
+    echo "For more instructions, please refer to ci/README.md"
+    exit 1
+fi
+
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST_PATH="${BASE_DIR}/Cargo.toml"
 BUILD_DIR="."
@@ -18,9 +28,8 @@ export RUST_TEST_THREADS=1
 # Tell cargo what linker to use and whatever else is required
 #
 configure_cargo() {
-  rm -rf .cargo
-  mkdir .cargo
-  cp "${BASE_DIR}/ci/cargo-config" .cargo/config
+  mkdir -p .cargo
+  cp -b "${BASE_DIR}/ci/cargo-config" .cargo/config
 }
 
 #

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,7 +4,6 @@
 # script.
 
 set -e
-set -x
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST_PATH="${BASE_DIR}/Cargo.toml"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -110,6 +110,9 @@ echo "======================================================="
 
 configure_cargo
 export CC="$(cc_for_target)"
+if [ "${CC}" = "" ]; then
+    unset CC
+fi
 
 # select the proper version
 multirust override ${VERSION}

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -14,10 +14,6 @@ TARGET="$2"
 
 export RUST_TEST_THREADS=1
 
-echo "======================================================="
-echo "TESTING VERSION: ${VERSION}, TARGET: ${TARGET}"
-echo "======================================================="
-
 #
 # Tell cargo what linker to use and whatever else is required
 #
@@ -108,8 +104,11 @@ test_binary() {
   esac
 }
 
-configure_cargo
+echo "======================================================="
+echo "TESTING VERSION: ${VERSION}, TARGET: ${TARGET}"
+echo "======================================================="
 
+configure_cargo
 export CC="$(cc_for_target)"
 
 # select the proper version


### PR DESCRIPTION
These commits contain the first portion of new infrastructure that will allow us to build for and test on a much larger set of platforms.  Nix and the tests are *not* compiling on many platforms right now, but I believe at this point that most of those problems are issues with nix (or libc) rather than the test infrastructure.

I want to get this out there so we can start filing issues and other people can start doing testing and development to resolve the issues popping up on various platforms.  None of this is integrated in with travis at this point -- that will be phase 3.  Phase 2 will be getting qemu going to run the tests for non-host platforms (this might be tricky when running in a container as `/dev/kvm` might need to be passed through).

This is based on the testing infrastructure in libc but modified quite a bit -- The libc infrastructure doesn't seem to be a great experience for testing locally.  If this approach works out, we might want to push this approach toward libc.

The Dockerfile/Image that goes along with this is currently here:
* https://github.com/posborne/docker-rust-cross
* https://hub.docker.com/r/posborne/rust-cross/

I would have no problem moving this into the org if that makes sense down the line.