### PR TITLE
tests: Disable test_sigwait on apple platforms

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -292,6 +292,8 @@ mod tests {
         assert!(!oldmask.contains(SIGUSR2).unwrap());
     }
 
+    // TODO(#251): Re-enable after figuring out flakiness.
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     #[test]
     fn test_sigwait() {
         let mut mask = SigSet::empty();


### PR DESCRIPTION
After #292 was merged, this flakiness remained. I observe it only on
Darwin, hence the targetted disabling until there's been more
investigation.