### PR TITLE
Update signalfd

### DIFF
--- a/test/test_signalfd.rs
+++ b/test/test_signalfd.rs
@@ -2,11 +2,15 @@ extern crate nix;
 
 #[cfg(feature = "signalfd")]
 
-use nix::sys::signalfd::*;
+use nix::sys::signalfd::SignalFd;
+use nix::sys::signal;
+use nix::unistd;
 
 #[cfg(feature = "signalfd")]
 fn main() {
-    let mut mask = SigSet::empty();
+    print!("test test_signalfd ... ");
+
+    let mut mask = signal::SigSet::empty();
     mask.add(signal::SIGUSR1).unwrap();
     mask.thread_block().unwrap();
 
@@ -16,13 +20,9 @@ fn main() {
     signal::kill(pid, signal::SIGUSR1).unwrap();
 
     let res = fd.read_signal();
-    assert!(res.is_ok());
 
-    let opt = res.ok().unwrap();
-    assert!(opt.is_some());
-
-    let info = opt.unwrap();
-    assert_eq!(info.ssi_signo as i32, signal::SIGUSR1);
+    assert_eq!(res.unwrap().unwrap().ssi_signo as i32, signal::SIGUSR1);
+    println!("ok");
 }
 
 #[cfg(not(feature = "signalfd"))]


### PR DESCRIPTION
Update `signalfd` to use types and functions from `libc`.

It is a breaking change, because:
- renamed pub const `CREATE_NEW_FD` to `SIGNALFD_NEW`
- renamed pub const `SIGINFO_SIZE` to `SIGNALFD_SIGINFO_SIZE`
- removed pub const `SIGINFO_PADDING`

Fixes #307