### PR TITLE
Fix arm and x86 ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,6 @@ matrix:
       sudo: true
   allow_failures:
     - rust: nightly
-    - env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm
-    - env: TARGET=arm-unknown-linux-gnueabihf DOCKER_IMAGE=posborne/rust-cross:arm
     - env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=mipsel-unknwon-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android

--- a/ci/run-all.sh
+++ b/ci/run-all.sh
@@ -11,7 +11,8 @@ RUN_DOCKER="${BASE_DIR}/ci/run-docker.sh"
 
 export RUST_VERSION=1.7.0
 
-export DOCKER_IMAGE=posborne/rust-cross:base
+export DOCKER_IMAGE=posborne/rust-cross:x86
+RUST_TARGET=i686-unknown-linux-gnu ${RUN_DOCKER}
 RUST_TARGET=x86_64-unknown-linux-gnu ${RUN_DOCKER}
 RUST_TARGET=x86_64-unknown-linux-musl ${RUN_DOCKER}
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -22,7 +22,9 @@ BUILD_DIR="."
 VERSION="$1"
 TARGET="$2"
 
+export DOCKER_ENVIRONMENT=1
 export RUST_TEST_THREADS=1
+export RUST_BACKTRACE=1
 
 #
 # Tell cargo what linker to use and whatever else is required


### PR DESCRIPTION
See the individual commit message for more detail.  ARM is now passing (but we don't run mount tests any more when in the docker container).  For x86_64/i686, there were some changes in the posborne/rust-cross stuff.