### PR TITLE
epoll: Add EPOLLEXCLUSIVE flag.

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -27,6 +27,7 @@ bitflags!(
         const EPOLLERR = 0x008,
         const EPOLLHUP = 0x010,
         const EPOLLRDHUP = 0x2000,
+        const EPOLLEXCLUSIVE = 1 << 28,
         const EPOLLWAKEUP = 1 << 29,
         const EPOLLONESHOT = 1 << 30,
         const EPOLLET = 1 << 31


### PR DESCRIPTION
EPOLLEXCLUSIVE flag is available in Linux4.5.