### PR TITLE
unistd: Redesign the enum returned by fork()

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -12,33 +12,33 @@ use std::os::unix::io::RawFd;
 pub use self::linux::*;
 
 #[derive(Clone, Copy)]
-pub enum Fork {
-    Parent(pid_t),
+pub enum ForkResult {
+    Parent {
+        child: pid_t
+    },
     Child
 }
 
-impl Fork {
+impl ForkResult {
     pub fn is_child(&self) -> bool {
         match *self {
-            Fork::Child => true,
+            ForkResult::Child => true,
             _ => false
         }
     }
 
     pub fn is_parent(&self) -> bool {
-        match *self {
-            Fork::Parent(_) => true,
-            _ => false
-        }
+        !self.is_child()
     }
 }
 
-pub fn fork() -> Result<Fork> {
+pub fn fork() -> Result<ForkResult> {
+    use self::ForkResult::*;
     let res = unsafe { libc::fork() };
 
     Errno::result(res).map(|res| match res {
-        0 => Fork::Child,
-        res => Fork::Parent(res)
+        0 => Child,
+        res => Parent { child: res }
     })
 }
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -20,6 +20,7 @@ pub enum ForkResult {
 }
 
 impl ForkResult {
+    #[inline]
     pub fn is_child(&self) -> bool {
         match *self {
             ForkResult::Child => true,
@@ -27,11 +28,13 @@ impl ForkResult {
         }
     }
 
+    #[inline]
     pub fn is_parent(&self) -> bool {
         !self.is_child()
     }
 }
 
+#[inline]
 pub fn fork() -> Result<ForkResult> {
     use self::ForkResult::*;
     let res = unsafe { libc::fork() };

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -1,5 +1,5 @@
 use nix::unistd::*;
-use nix::unistd::Fork::*;
+use nix::unistd::ForkResult::*;
 use nix::sys::signal::*;
 use nix::sys::wait::*;
 use libc::exit;
@@ -8,9 +8,9 @@ use libc::exit;
 fn test_wait_signal() {
     match fork() {
       Ok(Child) => pause().unwrap_or(()),
-      Ok(Parent(child_pid)) => {
-          kill(child_pid, SIGKILL).ok().expect("Error: Kill Failed");
-          assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Signaled(child_pid, SIGKILL, false)));
+      Ok(Parent { child }) => {
+          kill(child, SIGKILL).ok().expect("Error: Kill Failed");
+          assert_eq!(waitpid(child, None), Ok(WaitStatus::Signaled(child, SIGKILL, false)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")
@@ -21,8 +21,8 @@ fn test_wait_signal() {
 fn test_wait_exit() {
     match fork() {
       Ok(Child) => unsafe { exit(12); },
-      Ok(Parent(child_pid)) => {
-          assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Exited(child_pid, 12)));
+      Ok(Parent { child }) => {
+          assert_eq!(waitpid(child, None), Ok(WaitStatus::Exited(child, 12)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -9,7 +9,7 @@ use std::str;
 use libc::c_long;
 
 use nix::unistd::{fork, read, write, pipe};
-use nix::unistd::Fork::{Child, Parent};
+use nix::unistd::ForkResult::*;
 use nix::sys::wait::*;
 use nix::errno::Errno::*;
 use nix::Error::Sys;
@@ -37,11 +37,11 @@ fn test_mq_send_and_receive() {
             write(writer, &buf).unwrap();  // pipe result to parent process. Otherwise cargo does not report test failures correctly
             mq_close(mqd_in_child).unwrap();
       }
-      Ok(Parent(child_pid)) => {
+      Ok(Parent { child }) => {
           mq_close(mqd_in_parent).unwrap();
 
           // Wait for the child to exit.
-          waitpid(child_pid, None).unwrap();
+          waitpid(child, None).unwrap();
           // Read 1024 bytes.
           let mut read_buf = [0u8; 32];
           read(reader, &mut read_buf).unwrap();


### PR DESCRIPTION
This changes the name of the enum returned by `fork()` to `ForkResult`,
and changes the `Parent` variant to be struct-like.

The result can be matched like

    use nix::unistd::ForkResult::*;
    match fork().unwrap() {
        Parent { child } => { ... }
        Child => { ... }
    }

using the shorthand matching syntax for struct-like enum variants.

This is a breaking change.
