### PR TITLE
tests: Unwrap result of fork in tests

### DIFF
--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -6,25 +6,21 @@ use libc::exit;
 
 #[test]
 fn test_wait_signal() {
-    match fork() {
-      Ok(Child) => loop { /* Wait for signal */ },
-      Ok(Parent(child_pid)) => {
+    match fork().expect("fork") {
+      Child => loop { /* Wait for signal */ },
+      Parent(child_pid) => {
           kill(child_pid, SIGKILL).ok().expect("Error: Kill Failed");
           assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Signaled(child_pid, SIGKILL, false)));
       },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
     }
 }
 
 #[test]
 fn test_wait_exit() {
-    match fork() {
-      Ok(Child) => unsafe { exit(12); },
-      Ok(Parent(child_pid)) => {
+    match fork().expect("fork") {
+      Child => unsafe { exit(12); },
+      Parent(child_pid) => {
           assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Exited(child_pid, 12)));
       },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
     }
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -5,10 +5,9 @@ use std::ffi::CString;
 
 #[test]
 fn test_fork_and_waitpid() {
-    let pid = fork();
-    match pid {
-      Ok(Child) => {} // ignore child here
-      Ok(Parent(child_pid)) => {
+    match fork().expect("fork") {
+      Child => {} // ignore child here
+      Parent(child_pid) => {
           // assert that child was created and pid > 0
           assert!(child_pid > 0);
           let wait_status = waitpid(child_pid, None);
@@ -24,24 +23,19 @@ fn test_fork_and_waitpid() {
           }
 
       },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
     }
 }
 
 #[test]
 fn test_wait() {
-    let pid = fork();
-    match pid {
-      Ok(Child) => {} // ignore child here
-      Ok(Parent(child_pid)) => {
+    match fork().expect("fork") {
+      Child => {} // ignore child here
+      Parent(child_pid) => {
           let wait_status = wait();
 
           // just assert that (any) one child returns with WaitStatus::Exited
           assert_eq!(wait_status, Ok(WaitStatus::Exited(child_pid, 0)));
       },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
     }
 }
 


### PR DESCRIPTION
All tests were panicking in the `Err(..)` case. This makes the code a
little cleaner by moving the panic into a call to `expect()`, tidying up
the match arms.