### PR TITLE
Fixed warning with raw_pointer_derive

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -154,7 +154,6 @@ impl AsRef<libc::sigset_t> for SigSet {
 }
 
 #[allow(unknown_lints)]
-#[allow(raw_pointer_derive)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum SigHandler {
     SigDfl,


### PR DESCRIPTION
There is no need to allow raw_pointer_derive, and it gives a warning in Rust stable. This fixes that warning.