### PR TITLE
Fix raw_pointer_derive warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ exclude     = [
   "test/**/*"
 ]
 
+build = "build.rs"
+
 [features]
 eventfd = []
 execvpe = []
@@ -23,6 +25,10 @@ signalfd = []
 libc     = "0.2.8"
 bitflags = "0.4"
 cfg-if = "0.1.0"
+
+[build-dependencies]
+rustc_version = "0.1.7"
+semver = "0.1.20"  # Old version for compatibility with rustc_version.
 
 [dev-dependencies]
 rand = "0.3.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+extern crate rustc_version;
+extern crate semver;
+
+use semver::Version;
+
+fn main() {
+    if rustc_version::version() >= Version::parse("1.6.0").unwrap() {
+        println!("cargo:rustc-cfg=raw_pointer_derive_allowed");
+    }
+}

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -154,7 +154,7 @@ impl AsRef<libc::sigset_t> for SigSet {
 }
 
 #[allow(unknown_lints)]
-#[allow(raw_pointer_derive)]
+#[cfg_attr(not(raw_pointer_derive_allowed), allow(raw_pointer_derive))]
 #[derive(Clone, Copy, PartialEq)]
 pub enum SigHandler {
     SigDfl,


### PR DESCRIPTION
This commit adds a small build script to detect if we need to
`#[allow(raw_pointer_derive)]` and makes the attribute conditional.

Refs #337