### PR TITLE
Use libc's syscall declaration.

### DIFF
--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -1,14 +1,32 @@
 //! Indirect system call
-//!
-use libc::c_int;
+
+pub use self::os::*;
+
+#[cfg(any(target_os = "linux",
+          target_os = "android",
+          target_os = "emscripten"))]
+mod os {
+    use libc::c_long;
+    pub type Syscall = c_long;
+}
+
+#[cfg(any(target_os = "macos",
+          target_os = "ios",
+          target_os = "freebsd",
+          target_os = "dragonfly",
+          target_os = "openbsd",
+          target_os = "netbsd",
+          target_os = "bitrig"))]
+mod os {
+    use libc::c_int;
+    pub type Syscall = c_int;
+}
 
 pub use self::arch::*;
 
 #[cfg(target_arch = "x86_64")]
 mod arch {
-    use libc::c_long;
-
-    pub type Syscall = c_long;
+    use super::Syscall;
 
     pub static SYSPIVOTROOT: Syscall = 155;
     pub static MEMFD_CREATE: Syscall = 319;
@@ -16,9 +34,7 @@ mod arch {
 
 #[cfg(target_arch = "x86")]
 mod arch {
-    use libc::c_long;
-
-    pub type Syscall = c_long;
+    use super::Syscall;
 
     pub static SYSPIVOTROOT: Syscall = 217;
     pub static MEMFD_CREATE: Syscall = 356;
@@ -26,9 +42,7 @@ mod arch {
 
 #[cfg(target_arch = "aarch64")]
 mod arch {
-    use libc::c_long;
-
-    pub type Syscall = c_long;
+    use super::Syscall;
 
     pub static SYSPIVOTROOT: Syscall = 41;
     pub static MEMFD_CREATE: Syscall = 279;
@@ -36,9 +50,7 @@ mod arch {
 
 #[cfg(target_arch = "arm")]
 mod arch {
-    use libc::c_long;
-
-    pub type Syscall = c_long;
+    use super::Syscall;
 
     pub static SYSPIVOTROOT: Syscall = 218;
     pub static MEMFD_CREATE: Syscall = 385;
@@ -46,14 +58,10 @@ mod arch {
 
 #[cfg(target_arch = "mips")]
 mod arch {
-    use libc::c_long;
-
-    pub type Syscall = c_long;
+    use super::Syscall;
 
     pub static SYSPIVOTROOT: Syscall = 216;
     pub static MEMFD_CREATE: Syscall = 354;
 }
 
-extern {
-    pub fn syscall(num: Syscall, ...) -> c_int;
-}
+pub use libc::syscall;


### PR DESCRIPTION
Another proposal for fixing an issue ( #341 ). I decided against removing the module, since the constants defined in there are used and they are not defined in libc.