### PR TITLE
Cast function item to function pointer in order to appease compiler.

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -205,7 +205,10 @@ pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> Result<pid
 
     let res = unsafe {
         let ptr = stack.as_mut_ptr().offset(stack.len() as isize);
-        ffi::clone(mem::transmute(callback), ptr as *mut c_void, flags.bits(), &mut cb)
+        ffi::clone(mem::transmute(callback as extern "C" fn(*mut Box<::std::ops::FnMut() -> isize>) -> i32),
+                   ptr as *mut c_void,
+                   flags.bits(),
+                   &mut cb)
     };
 
     Errno::result(res)


### PR DESCRIPTION
This is necessary because of compiler changes. For further information
look at rust-lang/rust#19925.

This solves #346.

I know that there are other problems with the affected function. We are thinking about how to best pass the arguments to the function and we don't want to define the ffi's ourselves. However, I would like to get the warning out of our tree as soon as possible. We do not need to wait for our polish.