### PR TITLE
mount: Use bindings from libc instead of our own

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,4 +1,5 @@
 use libc::{c_ulong, c_int};
+use libc;
 use {Errno, Result, NixPath};
 
 bitflags!(
@@ -48,23 +49,6 @@ bitflags!(
     }
 );
 
-mod ffi {
-    use libc::{c_char, c_int, c_ulong, c_void};
-
-    extern {
-        pub fn mount(
-                source: *const c_char,
-                target: *const c_char,
-                fstype: *const c_char,
-                flags: c_ulong,
-                data: *const c_void) -> c_int;
-
-        pub fn umount(target: *const c_char) -> c_int;
-
-        pub fn umount2(target: *const c_char, flags: c_int) -> c_int;
-    }
-}
-
 pub fn mount<P1: ?Sized + NixPath, P2: ?Sized + NixPath, P3: ?Sized + NixPath, P4: ?Sized + NixPath>(
         source: Option<&P1>,
         target: &P2,
@@ -79,7 +63,7 @@ pub fn mount<P1: ?Sized + NixPath, P2: ?Sized + NixPath, P3: ?Sized + NixPath, P
                 fstype.with_nix_path(|fstype| {
                     data.with_nix_path(|data| {
                         unsafe {
-                            ffi::mount(source.as_ptr(),
+                            libc::mount(source.as_ptr(),
                                        target.as_ptr(),
                                        fstype.as_ptr(),
                                        flags.bits,
@@ -95,7 +79,7 @@ pub fn mount<P1: ?Sized + NixPath, P2: ?Sized + NixPath, P3: ?Sized + NixPath, P
 
 pub fn umount<P: ?Sized + NixPath>(target: &P) -> Result<()> {
     let res = try!(target.with_nix_path(|cstr| {
-        unsafe { ffi::umount(cstr.as_ptr()) }
+        unsafe { libc::umount(cstr.as_ptr()) }
     }));
 
     Errno::result(res).map(drop)
@@ -103,7 +87,7 @@ pub fn umount<P: ?Sized + NixPath>(target: &P) -> Result<()> {
 
 pub fn umount2<P: ?Sized + NixPath>(target: &P, flags: MntFlags) -> Result<()> {
     let res = try!(target.with_nix_path(|cstr| {
-        unsafe { ffi::umount2(cstr.as_ptr(), flags.bits) }
+        unsafe { libc::umount2(cstr.as_ptr(), flags.bits) }
     }));
 
     Errno::result(res).map(drop)


### PR DESCRIPTION
Ref #264

Changing internal usage of `ffi::mount` and `ffi:umount` to make use of libc.