### PR TITLE
Add mkstemp(3)

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -374,6 +374,19 @@ pub fn sleep(seconds: libc::c_uint) -> c_uint {
     unsafe { libc::sleep(seconds) }
 }
 
+#[inline]
+pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<RawFd> {
+    let res = try!(template.with_nix_path(|path| {
+        let mut path_copy = path.to_bytes_with_nul().to_owned();
+        let c_template: *mut c_char = path_copy.as_mut_ptr() as *mut c_char;
+        unsafe {
+            libc::mkstemp(c_template)
+        }
+    }));
+    Errno::result(res)
+
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux {
     use sys::syscall::{syscall, SYSPIVOTROOT};

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -47,10 +47,11 @@ fn test_wait() {
 
 #[test]
 fn test_mkstemp() {
-    let result = mkstemp("/tmp/tempfile.XXXXXXXX");
+    let result = mkstemp("/tmp/nix_tempfile.XXXXXXXX");
     match result {
-        Ok(fd) => {
+        Ok((fd, path)) => {
             close(fd).unwrap();
+            unlink(path.as_path()).unwrap();
         }
         Err(e) => panic!("mkstemp failed: {}", e)
     }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -50,7 +50,7 @@ fn test_mkstemp() {
     let result = mkstemp("/tmp/tempfile.XXXXXXXX");
     match result {
         Ok(fd) => {
-            close(fd).expect("Couldn't close the file descriptor");
+            close(fd).unwrap();
         }
         Err(e) => panic!("mkstemp failed: {}", e)
     }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -45,6 +45,16 @@ fn test_wait() {
     }
 }
 
+#[test]
+fn test_mkstemp() {
+    let result = mkstemp("/tmp/tempfile.XXXXXXXX");
+    match result {
+        Ok(fd) => {
+            close(fd).expect("Couldn't close the file descriptor");
+        }
+        Err(e) => panic!("mkstemp failed: {}", e)
+    }
+}
 
 #[test]
 fn test_getpid() {


### PR DESCRIPTION
I've missed this call in a project that uses nix, so I added it to the `unistd` module; the placement is only a half-truth (as the header is `stdlib.h` on most systems, but some related functions are documented to live in `unistd.h` on BSD-derivatives), so I'm not sure my PR is completely right. But then, there is no `stdlib` module yet! Any guidance here is much appreciated! (-: