### PR TITLE
Support sockaddr_nl in sockaddr_storage_to_addr().

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -630,6 +630,11 @@ pub unsafe fn sockaddr_storage_to_addr(
         consts::AF_UNIX => {
             Ok(SockAddr::Unix(UnixAddr(*(addr as *const _ as *const sockaddr_un), len)))
         }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        consts::AF_NETLINK => {
+            use libc::sockaddr_nl;
+            Ok(SockAddr::Netlink(NetlinkAddr(*(addr as *const _ as *const sockaddr_nl))))
+        }
         af => panic!("unexpected address family {}", af),
     }
 }


### PR DESCRIPTION
Add support for converting AF_NETLINK  sockaddr_nl addresses to
Sockaddr::Netlink(). This lets socket::recvmsg() work on netlink
sockets.