### PR TITLE
Add SO_ORIGINAL_DST

### DIFF
--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -59,6 +59,8 @@ mod os {
     pub const SO_TIMESTAMP: c_int = 29;
     pub const SO_TYPE: c_int = 3;
     pub const SO_BUSY_POLL: c_int = 46;
+    #[cfg(target_os = "linux")]
+    pub const SO_ORIGINAL_DST: c_int = 80;
 
     // Socket options for TCP sockets
     pub const TCP_NODELAY: c_int = 1;

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -2,6 +2,8 @@ use super::{ffi, consts, GetSockOpt, SetSockOpt};
 use {Errno, Result};
 use sys::time::TimeVal;
 use libc::{c_int, uint8_t, c_void, socklen_t};
+#[cfg(target_os = "linux")]
+use libc::sockaddr_in;
 use std::mem;
 use std::os::unix::io::RawFd;
 
@@ -168,6 +170,8 @@ sockopt_impl!(GetOnly, SockType, consts::SOL_SOCKET, consts::SO_TYPE, super::Soc
           target_os = "linux",
           target_os = "nacl"))]
 sockopt_impl!(GetOnly, AcceptConn, consts::SOL_SOCKET, consts::SO_ACCEPTCONN, bool);
+#[cfg(target_os = "linux")]
+sockopt_impl!(GetOnly, OriginalDst, consts::SOL_IP, consts::SO_ORIGINAL_DST, sockaddr_in);
 
 /*
  *


### PR DESCRIPTION
In Linux, the SO_ORIGINAL_DST socket option can be used to get the original destination, which can be needed if the connection is translated by a NAT, i.e. iptables. In C, this information can be obtained by ``getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &remote, &remote_len)`` and returns a ``sockaddr_in`` struct. I've added a binding for this option.

Thanks!