### PR TITLE
Exclude UContext::get(),set() on musl, not available from libc.

### DIFF
--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -1,5 +1,7 @@
 use libc;
+#[cfg(not(target_env = "musl"))]
 use {Errno, Result};
+#[cfg(not(target_env = "musl"))]
 use std::mem;
 
 #[derive(Clone, Copy)]
@@ -8,6 +10,7 @@ pub struct UContext {
 }
 
 impl UContext {
+    #[cfg(not(target_env = "musl"))]
     pub fn get() -> Result<UContext> {
         let mut context: libc::ucontext_t = unsafe { mem::uninitialized() };
         let res = unsafe {
@@ -16,6 +19,7 @@ impl UContext {
         Errno::result(res).map(|_| UContext { context: context })
     }
 
+    #[cfg(not(target_env = "musl"))]
     pub fn set(&self) -> Result<()> {
         let res = unsafe {
             libc::setcontext(&self.context as *const libc::ucontext_t)


### PR DESCRIPTION
It looks like ``libc`` doesn't provide ``libc::getcontext`` or ``libc::setcontext`` when targeting musl, so I've excluded the ``ucontext`` module from being built when targeting musl which allows the module to be built successfully.

Thanks!