### PR TITLE
Only deny warnings in test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // latest bitflags triggers a rustc bug with cross-crate macro expansions causing dead_code
 // warnings even though the macro expands into something with allow(dead_code)
 #![allow(dead_code)]
-#![deny(warnings)]
+#![cfg_attr(test, deny(warnings))]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
This prevents us breaking builds under newer Rust versions with
additional warnings.