### PR TITLE
musl target needs std::mem now

### DIFF
--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -1,7 +1,6 @@
 use libc;
 #[cfg(not(target_env = "musl"))]
 use {Errno, Result};
-#[cfg(not(target_env = "musl"))]
 use std::mem;
 use sys::signal::SigSet;
 


### PR DESCRIPTION
Closes nix-rust/nix#325.