### PR TITLE
Add reboot() support on Linux

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -31,7 +31,7 @@ pub mod stat;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod syscall;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux"))]
 pub mod reboot;
 
 #[cfg(not(target_os = "ios"))]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -31,6 +31,9 @@ pub mod stat;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod syscall;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub mod reboot;
+
 #[cfg(not(target_os = "ios"))]
 pub mod termios;
 

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -1,0 +1,36 @@
+use {Errno, Error, Result};
+use libc::c_int;
+use void::Void;
+use std::mem::drop;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RebootMode {
+    Halt = 0xcdef0123,
+    kexec = 0x45584543,
+    PowerOff = 0x4321fedc,
+    Restart = 0x1234567,
+    // we do not support Restart2,
+    Suspend = 0xd000fce1,
+}
+
+pub fn reboot(how: RebootMode) -> Result<Void> {
+    unsafe {
+        ext::reboot(how as c_int)
+    };
+    Err(Error::Sys(Errno::last()))
+}
+
+#[allow(overflowing_literals)]
+pub fn set_cad_enabled(enable: bool) -> Result<()> {
+    let res = unsafe {
+        ext::reboot(if enable { 0x89abcdef } else { 0 })
+    };
+    Errno::result(res).map(drop)
+}
+
+mod ext {
+    use libc::c_int;
+    extern {
+        pub fn reboot(cmd: c_int) -> c_int;
+    }
+}

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -12,12 +12,12 @@ use std::mem::drop;
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RebootMode {
-    Halt = libc::RB_HALT_SYSTEM,
-    kexec = libc::RB_KEXEC,
-    PowerOff = libc::RB_POWER_OFF,
-    Restart = libc::RB_AUTOBOOT,
+    RB_HALT_SYSTEM = libc::RB_HALT_SYSTEM,
+    RB_KEXEC = libc::RB_KEXEC,
+    RB_POWER_OFF = libc::RB_POWER_OFF,
+    RB_AUTOBOOT = libc::RB_AUTOBOOT,
     // we do not support Restart2,
-    Suspend = libc::RB_SW_SUSPEND,
+    RB_SW_SUSPEND = libc::RB_SW_SUSPEND,
 }
 
 pub fn reboot(how: RebootMode) -> Result<Void> {

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -3,7 +3,7 @@ use libc;
 use void::Void;
 use std::mem::drop;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RebootMode {
     Halt,
     kexec,

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -9,27 +9,20 @@ use std::mem::drop;
 ///
 /// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
 /// enabling/disabling Ctrl-Alt-Delete.
+#[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RebootMode {
-    Halt,
-    kexec,
-    PowerOff,
-    Restart,
+    Halt = libc::RB_HALT_SYSTEM,
+    kexec = libc::RB_KEXEC,
+    PowerOff = libc::RB_POWER_OFF,
+    Restart = libc::RB_AUTOBOOT,
     // we do not support Restart2,
-    Suspend,
+    Suspend = libc::RB_SW_SUSPEND,
 }
 
 pub fn reboot(how: RebootMode) -> Result<Void> {
-    let cmd = match how {
-        RebootMode::Halt => libc::RB_HALT_SYSTEM,
-        RebootMode::kexec => libc::RB_KEXEC,
-        RebootMode::PowerOff => libc::RB_POWER_OFF,
-        RebootMode::Restart => libc::RB_AUTOBOOT,
-        // we do not support Restart2,
-        RebootMode::Suspend => libc::RB_SW_SUSPEND,
-    };
     unsafe {
-        libc::reboot(cmd)
+        libc::reboot(how as libc::c_int)
     };
     Err(Error::Sys(Errno::last()))
 }

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -1,41 +1,37 @@
 use {Errno, Error, Result};
-use libc::c_int;
+use libc;
 use void::Void;
 use std::mem::drop;
 
-#[allow(overflowing_literals)]
+#[repr(i32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RebootMode {
-    Halt = 0xcdef0123,
-    kexec = 0x45584543,
-    PowerOff = 0x4321fedc,
-    Restart = 0x1234567,
+    Halt = libc::RB_HALT_SYSTEM,
+    kexec = libc::RB_KEXEC,
+    PowerOff = libc::RB_POWER_OFF,
+    Restart = libc::RB_AUTOBOOT,
     // we do not support Restart2,
-    Suspend = 0xd000fce1,
+    Suspend = libc::RB_SW_SUSPEND,
 }
 
 pub fn reboot(how: RebootMode) -> Result<Void> {
     unsafe {
-        ext::reboot(how as c_int)
+        libc::reboot(how as libc::c_int)
     };
     Err(Error::Sys(Errno::last()))
 }
 
-
 /// Enable or disable the reboot keystroke (Ctrl-Alt-Delete).
 ///
 /// Corresponds to calling `reboot(RB_ENABLE_CAD)` or `reboot(RB_DISABLE_CAD)` in C.
-#[allow(overflowing_literals)]
 pub fn set_cad_enabled(enable: bool) -> Result<()> {
+    let cmd = if enable {
+        libc::RB_ENABLE_CAD
+    } else {
+        libc::RB_DISABLE_CAD
+    };
     let res = unsafe {
-        ext::reboot(if enable { 0x89abcdef } else { 0 })
+        libc::reboot(cmd)
     };
     Errno::result(res).map(drop)
-}
-
-mod ext {
-    use libc::c_int;
-    extern {
-        pub fn reboot(cmd: c_int) -> c_int;
-    }
 }

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -3,20 +3,27 @@ use libc;
 use void::Void;
 use std::mem::drop;
 
-#[repr(i32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RebootMode {
-    Halt = libc::RB_HALT_SYSTEM,
-    kexec = libc::RB_KEXEC,
-    PowerOff = libc::RB_POWER_OFF,
-    Restart = libc::RB_AUTOBOOT,
+    Halt,
+    kexec,
+    PowerOff,
+    Restart,
     // we do not support Restart2,
-    Suspend = libc::RB_SW_SUSPEND,
+    Suspend,
 }
 
 pub fn reboot(how: RebootMode) -> Result<Void> {
+    let cmd = match how {
+        RebootMode::Halt => libc::RB_HALT_SYSTEM,
+        RebootMode::kexec => libc::RB_KEXEC,
+        RebootMode::PowerOff => libc::RB_POWER_OFF,
+        RebootMode::Restart => libc::RB_AUTOBOOT,
+        // we do not support Restart2,
+        RebootMode::Suspend => libc::RB_SW_SUSPEND,
+    };
     unsafe {
-        libc::reboot(how as libc::c_int)
+        libc::reboot(cmd)
     };
     Err(Error::Sys(Errno::last()))
 }

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -1,8 +1,14 @@
+//! Reboot/shutdown or enable/disable Ctrl-Alt-Delete.
+
 use {Errno, Error, Result};
 use libc;
 use void::Void;
 use std::mem::drop;
 
+/// How exactly should the system be rebooted.
+///
+/// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
+/// enabling/disabling Ctrl-Alt-Delete.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RebootMode {
     Halt,

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -3,6 +3,7 @@ use libc::c_int;
 use void::Void;
 use std::mem::drop;
 
+#[allow(overflowing_literals)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RebootMode {
     Halt = 0xcdef0123,

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -20,6 +20,10 @@ pub fn reboot(how: RebootMode) -> Result<Void> {
     Err(Error::Sys(Errno::last()))
 }
 
+
+/// Enable or disable the reboot keystroke (Ctrl-Alt-Delete).
+///
+/// Corresponds to calling `reboot(RB_ENABLE_CAD)` or `reboot(RB_DISABLE_CAD)` in C.
 #[allow(overflowing_literals)]
 pub fn set_cad_enabled(enable: bool) -> Result<()> {
     let res = unsafe {


### PR DESCRIPTION
This adds support for calling [reboot(2)](http://linux.die.net/man/2/reboot) on Linux (useful for implementing PID 1!).

* **Testing**: I can't imagine how this could be tested other than manually, which is what I did to ensure it works.
* **libc**: for some reason libc includes neither `reboot()` function, nor `RB_*` constants, so I had to hack-define them here. Should I open a bug/PR against the libc crate?
* **API**: I went with `reboot()` function for restarting, powering off, halting, etc. and an additional `set_cad_enabled()` function for enabling/disabling Ctrl-Alt-Delete, which still corresponds to `reboot()` C call, but has different semantics and return type. (But I'm open to suggestions here -- maybe it would be better to separate each action into its own function, i.e. `restart()`, `poweroff()`, `halt()`?)
* **Documentation**: I see most of the things in nix are undocumented, so I didn't document anything except for the `set_cad_enabled()` function, which obviously uses a non-standard name.
* **Portability**: I implemented the Linux version as I'm not familiar with anything else, but there surely are others (ex. [BSD](http://www.freebsd.org/cgi/man.cgi?reboot(2))). If I didn't mess up anything, the new code is only compiled on Linux/Android, so it should be straightforward to implement the other versions too.