### PR TITLE
Use git master as libc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc = "0.2.13"
+libc = { git = "https://github.com/rust-lang/libc" }
 bitflags = "0.4"
 cfg-if = "0.1.0"
 void = "1.0.2"


### PR DESCRIPTION
As mentioned by @fiveop in #363,

> We should use the Github version of libc for development and a fixed version for releases.

So this changes the required libc version to GitHub's master.

The dependency is supposed to be manually changed to a fixed version when doing a release, out of the GitHub repository (i.e. nix's master always tracks libc's master).