### PR TITLE
Use specific version 0.3.4 of tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ semver = "0.1.20"  # Old version for compatibility with rustc_version.
 
 [dev-dependencies]
 rand = "0.3.8"
-tempdir = "0.3"
+tempdir = "0.3.4"
 tempfile = "2"
 nix-test = { path = "nix-test", version = "0.0.1" }
 


### PR DESCRIPTION
Version 0.3.5 is broken for Rust 1.1.