### PR TITLE
No longer support Rust 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - binutils-dev
 
 rust:
-  - 1.1.0  # Oldest supported version
+  - 1.2.0  # Oldest supported version
   - 1.7.0
   - 1.8.0
   - stable
@@ -50,10 +50,10 @@ matrix:
       rust: stable
     - os: osx
       env: ARCH=x86_64
-      rust: 1.1.0
+      rust: 1.2.0
     - os: osx
       env: ARCH=i686
-      rust: 1.1.0
+      rust: 1.2.0
     # Docker builds for other targets
     - os: linux
       env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm


### PR DESCRIPTION
Since tempdir is broken on Rust 1.1 I propose to push the minimum supported Rust version to 1.2.