### PR TITLE
ci: fix docker container check

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,7 +6,7 @@
 set -e
 
 # This should only be run in a docker container, so verify that
-if [ ! -f /.dockerinit ]; then
+if [ ! $(pidof $0) = "1" ]; then
     echo "run.sh should only be executed in a docker container"
     echo "and that does not appear to be the case.  Maybe you meant"
     echo "to execute the tests via run-all.sh or run-docker.sh."


### PR DESCRIPTION
Newer version of docker no longer have the /.dockerinit file present
when the container is executing, so that is no longer an option.
When executing in a container, we do know that we will be executing
as pid 1 -- this is probably not ever the case on the host system.

r? @fiveop 