### PR TITLE
Add support for Solaris platform

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -35,6 +35,12 @@ unsafe fn errno_location() -> *mut c_int {
     __errno()
 }
 
+#[cfg(target_os = "solaris")]
+unsafe fn errno_location() -> *mut c_int {
+    extern { fn ___errno() -> *mut c_int; }
+    ___errno()
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 unsafe fn errno_location() -> *mut c_int {
     extern { fn __errno_location() -> *mut c_int; }
@@ -194,88 +200,88 @@ fn desc(errno: Errno) -> &'static str {
         EHOSTDOWN       => "Host is down",
         EHOSTUNREACH    => "No route to host",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ECHRNG          => "Channel number out of range",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EL2NSYNC        => "Level 2 not synchronized",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EL3HLT          => "Level 3 halted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EL3RST          => "Level 3 reset",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELNRNG          => "Link number out of range",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EUNATCH         => "Protocol driver not attached",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOCSI          => "No CSI structure available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EL2HLT          => "Level 2 halted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBADE           => "Invalid exchange",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBADR           => "Invalid request descriptor",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EXFULL          => "Exchange full",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOANO          => "No anode",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBADRQC         => "Invalid request code",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBADSLT         => "Invalid slot",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBFONT          => "Bad font file format",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOSTR          => "Device not a stream",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENODATA         => "No data available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ETIME           => "Timer expired",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOSR           => "Out of streams resources",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENONET          => "Machine is not on the network",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOPKG          => "Package not installed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EREMOTE         => "Object is remote",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOLINK         => "Link has been severed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EADV            => "Advertise error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ESRMNT          => "Srmount error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ECOMM           => "Communication error on send",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EPROTO          => "Protocol error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EMULTIHOP       => "Multihop attempted",
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -287,37 +293,37 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         EOVERFLOW       => "Value too large for defined data type",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ENOTUNIQ        => "Name not unique on network",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EBADFD          => "File descriptor in bad state",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         EREMCHG         => "Remote address changed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELIBACC         => "Can not acces a needed shared library",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELIBBAD         => "Accessing a corrupted shared library",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELIBSCN         => ".lib section in a.out corrupted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELIBMAX         => "Attempting to link in too many shared libraries",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ELIBEXEC        => "Cannot exec a shared library directly",
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd", target_os = "solaris"))]
         EILSEQ          => "Illegal byte sequence",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ERESTART        => "Interrupted system call should be restarted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
         ESTRPIPE        => "Streams pipe error",
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -398,7 +404,7 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
         ENEEDAUTH       => "Need authenticator",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         EOVERFLOW       => "Value too large to be stored in data type",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "netbsd"))]
@@ -407,7 +413,7 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
         ENOATTR         => "Attribute not found",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "netbsd", target_os = "solaris"))]
         EBADMSG         => "Bad message",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "netbsd"))]
@@ -419,19 +425,19 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "ios"))]
         EOWNERDEAD      => "Previous owner died",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         ENOTSUP         => "Operation not supported",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
         EPROCLIM        => "Too many processes",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         EUSERS          => "Too many users",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         EDQUOT          => "Disc quota exceeded",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         ESTALE          => "Stale NFS file handle",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
@@ -458,7 +464,7 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
         EAUTH           => "Authentication error",
 
-        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
         ECANCELED       => "Operation canceled",
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -506,7 +512,7 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         EQFULL          => "Interface output queue is full",
 
-        #[cfg(target_os = "openbsd")]
+        #[cfg(any(target_os = "openbsd", target_os = "solaris"))]
         EOPNOTSUPP      => "Operation not supported",
 
         #[cfg(target_os = "openbsd")]
@@ -517,6 +523,22 @@ fn desc(errno: Errno) -> &'static str {
  
         #[cfg(target_os = "dragonfly")]
         EASYNC          => "Async",
+
+
+        #[cfg(target_os = "solaris")]
+        EDEADLOCK       => "File locking deadlock error",
+
+        #[cfg(target_os = "solaris")]
+        EOWNERDEAD      => "Process died with the lock",
+
+        #[cfg(target_os = "solaris")]
+        ENOTRECOVERABLE => "Lock is not recoverable",
+
+        #[cfg(target_os = "solaris")]
+        ELOCKUNMAPPED   => "Locked lock was unmapped",
+
+        #[cfg(target_os = "solaris")]
+        ENOTACTIVE      => "Facility is not active",
     }
 }
 
@@ -1897,6 +1919,267 @@ mod consts {
             94	=> EMULTIHOP,
             95	=> ENOLINK,
             96	=> EPROTO,
+            _   => UnknownErrno,
+        }
+    }
+}
+
+#[cfg(target_os = "solaris")]
+mod consts {
+    #[derive(Copy, Debug, Clone, PartialEq)]
+    pub enum Errno {
+        UnknownErrno    = 0,
+        EPERM           = 1,
+        ENOENT          = 2,
+        ESRCH           = 3,
+        EINTR           = 4,
+        EIO             = 5,
+        ENXIO           = 6,
+        E2BIG           = 7,
+        ENOEXEC         = 8,
+        EBADF           = 9,
+        ECHILD          = 10,
+        EAGAIN          = 11,
+        ENOMEM          = 12,
+        EACCES          = 13,
+        EFAULT          = 14,
+        ENOTBLK         = 15,
+        EBUSY           = 16,
+        EEXIST          = 17,
+        EXDEV           = 18,
+        ENODEV          = 19,
+        ENOTDIR         = 20,
+        EISDIR          = 21,
+        EINVAL          = 22,
+        ENFILE          = 23,
+        EMFILE          = 24,
+        ENOTTY          = 25,
+        ETXTBSY         = 26,
+        EFBIG           = 27,
+        ENOSPC          = 28,
+        ESPIPE          = 29,
+        EROFS           = 30,
+        EMLINK          = 31,
+        EPIPE           = 32,
+        EDOM            = 33,
+        ERANGE          = 34,
+        ENOMSG          = 35,
+        EIDRM           = 36,
+        ECHRNG          = 37,
+        EL2NSYNC        = 38,
+        EL3HLT          = 39,
+        EL3RST          = 40,
+        ELNRNG          = 41,
+        EUNATCH         = 42,
+        ENOCSI          = 43,
+        EL2HLT          = 44,
+        EDEADLK         = 45,
+        ENOLCK          = 46,
+        ECANCELED       = 47,
+        ENOTSUP         = 48,
+        EDQUOT          = 49,
+        EBADE           = 50,
+        EBADR           = 51,
+        EXFULL          = 52,
+        ENOANO          = 53,
+        EBADRQC         = 54,
+        EBADSLT         = 55,
+        EDEADLOCK       = 56,
+        EBFONT          = 57,
+        EOWNERDEAD      = 58,
+        ENOTRECOVERABLE = 59,
+        ENOSTR          = 60,
+        ENODATA         = 61,
+        ETIME           = 62,
+        ENOSR           = 63,
+        ENONET          = 64,
+        ENOPKG          = 65,
+        EREMOTE         = 66,
+        ENOLINK         = 67,
+        EADV            = 68,
+        ESRMNT          = 69,
+        ECOMM           = 70,
+        EPROTO          = 71,
+        ELOCKUNMAPPED   = 72,
+        ENOTACTIVE      = 73,
+        EMULTIHOP       = 74,
+        EBADMSG         = 77,
+        ENAMETOOLONG    = 78,
+        EOVERFLOW       = 79,
+        ENOTUNIQ        = 80,
+        EBADFD          = 81,
+        EREMCHG         = 82,
+        ELIBACC         = 83,
+        ELIBBAD         = 84,
+        ELIBSCN         = 85,
+        ELIBMAX         = 86,
+        ELIBEXEC        = 87,
+        EILSEQ          = 88,
+        ENOSYS          = 89,
+        ELOOP           = 90,
+        ERESTART        = 91,
+        ESTRPIPE        = 92,
+        ENOTEMPTY       = 93,
+        EUSERS          = 94,
+        ENOTSOCK        = 95,
+        EDESTADDRREQ    = 96,
+        EMSGSIZE        = 97,
+        EPROTOTYPE      = 98,
+        ENOPROTOOPT     = 99,
+        EPROTONOSUPPORT = 120,
+        ESOCKTNOSUPPORT = 121,
+        EOPNOTSUPP      = 122,
+        EPFNOSUPPORT    = 123,
+        EAFNOSUPPORT    = 124,
+        EADDRINUSE      = 125,
+        EADDRNOTAVAIL   = 126,
+        ENETDOWN        = 127,
+        ENETUNREACH     = 128,
+        ENETRESET       = 129,
+        ECONNABORTED    = 130,
+        ECONNRESET      = 131,
+        ENOBUFS         = 132,
+        EISCONN         = 133,
+        ENOTCONN        = 134,
+        ESHUTDOWN       = 143,
+        ETOOMANYREFS    = 144,
+        ETIMEDOUT       = 145,
+        ECONNREFUSED    = 146,
+        EHOSTDOWN       = 147,
+        EHOSTUNREACH    = 148,
+        EALREADY        = 149,
+        EINPROGRESS     = 150,
+        ESTALE          = 151,
+    }
+
+    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+
+    pub fn from_i32(e: i32) -> Errno {
+        use self::Errno::*;
+
+        match e {
+            0   => UnknownErrno,
+            1   => EPERM,
+            2   => ENOENT,
+            3   => ESRCH,
+            4   => EINTR,
+            5   => EIO,
+            6   => ENXIO,
+            7   => E2BIG,
+            8   => ENOEXEC,
+            9   => EBADF,
+            10  => ECHILD,
+            11  => EAGAIN,
+            12  => ENOMEM,
+            13  => EACCES,
+            14  => EFAULT,
+            15  => ENOTBLK,
+            16  => EBUSY,
+            17  => EEXIST,
+            18  => EXDEV,
+            19  => ENODEV,
+            20  => ENOTDIR,
+            21  => EISDIR,
+            22  => EINVAL,
+            23  => ENFILE,
+            24  => EMFILE,
+            25  => ENOTTY,
+            26  => ETXTBSY,
+            27  => EFBIG,
+            28  => ENOSPC,
+            29  => ESPIPE,
+            30  => EROFS,
+            31  => EMLINK,
+            32  => EPIPE,
+            33  => EDOM,
+            34  => ERANGE,
+            35  => ENOMSG,
+            36  => EIDRM,
+            37  => ECHRNG,
+            38  => EL2NSYNC,
+            39  => EL3HLT,
+            40  => EL3RST,
+            41  => ELNRNG,
+            42  => EUNATCH,
+            43  => ENOCSI,
+            44  => EL2HLT,
+            45  => EDEADLK,
+            46  => ENOLCK,
+            47  => ECANCELED,
+            48  => ENOTSUP,
+            49  => EDQUOT,
+            50  => EBADE,
+            51  => EBADR,
+            52  => EXFULL,
+            53  => ENOANO,
+            54  => EBADRQC,
+            55  => EBADSLT,
+            56  => EDEADLOCK,
+            57  => EBFONT,
+            58  => EOWNERDEAD,
+            59  => ENOTRECOVERABLE,
+            60  => ENOSTR,
+            61  => ENODATA,
+            62  => ETIME,
+            63  => ENOSR,
+            64  => ENONET,
+            65  => ENOPKG,
+            66  => EREMOTE,
+            67  => ENOLINK,
+            68  => EADV,
+            69  => ESRMNT,
+            70  => ECOMM,
+            71  => EPROTO,
+            72  => ELOCKUNMAPPED,
+            73  => ENOTACTIVE,
+            74  => EMULTIHOP,
+            77  => EBADMSG,
+            78  => ENAMETOOLONG,
+            79  => EOVERFLOW,
+            80  => ENOTUNIQ,
+            81  => EBADFD,
+            82  => EREMCHG,
+            83  => ELIBACC,
+            84  => ELIBBAD,
+            85  => ELIBSCN,
+            86  => ELIBMAX,
+            87  => ELIBEXEC,
+            88  => EILSEQ,
+            89  => ENOSYS,
+            90  => ELOOP,
+            91  => ERESTART,
+            92  => ESTRPIPE,
+            93  => ENOTEMPTY,
+            94  => EUSERS,
+            95  => ENOTSOCK,
+            96  => EDESTADDRREQ,
+            97  => EMSGSIZE,
+            98  => EPROTOTYPE,
+            99  => ENOPROTOOPT,
+            120 => EPROTONOSUPPORT,
+            121 => ESOCKTNOSUPPORT,
+            122 => EOPNOTSUPP,
+            123 => EPFNOSUPPORT,
+            124 => EAFNOSUPPORT,
+            125 => EADDRINUSE,
+            126 => EADDRNOTAVAIL,
+            127 => ENETDOWN,
+            128 => ENETUNREACH,
+            129 => ENETRESET,
+            130 => ECONNABORTED,
+            131 => ECONNRESET,
+            132 => ENOBUFS,
+            133 => EISCONN,
+            134 => ENOTCONN,
+            143 => ESHUTDOWN,
+            144 => ETOOMANYREFS,
+            145 => ETIMEDOUT,
+            146 => ECONNREFUSED,
+            147 => EHOSTDOWN,
+            148 => EHOSTUNREACH,
+            149 => EALREADY,
+            150 => EINPROGRESS,
+            151 => ESTALE,
             _   => UnknownErrno,
         }
     }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -330,3 +330,36 @@ mod consts {
         }
     );
 }
+
+#[cfg(target_os = "solaris")]
+mod consts {
+    use libc::c_int;
+
+    bitflags!(
+        flags OFlag: c_int {
+            const O_ACCMODE   = 0x00600003,
+            const O_RDONLY    = 0000000000,
+            const O_WRONLY    = 0x00000001,
+            const O_RDWR      = 0x00000002,
+            const O_NONBLOCK  = 0x00000080,
+            const O_APPEND    = 0x00000008,
+            const O_SYNC      = 0x00000010,
+            const O_NOFOLLOW  = 0x00020000,
+            const O_CREAT     = 0x00000100,
+            const O_TRUNC     = 0x00000200,
+            const O_EXCL      = 0x00000400,
+            const O_NOCTTY    = 0x00000800,
+            const O_DSYNC     = 0x00000040,
+            const O_RSYNC     = 0x00008000,
+            const O_CLOEXEC   = 0x00800000,
+            const O_SEARCH    = 0x00200000,
+            const O_NDELAY    = 0x04,
+        }
+    );
+
+    bitflags!(
+        flags FdFlag: c_int {
+            const FD_CLOEXEC = 1
+        }
+    );
+}

--- a/src/features.rs
+++ b/src/features.rs
@@ -92,7 +92,7 @@ mod os {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
 mod os {
     pub fn socket_atomic_cloexec() -> bool {
         false

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -134,6 +134,11 @@ mod platform;
 #[macro_use]
 mod platform;
 
+#[cfg(target_os = "solaris")]
+#[path = "platform/solaris.rs"]
+#[macro_use]
+mod platform;
+
 pub use self::platform::*;
 
 // liblibc has the wrong decl for linux :| hack until #26809 lands.

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -175,6 +175,50 @@ mod consts {
     pub const MAP_FAILED: isize                 = -1;
 }
 
+#[cfg(target_os = "solaris")]
+mod consts {
+    use libc::{self, c_int};
+
+    bitflags!{
+        flags MapFlags: c_int {
+            const MAP_SHARED       = libc::MAP_SHARED,
+            const MAP_PRIVATE      = libc::MAP_PRIVATE,
+            const MAP_FIXED        = libc::MAP_FIXED,
+            const MAP_RENAME       = libc::MAP_RENAME,
+            const MAP_NORESERVE    = libc::MAP_NORESERVE,
+            const MAP_ANON         = libc::MAP_ANON,
+            const MAP_ANONYMOUS    = libc::MAP_ANON,
+            const MAP_ALIGN        = libc::MAP_ALIGN,
+            const MAP_TEXT         = libc::MAP_TEXT,
+            const MAP_INITDATA     = libc::MAP_INITDATA,
+        }
+    }
+
+    pub type MmapAdvise = c_int;
+
+    pub const MADV_NORMAL     : MmapAdvise      = 0; /* No further special treatment.  */
+    pub const MADV_RANDOM     : MmapAdvise      = 1; /* Expect random page references.  */
+    pub const MADV_SEQUENTIAL : MmapAdvise      = 2; /* Expect sequential page references.  */
+    pub const MADV_WILLNEED   : MmapAdvise      = 3; /* Will need these pages.  */
+    pub const MADV_DONTNEED   : MmapAdvise      = 4; /* Don't need these pages.  */
+    pub const MADV_FREE       : MmapAdvise      = 5; /* Contents can be freed. */
+    pub const MADV_ACCESS_DEFAULT  : MmapAdvise = 6; /* Default access. */
+    pub const MADV_ACCESS_LWP      : MmapAdvise = 7; /* Next LWP to access heavily. */
+    pub const MADV_ACCESS_MANY     : MmapAdvise = 8; /* Many processes to access heavily. */
+    pub const MADV_PURGE       : MmapAdvise     = 9; /* Contents will be purged. */
+
+    bitflags!{
+        flags MsFlags: c_int {
+            const MS_ASYNC      = libc::MS_ASYNC, /* [MF|SIO] return immediately */
+            const MS_INVALIDATE = libc::MS_INVALIDATE, /* [MF|SIO] invalidate all cached data */
+            const MS_SYNC       = libc::MS_SYNC, /* [MF|SIO] msync synchronously */
+            const MS_INVALCURPROC = libc::MS_INVALCURPROC, /* [MF|SIO] invalidate cache for curproc only */
+        }
+    }
+
+    pub const MAP_FAILED: isize                 = -1;
+}
+
 mod ffi {
     use libc::{c_void, size_t, c_int, c_char, mode_t};
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -87,7 +87,7 @@ const SIGNALS: [Signal; 31] = [
     SIGIO,
     SIGPWR,
     SIGSYS];
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten", target_os = "solaris")))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -120,6 +120,37 @@ const SIGNALS: [Signal; 31] = [
     SIGSYS,
     SIGEMT,
     SIGINFO];
+#[cfg(target_os = "solaris")]
+const SIGNALS: [Signal; 29] = [
+    SIGHUP,
+    SIGINT,
+    SIGQUIT,
+    SIGILL,
+    SIGTRAP,
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGKILL,
+    SIGUSR1,
+    SIGSEGV,
+    SIGUSR2,
+    SIGPIPE,
+    SIGALRM,
+    SIGTERM,
+    SIGCHLD,
+    SIGCONT,
+    SIGSTOP,
+    SIGTSTP,
+    SIGTTIN,
+    SIGTTOU,
+    SIGURG,
+    SIGXCPU,
+    SIGXFSZ,
+    SIGVTALRM,
+    SIGPROF,
+    SIGWINCH,
+    SIGIO,
+    SIGSYS];
 
 pub const NSIG: libc::c_int = 32;
 

--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -323,6 +323,94 @@ mod os {
     pub const SHUT_RDWR: c_int = 2;
 }
 
+#[cfg(target_os = "solaris")]
+mod os {
+    use libc::{self, c_int, uint8_t};
+
+    pub const AF_UNIX: c_int = 1;
+    pub const AF_LOCAL: c_int = AF_UNIX;
+    pub const AF_INET: c_int  = 2;
+    pub const AF_INET6: c_int = 26;
+
+    pub const SOCK_STREAM: c_int = 2;
+    pub const SOCK_DGRAM: c_int = 1;
+    pub const SOCK_SEQPACKET: c_int = 6;
+    pub const SOCK_RAW: c_int = 4;
+    pub const SOCK_RDM: c_int = 5;
+
+    pub const SOL_SOCKET: c_int = 0xffff;
+    pub const IPPROTO_IP: c_int = 0;
+    pub const IPPROTO_IPV6: c_int = 41;
+    pub const IPPROTO_TCP: c_int = 6;
+    pub const IPPROTO_UDP: c_int = 17;
+
+    pub const SO_ACCEPTCONN: c_int          = 0x0002;
+    pub const SO_BROADCAST: c_int           = 0x0020;
+    pub const SO_DEBUG: c_int               = 0x0001;
+    pub const SO_ERROR: c_int               = 0x1007;
+    pub const SO_DONTROUTE: c_int           = 0x0010;
+    pub const SO_KEEPALIVE: c_int           = 0x0008;
+    pub const SO_LINGER: c_int              = 0x0080;
+    pub const SO_OOBINLINE: c_int           = 0x0100;
+    pub const SO_RCVBUF: c_int              = 0x1002;
+    pub const SO_RCVLOWAT: c_int            = 0x1004;
+    pub const SO_SNDLOWAT: c_int            = 0x1003;
+    pub const SO_RCVTIMEO: c_int            = 0x1006;
+    pub const SO_SNDTIMEO: c_int            = 0x1005;
+    pub const SO_REUSEADDR: c_int           = 0x0004;
+    pub const SO_SNDBUF: c_int              = 0x1001;
+    pub const SO_TIMESTAMP: c_int           = 0x1013;
+    pub const SO_TYPE: c_int                = 0x1008;
+    // FIXME: these values isn't supported by Solaris
+    // http://stackoverflow.com/a/14388707/168853
+    // pub const SO_NOSIGPIPE: c_int           = 0x0800;
+    // pub const SO_REUSEPORT: c_int           = 0x0200;
+
+    // Socket options for TCP sockets
+    pub const TCP_NODELAY: c_int = 1;
+    pub const TCP_MAXSEG: c_int = 2;
+    pub const TCP_KEEPIDLE: c_int = 0x22;
+
+    // Socket options for the IP layer of the socket
+    pub const IP_MULTICAST_IF: c_int = 0x10;
+
+    pub type IpMulticastTtl = uint8_t;
+
+    pub const IP_MULTICAST_TTL: c_int = 0x11;
+    pub const IP_MULTICAST_LOOP: c_int = 0x12;
+    pub const IP_ADD_MEMBERSHIP: c_int = 0x13;
+    pub const IP_DROP_MEMBERSHIP: c_int = 0x14;
+    pub const IPV6_JOIN_GROUP: c_int = 0x9;
+    pub const IPV6_LEAVE_GROUP: c_int = 0xa;
+
+    pub type InAddrT = u32;
+
+    // Declarations of special addresses
+    pub const INADDR_ANY: InAddrT = 0;
+    pub const INADDR_NONE: InAddrT = 0xffffffff;
+    pub const INADDR_BROADCAST: InAddrT = 0xffffffff;
+
+    // Flags for send/recv and their relatives
+    bitflags!{
+        flags MsgFlags : libc::c_int {
+            const MSG_OOB      = 0x01,
+            const MSG_PEEK     = 0x02,
+            const MSG_EOR      = 0x08,
+            const MSG_CTRUNC   = 0x10,
+            const MSG_TRUNC    = 0x20,
+            const MSG_DONTWAIT = 0x80,
+        }
+    }
+
+    // shutdown flags
+    pub const SHUT_RD: c_int   = 0;
+    pub const SHUT_WR: c_int   = 1;
+    pub const SHUT_RDWR: c_int = 2;
+
+    // Ancillary message types
+    pub const SCM_RIGHTS: c_int = 0x1010;
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -379,7 +467,6 @@ mod test {
             SO_RCVTIMEO,
             SO_SNDTIMEO,
             SO_REUSEADDR,
-            // SO_REUSEPORT,
             SO_SNDBUF,
             SO_TIMESTAMP,
             SO_TYPE,
@@ -403,8 +490,16 @@ mod test {
             SHUT_WR,
             SHUT_RDWR
             );
+    }
 
-
+    #[cfg(not(target_os = "solaris"))]
+    #[test]
+    pub fn test_reuse_port_const() {
+        /*
+        check_const!(
+            SO_REUSEPORT
+            );
+        */
     }
 
     #[cfg(target_os = "linux")]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -131,18 +131,19 @@ macro_rules! sockopt_impl {
  */
 
 sockopt_impl!(Both, ReuseAddr, consts::SOL_SOCKET, consts::SO_REUSEADDR, bool);
+#[cfg(not(target_os = "solaris"))]
 sockopt_impl!(Both, ReusePort, consts::SOL_SOCKET, consts::SO_REUSEPORT, bool);
 sockopt_impl!(Both, TcpNoDelay, consts::IPPROTO_TCP, consts::TCP_NODELAY, bool);
 sockopt_impl!(Both, Linger, consts::SOL_SOCKET, consts::SO_LINGER, super::linger);
 sockopt_impl!(SetOnly, IpAddMembership, consts::IPPROTO_IP, consts::IP_ADD_MEMBERSHIP, super::ip_mreq);
 sockopt_impl!(SetOnly, IpDropMembership, consts::IPPROTO_IP, consts::IP_DROP_MEMBERSHIP, super::ip_mreq);
-#[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris")))]
 sockopt_impl!(SetOnly, Ipv6AddMembership, consts::IPPROTO_IPV6, consts::IPV6_ADD_MEMBERSHIP, super::ipv6_mreq);
-#[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris")))]
 sockopt_impl!(SetOnly, Ipv6DropMembership, consts::IPPROTO_IPV6, consts::IPV6_DROP_MEMBERSHIP, super::ipv6_mreq);
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))]
 sockopt_impl!(SetOnly, Ipv6AddMembership, consts::IPPROTO_IPV6, consts::IPV6_JOIN_GROUP, super::ipv6_mreq);
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))]
 sockopt_impl!(SetOnly, Ipv6DropMembership, consts::IPPROTO_IPV6, consts::IPV6_LEAVE_GROUP, super::ipv6_mreq);
 sockopt_impl!(Both, IpMulticastTtl, consts::IPPROTO_IP, consts::IP_MULTICAST_TTL, u8);
 sockopt_impl!(Both, IpMulticastLoop, consts::IPPROTO_IP, consts::IP_MULTICAST_LOOP, bool);

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -178,6 +178,51 @@ mod status {
     }
 }
 
+#[cfg(target_os = "solaris")]
+mod status {
+    use sys::signal::Signal;
+
+    const WCOREFLG: i32 = 0x80;
+    const WSTOPFLG: i32 = 0x7f;
+    const WCONTFLG: i32 = 0xffff;
+
+    fn wstatus(status: i32) -> i32 {
+        status & 0x7F
+    }
+
+    pub fn stopped(status: i32) -> bool {
+        wstatus(status) == WSTOPFLG
+    }
+
+    pub fn stop_signal(status: i32) -> Signal {
+        Signal::from_c_int(status >> 8).unwrap()
+    }
+
+    pub fn signaled(status: i32) -> bool {
+        wstatus(status) != WSTOPFLG && wstatus(status) != 0
+    }
+
+    pub fn term_signal(status: i32) -> Signal {
+        Signal::from_c_int(wstatus(status)).unwrap()
+    }
+
+    pub fn exited(status: i32) -> bool {
+        wstatus(status) == 0
+    }
+
+    pub fn exit_status(status: i32) -> i8 {
+        (status >> 8) as i8
+    }
+
+    pub fn continued(status: i32) -> bool {
+        status == WCONTFLG
+    }
+
+    pub fn dumped_core(status: i32) -> bool {
+        (status & WCOREFLG) != 0
+    }
+}
+
 fn decode(pid : pid_t, status: i32) -> WaitStatus {
     if status::exited(status) {
         WaitStatus::Exited(pid, status::exit_status(status))


### PR DESCRIPTION
This PR adds preliminary support for the Solaris/Illumos-derived operating systems (SmartOS, OmniOS, and others) and lays a foundation for adding more Solaris-specific features (like e.g. [event ports](https://blogs.oracle.com/barts/entry/entry_2_event_ports) for subsequent _mio_ port).

However, though patched version builds OK, it doesn't pass the full test suite yet. So more updates & patches coming soon. :)