### PR TITLE
Add epoll_create1

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::RawFd;
 
 bitflags!(
     #[repr(C)]
-    flags EpollEventKind: u32 {
+    flags EpollFlags: u32 {
         const EPOLLIN = 0x001,
         const EPOLLPRI = 0x002,
         const EPOLLOUT = 0x004,
@@ -44,12 +44,12 @@ pub struct EpollEvent {
 }
 
 impl EpollEvent {
-    pub fn new(events: EpollEventKind, data: u64) -> EpollEvent {
+    pub fn new(events: EpollFlags, data: u64) -> EpollEvent {
         EpollEvent { event: libc::epoll_event { events: events.bits(), u64: data } }
     }
 
-    pub fn events(&self) -> EpollEventKind {
-        EpollEventKind::from_bits(self.event.events).unwrap()
+    pub fn events(&self) -> EpollFlags {
+        EpollFlags::from_bits(self.event.events).unwrap()
     }
 
     pub fn data(&self) -> u64 {

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -38,8 +38,16 @@ pub struct EpollEvent {
 }
 
 impl EpollEvent {
-    fn new(events: EpollEventKind, data: u64) -> EpollEvent {
+    pub fn new(events: EpollEventKind, data: u64) -> EpollEvent {
         EpollEvent { event: libc::epoll_event { events: events.bits(), u64: data } }
+    }
+
+    pub fn events(&self) -> EpollEventKind {
+        EpollEventKind::from_bits(self.event.events).unwrap()
+    }
+
+    pub fn data(&self) -> u64 {
+        self.event.u64
     }
 }
 

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -89,7 +89,7 @@ pub fn epoll_create() -> Result<RawFd> {
 
 #[inline]
 pub fn epoll_create1(flags: EpollFdFlag) -> Result<RawFd> {
-    let res = unsafe { ffi::epoll_create1(flags.bits() | EPOLL_CLOEXEC.bits) };
+    let res = unsafe { ffi::epoll_create1(flags.bits()) };
 
     Errno::result(res)
 }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -31,6 +31,12 @@ pub enum EpollOp {
     EpollCtlMod = 3
 }
 
+libc_bitflags!{
+    flags EpollCreateFlags: c_int {
+        EPOLL_CLOEXEC,
+    }
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct EpollEvent {
@@ -59,8 +65,8 @@ pub fn epoll_create() -> Result<RawFd> {
 }
 
 #[inline]
-pub fn epoll_create1(flags: c_int) -> Result<RawFd> {
-    let res = unsafe { libc::epoll_create1(flags) };
+pub fn epoll_create1(flags: EpollCreateFlags) -> Result<RawFd> {
+    let res = unsafe { libc::epoll_create1(flags.bits()) };
 
     Errno::result(res)
 }


### PR DESCRIPTION
In order to get @kubo39's PR #384 forward, I cleaned up the commit history a bit and added `EpollEvent` back.

Since this module is used by mio, maybe @carllerche could comment on these changes.