### PR TITLE
add unistd::getcwd and unistd::mkdir

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -139,8 +139,11 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 ///     let mut tmp_dir = TempDir::new("test_mkdir").unwrap().into_path();
 ///     tmp_dir.push("new_dir");
 ///
-///     // owner has read, write and execute rights on the new directory
-///     unistd::mkdir(&tmp_dir, stat::S_IRWXU).expect("couldn't create directory");
+///     // create new directory and give read, write and execute rights to the owner
+///     match unistd::mkdir(&tmp_dir, stat::S_IRWXU) {
+///        Ok(_) => println!("created {:?}", tmp_dir.display()),
+///        Err(err) => println!("Error creating directory: {}", err),
+///     }
 /// }
 /// ```
 #[inline]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -144,7 +144,7 @@ pub fn getcwd() -> Result<PathBuf> {
                 // ERANGE means buffer was too small to store directory name
                 if error != Errno::ERANGE {
                     return Err(Error::Sys(error));
-                }                
+                }
             }
 
             // Trigger the internal buffer resizing logic of `Vec` by requiring
@@ -153,7 +153,7 @@ pub fn getcwd() -> Result<PathBuf> {
             buf.set_len(cap);
             buf.reserve(1);
         }
-    }    
+    }
 }
 
 #[inline]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -5,7 +5,7 @@ use fcntl::{fcntl, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 use libc::{self, c_char, c_void, c_int, c_uint, size_t, pid_t, off_t, uid_t, gid_t, mode_t};
 use std::mem;
-use std::ffi::{CString,CStr,OsString};
+use std::ffi::{CString, CStr, OsString};
 use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::os::unix::io::RawFd;
@@ -118,12 +118,14 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 ///
 /// # Errors
 ///
-/// `Err` is returned in case of an error. There are several situations where mkdir might fail.
-/// For a full list consult `man mkdir(2)`
+/// There are several situations where mkdir might fail:
 ///
 /// - current user has insufficient rights in the parent directory
 /// - the path already exists
 /// - the path name is too long (longer than `PATH_MAX`, usually 4096 on linux, 1024 on OS X)
+///
+/// For a full list consult 
+/// [man mkdir(2)](http://man7.org/linux/man-pages/man2/mkdir.2.html#ERRORS)
 ///
 /// # Example
 ///
@@ -141,7 +143,7 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 ///
 ///     // create new directory and give read, write and execute rights to the owner
 ///     match unistd::mkdir(&tmp_dir, stat::S_IRWXU) {
-///        Ok(_) => println!("created {:?}", tmp_dir.display()),
+///        Ok(_) => println!("created {:?}", tmp_dir),
 ///        Err(err) => println!("Error creating directory: {}", err),
 ///     }
 /// }
@@ -157,15 +159,21 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 
 /// Returns the current directory as a PathBuf
 ///
-/// Err is returned if the current user doesn't have the permission to read or search a component of the current path.
+/// Err is returned if the current user doesn't have the permission to read or search a component
+/// of the current path.
 ///
 /// # Example
 ///
 /// ```rust
+/// extern crate nix;
+///
 /// use nix::unistd;
 ///
-/// let dir = unistd::getcwd().expect("not allowed to get current directory");
-/// println!("The current directory is {:?}", dir.display());
+/// fn main() {
+///     // assume that we are allowed to get current directory
+///     let dir = unistd::getcwd().unwrap();
+///     println!("The current directory is {:?}", dir);
+/// }
 /// ```
 #[inline]
 pub fn getcwd() -> Result<PathBuf> {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -131,7 +131,7 @@ fn test_getcwd() {
   } else {
     "/tmp/"
   };
-  let mut tmp_dir = TempDir::new_in(base, "test_getcwd").expect("create temp dir").into_path();
+  let mut tmp_dir = TempDir::new_in(base, "test_getcwd").unwrap().into_path();
   assert!(chdir(tmp_dir.as_path()).is_ok());
   assert_eq!(getcwd().unwrap(), tmp_dir);
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -120,6 +120,11 @@ macro_rules! execve_test_factory(
 );
 
 #[test]
+fn test_getcwd() {
+  println!("{}", getcwd().unwrap().display());
+}
+
+#[test]
 fn test_lseek() {
     const CONTENTS: &'static [u8] = b"abcdef123456";
     let mut tmp = tempfile().unwrap();

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -17,25 +17,25 @@ use libc::off_t;
 fn test_fork_and_waitpid() {
     let pid = fork();
     match pid {
-      Ok(Child) => {} // ignore child here
-      Ok(Parent { child }) => {
-          // assert that child was created and pid > 0
-          assert!(child > 0);
-          let wait_status = waitpid(child, None);
-          match wait_status {
-              // assert that waitpid returned correct status and the pid is the one of the child
-              Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child),
+        Ok(Child) => {} // ignore child here
+        Ok(Parent { child }) => {
+            // assert that child was created and pid > 0
+            assert!(child > 0);
+            let wait_status = waitpid(child, None);
+            match wait_status {
+                // assert that waitpid returned correct status and the pid is the one of the child
+                Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child),
 
-              // panic, must never happen
-              Ok(_) => panic!("Child still alive, should never happen"),
+                // panic, must never happen
+                Ok(_) => panic!("Child still alive, should never happen"),
 
-              // panic, waitpid should never fail
-              Err(_) => panic!("Error: waitpid Failed")
-          }
+                // panic, waitpid should never fail
+                Err(_) => panic!("Error: waitpid Failed")
+            }
 
-      },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
+        },
+        // panic, fork should never fail unless there is a serious problem with the OS
+        Err(_) => panic!("Error: Fork Failed")
     }
 }
 
@@ -43,15 +43,15 @@ fn test_fork_and_waitpid() {
 fn test_wait() {
     let pid = fork();
     match pid {
-      Ok(Child) => {} // ignore child here
-      Ok(Parent { child }) => {
-          let wait_status = wait();
+        Ok(Child) => {} // ignore child here
+        Ok(Parent { child }) => {
+            let wait_status = wait();
 
-          // just assert that (any) one child returns with WaitStatus::Exited
-          assert_eq!(wait_status, Ok(WaitStatus::Exited(child, 0)));
-      },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
+            // just assert that (any) one child returns with WaitStatus::Exited
+            assert_eq!(wait_status, Ok(WaitStatus::Exited(child, 0)));
+        },
+        // panic, fork should never fail unless there is a serious problem with the OS
+        Err(_) => panic!("Error: Fork Failed")
     }
 }
 
@@ -124,20 +124,20 @@ macro_rules! execve_test_factory(
 
 #[test]
 fn test_getcwd() {
-  let mut tmp_dir = TempDir::new("test_getcwd").unwrap().into_path();
-  assert!(chdir(tmp_dir.as_path()).is_ok());
-  assert_eq!(getcwd().unwrap(), current_dir().unwrap());
+    let mut tmp_dir = TempDir::new("test_getcwd").unwrap().into_path();
+    assert!(chdir(tmp_dir.as_path()).is_ok());
+    assert_eq!(getcwd().unwrap(), current_dir().unwrap());
 
-  // make path 500 chars longer so that buffer doubling in getcwd kicks in.
-  // Note: One path cannot be longer than 255 bytes (NAME_MAX)
-  // whole path cannot be longer than PATH_MAX (usually 4096 on linux, 1024 on macos)
-  for _ in 0..5 {
-    let newdir = iter::repeat("a").take(100).collect::<String>();
-    tmp_dir.push(newdir);
-    assert!(mkdir(tmp_dir.as_path(), stat::S_IRWXU).is_ok());
-  }
-  assert!(chdir(tmp_dir.as_path()).is_ok());
-  assert_eq!(getcwd().unwrap(), current_dir().unwrap());
+    // make path 500 chars longer so that buffer doubling in getcwd kicks in.
+    // Note: One path cannot be longer than 255 bytes (NAME_MAX)
+    // whole path cannot be longer than PATH_MAX (usually 4096 on linux, 1024 on macos)
+    for _ in 0..5 {
+        let newdir = iter::repeat("a").take(100).collect::<String>();
+        tmp_dir.push(newdir);
+        assert!(mkdir(tmp_dir.as_path(), stat::S_IRWXU).is_ok());
+    }
+    assert!(chdir(tmp_dir.as_path()).is_ok());
+    assert_eq!(getcwd().unwrap(), current_dir().unwrap());
 }
 
 #[test]
@@ -150,10 +150,10 @@ fn test_lseek() {
     lseek(tmp.as_raw_fd(), offset, Whence::SeekSet).unwrap();
 
     let mut buf = String::new();
-     tmp.read_to_string(&mut buf).unwrap();
-     assert_eq!(b"f123456", buf.as_bytes());
+    tmp.read_to_string(&mut buf).unwrap();
+    assert_eq!(b"f123456", buf.as_bytes());
 
-     close(tmp.as_raw_fd()).unwrap();
+    close(tmp.as_raw_fd()).unwrap();
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
As a (late) followup of [this withdrawn PR](https://github.com/rust-lang/libc/pull/326) I have added getcwd (wrapper around `libc::getcwd`) and mkdir (wrapper around `libc::mkdir`) and added testing.

A few notes:

 - I'm new to rust so I would appreciate some pair of eyes testing the code, plus I'm open for revision of code or general remarks about my coding style
 - I have run the tests both on OSX as on Linux (Ubuntu)
 - I've run `clippy` to see if my code is well formatted, however clippy issues many warnings about the project. I think I didn't add any more warnings
 - the methods in unistd are not documented so I also left out the documentation of `getcwd` and `mkdir`, although I think it'd probably be good to add some documentation, especially some example code how to use the methods
 - the base idea of `getcwd` is [taken from std](https://github.com/rust-lang/rust/blob/1.9.0/src/libstd/sys/unix/os.rs#L95-L119), should I mention that somewhere?