### PR TITLE
Add MSG_CMSG_CLOEXEC to MsgFlags on Linux

### DIFF
--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -98,6 +98,7 @@ mod os {
             const MSG_DONTWAIT = 0x0040,
             const MSG_EOR      = 0x0080,
             const MSG_ERRQUEUE = 0x2000,
+            const MSG_CMSG_CLOEXEC = 0x40000000,
         }
     }
 


### PR DESCRIPTION
Fixes #421.