### PR TITLE
call pipe2 directly on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `pipe2` now calls `libc::pipe2` where available. Previously it was emulated
   using `pipe`, which meant that setting `O_CLOEXEC` was not atomic.
+  ([#427](https://github.com/nix-rust/nix/pull/427))
 
 ## [0.7.0] 2016-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `pipe2` now calls `libc::pipe2` where available. Previously it was emulated
+  using `pipe`, which meant that setting `O_CLOEXEC` was not atomic.
+
 ## [0.7.0] 2016-09-09
 
 ### Added

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -365,32 +365,28 @@ pub fn pipe() -> Result<(RawFd, RawFd)> {
           target_os = "android",
           target_os = "emscripten"))]
 pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
-    unsafe {
-        let mut fds: [c_int; 2] = mem::uninitialized();
+    let mut fds: [c_int; 2] = unsafe { mem::uninitialized() };
 
-        let res = libc::pipe2(fds.as_mut_ptr(), flags.bits());
+    let res = unsafe { libc::pipe2(fds.as_mut_ptr(), flags.bits()) };
 
-        try!(Errno::result(res));
+    try!(Errno::result(res));
 
-        Ok((fds[0], fds[1]))
-    }
+    Ok((fds[0], fds[1]))
 }
 
 #[cfg(not(any(target_os = "linux",
               target_os = "android",
               target_os = "emscripten")))]
 pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
-    unsafe {
-        let mut fds: [c_int; 2] = mem::uninitialized();
+    let mut fds: [c_int; 2] = unsafe { mem::uninitialized() };
 
-        let res = libc::pipe(fds.as_mut_ptr());
+    let res = unsafe { libc::pipe(fds.as_mut_ptr()) };
 
-        try!(Errno::result(res));
+    try!(Errno::result(res));
 
-        try!(pipe2_setflags(fds[0], fds[1], flags));
+    try!(pipe2_setflags(fds[0], fds[1], flags));
 
-        Ok((fds[0], fds[1]))
-    }
+    Ok((fds[0], fds[1]))
 }
 
 #[cfg(not(any(target_os = "linux",


### PR DESCRIPTION
A first shot at fixing https://github.com/nix-rust/nix/issues/414. This approach keeps the old implementation for platforms other than `notbsd`, because `libc` only exposes `pipe2` in the `notbsd` module.

I've tested this by hand on my Linux machine in a couple ways:

- Create a toy program that opens a pipe and passes it to `cat`, which hags if `O_CLOEXEC` doesn't get set properly. Confirm that it doesn't hang, but that it does if I pass `0` as the flags to `libc::pipe2`.
- Delete the new implementation entirely, and delete the `cfg` guards on the old implementation, and confirm that above is still true.

I haven't actually tested a cross compilation build though. Is there a standard way to do that?