### PR TITLE
Removes SIGSTKFLT when cross-compiling to MIPS.

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -28,7 +28,7 @@ pub enum Signal {
     SIGPIPE = libc::SIGPIPE,
     SIGALRM = libc::SIGALRM,
     SIGTERM = libc::SIGTERM,
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(target_arch = "mips")))]
     SIGSTKFLT = libc::SIGSTKFLT,
     SIGCHLD = libc::SIGCHLD,
     SIGCONT = libc::SIGCONT,
@@ -54,7 +54,7 @@ pub enum Signal {
 
 pub use self::Signal::*;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(target_arch = "mips")))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -72,6 +72,38 @@ const SIGNALS: [Signal; 31] = [
     SIGALRM,
     SIGTERM,
     SIGSTKFLT,
+    SIGCHLD,
+    SIGCONT,
+    SIGSTOP,
+    SIGTSTP,
+    SIGTTIN,
+    SIGTTOU,
+    SIGURG,
+    SIGXCPU,
+    SIGXFSZ,
+    SIGVTALRM,
+    SIGPROF,
+    SIGWINCH,
+    SIGIO,
+    SIGPWR,
+    SIGSYS];
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), target_arch = "mips"))]
+const SIGNALS: [Signal; 30] = [
+    SIGHUP,
+    SIGINT,
+    SIGQUIT,
+    SIGILL,
+    SIGTRAP,
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGKILL,
+    SIGUSR1,
+    SIGSEGV,
+    SIGUSR2,
+    SIGPIPE,
+    SIGALRM,
+    SIGTERM,
     SIGCHLD,
     SIGCONT,
     SIGSTOP,


### PR DESCRIPTION
This is the only failing error when cross compiling to Tessel, which is a MIPS-based architecture. 

Apparently libc does not have SIGSTKFLT (Term Stack fault on coprocessor) on this system, and indeed it does not have a coprocessor.

This commit should preserve the semantics for all other architectures. Potentially this can be inverted in the future if more platforms are added to only *whitelist* ARM, x86, x86_64, but I thought this conditional would suffice.