### PR TITLE
add getpgid call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#410](https://github.com/nix-rust/nix/pull/410))
 - Added `setresuid` and `setresgid` for Linux in `::nix::unistd`
   ([#448](https://github.com/nix-rust/nix/pull/448))
+- Added `getpgid` in `::nix::unistd`
+  ([#433](https://github.com/nix-rust/nix/pull/433))
 
 ### Changed
 - The minimum supported version of rustc is now 1.7.0.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -62,6 +62,11 @@ pub fn setpgid(pid: pid_t, pgid: pid_t) -> Result<()> {
     let res = unsafe { libc::setpgid(pid, pgid) };
     Errno::result(res).map(drop)
 }
+#[inline]
+pub fn getpgid(pid: Option<pid_t>) -> Result<pid_t> {
+    let res = unsafe { libc::getpgid(pid.unwrap_or(0 as pid_t)) };
+    Errno::result(res)
+}
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[inline]
@@ -440,6 +445,7 @@ pub fn isatty(fd: RawFd) -> Result<bool> {
         }
     }
 }
+
 
 pub fn unlink<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     let res = try!(path.with_nix_path(|cstr| {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -446,7 +446,6 @@ pub fn isatty(fd: RawFd) -> Result<bool> {
     }
 }
 
-
 pub fn unlink<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     let res = try!(path.with_nix_path(|cstr| {
         unsafe {


### PR DESCRIPTION
Add a `getpgid` function to nix.

Argument is required, either pass in `None` or `Some(pid_t)`. It should have the same behavior
as the `libc` one.