### PR TITLE
Bump gcc crate version to 0.3.35

### DIFF
--- a/nix-test/Cargo.toml
+++ b/nix-test/Cargo.toml
@@ -12,4 +12,4 @@ license     = "MIT"
 libc = "*"
 
 [build-dependencies]
-gcc = "0.3.8"
+gcc = "0.3.35"


### PR DESCRIPTION
Let's see where this gets us regarding #435. (I had problems with this on my local machine).