### PR TITLE
wait: Support ptrace events for Linux

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -191,7 +191,7 @@ fn decode(pid : pid_t, status: i32) -> WaitStatus {
     } else if status::signaled(status) {
         WaitStatus::Signaled(pid, status::term_signal(status), status::dumped_core(status))
     } else if status::stopped(status) {
-        if cfg!(any(target_os = "linux", target_os = "android")) {
+        #[cfg(any(target_os = "linux", target_os = "android"))] {
             let status_additional = status::stop_additional(status);
             if status_additional != 0 {
                 return WaitStatus::PtraceEvent(pid, status::stop_signal(status), status::stop_additional(status))


### PR DESCRIPTION
Adds new WaitStatus value `PtraceEvent`. Implementation of #273 that only affects Linux/Android.
