### PR TITLE
Temporarily allow beta failures till 1.13.0-beta.3 or later is released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,8 @@ matrix:
       sudo: true
   allow_failures:
     - rust: nightly
+    # Fail on beta failures again, when 1.13.0-beta.3 or newer is released.
+    - rust: beta
     - env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=mipsel-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android


### PR DESCRIPTION
@kamalmarhubi @posborne, is that alright with you? I would let the Issue #435 open, till this is reverted, once we have a working beta again.