### PR TITLE
impl Send for KEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#410](https://github.com/nix-rust/nix/pull/410))
 
 ### Changed
+- Implement `Send` for `KEvent`
+  ([#442](https://github.com/nix-rust/nix/pull/442))
 - Changed `KEvent` to an opaque structure that may only be modified by its
   constructor and the `ev_set` method.
   ([#415](https://github.com/nix-rust/nix/pull/415))

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -191,6 +191,15 @@ pub fn kqueue() -> Result<RawFd> {
     Errno::result(res)
 }
 
+
+/*
+ * KEvent can't derive Send because on some operating systems, udata is defined
+ * as a void*.  However, KEvent's public API always treats udata as a uintptr_t,
+ * which is safe to Send.
+ */
+unsafe impl Send for KEvent {
+}
+
 impl KEvent {
     pub fn new(ident: uintptr_t, filter: EventFilter, flags: EventFlag,
                fflags:FilterFlag, data: intptr_t, udata: uintptr_t) -> KEvent {

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -192,11 +192,9 @@ pub fn kqueue() -> Result<RawFd> {
 }
 
 
-/*
- * KEvent can't derive Send because on some operating systems, udata is defined
- * as a void*.  However, KEvent's public API always treats udata as a uintptr_t,
- * which is safe to Send.
- */
+// KEvent can't derive Send because on some operating systems, udata is defined
+// as a void*.  However, KEvent's public API always treats udata as a uintptr_t,
+// which is safe to Send.
 unsafe impl Send for KEvent {
 }
 


### PR DESCRIPTION
carllerche/mio needs KEvent to be Send-able.  It's safe to send because udata is always treated as a uintptr_t.  The only ways to use udata that wouldn't be Send-able would also be unsafe because they would require casting udata to a pointer.  So I think it's safe to add the Send trait to KEvent.