### PR TITLE
ci: drop official support for rustc < 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ addons:
       - binutils-dev
 
 rust:
-  - 1.2.0  # Oldest supported version
-  - 1.7.0
-  - 1.8.0
+  - 1.7.0  # Oldest supported version
   - stable
   - beta
   - nightly
@@ -48,12 +46,6 @@ matrix:
     - os: osx
       env: ARCH=i686
       rust: stable
-    - os: osx
-      env: ARCH=x86_64
-      rust: 1.2.0
-    - os: osx
-      env: ARCH=i686
-      rust: 1.2.0
     # Docker builds for other targets
     - os: linux
       env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#410](https://github.com/nix-rust/nix/pull/410))
 
 ### Changed
+- The minimum supported version of rustc is now 1.7.0.
+  ([#444](https://github.com/nix-rust/nix/pull/444))
 - Changed `KEvent` to an opaque structure that may only be modified by its
   constructor and the `ev_set` method.
   ([#415](https://github.com/nix-rust/nix/pull/415))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 
 name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
-version     = "0.7.1-pre"
-authors     = ["Carl Lerche <me@carllerche.com>"]
+version     = "0.8.0-pre"
+authors     = ["The nix-rust Project Developers"]
 homepage    = "https://github.com/nix-rust/nix"
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"


### PR DESCRIPTION
Supporting older versions of rust is causing CI to fail and is
a somewhat constant support burden with questionable value.  1.7.0
is the oldest I have seen that people have had a requirement on
supporting in recent history.

It may make sense to work toward a more official policy on
what version of rust we will support in the future.  Users of
older version of rust are, of course, welcome to use older versions
of nix and everything else in the ecosystem.

r? @kamalmarhubi @fiveop 