### PR TITLE
Add CLONE_NEWCGROUP

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -24,6 +24,7 @@ libc_bitflags!{
         CLONE_DETACHED,
         CLONE_UNTRACED,
         CLONE_CHILD_SETTID,
+        CLONE_NEWCGROUP,
         CLONE_NEWUTS,
         CLONE_NEWIPC,
         CLONE_NEWUSER,


### PR DESCRIPTION
This is a new option to clone added earlier this year.  It was already added to rust/libc.