### PR TITLE
Change KEvent to treat udata as an intptr_t instead of a uintptr_t.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The minimum supported version of rustc is now 1.7.0.
   ([#444](https://github.com/nix-rust/nix/pull/444))
-- Implement `Send` for `KEvent`
-  ([#442](https://github.com/nix-rust/nix/pull/442))
 - Changed `KEvent` to an opaque structure that may only be modified by its
   constructor and the `ev_set` method.
   ([#415](https://github.com/nix-rust/nix/pull/415))
+  ([#442](https://github.com/nix-rust/nix/pull/442))
+  ([#463](https://github.com/nix-rust/nix/pull/463))
 - `pipe2` now calls `libc::pipe2` where available. Previously it was emulated
   using `pipe`, which meant that setting `O_CLOEXEC` was not atomic.
   ([#427](https://github.com/nix-rust/nix/pull/427))

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -193,14 +193,14 @@ pub fn kqueue() -> Result<RawFd> {
 
 
 // KEvent can't derive Send because on some operating systems, udata is defined
-// as a void*.  However, KEvent's public API always treats udata as a uintptr_t,
+// as a void*.  However, KEvent's public API always treats udata as an intptr_t,
 // which is safe to Send.
 unsafe impl Send for KEvent {
 }
 
 impl KEvent {
     pub fn new(ident: uintptr_t, filter: EventFilter, flags: EventFlag,
-               fflags:FilterFlag, data: intptr_t, udata: uintptr_t) -> KEvent {
+               fflags:FilterFlag, data: intptr_t, udata: intptr_t) -> KEvent {
         KEvent { kevent: libc::kevent {
             ident: ident,
             filter: filter as type_of_event_filter,
@@ -231,8 +231,8 @@ impl KEvent {
         self.kevent.data
     }
 
-    pub fn udata(&self) -> uintptr_t {
-        self.kevent.udata as uintptr_t
+    pub fn udata(&self) -> intptr_t {
+        self.kevent.udata as intptr_t
     }
 }
 
@@ -282,7 +282,7 @@ pub fn ev_set(ev: &mut KEvent,
               filter: EventFilter,
               flags: EventFlag,
               fflags: FilterFlag,
-              udata: uintptr_t) {
+              udata: intptr_t) {
 
     ev.kevent.ident  = ident as uintptr_t;
     ev.kevent.filter = filter as type_of_event_filter;
@@ -294,7 +294,7 @@ pub fn ev_set(ev: &mut KEvent,
 
 #[test]
 fn test_struct_kevent() {
-    let udata : uintptr_t = 12345;
+    let udata : intptr_t = 12345;
 
     let expected = libc::kevent{ident: 0xdeadbeef,
                                 filter: libc::EVFILT_READ,


### PR DESCRIPTION
This matches NetBSD's C definitions.  Other operating systems define
it as void*, despite not really being a pointer, but none actually
define it as uintptr_t.  Better to be right on NetBSD and wrong
everywhere else than wrong everywhere.  Plus, it's what mio expects.

Please include this PR in nix 0.8.0