### PR TITLE
Get rid of a few test compilation warnings

### DIFF
--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -2,7 +2,7 @@ use nix::sys::uio::*;
 use nix::unistd::*;
 use rand::{thread_rng, Rng};
 use std::{cmp, iter};
-use std::fs::{OpenOptions, remove_file};
+use std::fs::{OpenOptions};
 use std::os::unix::io::AsRawFd;
 
 use tempdir::TempDir;

--- a/test/test_mount.rs
+++ b/test/test_mount.rs
@@ -128,8 +128,6 @@ exit 23";
     }
 
     pub fn test_mount_bind() {
-        use std::env;
-
         let tempdir = TempDir::new("nix-test_mount")
                           .unwrap_or_else(|e| panic!("tempdir failed: {}", e));
         let file_name = "test";


### PR DESCRIPTION
Cleans up after 0fa7250b9575a2746519a854d0138c4c8255f109 and 40351db00da6ee8c904f47599ee692a85e3d96ef.