### PR TITLE
Push minimum supported version of Rust to 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - binutils-dev
 
 rust:
-  - 1.7.0  # Oldest supported version
+  - 1.9.0  # Oldest supported version
   - stable
   - beta
   - nightly
@@ -49,23 +49,23 @@ matrix:
     # Docker builds for other targets
     - os: linux
       env: TARGET=aarch64-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:arm
-      rust: 1.7.0
+      rust: 1.9.0
       sudo: true
     - os: linux
       env: TARGET=arm-unknown-linux-gnueabihf DOCKER_IMAGE=posborne/rust-cross:arm
-      rust: 1.7.0
+      rust: 1.9.0
       sudo: true
     - os: linux
       env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
-      rust: 1.7.0
+      rust: 1.9.0
       sudo: true
     - os: linux
       env: TARGET=mipsel-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
-      rust: 1.7.0
+      rust: 1.9.0
       sudo: true
     - os: linux
       env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android
-      rust: 1.7.0
+      rust: 1.9.0
       sudo: true
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
This PR is not fully prepared yet. I first want to see what breaks in the CI, if we do this. Once everything works, I will add a CHANGELOG.md entry.

This is done to allow #431 to go forward.