### PR TITLE
Add POSIX AIO support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added support for POSIX AIO
-  ([#483](https://github.com/nix-rust/nix/pull/835))
+  ([#483](https://github.com/nix-rust/nix/pull/483))
 - Added support for XNU system control sockets
   ([#478](https://github.com/nix-rust/nix/pull/478))
 - Added support for `ioctl` calls on BSD platforms
   ([#478](https://github.com/nix-rust/nix/pull/478))
 - Added struct `TimeSpec`
   ([#475](https://github.com/nix-rust/nix/pull/475))
-  ([#483](https://github.com/nix-rust/nix/pull/835))
+  ([#483](https://github.com/nix-rust/nix/pull/483))
 - Added complete definitions for all kqueue-related constants on all supported
   OSes
   ([#415](https://github.com/nix-rust/nix/pull/415))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added support for POSIX AIO
+  ([#483](https://github.com/nix-rust/nix/pull/835))
 - Added support for XNU system control sockets
   ([#478](https://github.com/nix-rust/nix/pull/478))
 - Added support for `ioctl` calls on BSD platforms
   ([#478](https://github.com/nix-rust/nix/pull/478))
 - Added struct `TimeSpec`
   ([#475](https://github.com/nix-rust/nix/pull/475))
+  ([#483](https://github.com/nix-rust/nix/pull/835))
 - Added complete definitions for all kqueue-related constants on all supported
   OSes
   ([#415](https://github.com/nix-rust/nix/pull/415))

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1,0 +1,247 @@
+use {Error, Errno, Result};
+use std::os::unix::io::RawFd;
+use libc::{c_void, off_t, size_t};
+use libc;
+use std::mem;
+use std::ptr::{null, null_mut};
+use sys::signal::*;
+use sys::time::TimeSpec;
+
+/// Mode for `aio_fsync`.  Controls whether only data or both data and metadata
+/// are synced.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AioFsyncMode {
+    /// do it like `fsync`
+    O_SYNC = libc::O_SYNC,
+    /// on supported operating systems only, do it like `fdatasync`
+    #[cfg(any(target_os = "openbsd", target_os = "bitrig",
+              target_os = "netbsd", target_os = "macos", target_os = "ios",
+              target_os = "linux"))]
+    O_DSYNC = libc::O_DSYNC
+}
+
+/// When used with `lio_listio`, determines whether a given `aiocb` should be
+/// used for a read operation, a write operation, or ignored.  Has no effect for
+/// any other aio functions.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LioOpcode {
+    LIO_NOP = libc::LIO_NOP,
+    LIO_WRITE = libc::LIO_WRITE,
+    LIO_READ = libc::LIO_READ
+}
+
+/// Mode for `lio_listio`.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LioMode {
+    /// Requests that `lio_listio` block until all requested operations have
+    /// been completed
+    LIO_WAIT = libc::LIO_WAIT,
+    /// Requests that `lio_listio` return immediately
+    LIO_NOWAIT = libc::LIO_NOWAIT,
+}
+
+/// Return values for `aio_cancel`
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AioCancelStat {
+    /// All outstanding requests were canceled
+    AioCanceled = libc::AIO_CANCELED,
+    /// Some requests were not canceled.  Their status should be checked with
+    /// `aio_error`
+    AioNotCanceled = libc::AIO_NOTCANCELED,
+    /// All of the requests have already finished
+    AioAllDone = libc::AIO_ALLDONE,
+}
+
+/// The basic structure used by all aio functions.  Each `aiocb` represents one
+/// I/O request.
+#[repr(C)]
+pub struct AioCb {
+    aiocb: libc::aiocb
+}
+
+impl AioCb {
+    /// Constructs a new `AioCb` with no associated buffer.
+    ///
+    /// The resulting `AioCb` structure is suitable for use with `aio_fsync`.
+    /// * `fd`  File descriptor.  Required for all aio functions.
+    /// * `prio` If POSIX Prioritized IO is supported, then the operation will
+    /// be prioritized at the process's priority level minus `prio`
+    /// * `sigev_notify` Determines how you will be notified of event
+    /// completion.
+    pub fn from_fd(fd: RawFd, prio: ::c_int,
+                    sigev_notify: SigevNotify) -> AioCb {
+        let mut a = AioCb::common_init(fd, prio, sigev_notify);
+        a.aio_offset = 0;
+        a.aio_nbytes = 0;
+        a.aio_buf = null_mut();
+
+        let aiocb = AioCb { aiocb: a};
+        aiocb
+    }
+
+    /// Constructs a new `AioCb`.
+    ///
+    /// * `fd`  File descriptor.  Required for all aio functions.
+    /// * `offs` File offset
+    /// * `buf` A memory buffer
+    /// * `prio` If POSIX Prioritized IO is supported, then the operation will
+    /// be prioritized at the process's priority level minus `prio`
+    /// * `sigev_notify` Determines how you will be notified of event
+    /// completion.
+    /// * `opcode` This field is only used for `lio_listio`.  It determines
+    /// which operation to use for this individual aiocb
+    pub fn from_mut_slice(fd: RawFd, offs: off_t, buf: &mut [u8],
+                          prio: ::c_int, sigev_notify: SigevNotify,
+                          opcode: LioOpcode) -> AioCb {
+        let mut a = AioCb::common_init(fd, prio, sigev_notify);
+        a.aio_offset = offs;
+        a.aio_nbytes = buf.len() as size_t;
+        a.aio_buf = buf.as_ptr() as *mut c_void;
+        a.aio_lio_opcode = opcode as ::c_int;
+
+        let aiocb = AioCb { aiocb: a};
+        aiocb
+    }
+
+    /// Like `from_mut_slice`, but works on constant slices rather than
+    /// mutable slices.
+    ///
+    /// This is technically unsafe, but in practice it's fine
+    /// to use with any aio functions except `aio_read` and `lio_listio` (with
+    /// `opcode` set to `LIO_READ`).  This method is useful when writing a const
+    /// buffer with `aio_write`, since from_mut_slice can't work with const
+    /// buffers.
+    // Note: another solution to the problem of writing const buffers would be
+    // to genericize AioCb for both &mut [u8] and &[u8] buffers.  aio_read could
+    // take the former and aio_write could take the latter.  However, then
+    // lio_listio wouldn't work, because that function needs a slice of AioCb,
+    // and they must all be the same type.  We're basically stuck with using an
+    // unsafe function, since aio (as designed in C) is an unsafe API.
+    pub unsafe fn from_slice(fd: RawFd, offs: off_t, buf: &[u8],
+                             prio: ::c_int, sigev_notify: SigevNotify,
+                             opcode: LioOpcode) -> AioCb {
+        let mut a = AioCb::common_init(fd, prio, sigev_notify);
+        a.aio_offset = offs;
+        a.aio_nbytes = buf.len() as size_t;
+        a.aio_buf = buf.as_ptr() as *mut c_void;
+        a.aio_lio_opcode = opcode as ::c_int;
+
+        let aiocb = AioCb { aiocb: a};
+        aiocb
+    }
+
+    fn common_init(fd: RawFd, prio: ::c_int,
+                   sigev_notify: SigevNotify) -> libc::aiocb {
+        // Use mem::zeroed instead of explicitly zeroing each field, because the
+        // number and name of reserved fields is OS-dependent.  On some OSes,
+        // some reserved fields are used the kernel for state, and must be
+        // explicitly zeroed when allocated.
+        let mut a = unsafe { mem::zeroed::<libc::aiocb>()};
+        a.aio_fildes = fd;
+        a.aio_reqprio = prio;
+        a.aio_sigevent = SigEvent::new(sigev_notify).sigevent();
+        a
+    }
+
+    /// Update the notification settings for an existing `aiocb`
+    pub fn set_sigev_notify(&mut self, sigev_notify: SigevNotify) {
+        self.aiocb.aio_sigevent = SigEvent::new(sigev_notify).sigevent();
+    }
+}
+
+/// Cancels outstanding AIO requests.  If `aiocb` is `None`, then all requests
+/// for `fd` will be cancelled.  Otherwise, only the given `AioCb` will be
+/// cancelled.
+pub fn aio_cancel(fd: RawFd, aiocb: Option<&mut AioCb>) -> Result<AioCancelStat> {
+    let p: *mut libc::aiocb = match aiocb {
+        None => null_mut(),
+        Some(x) => &mut x.aiocb
+    };
+    match unsafe { libc::aio_cancel(fd, p) } {
+        libc::AIO_CANCELED => Ok(AioCancelStat::AioCanceled),
+        libc::AIO_NOTCANCELED => Ok(AioCancelStat::AioNotCanceled),
+        libc::AIO_ALLDONE => Ok(AioCancelStat::AioAllDone),
+        -1 => Err(Error::last()),
+        _ => panic!("unknown aio_cancel return value")
+    }
+}
+
+/// Retrieve error status of an asynchronous operation.  If the request has not
+/// yet completed, returns `EINPROGRESS`.  Otherwise, returns `Ok` or any other
+/// error.
+pub fn aio_error(aiocb: &mut AioCb) -> Result<()> {
+    let p: *mut libc::aiocb = &mut aiocb.aiocb;
+    match unsafe { libc::aio_error(p) } {
+        0 => Ok(()),
+        num if num > 0 => Err(Error::from_errno(Errno::from_i32(num))),
+        -1 => Err(Error::last()),
+        num => panic!("unknown aio_error return value {:?}", num)
+    }
+}
+
+/// An asynchronous version of `fsync`.
+pub fn aio_fsync(mode: AioFsyncMode, aiocb: &mut AioCb) -> Result<()> {
+    let p: *mut libc::aiocb = &mut aiocb.aiocb;
+    Errno::result(unsafe { libc::aio_fsync(mode as ::c_int, p) }).map(drop)
+}
+
+/// Asynchously reads from a file descriptor into a buffer
+pub fn aio_read(aiocb: &mut AioCb) -> Result<()> {
+    let p: *mut libc::aiocb = &mut aiocb.aiocb;
+    Errno::result(unsafe { libc::aio_read(p) }).map(drop)
+}
+
+/// Retrieve return status of an asynchronous operation.  Should only be called
+/// once for each `AioCb`, after `aio_error` indicates that it has completed.
+/// The result the same as for `read`, `write`, of `fsync`.
+pub fn aio_return(aiocb: &mut AioCb) -> Result<isize> {
+    let p: *mut libc::aiocb = &mut aiocb.aiocb;
+    Errno::result(unsafe { libc::aio_return(p) })
+}
+
+/// Suspends the calling process until at least one of the specified `AioCb`s
+/// has completed, a signal is delivered, or the timeout has passed.  If
+/// `timeout` is `None`, `aio_suspend` will block indefinitely.
+pub fn aio_suspend(list: &[&AioCb], timeout: Option<TimeSpec>) -> Result<()> {
+    // We must use transmute because Rust doesn't understand that a pointer to a
+    // Struct is the same as a pointer to its first element.
+    let plist = unsafe {
+        mem::transmute::<&[&AioCb], *const [*const libc::aiocb]>(list)
+    };
+    let p = plist as *const *const libc::aiocb;
+    let timep = match timeout {
+        None    => null::<libc::timespec>(),
+        Some(x) => x.as_ref() as *const libc::timespec
+    };
+    Errno::result(unsafe {
+        libc::aio_suspend(p, list.len() as i32, timep)
+    }).map(drop)
+}
+
+/// Asynchronously writes from a buffer to a file descriptor
+pub fn aio_write(aiocb: &mut AioCb) -> Result<()> {
+    let p: *mut libc::aiocb = &mut aiocb.aiocb;
+    Errno::result(unsafe { libc::aio_write(p) }).map(drop)
+}
+
+/// Submits multiple asynchronous I/O requests with a single system call.  The
+/// order in which the requests are carried out is not specified.
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+pub fn lio_listio(mode: LioMode, list: &[&mut AioCb],
+                  sigev_notify: SigevNotify) -> Result<()> {
+    let sigev = SigEvent::new(sigev_notify);
+    let sigevp = &mut sigev.sigevent() as *mut libc::sigevent;
+    // We must use transmute because Rust doesn't understand that a pointer to a
+    // Struct is the same as a pointer to its first element.
+    let plist = unsafe {
+        mem::transmute::<&[&mut AioCb], *const [*mut libc::aiocb]>(list)
+    };
+    let p = plist as *const *mut libc::aiocb;
+    Errno::result(unsafe {
+        libc::lio_listio(mode as i32, p, list.len() as i32, sigevp)
+    }).map(drop)
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "ios",
+          target_os = "netbsd", target_os = "macos", target_os = "linux"))]
+pub mod aio;
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod epoll;
 

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -59,6 +59,12 @@ const TS_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
 const TS_MIN_SECONDS: i64 = -TS_MAX_SECONDS;
 
 
+impl AsRef<timespec> for TimeSpec {
+    fn as_ref(&self) -> &timespec {
+        &self.0
+    }
+}
+
 impl fmt::Debug for TimeSpec {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("TimeSpec")
@@ -263,6 +269,12 @@ const TV_MAX_SECONDS: i64 = (::std::i64::MAX / MICROS_PER_SEC) - 1;
 const TV_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
 
 const TV_MIN_SECONDS: i64 = -TV_MAX_SECONDS;
+
+impl AsRef<timeval> for TimeVal {
+    fn as_ref(&self) -> &timeval {
+        &self.0
+    }
+}
 
 impl fmt::Debug for TimeVal {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -1,4 +1,7 @@
 mod test_signal;
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "ios",
+          target_os = "netbsd", target_os = "macos", target_os = "linux"))]
+mod test_aio;
 mod test_socket;
 mod test_sockopt;
 mod test_termios;

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -1,0 +1,375 @@
+use libc::c_int;
+use nix::{Error, Result};
+use nix::errno::*;
+use nix::sys::aio::*;
+use nix::sys::signal::*;
+use nix::sys::time::{TimeSpec, TimeValLike};
+use std::io::{Write, Read, Seek, SeekFrom};
+use std::os::unix::io::AsRawFd;
+use std::{thread, time};
+use tempfile::tempfile;
+
+// Helper that polls an AioCb for completion or error
+fn poll_aio(mut aiocb: &mut AioCb) -> Result<()> {
+    loop {
+        let err = aio_error(&mut aiocb);
+        if err != Err(Error::from(Errno::EINPROGRESS)) { return err; };
+        thread::sleep(time::Duration::from_millis(10));
+    }
+}
+
+// Tests aio_cancel.  We aren't trying to test the OS's implementation, only our
+// bindings.  So it's sufficient to check that aio_cancel returned any
+// AioCancelStat value.
+#[test]
+fn test_aio_cancel() {
+    let mut wbuf = "CDEF".to_string().into_bytes();
+
+    let f = tempfile().unwrap();
+    let mut aiocb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            0,   //offset
+                            &mut wbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_NOP);
+    aio_write(&mut aiocb).unwrap();
+    let err = aio_error(&mut aiocb);
+    assert!(err == Ok(()) || err == Err(Error::from(Errno::EINPROGRESS)));
+
+    let cancelstat = aio_cancel(f.as_raw_fd(), Some(&mut aiocb));
+    assert!(cancelstat.is_ok());
+
+    // Wait for aiocb to complete, but don't care whether it succeeded
+    let _ = poll_aio(&mut aiocb);
+    let _ = aio_return(&mut aiocb);
+}
+
+// Tests using aio_cancel for all outstanding IOs.
+#[test]
+fn test_aio_cancel_all() {
+    let mut wbuf = "CDEF".to_string().into_bytes();
+
+    let f = tempfile().unwrap();
+    let mut aiocb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            0,   //offset
+                            &mut wbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_NOP);
+    aio_write(&mut aiocb).unwrap();
+    let err = aio_error(&mut aiocb);
+    assert!(err == Ok(()) || err == Err(Error::from(Errno::EINPROGRESS)));
+
+    let cancelstat = aio_cancel(f.as_raw_fd(), None);
+    assert!(cancelstat.is_ok());
+
+    // Wait for aiocb to complete, but don't care whether it succeeded
+    let _ = poll_aio(&mut aiocb);
+    let _ = aio_return(&mut aiocb);
+}
+
+#[test]
+fn test_aio_fsync() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    let mut f = tempfile().unwrap();
+    f.write(INITIAL).unwrap();
+    let mut aiocb = AioCb::from_fd( f.as_raw_fd(),
+                            0,   //priority
+                            SigevNotify::SigevNone);
+    let err = aio_fsync(AioFsyncMode::O_SYNC, &mut aiocb);
+    assert!(err.is_ok());
+    poll_aio(&mut aiocb).unwrap();
+    aio_return(&mut aiocb).unwrap();
+}
+
+
+#[test]
+fn test_aio_suspend() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF";
+    let timeout = TimeSpec::seconds(10);
+    let mut rbuf = vec![0; 4];
+    let mut f = tempfile().unwrap();
+    f.write(INITIAL).unwrap();
+
+    let mut wcb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &mut WBUF,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_WRITE)
+    };
+
+    let mut rcb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            8,   //offset
+                            &mut rbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_READ);
+    aio_write(&mut wcb).unwrap();
+    aio_read(&mut rcb).unwrap();
+    loop {
+        {
+            let cbbuf = [&wcb, &rcb];
+            assert!(aio_suspend(&cbbuf[..], Some(timeout)).is_ok());
+        }
+        if aio_error(&mut rcb) != Err(Error::from(Errno::EINPROGRESS)) &&
+           aio_error(&mut wcb) != Err(Error::from(Errno::EINPROGRESS)) {
+            break
+        }
+    }
+
+    assert!(aio_return(&mut wcb).unwrap() as usize == WBUF.len());
+    assert!(aio_return(&mut rcb).unwrap() as usize == rbuf.len());
+}
+
+// Test a simple aio operation with no completion notification.  We must poll
+// for completion
+#[test]
+fn test_aio_read() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    let mut rbuf = vec![0; 4];
+    const EXPECT: &'static [u8] = b"cdef";
+    let mut f = tempfile().unwrap();
+    f.write(INITIAL).unwrap();
+    let mut aiocb = AioCb::from_mut_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &mut rbuf,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_NOP);
+    aio_read(&mut aiocb).unwrap();
+
+    let err = poll_aio(&mut aiocb);
+    assert!(err == Ok(()));
+    assert!(aio_return(&mut aiocb).unwrap() as usize == rbuf.len());
+
+    assert!(rbuf == EXPECT);
+}
+
+// Test a simple aio operation with no completion notification.  We must poll
+// for completion.  Unlike test_aio_read, this test uses AioCb::from_slice
+#[test]
+fn test_aio_write() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF"; //"CDEF".to_string().into_bytes();
+    let mut rbuf = Vec::new();
+    const EXPECT: &'static [u8] = b"abCDEF123456";
+
+    let mut f = tempfile().unwrap();
+    f.write(INITIAL).unwrap();
+    let mut aiocb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &WBUF,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_NOP)
+    };
+    aio_write(&mut aiocb).unwrap();
+
+    let err = poll_aio(&mut aiocb);
+    assert!(err == Ok(()));
+    assert!(aio_return(&mut aiocb).unwrap() as usize == WBUF.len());
+
+    f.seek(SeekFrom::Start(0)).unwrap();
+    let len = f.read_to_end(&mut rbuf).unwrap();
+    assert!(len == EXPECT.len());
+    assert!(rbuf == EXPECT);
+}
+
+// XXX: should be sig_atomic_t, but rust's libc doesn't define that yet
+static mut signaled: i32 = 0;
+
+extern fn sigfunc(_: c_int) {
+    // It's a pity that Rust can't understand that static mutable sig_atomic_t
+    // variables can be safely accessed
+    unsafe { signaled = 1 };
+}
+
+// Test an aio operation with completion delivered by a signal
+#[test]
+fn test_aio_write_sigev_signal() {
+    let sa = SigAction::new(SigHandler::Handler(sigfunc),
+                            SA_RESETHAND,
+                            SigSet::empty());
+    unsafe {signaled = 0 };
+    unsafe { sigaction(Signal::SIGUSR2, &sa) }.unwrap();
+
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF";
+    let mut rbuf = Vec::new();
+    const EXPECT: &'static [u8] = b"abCDEF123456";
+
+    let mut f = tempfile().unwrap();
+    f.write(INITIAL).unwrap();
+    let mut aiocb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &WBUF,
+                           0,   //priority
+                           SigevNotify::SigevSignal {
+                               signal: Signal::SIGUSR2,
+                               si_value: 0  //TODO: validate in sigfunc
+                           },
+                           LioOpcode::LIO_NOP)
+    };
+    aio_write(&mut aiocb).unwrap();
+    while unsafe { signaled == 0 } {
+        thread::sleep(time::Duration::from_millis(10));
+    }
+
+    assert!(aio_return(&mut aiocb).unwrap() as usize == WBUF.len());
+    f.seek(SeekFrom::Start(0)).unwrap();
+    let len = f.read_to_end(&mut rbuf).unwrap();
+    assert!(len == EXPECT.len());
+    assert!(rbuf == EXPECT);
+}
+
+// Test lio_listio with LIO_WAIT, so all AIO ops should be complete by the time
+// lio_listio returns.
+#[test]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+fn test_lio_listio_wait() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF";
+    let mut rbuf = vec![0; 4];
+    let mut rbuf2 = Vec::new();
+    const EXPECT: &'static [u8] = b"abCDEF123456";
+    let mut f = tempfile().unwrap();
+
+    f.write(INITIAL).unwrap();
+
+    let mut wcb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &WBUF,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_WRITE)
+    };
+
+    let mut rcb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            8,   //offset
+                            &mut rbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_READ);
+    {
+        let cbbuf = [&mut wcb, &mut rcb];
+        let err = lio_listio(LioMode::LIO_WAIT, &cbbuf[..], SigevNotify::SigevNone);
+        err.expect("lio_listio failed");
+    }
+
+    assert!(aio_return(&mut wcb).unwrap() as usize == WBUF.len());
+    assert!(aio_return(&mut rcb).unwrap() as usize == rbuf.len());
+    assert!(rbuf == b"3456");
+
+    f.seek(SeekFrom::Start(0)).unwrap();
+    let len = f.read_to_end(&mut rbuf2).unwrap();
+    assert!(len == EXPECT.len());
+    assert!(rbuf2 == EXPECT);
+}
+
+// Test lio_listio with LIO_NOWAIT and no SigEvent, so we must use some other
+// mechanism to check for the individual AioCb's completion.
+#[test]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+fn test_lio_listio_nowait() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF";
+    let mut rbuf = vec![0; 4];
+    let mut rbuf2 = Vec::new();
+    const EXPECT: &'static [u8] = b"abCDEF123456";
+    let mut f = tempfile().unwrap();
+
+    f.write(INITIAL).unwrap();
+
+    let mut wcb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &WBUF,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_WRITE)
+    };
+
+    let mut rcb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            8,   //offset
+                            &mut rbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_READ);
+    {
+        let cbbuf = [&mut wcb, &mut rcb];
+        let err = lio_listio(LioMode::LIO_NOWAIT, &cbbuf[..], SigevNotify::SigevNone);
+        err.expect("lio_listio failed");
+    }
+
+    poll_aio(&mut wcb).unwrap();
+    poll_aio(&mut rcb).unwrap();
+    assert!(aio_return(&mut wcb).unwrap() as usize == WBUF.len());
+    assert!(aio_return(&mut rcb).unwrap() as usize == rbuf.len());
+    assert!(rbuf == b"3456");
+
+    f.seek(SeekFrom::Start(0)).unwrap();
+    let len = f.read_to_end(&mut rbuf2).unwrap();
+    assert!(len == EXPECT.len());
+    assert!(rbuf2 == EXPECT);
+}
+
+// Test lio_listio with LIO_NOWAIT and a SigEvent to indicate when all AioCb's
+// are complete.
+#[test]
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+fn test_lio_listio_signal() {
+    const INITIAL: &'static [u8] = b"abcdef123456";
+    const WBUF: &'static [u8] = b"CDEF";
+    let mut rbuf = vec![0; 4];
+    let mut rbuf2 = Vec::new();
+    const EXPECT: &'static [u8] = b"abCDEF123456";
+    let mut f = tempfile().unwrap();
+    let sa = SigAction::new(SigHandler::Handler(sigfunc),
+                            SA_RESETHAND,
+                            SigSet::empty());
+    let sigev_notify = SigevNotify::SigevSignal { signal: Signal::SIGUSR2,
+                                                  si_value: 0 };
+
+    f.write(INITIAL).unwrap();
+
+    let mut wcb = unsafe {
+        AioCb::from_slice( f.as_raw_fd(),
+                           2,   //offset
+                           &WBUF,
+                           0,   //priority
+                           SigevNotify::SigevNone,
+                           LioOpcode::LIO_WRITE)
+    };
+
+    let mut rcb = AioCb::from_mut_slice( f.as_raw_fd(),
+                            8,   //offset
+                            &mut rbuf,
+                            0,   //priority
+                            SigevNotify::SigevNone,
+                            LioOpcode::LIO_READ);
+    unsafe {signaled = 0 };
+    unsafe { sigaction(Signal::SIGUSR2, &sa) }.unwrap();
+    {
+        let cbbuf = [&mut wcb, &mut rcb];
+        let err = lio_listio(LioMode::LIO_NOWAIT, &cbbuf[..], sigev_notify);
+        err.expect("lio_listio failed");
+    }
+    while unsafe { signaled == 0 } {
+        thread::sleep(time::Duration::from_millis(10));
+    }
+
+    assert!(aio_return(&mut wcb).unwrap() as usize == WBUF.len());
+    assert!(aio_return(&mut rcb).unwrap() as usize == rbuf.len());
+    assert!(rbuf == b"3456");
+
+    f.seek(SeekFrom::Start(0)).unwrap();
+    let len = f.read_to_end(&mut rbuf2).unwrap();
+    assert!(len == EXPECT.len());
+    assert!(rbuf2 == EXPECT);
+}


### PR DESCRIPTION
POSIX AIO is a standard for asynchronous file I/O.  Read, write, and
fsync operations can all take place in the background, with completion
notification delivered by a signal, by a new thread, by kqueue, or not
at all.

The SigEvent class, used for AIO notifications among other things, is
also added.