### PR TITLE
Allow failures of 1.7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ matrix:
       sudo: true
   allow_failures:
     - rust: nightly
+    # We need to upgrade the lowest supported version. However, the build
+    # infrastructure for arm/mips/android is not ready yet.
+    - rust: 1.7.0
     - env: TARGET=mips-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=mipsel-unknown-linux-gnu DOCKER_IMAGE=posborne/rust-cross:mips
     - env: TARGET=arm-linux-androideabi DOCKER_IMAGE=posborne/rust-cross:android


### PR DESCRIPTION
Libraries we depend on need newer versions of Rust. The current
stable release is 1.13.

This also disables the CI for the platforms/architectures MIPS, ARM
and Android. This cannot be helped as long as the test infrastructure
only runs on 1.7.