### PR TITLE
Fix ControlMessage::encode_into when encoding multiple messages

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -238,8 +238,13 @@ impl<'a> ControlMessage<'a> {
 
                 let padlen = cmsg_align(mem::size_of_val(&cmsg)) -
                     mem::size_of_val(&cmsg);
-                let buf2 = &mut &mut buf[padlen..];
-                copy_bytes(fds, buf2);
+
+                let mut tmpbuf = &mut [][..];
+                mem::swap(&mut tmpbuf, buf);
+                let (_padding, mut remainder) = tmpbuf.split_at_mut(padlen);
+                mem::swap(buf, &mut remainder);
+
+                copy_bytes(fds, buf);
             },
             ControlMessage::Unknown(UnknownCmsg(orig_cmsg, bytes)) => {
                 copy_bytes(orig_cmsg, buf);


### PR DESCRIPTION
copy_bytes updates dst so that it points after the bytes that were just
copied into it. encode_into did not advance the buffer in the same way
when encoding the data.

See #473