### PR TITLE
Ensure child stack passed to clone is 16 byte aligned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#397](https://github.com/nix-rust/nix/pull/397))
 - Fixed an off-by-one bug in `UnixAddr::new_abstract` in `::nix::sys::socket`.
   ([#429](https://github.com/nix-rust/nix/pull/429))
+- Fixed clone passing a potentially unaligned stack.
+  ([#490](https://github.com/nix-rust/nix/pull/490))
 
 ## [0.7.0] 2016-09-09
 

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -114,8 +114,9 @@ pub fn clone(mut cb: CloneCb,
     let res = unsafe {
         let combined = flags.bits() | signal.unwrap_or(0);
         let ptr = stack.as_mut_ptr().offset(stack.len() as isize);
+        let ptr_aligned = ptr.offset((ptr as usize % 16) as isize * -1);
         ffi::clone(mem::transmute(callback as extern "C" fn(*mut Box<::std::ops::FnMut() -> isize>) -> i32),
-                   ptr as *mut c_void,
+                   ptr_aligned as *mut c_void,
                    combined,
                    &mut cb)
     };


### PR DESCRIPTION
The current implementation assumes that the array passed by the caller is word aligned (which I don't think Rust guarantees for [u8]) and a multiple of the word size.