### PR TITLE
Always use libc's socketaddr_storage

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -50,16 +50,7 @@ pub use self::multicast::{
 };
 pub use self::consts::*;
 
-#[cfg(any(not(target_os = "linux"), not(target_arch = "x86")))]
 pub use libc::sockaddr_storage;
-
-// Working around rust-lang/rust#23425
-#[cfg(all(target_os = "linux", target_arch = "x86"))]
-pub struct sockaddr_storage {
-    pub ss_family: sa_family_t,
-    pub __ss_align: u32,
-    pub __ss_pad2: [u8; 120],
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(i32)]


### PR DESCRIPTION
Since rust-lang/rust#23425 is closed, we no longer need the special
case.