### PR TITLE
unistd: add fchdir(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#457](https://github.com/nix-rust/nix/pull/457))
 - Added `getpgrp` in `::nix::unistd`
   ([#491](https://github.com/nix-rust/nix/pull/491))
+- Added `fchdir` in `::nix::unistd`
+  ([#497](https://github.com/nix-rust/nix/pull/497))
 
 ### Changed
 - `epoll_ctl` now could accept None as argument `event`

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -249,6 +249,19 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+/// Change the current working directory of the process to the one
+/// given as an open file descriptor (see
+/// [fchdir(2)](http://man7.org/linux/man-pages/man2/fchdir.2.html)).
+///
+/// This function may fail in a number of different scenarios.  See the man
+/// pages for additional details on possible failure cases.
+#[inline]
+pub fn fchdir(dirfd: RawFd) -> Result<()> {
+    let res = unsafe { libc::fchdir(dirfd) };
+
+    Errno::result(res).map(drop)
+}
+
 /// Creates new directory `path` with access rights `mode`.
 ///
 /// # Errors


### PR DESCRIPTION
This introduces a wrapper for fchdir(2), allowing a process to change
directory based on an open file descriptor.

The underlying function is available in libc crate since 0.2.20.