### PR TITLE
Fix the style for bitflags!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#497](https://github.com/nix-rust/nix/pull/497))
 - Added `major` and `minor` in `::nix::sys::stat` for decomposing `dev_t`
   ([#508](https://github.com/nix-rust/nix/pull/508))
+- Fixed the style of many bitflags and use `libc` in more places.
+  ([#503](https://github.com/nix-rust/nix/pull/503))
 
 ### Changed
 - `epoll_ctl` now could accept None as argument `event`

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -137,38 +137,38 @@ pub fn vmsplice(fd: RawFd, iov: &[IoVec<&[u8]>], flags: SpliceFFlags) -> Result<
 mod consts {
     use libc::{self, c_int, c_uint};
 
-    bitflags! {
+    libc_bitflags! {
         pub flags SpliceFFlags: c_uint {
-            const SPLICE_F_MOVE = libc::SPLICE_F_MOVE,
-            const SPLICE_F_NONBLOCK = libc::SPLICE_F_NONBLOCK,
-            const SPLICE_F_MORE = libc::SPLICE_F_MORE,
-            const SPLICE_F_GIFT = libc::SPLICE_F_GIFT,
+            SPLICE_F_MOVE,
+            SPLICE_F_NONBLOCK,
+            SPLICE_F_MORE,
+            SPLICE_F_GIFT,
         }
     }
 
     bitflags!(
         pub flags OFlag: c_int {
-            const O_ACCMODE   = 0o00000003,
-            const O_RDONLY    = 0o00000000,
-            const O_WRONLY    = 0o00000001,
-            const O_RDWR      = 0o00000002,
-            const O_CREAT     = 0o00000100,
-            const O_EXCL      = 0o00000200,
-            const O_NOCTTY    = 0o00000400,
-            const O_TRUNC     = 0o00001000,
-            const O_APPEND    = 0o00002000,
-            const O_NONBLOCK  = 0o00004000,
-            const O_DSYNC     = 0o00010000,
-            const O_DIRECT    = 0o00040000,
+            const O_ACCMODE   = libc::O_ACCMODE,
+            const O_RDONLY    = libc::O_RDONLY,
+            const O_WRONLY    = libc::O_WRONLY,
+            const O_RDWR      = libc::O_RDWR,
+            const O_CREAT     = libc::O_CREAT,
+            const O_EXCL      = libc::O_EXCL,
+            const O_NOCTTY    = libc::O_NOCTTY,
+            const O_TRUNC     = libc::O_TRUNC,
+            const O_APPEND    = libc::O_APPEND,
+            const O_NONBLOCK  = libc::O_NONBLOCK,
+            const O_DSYNC     = libc::O_DSYNC,
+            const O_DIRECT    = libc::O_DIRECT,
             const O_LARGEFILE = 0o00100000,
-            const O_DIRECTORY = 0o00200000,
-            const O_NOFOLLOW  = 0o00400000,
+            const O_DIRECTORY = libc::O_DIRECTORY,
+            const O_NOFOLLOW  = libc::O_NOFOLLOW,
             const O_NOATIME   = 0o01000000,
-            const O_CLOEXEC   = 0o02000000,
-            const O_SYNC      = 0o04000000,
+            const O_CLOEXEC   = libc::O_CLOEXEC,
+            const O_SYNC      = libc::O_SYNC,
             const O_PATH      = 0o10000000,
-            const O_TMPFILE   = 0o20000000,
-            const O_NDELAY    = O_NONBLOCK.bits
+            const O_TMPFILE   = libc::O_TMPFILE,
+            const O_NDELAY    = libc::O_NDELAY,
         }
     );
 
@@ -191,27 +191,27 @@ mod consts {
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod consts {
-    use libc::c_int;
+    use libc::{self, c_int};
 
     bitflags!(
         pub flags OFlag: c_int {
-            const O_ACCMODE   = 0x0000003,
-            const O_RDONLY    = 0x0000000,
-            const O_WRONLY    = 0x0000001,
-            const O_RDWR      = 0x0000002,
-            const O_CREAT     = 0x0000200,
-            const O_EXCL      = 0x0000800,
-            const O_NOCTTY    = 0x0020000,
-            const O_TRUNC     = 0x0000400,
-            const O_APPEND    = 0x0000008,
-            const O_NONBLOCK  = 0x0000004,
-            const O_DSYNC     = 0x0400000,
-            const O_DIRECTORY = 0x0100000,
-            const O_NOFOLLOW  = 0x0000100,
-            const O_CLOEXEC   = 0x1000000,
-            const O_SYNC      = 0x0000080,
+            const O_ACCMODE   = libc::O_ACCMODE,
+            const O_RDONLY    = libc::O_RDONLY,
+            const O_WRONLY    = libc::O_WRONLY,
+            const O_RDWR      = libc::O_RDWR,
+            const O_CREAT     = libc::O_CREAT,
+            const O_EXCL      = libc::O_EXCL,
+            const O_NOCTTY    = libc::O_NOCTTY,
+            const O_TRUNC     = libc::O_TRUNC,
+            const O_APPEND    = libc::O_APPEND,
+            const O_NONBLOCK  = libc::O_NONBLOCK,
+            const O_DSYNC     = libc::O_DSYNC,
+            const O_DIRECTORY = libc::O_DIRECTORY,
+            const O_NOFOLLOW  = libc::O_NOFOLLOW,
+            const O_CLOEXEC   = libc::O_CLOEXEC,
+            const O_SYNC      = libc::O_SYNC,
             const O_NDELAY    = O_NONBLOCK.bits,
-            const O_FSYNC     = O_SYNC.bits
+            const O_FSYNC     = libc::O_FSYNC,
         }
     );
 
@@ -224,26 +224,26 @@ mod consts {
 
 #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
 mod consts {
-    use libc::c_int;
+    use libc::{self, c_int};
 
     bitflags!(
         pub flags OFlag: c_int {
-            const O_ACCMODE   = 0x0000003,
-            const O_RDONLY    = 0x0000000,
-            const O_WRONLY    = 0x0000001,
-            const O_RDWR      = 0x0000002,
-            const O_CREAT     = 0x0000200,
-            const O_EXCL      = 0x0000800,
-            const O_NOCTTY    = 0x0008000,
-            const O_TRUNC     = 0x0000400,
-            const O_APPEND    = 0x0000008,
-            const O_NONBLOCK  = 0x0000004,
+            const O_ACCMODE   = libc::O_ACCMODE,
+            const O_RDONLY    = libc::O_RDONLY,
+            const O_WRONLY    = libc::O_WRONLY,
+            const O_RDWR      = libc::O_RDWR,
+            const O_CREAT     = libc::O_CREAT,
+            const O_EXCL      = libc::O_EXCL,
+            const O_NOCTTY    = libc::O_NOCTTY,
+            const O_TRUNC     = libc::O_TRUNC,
+            const O_APPEND    = libc::O_APPEND,
+            const O_NONBLOCK  = libc::O_NONBLOCK,
             const O_DIRECTORY = 0x0020000,
-            const O_NOFOLLOW  = 0x0000100,
-            const O_CLOEXEC   = 0x0100000,
-            const O_SYNC      = 0x0000080,
-            const O_NDELAY    = O_NONBLOCK.bits,
-            const O_FSYNC     = O_SYNC.bits,
+            const O_NOFOLLOW  = libc::O_NOFOLLOW,
+            const O_CLOEXEC   = libc::O_CLOEXEC,
+            const O_SYNC      = libc::O_SYNC,
+            const O_NDELAY    = libc::O_NDELAY,
+            const O_FSYNC     = libc::O_FSYNC,
             const O_SHLOCK    = 0x0000080,
             const O_EXLOCK    = 0x0000020,
             const O_DIRECT    = 0x0010000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 // warnings even though the macro expands into something with allow(dead_code)
 #![allow(dead_code)]
 #![cfg_attr(test, deny(warnings))]
+#![recursion_limit = "500"]
 
 #[macro_use]
 extern crate bitflags;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -4,48 +4,45 @@ use {Errno, Result, NixPath};
 
 bitflags!(
     pub flags MsFlags: c_ulong {
-        const MS_RDONLY      = 1 << 0,  // Mount read-only
-        const MS_NOSUID      = 1 << 1,  // Ignore suid and sgid bits
-        const MS_NODEV       = 1 << 2,  // Disallow access to device special files
-        const MS_NOEXEC      = 1 << 3,  // Disallow program execution
-        const MS_SYNCHRONOUS = 1 << 4,  // Writes are synced at once
-        const MS_REMOUNT     = 1 << 5,  // Alter flags of a mounted FS
-        const MS_MANDLOCK    = 1 << 6,  // Allow mandatory locks on a FS
-        const MS_DIRSYNC     = 1 << 7,  // Directory modifications are synchronous
-        const MS_NOATIME     = 1 << 10, // Do not update access times
-        const MS_NODIRATIME  = 1 << 11, // Do not update directory access times
-        const MS_BIND        = 1 << 12, // Linux 2.4.0 - Bind directory at different place
-        const MS_MOVE        = 1 << 13,
-        const MS_REC         = 1 << 14,
-        const MS_VERBOSE     = 1 << 15, // Deprecated
-        const MS_SILENT      = 1 << 15,
-        const MS_POSIXACL    = 1 << 16,
-        const MS_UNBINDABLE  = 1 << 17,
-        const MS_PRIVATE     = 1 << 18,
-        const MS_SLAVE       = 1 << 19,
-        const MS_SHARED      = 1 << 20,
-        const MS_RELATIME    = 1 << 21,
-        const MS_KERNMOUNT   = 1 << 22,
-        const MS_I_VERSION   = 1 << 23,
-        const MS_STRICTATIME = 1 << 24,
+        const MS_RDONLY      = libc::MS_RDONLY,      // Mount read-only
+        const MS_NOSUID      = libc::MS_NOSUID,      // Ignore suid and sgid bits
+        const MS_NODEV       = libc::MS_NODEV,       // Disallow access to device special files
+        const MS_NOEXEC      = libc::MS_NOEXEC,      // Disallow program execution
+        const MS_SYNCHRONOUS = libc::MS_SYNCHRONOUS, // Writes are synced at once
+        const MS_REMOUNT     = libc::MS_REMOUNT,     // Alter flags of a mounted FS
+        const MS_MANDLOCK    = libc::MS_MANDLOCK,    // Allow mandatory locks on a FS
+        const MS_DIRSYNC     = libc::MS_DIRSYNC,     // Directory modifications are synchronous
+        const MS_NOATIME     = libc::MS_NOATIME,     // Do not update access times
+        const MS_NODIRATIME  = libc::MS_NODIRATIME,  // Do not update directory access times
+        const MS_BIND        = libc::MS_BIND,        // Linux 2.4.0 - Bind directory at different place
+        const MS_MOVE        = libc::MS_MOVE,
+        const MS_REC         = libc::MS_REC,
+        const MS_VERBOSE     = 1 << 15,              // Deprecated
+        const MS_SILENT      = libc::MS_SILENT,
+        const MS_POSIXACL    = libc::MS_POSIXACL,
+        const MS_UNBINDABLE  = libc::MS_UNBINDABLE,
+        const MS_PRIVATE     = libc::MS_PRIVATE,
+        const MS_SLAVE       = libc::MS_SLAVE,
+        const MS_SHARED      = libc::MS_SHARED,
+        const MS_RELATIME    = libc::MS_RELATIME,
+        const MS_KERNMOUNT   = libc::MS_KERNMOUNT,
+        const MS_I_VERSION   = libc::MS_I_VERSION,
+        const MS_STRICTATIME = libc::MS_STRICTATIME,
         const MS_NOSEC       = 1 << 28,
         const MS_BORN        = 1 << 29,
-        const MS_ACTIVE      = 1 << 30,
-        const MS_NOUSER      = 1 << 31,
-        const MS_RMT_MASK    = MS_RDONLY.bits
-                              | MS_SYNCHRONOUS.bits
-                              | MS_MANDLOCK.bits
-                              | MS_I_VERSION.bits,
-        const MS_MGC_VAL     = 0xC0ED0000,
-        const MS_MGC_MSK     = 0xffff0000
+        const MS_ACTIVE      = libc::MS_ACTIVE,
+        const MS_NOUSER      = libc::MS_NOUSER,
+        const MS_RMT_MASK    = libc::MS_RMT_MASK,
+        const MS_MGC_VAL     = libc::MS_MGC_VAL,
+        const MS_MGC_MSK     = libc::MS_MGC_MSK,
     }
 );
 
-bitflags!(
+libc_bitflags!(
     pub flags MntFlags: c_int {
-        const MNT_FORCE   = 1 << 0,
-        const MNT_DETACH  = 1 << 1,
-        const MNT_EXPIRE  = 1 << 2
+        MNT_FORCE,
+        MNT_DETACH,
+        MNT_EXPIRE,
     }
 );
 

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -8,21 +8,21 @@ use ::Error;
 bitflags!(
     #[repr(C)]
     pub flags EpollFlags: u32 {
-        const EPOLLIN = 0x001,
-        const EPOLLPRI = 0x002,
-        const EPOLLOUT = 0x004,
-        const EPOLLRDNORM = 0x040,
-        const EPOLLRDBAND = 0x080,
-        const EPOLLWRNORM = 0x100,
-        const EPOLLWRBAND = 0x200,
-        const EPOLLMSG = 0x400,
-        const EPOLLERR = 0x008,
-        const EPOLLHUP = 0x010,
-        const EPOLLRDHUP = 0x2000,
+        const EPOLLIN = libc::EPOLLIN as u32,
+        const EPOLLPRI = libc::EPOLLPRI as u32,
+        const EPOLLOUT = libc::EPOLLOUT as u32,
+        const EPOLLRDNORM = libc::EPOLLRDNORM as u32,
+        const EPOLLRDBAND = libc::EPOLLRDBAND as u32,
+        const EPOLLWRNORM = libc::EPOLLWRNORM as u32,
+        const EPOLLWRBAND = libc::EPOLLWRBAND as u32,
+        const EPOLLMSG = libc::EPOLLMSG as u32,
+        const EPOLLERR = libc::EPOLLERR as u32,
+        const EPOLLHUP = libc::EPOLLHUP as u32,
+        const EPOLLRDHUP = libc::EPOLLRDHUP as u32,
         const EPOLLEXCLUSIVE = 1 << 28,
-        const EPOLLWAKEUP = 1 << 29,
-        const EPOLLONESHOT = 1 << 30,
-        const EPOLLET = 1 << 31
+        const EPOLLWAKEUP = libc::EPOLLWAKEUP as u32,
+        const EPOLLONESHOT = libc::EPOLLONESHOT as u32,
+        const EPOLLET = libc::EPOLLET as u32,
     }
 );
 

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -7,22 +7,22 @@ use ::Error;
 
 bitflags!(
     #[repr(C)]
-    pub flags EpollFlags: u32 {
-        const EPOLLIN = libc::EPOLLIN as u32,
-        const EPOLLPRI = libc::EPOLLPRI as u32,
-        const EPOLLOUT = libc::EPOLLOUT as u32,
-        const EPOLLRDNORM = libc::EPOLLRDNORM as u32,
-        const EPOLLRDBAND = libc::EPOLLRDBAND as u32,
-        const EPOLLWRNORM = libc::EPOLLWRNORM as u32,
-        const EPOLLWRBAND = libc::EPOLLWRBAND as u32,
-        const EPOLLMSG = libc::EPOLLMSG as u32,
-        const EPOLLERR = libc::EPOLLERR as u32,
-        const EPOLLHUP = libc::EPOLLHUP as u32,
-        const EPOLLRDHUP = libc::EPOLLRDHUP as u32,
+    pub flags EpollFlags: libc::c_int {
+        const EPOLLIN = libc::EPOLLIN,
+        const EPOLLPRI = libc::EPOLLPRI,
+        const EPOLLOUT = libc::EPOLLOUT,
+        const EPOLLRDNORM = libc::EPOLLRDNORM,
+        const EPOLLRDBAND = libc::EPOLLRDBAND,
+        const EPOLLWRNORM = libc::EPOLLWRNORM,
+        const EPOLLWRBAND = libc::EPOLLWRBAND,
+        const EPOLLMSG = libc::EPOLLMSG,
+        const EPOLLERR = libc::EPOLLERR,
+        const EPOLLHUP = libc::EPOLLHUP,
+        const EPOLLRDHUP = libc::EPOLLRDHUP,
         const EPOLLEXCLUSIVE = 1 << 28,
-        const EPOLLWAKEUP = libc::EPOLLWAKEUP as u32,
-        const EPOLLONESHOT = libc::EPOLLONESHOT as u32,
-        const EPOLLET = libc::EPOLLET as u32,
+        const EPOLLWAKEUP = libc::EPOLLWAKEUP,
+        const EPOLLONESHOT = libc::EPOLLONESHOT,
+        const EPOLLET = libc::EPOLLET,
     }
 );
 
@@ -48,7 +48,7 @@ pub struct EpollEvent {
 
 impl EpollEvent {
     pub fn new(events: EpollFlags, data: u64) -> Self {
-        EpollEvent { event: libc::epoll_event { events: events.bits(), u64: data } }
+        EpollEvent { event: libc::epoll_event { events: events.bits() as u32, u64: data } }
     }
 
     pub fn empty() -> Self {
@@ -56,7 +56,7 @@ impl EpollEvent {
     }
 
     pub fn events(&self) -> EpollFlags {
-        EpollFlags::from_bits(self.event.events).unwrap()
+        EpollFlags::from_bits(self.event.events as libc::c_int).unwrap()
     }
 
     pub fn data(&self) -> u64 {

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -105,93 +105,93 @@ libc_bitflags!{
     }
 }
 
-bitflags!(
+libc_bitflags!(
     pub flags FilterFlag: u32 {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_ABSOLUTE                        = libc::NOTE_ABSOLUTE,
-        const NOTE_ATTRIB                          = libc::NOTE_ATTRIB,
-        const NOTE_CHILD                           = libc::NOTE_CHILD,
-        const NOTE_DELETE                          = libc::NOTE_DELETE,
+        NOTE_ABSOLUTE,
+        NOTE_ATTRIB,
+        NOTE_CHILD,
+        NOTE_DELETE,
         #[cfg(target_os = "openbsd")]
-        const NOTE_EOF                             = libc::NOTE_EOF,
-        const NOTE_EXEC                            = libc::NOTE_EXEC,
-        const NOTE_EXIT                            = libc::NOTE_EXIT,
+        NOTE_EOF,
+        NOTE_EXEC,
+        NOTE_EXIT,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_EXIT_REPARENTED                 = libc::NOTE_EXIT_REPARENTED,
+        NOTE_EXIT_REPARENTED,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_EXITSTATUS                      = libc::NOTE_EXITSTATUS,
-        const NOTE_EXTEND                          = libc::NOTE_EXTEND,
+        NOTE_EXITSTATUS,
+        NOTE_EXTEND,
         #[cfg(any(target_os = "macos", 
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFAND                           = libc::NOTE_FFAND,
+        NOTE_FFAND,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFCOPY                          = libc::NOTE_FFCOPY,
+        NOTE_FFCOPY,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFCTRLMASK                      = libc::NOTE_FFCTRLMASK,
+        NOTE_FFCTRLMASK,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFLAGSMASK                      = libc::NOTE_FFLAGSMASK,
+        NOTE_FFLAGSMASK,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFNOP                           = libc::NOTE_FFNOP,
+        NOTE_FFNOP,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_FFOR                            = libc::NOTE_FFOR,
-        const NOTE_FORK                            = libc::NOTE_FORK,
-        const NOTE_LINK                            = libc::NOTE_LINK,
-        const NOTE_LOWAT                           = libc::NOTE_LOWAT,
+        NOTE_FFOR,
+        NOTE_FORK,
+        NOTE_LINK,
+        NOTE_LOWAT,
         #[cfg(target_os = "freebsd")]
-        const NOTE_MSECONDS                        = libc::NOTE_MSECONDS,
+        NOTE_MSECONDS,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_NONE                            = libc::NOTE_NONE,
+        NOTE_NONE,
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
-        const NOTE_NSECONDS                        = libc::NOTE_NSECONDS,
+        NOTE_NSECONDS,
         #[cfg(target_os = "dragonfly")]
-        const NOTE_OOB                             = libc::NOTE_OOB,
-        const NOTE_PCTRLMASK                       = libc::NOTE_PCTRLMASK,
-        const NOTE_PDATAMASK                       = libc::NOTE_PDATAMASK,
+        NOTE_OOB,
+        NOTE_PCTRLMASK,
+        NOTE_PDATAMASK,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_REAP                            = libc::NOTE_REAP,
-        const NOTE_RENAME                          = libc::NOTE_RENAME,
-        const NOTE_REVOKE                          = libc::NOTE_REVOKE,
+        NOTE_REAP,
+        NOTE_RENAME,
+        NOTE_REVOKE,
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
-        const NOTE_SECONDS                         = libc::NOTE_SECONDS,
+        NOTE_SECONDS,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_SIGNAL                          = libc::NOTE_SIGNAL,
-        const NOTE_TRACK                           = libc::NOTE_TRACK,
-        const NOTE_TRACKERR                        = libc::NOTE_TRACKERR,
+        NOTE_SIGNAL,
+        NOTE_TRACK,
+        NOTE_TRACKERR,
         #[cfg(any(target_os = "macos",
                   target_os = "ios",
                   target_os = "freebsd",
                   target_os = "dragonfly"))]
-        const NOTE_TRIGGER                         = libc::NOTE_TRIGGER,
+        NOTE_TRIGGER,
         #[cfg(target_os = "openbsd")]
-        const NOTE_TRUNCATE                        = libc::NOTE_TRUNCATE,
+        NOTE_TRUNCATE,
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
-        const NOTE_USECONDS                        = libc::NOTE_USECONDS,
+        NOTE_USECONDS,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_VM_ERROR                        = libc::NOTE_VM_ERROR,
+        NOTE_VM_ERROR,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_VM_PRESSURE                     = libc::NOTE_VM_PRESSURE,
+        NOTE_VM_PRESSURE,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_VM_PRESSURE_SUDDEN_TERMINATE    = libc::NOTE_VM_PRESSURE_SUDDEN_TERMINATE,
+        NOTE_VM_PRESSURE_SUDDEN_TERMINATE,
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        const NOTE_VM_PRESSURE_TERMINATE           = libc::NOTE_VM_PRESSURE_TERMINATE,
-        const NOTE_WRITE                           = libc::NOTE_WRITE,
+        NOTE_VM_PRESSURE_TERMINATE,
+        NOTE_WRITE,
     }
 );
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -23,25 +23,25 @@ libc_bitflags!{
 mod consts {
     use libc::{self, c_int};
 
-    bitflags!{
+    libc_bitflags!{
         pub flags MapFlags: c_int {
-            const MAP_FILE       = libc::MAP_FILE,
-            const MAP_SHARED     = libc::MAP_SHARED,
-            const MAP_PRIVATE    = libc::MAP_PRIVATE,
-            const MAP_FIXED      = libc::MAP_FIXED,
-            const MAP_ANON       = libc::MAP_ANON,
-            const MAP_ANONYMOUS  = libc::MAP_ANON,
+            MAP_FILE,
+            MAP_SHARED,
+            MAP_PRIVATE,
+            MAP_FIXED,
+            MAP_ANON,
+            MAP_ANONYMOUS,
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            const MAP_32BIT      = libc::MAP_32BIT,
-            const MAP_GROWSDOWN  = libc::MAP_GROWSDOWN,
-            const MAP_DENYWRITE  = libc::MAP_DENYWRITE,
-            const MAP_EXECUTABLE = libc::MAP_EXECUTABLE,
-            const MAP_LOCKED     = libc::MAP_LOCKED,
-            const MAP_NORESERVE  = libc::MAP_NORESERVE,
-            const MAP_POPULATE   = libc::MAP_POPULATE,
-            const MAP_NONBLOCK   = libc::MAP_NONBLOCK,
-            const MAP_STACK      = libc::MAP_STACK,
-            const MAP_HUGETLB    = libc::MAP_HUGETLB,
+            MAP_32BIT,
+            MAP_GROWSDOWN,
+            MAP_DENYWRITE,
+            MAP_EXECUTABLE,
+            MAP_LOCKED,
+            MAP_NORESERVE,
+            MAP_POPULATE,
+            MAP_NONBLOCK,
+            MAP_STACK,
+            MAP_HUGETLB,
         }
     }
 
@@ -64,11 +64,11 @@ mod consts {
     pub const MADV_HWPOISON   : MmapAdvise  = 100; /* Poison a page for testing.  */
 
 
-    bitflags!{
+    libc_bitflags!{
         pub flags MsFlags: c_int {
-            const MS_ASYNC      = libc::MS_ASYNC,
-            const MS_INVALIDATE = libc::MS_INVALIDATE,
-            const MS_SYNC       = libc::MS_SYNC,
+            MS_ASYNC,
+            MS_INVALIDATE,
+            MS_SYNC,
         }
     }
 
@@ -80,15 +80,15 @@ mod consts {
 mod consts {
     use libc::{self, c_int};
 
-    bitflags!{
+    libc_bitflags!{
         pub flags MapFlags: c_int {
-            const MAP_FILE    = libc::MAP_FILE,
-            const MAP_SHARED  = libc::MAP_SHARED,
-            const MAP_PRIVATE = libc::MAP_PRIVATE,
-            const MAP_FIXED   = libc::MAP_FIXED,
-            const MAP_ANON    = libc::MAP_ANON,
-            const MAP_NOCACHE = libc::MAP_NOCACHE,
-            const MAP_JIT     = libc::MAP_JIT,
+            MAP_FILE,
+            MAP_SHARED,
+            MAP_PRIVATE,
+            MAP_FIXED,
+            MAP_ANON,
+            MAP_NOCACHE,
+            MAP_JIT,
         }
     }
 
@@ -105,13 +105,13 @@ mod consts {
     pub const MADV_FREE_REUSE : MmapAdvise      = 8; /* caller wants to reuse those pages */
     pub const MADV_CAN_REUSE : MmapAdvise       = 9;
 
-    bitflags!{
+    libc_bitflags!{
         pub flags MsFlags: c_int {
-            const MS_ASYNC      = libc::MS_ASYNC, /* [MF|SIO] return immediately */
-            const MS_INVALIDATE = libc::MS_INVALIDATE, /* [MF|SIO] invalidate all cached data */
-            const MS_KILLPAGES  = libc::MS_KILLPAGES, /* invalidate pages, leave mapped */
-            const MS_DEACTIVATE = libc::MS_DEACTIVATE, /* deactivate pages, leave mapped */
-            const MS_SYNC       = libc::MS_SYNC, /* [MF|SIO] msync synchronously */
+            MS_ASYNC, /* [MF|SIO] return immediately */
+            MS_INVALIDATE, /* [MF|SIO] invalidate all cached data */
+            MS_KILLPAGES, /* invalidate pages, leave mapped */
+            MS_DEACTIVATE, /* deactivate pages, leave mapped */
+            MS_SYNC, /* [MF|SIO] msync synchronously */
         }
     }
 
@@ -122,22 +122,22 @@ mod consts {
 mod consts {
     use libc::{self, c_int};
 
-    bitflags!{
+    libc_bitflags!{
         pub flags MapFlags: c_int {
-            const MAP_FILE         = libc::MAP_FILE,
-            const MAP_SHARED       = libc::MAP_SHARED,
-            const MAP_PRIVATE      = libc::MAP_PRIVATE,
-            const MAP_FIXED        = libc::MAP_FIXED,
-            const MAP_RENAME       = libc::MAP_RENAME,
-            const MAP_NORESERVE    = libc::MAP_NORESERVE,
-            const MAP_HASSEMAPHORE = libc::MAP_HASSEMAPHORE,
+            MAP_FILE,
+            MAP_SHARED,
+            MAP_PRIVATE,
+            MAP_FIXED,
+            MAP_RENAME,
+            MAP_NORESERVE,
+            MAP_HASSEMAPHORE,
             #[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
-            const MAP_STACK        = libc::MAP_STACK,
+            MAP_STACK,
             #[cfg(target_os = "netbsd")]
-            const MAP_WIRED        = libc::MAP_WIRED,
+            MAP_WIRED,
             #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-            const MAP_NOSYNC       = libc::MAP_NOSYNC,
-            const MAP_ANON         = libc::MAP_ANON,
+            MAP_NOSYNC,
+            MAP_ANON,
         }
     }
 

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -7,7 +7,7 @@ use libc::{c_int, c_char};
               target_arch = "arm")),
           )]
 pub mod quota {
-    use libc::c_int;
+    use libc::{self, c_int};
 
     pub struct QuotaCmd(pub QuotaSubCmd, pub QuotaType);
     pub type QuotaSubCmd = c_int;
@@ -39,19 +39,19 @@ pub mod quota {
     pub const QFMT_VFS_V0:	QuotaFmt = 2;
     pub const QFMT_VFS_V1:  QuotaFmt = 4;
 
-    bitflags!(
+    libc_bitflags!(
         #[derive(Default)]
         pub flags QuotaValidFlags: u32 {
-            const QIF_BLIMITS	 = 1,
-            const QIF_SPACE		 = 2,
-            const QIF_ILIMITS	 = 4,
-            const QIF_INODES	 = 8,
-            const QIF_BTIME 	 = 16,
-            const QIF_ITIME 	 = 32,
-            const QIF_LIMITS 	 = QIF_BLIMITS.bits | QIF_ILIMITS.bits,
-            const QIF_USAGE 	 = QIF_SPACE.bits | QIF_INODES.bits,
-            const QIF_TIMES 	 = QIF_BTIME.bits | QIF_ITIME.bits,
-            const QIF_ALL 		 = QIF_LIMITS.bits | QIF_USAGE.bits | QIF_TIMES.bits
+            QIF_BLIMITS,
+            QIF_SPACE,
+            QIF_ILIMITS,
+            QIF_INODES,
+            QIF_BTIME,
+            QIF_ITIME,
+            QIF_LIMITS,
+            QIF_USAGE,
+            QIF_TIMES,
+            QIF_ALL,
         }
     );
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -196,15 +196,15 @@ pub const SIGIOT : Signal = SIGABRT;
 pub const SIGPOLL : Signal = SIGIO;
 pub const SIGUNUSED : Signal = SIGSYS;
 
-bitflags!{
+libc_bitflags!{
     pub flags SaFlags: libc::c_int {
-        const SA_NOCLDSTOP = libc::SA_NOCLDSTOP,
-        const SA_NOCLDWAIT = libc::SA_NOCLDWAIT,
-        const SA_NODEFER   = libc::SA_NODEFER,
-        const SA_ONSTACK   = libc::SA_ONSTACK,
-        const SA_RESETHAND = libc::SA_RESETHAND,
-        const SA_RESTART   = libc::SA_RESTART,
-        const SA_SIGINFO   = libc::SA_SIGINFO,
+        SA_NOCLDSTOP,
+        SA_NOCLDWAIT,
+        SA_NODEFER,
+        SA_ONSTACK,
+        SA_RESETHAND,
+        SA_RESTART,
+        SA_SIGINFO,
     }
 }
 

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -25,10 +25,10 @@ use std::os::unix::io::{RawFd, AsRawFd};
 use std::mem;
 
 
-bitflags!{
+libc_bitflags!{
     pub flags SfdFlags: libc::c_int {
-        const SFD_NONBLOCK  = libc::SFD_NONBLOCK,
-        const SFD_CLOEXEC   = libc::SFD_CLOEXEC,
+        SFD_NONBLOCK,
+        SFD_CLOEXEC,
     }
 }
 

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -16,16 +16,16 @@ mod ffi {
     }
 }
 
-bitflags!(
+libc_bitflags!(
     pub flags SFlag: mode_t {
-        const S_IFIFO = libc::S_IFIFO,
-        const S_IFCHR = libc::S_IFCHR,
-        const S_IFDIR = libc::S_IFDIR,
-        const S_IFBLK = libc::S_IFBLK,
-        const S_IFREG = libc::S_IFREG,
-        const S_IFLNK = libc::S_IFLNK,
-        const S_IFSOCK = libc::S_IFSOCK,
-        const S_IFMT = libc::S_IFMT,
+        S_IFIFO,
+        S_IFCHR,
+        S_IFDIR,
+        S_IFBLK,
+        S_IFREG,
+        S_IFLNK,
+        S_IFSOCK,
+        S_IFMT,
     }
 );
 

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -13,25 +13,25 @@ mod ffi {
 
 #[cfg(not(any(target_os = "linux",
               target_os = "android")))]
-bitflags!(
+libc_bitflags!(
     pub flags WaitPidFlag: c_int {
-        const WNOHANG     = libc::WNOHANG,
-        const WUNTRACED   = libc::WUNTRACED,
+        WNOHANG,
+        WUNTRACED,
     }
 );
 
 #[cfg(any(target_os = "linux",
           target_os = "android"))]
-bitflags!(
+libc_bitflags!(
     pub flags WaitPidFlag: c_int {
-        const WNOHANG     = libc::WNOHANG,
-        const WUNTRACED   = libc::WUNTRACED,
-        const WEXITED     = libc::WEXITED,
-        const WCONTINUED  = libc::WCONTINUED,
-        const WNOWAIT     = libc::WNOWAIT, // Don't reap, just poll status.
-        const __WNOTHREAD = libc::__WNOTHREAD, // Don't wait on children of other threads in this group
-        const __WALL      = libc::__WALL, // Wait on all children, regardless of type
-        const __WCLONE    = libc::__WCLONE,
+        WNOHANG,
+        WUNTRACED,
+        WEXITED,
+        WCONTINUED,
+        WNOWAIT, // Don't reap, just poll status.
+        __WNOTHREAD, // Don't wait on children of other threads in this group
+        __WALL, // Wait on all children, regardless of type
+        __WCLONE,
     }
 );
 


### PR DESCRIPTION
Prefer `libc_bitflags!` over `bitflags!`. Prefer `libc::CONSTANTS` over
writing the constant manually.

This makes #501 unnecessary, since upstream now contains the `O_TMPFILE` constant.