### PR TITLE
Implement major/minor macros, correct mkdev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#491](https://github.com/nix-rust/nix/pull/491))
 - Added `fchdir` in `::nix::unistd`
   ([#497](https://github.com/nix-rust/nix/pull/497))
+- Added `major` and `minor` in `::nix::sys::stat` for decomposing `dev_t`
+  ([#508](https://github.com/nix-rust/nix/pull/508))
 
 ### Changed
 - `epoll_ctl` now could accept None as argument `event`
@@ -89,6 +91,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#429](https://github.com/nix-rust/nix/pull/429))
 - Fixed clone passing a potentially unaligned stack.
   ([#490](https://github.com/nix-rust/nix/pull/490))
+- Fixed mkdev not creating a `dev_t` the same way as libc.
+  ([#508](https://github.com/nix-rust/nix/pull/508))
 
 ## [0.7.0] 2016-09-09
 

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -63,11 +63,23 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
 }
 
 #[cfg(target_os = "linux")]
-const MINORBITS: usize = 20;
+pub fn major(dev: dev_t) -> u64 {
+    ((dev >> 32) & 0xfffff000) |
+    ((dev >>  8) & 0x00000fff)
+}
 
 #[cfg(target_os = "linux")]
-pub fn mkdev(major: u64, minor: u64) -> dev_t {
-    (major << MINORBITS) | minor
+pub fn minor(dev: dev_t) -> u64 {
+    ((dev >> 12) & 0xffffff00) |
+    ((dev      ) & 0x000000ff)
+}
+
+#[cfg(target_os = "linux")]
+pub fn makedev(major: u64, minor: u64) -> dev_t {
+    ((major & 0xfffff000) << 32) |
+    ((major & 0x00000fff) <<  8) |
+    ((minor & 0xffffff00) << 12) |
+    ((minor & 0x000000ff)      )
 }
 
 pub fn umask(mode: Mode) -> Mode {


### PR DESCRIPTION
It appears that the previous `mkdev` was based on the kernel headers (https://github.com/torvalds/linux/blob/v4.7/include/linux/kdev_t.h#L6) which (I guess) is the internal kernel dev_t. Scrolling down the file you can see some bitshifting operations to do conversions.

The new implementation(s) are based on [musl](http://git.musl-libc.org/cgit/musl/tree/include/sys/sysmacros.h?id=dbbb3734d8c0176feabd6c46e2e85bbc3b8a60af) and [glibc](https://github.molgen.mpg.de/git-mirror/glibc/blob/20003c49884422da7ffbc459cdeee768a6fee07b/sysdeps/unix/sysv/linux/sys/sysmacros.h#L38), which are in agreement about how dev_t should be handled.

(as it happens I suspect we could omit the shift by 32 since I don't see that in the kernel headers, but doesn't hurt to take the conservative route and mimic the libcs)