### PR TITLE
Add ppoll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#508](https://github.com/nix-rust/nix/pull/508))
 - Fixed the style of many bitflags and use `libc` in more places.
   ([#503](https://github.com/nix-rust/nix/pull/503))
+- Added `ppoll` in `::nix::poll`
+  ([#520](https://github.com/nix-rust/nix/pull/520))
 
 ### Changed
 - `epoll_ctl` now could accept None as argument `event`

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,3 +1,8 @@
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use sys::time::TimeSpec;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use sys::signal::SigSet;
+
 use libc;
 use {Errno, Result};
 
@@ -45,5 +50,18 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
                    timeout)
     };
 
+    Errno::result(res)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn ppoll(fds: &mut [PollFd], timeout: TimeSpec, sigmask: SigSet) -> Result<libc::c_int> {
+
+
+    let res = unsafe {
+        libc::ppoll(fds.as_mut_ptr() as *mut libc::pollfd,
+                    fds.len() as libc::nfds_t,
+                    timeout.as_ref(),
+                    sigmask.as_ref())
+    };
     Errno::result(res)
 }


### PR DESCRIPTION
This will currently fail CI, as the necessary changes haven't hit libc yet. That is tracked in rust-lang/libc#537. This does build on my computer using the changes tracked on that PR, so I'd appreciate any visual review of this code as it should be "done".

I also wanted to get this submitted so hopefully it'd be in the queue for the 0.8 release.