### PR TITLE
Specify Rust minimum version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ pub unsafe extern fn gethostname(name: *mut c_char, len: size_t) -> c_int;
 pub fn gethostname(name: &mut [u8]) -> Result<()>;
 ```
 
+## Requirements
+Rust >= 1.7.0
+
 ## Usage
 
 To use `nix`, first add this to your `Cargo.toml`:


### PR DESCRIPTION
I think this is important for 2 reasons:

1) Users know if they can use this library
2) Developers know what Rust features they can use in merge requests

What this doesn't do is establish any kind of policy for raising the Rust requirements, which is something  worth addressing in the near-future.