### PR TITLE
Update minimum rust version to 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pub fn gethostname(name: &mut [u8]) -> Result<()>;
 ```
 
 ## Requirements
-Rust >= 1.7.0
+Rust >= 1.9.0
 
 ## Usage
 


### PR DESCRIPTION
This is largely because of features used in `tempfile` from 1.8 and 1.9. This was tested locally, so we'll see what CI says.

This does bring up the issue of the CI testing in the `ci` folder. That specifies the rust version as 1.7.0, but then when I looked at the docker images they seemed to only support 1.10, so maybe someone can comment on whether anything should be done about those things.