### PR TITLE
Remove EPOLLWAKEUP and SIGEV_THREAD_ID when cross-compiling to MIPS.

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -20,6 +20,7 @@ libc_bitflags!(
         EPOLLRDHUP,
         #[cfg(target_os = "linux")]  // Added in 4.5; not in Android.
         EPOLLEXCLUSIVE,
+        #[cfg(not(target_arch = "mips"))]
         EPOLLWAKEUP,
         EPOLLONESHOT,
         EPOLLET,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -467,9 +467,9 @@ impl SigEvent {
             SigevNotify::SigevKevent{..} => libc::SIGEV_KEVENT,
             #[cfg(target_os = "freebsd")]
             SigevNotify::SigevThreadId{..} => libc::SIGEV_THREAD_ID,
-            #[cfg(all(target_os = "linux", target_env = "gnu"))]
+            #[cfg(all(target_os = "linux", target_env = "gnu", not(target_arch = "mips")))]
             SigevNotify::SigevThreadId{..} => libc::SIGEV_THREAD_ID,
-            #[cfg(all(target_os = "linux", target_env = "musl"))]
+            #[cfg(any(all(target_os = "linux", target_env = "musl"), target_arch = "mips"))]
             SigevNotify::SigevThreadId{..} => 4  // No SIGEV_THREAD_ID defined
         };
         sev.sigev_signo = match sigev_notify {


### PR DESCRIPTION
With this nix builds for mipsel-unknown-linux-gnu.