### PR TITLE
fcntl: Expose FcntlArg variants at the module level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   return a `&CStr` within the provided buffer that is always properly
   NUL-terminated (this is not guaranteed by the call with all platforms/libc
   implementations).
+- Exposed all fcntl(2) operations at the module level, so they can be
+  imported direclty instead of via `FcntlArg` enum.
+  ([#541](https://github.com/nix-rust/nix/pull/541))
 
 ### Fixed
 - Fixed multiple issues with Unix domain sockets on non-Linux OSes

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -55,11 +55,10 @@ pub enum FcntlArg<'a> {
 
     // TODO: Rest of flags
 }
+pub use self::FcntlArg::*;
 
 // TODO: Figure out how to handle value fcntl returns
 pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
-    use self::FcntlArg::*;
-
     let res = unsafe {
         match arg {
             F_DUPFD(rawfd) => libc::fcntl(fd, libc::F_DUPFD, rawfd),


### PR DESCRIPTION
This allows importing them directly from `nix::fcntl` which is more
ergonomic than needing to use them via `FcntlArg`.