### PR TITLE
Remove revents from PollFd::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Exposed all fcntl(2) operations at the module level, so they can be
   imported direclty instead of via `FcntlArg` enum.
   ([#541](https://github.com/nix-rust/nix/pull/541))
+- Removed `revents` argument from `PollFd::new()` as it's an output argument and
+  will be overwritten regardless of value.
+  ([#542](https://github.com/nix-rust/nix/pull/542)
 
 ### Fixed
 - Fixed multiple issues with Unix domain sockets on non-Linux OSes

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -13,12 +13,12 @@ pub struct PollFd {
 }
 
 impl PollFd {
-    pub fn new(fd: libc::c_int, events: EventFlags, revents: EventFlags) -> PollFd {
+    pub fn new(fd: libc::c_int, events: EventFlags) -> PollFd {
         PollFd {
             pollfd: libc::pollfd {
                 fd: fd,
                 events: events.bits(),
-                revents: revents.bits(),
+                revents: EventFlags::empty().bits(),
             },
         }
     }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -4,7 +4,7 @@ use nix::unistd::{write, pipe};
 #[test]
 fn test_poll() {
     let (r, w) = pipe().unwrap();
-    let mut fds = [PollFd::new(r, POLLIN, EventFlags::empty())];
+    let mut fds = [PollFd::new(r, POLLIN)];
 
     let nfds = poll(&mut fds, 100).unwrap();
     assert_eq!(nfds, 0);


### PR DESCRIPTION
I could've used a `0i16`here as well but I liked the better semantics of `empty()`.