### PR TITLE
Don't consider 7th bit of signal to calculate signal for Linux platform.

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -81,7 +81,7 @@ mod status {
     }
 
     pub fn stop_signal(status: i32) -> Signal {
-        Signal::from_c_int((status & 0xFF00) >> 8).unwrap()
+        Signal::from_c_int((status & 0x7F00) >> 8).unwrap()
     }
 
     pub fn stop_additional(status: i32) -> c_int {


### PR DESCRIPTION
It's used for PTRACE_O_SYSGOOD, and creates a bad signal if on.