### PR TITLE
Compile on all travis platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   implementations).
 
 ### Fixed
+- Fixed multiple issues compiling under different archetectures and OSes.
+  Now compiles on Linux/MIPS ([#538](https://github.com/nix-rust/nix/pull/538)),
+  `Linux/PPC` ([#553](https://github.com/nix-rust/nix/pull/553)), 
+  `MacOS/x86_64,i686` ([#553](https://github.com/nix-rust/nix/pull/553),
+  and `NetBSD/x64_64` ([#538](https://github.com/nix-rust/nix/pull/538).
 - Fixed multiple issues with Unix domain sockets on non-Linux OSes
   ([#474](https://github.com/nix-rust/nix/pull/415))
 - Fixed using kqueue with `EVFILT_USER` on FreeBSD

--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -420,7 +420,7 @@ mod test {
 
     #[cfg(target_os = "linux")]
     #[test]
-    pub fn test_linux_consts() {
+    pub fn test_general_linux_consts() {
         // TODO Figure out how to test new constants
         check_const!(
             SOL_IP,
@@ -434,16 +434,21 @@ mod test {
             TCP_CORK,
             // SO_BUSY_POLL,
             // SO_RXQ_OVFL,
-            #[cfg(not(target_arch="arm"))]
-            SO_PASSCRED,
             SO_PRIORITY,
             // SO_PROTOCOL,
             SO_RCVBUFFORCE,
             // SO_PEEK_OFF,
-            #[cfg(not(target_arch="arm"))]
-            SO_PEERCRED,
-            #[cfg(not(target_arch="arm"))]
-            SO_SNDBUFFORCE,
             MSG_ERRQUEUE);
     }
+
+    #[cfg(all(target_os = "linux", not(target_arch="arm")))]
+    #[test]
+    pub fn test_linux_not_arm_consts() {
+        // TODO Figure out how to test new constants
+        check_const!(
+            SO_PASSCRED,
+            SO_PEERCRED,
+            SO_SNDBUFFORCE);
+    }
+
 }

--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -434,12 +434,15 @@ mod test {
             TCP_CORK,
             // SO_BUSY_POLL,
             // SO_RXQ_OVFL,
+            #[cfg(not(target_arch="arm"))]
             SO_PASSCRED,
             SO_PRIORITY,
             // SO_PROTOCOL,
             SO_RCVBUFFORCE,
             // SO_PEEK_OFF,
+            #[cfg(not(target_arch="arm"))]
             SO_PEERCRED,
+            #[cfg(not(target_arch="arm"))]
             SO_SNDBUFFORCE,
             MSG_ERRQUEUE);
     }

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -378,7 +378,7 @@ impl<'a> Set<'a, usize> for SetUsize {
 
 #[cfg(test)]
 mod test {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", not(target_arch = "arm")))]
     #[test]
     fn can_get_peercred_on_unix_socket() {
         use super::super::*;

--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -54,6 +54,16 @@ mod arch {
     pub static MEMFD_CREATE: Syscall = 354;
 }
 
+#[cfg(target_arch = "powerpc")]
+mod arch {
+    use libc::c_long;
+
+    pub type Syscall = c_long;
+
+    pub static SYSPIVOTROOT: Syscall = 203;
+    pub static MEMFD_CREATE: Syscall = 360;
+}
+
 extern {
     pub fn syscall(num: Syscall, ...) -> c_int;
 }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -99,7 +99,7 @@ mod ffi {
 
         use libc;
 
-        use libc::{c_int, c_uint, c_ulong, c_uchar};
+        use libc::c_int;
 
         pub type tcflag_t = libc::tcflag_t;
         pub type cc_t = libc::cc_t;


### PR DESCRIPTION
Addresses nix-rust/nix#534

One test failing:

```
failures:

---- sys::test_select::test_select stdout ----

	thread 'sys::test_select::test_select' panicked at 'assertion failed: `(left == right)` (left: `1`, right: `0`)', test/sys/test_select.rs:45

note: Run with `RUST_BACKTRACE=1` for a backtrace.

failures:

    sys::test_select::test_select

test result: FAILED. 57 passed; 1 failed; 0 ignored; 0 measured

error: test failed
```

This failure is consistent.  I suspect it may stem from the `nix` implementation of `fd_set`, but nothing immediate jumps out as a cause.