### PR TITLE
Actually mark mmap and related functions as `unsafe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Marked `sys::mman::{ mmap, munmap, madvise, munlock, msync }` as unsafe.
+  ([#559](https://github.com/nix-rust/nix/pull/559))
+
 ## [0.8.0] 2017-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+<!--### Added-->
+
+### Changed
 - Marked `sys::mman::{ mmap, munmap, madvise, munlock, msync }` as unsafe.
   ([#559](https://github.com/nix-rust/nix/pull/559))
+  
+<!--### Fixed-->
 
 ## [0.8.0] 2017-03-02
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -195,14 +195,14 @@ pub unsafe fn mlock(addr: *const c_void, length: size_t) -> Result<()> {
     Errno::result(ffi::mlock(addr, length)).map(drop)
 }
 
-pub fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
-    Errno::result(unsafe { ffi::munlock(addr, length) }).map(drop)
+pub unsafe fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
+    Errno::result(ffi::munlock(addr, length)).map(drop)
 }
 
 /// Calls to mmap are inherently unsafe, so they must be made in an unsafe block. Typically
 /// a higher-level abstraction will hide the unsafe interactions with the mmap'd region.
-pub fn mmap(addr: *mut c_void, length: size_t, prot: ProtFlags, flags: MapFlags, fd: RawFd, offset: off_t) -> Result<*mut c_void> {
-    let ret = unsafe { ffi::mmap(addr, length, prot.bits(), flags.bits(), fd, offset) };
+pub unsafe fn mmap(addr: *mut c_void, length: size_t, prot: ProtFlags, flags: MapFlags, fd: RawFd, offset: off_t) -> Result<*mut c_void> {
+    let ret = ffi::mmap(addr, length, prot.bits(), flags.bits(), fd, offset);
 
     if ret as isize == MAP_FAILED  {
         Err(Error::Sys(Errno::last()))
@@ -211,16 +211,16 @@ pub fn mmap(addr: *mut c_void, length: size_t, prot: ProtFlags, flags: MapFlags,
     }
 }
 
-pub fn munmap(addr: *mut c_void, len: size_t) -> Result<()> {
-    Errno::result(unsafe { ffi::munmap(addr, len) }).map(drop)
+pub unsafe fn munmap(addr: *mut c_void, len: size_t) -> Result<()> {
+    Errno::result(ffi::munmap(addr, len)).map(drop)
 }
 
-pub fn madvise(addr: *const c_void, length: size_t, advise: MmapAdvise) -> Result<()> {
-    Errno::result(unsafe { ffi::madvise(addr, length, advise) }).map(drop)
+pub unsafe fn madvise(addr: *const c_void, length: size_t, advise: MmapAdvise) -> Result<()> {
+    Errno::result(ffi::madvise(addr, length, advise)).map(drop)
 }
 
-pub fn msync(addr: *const c_void, length: size_t, flags: MsFlags) -> Result<()> {
-    Errno::result(unsafe { ffi::msync(addr, length, flags.bits()) }).map(drop)
+pub unsafe fn msync(addr: *const c_void, length: size_t, flags: MsFlags) -> Result<()> {
+    Errno::result(ffi::msync(addr, length, flags.bits())).map(drop)
 }
 
 pub fn shm_open<P: ?Sized + NixPath>(name: &P, flag: OFlag, mode: Mode) -> Result<RawFd> {


### PR DESCRIPTION
The nix::sys::mman::mmap documentation says

> Calls to mmap are inherently unsafe, so they must be made in an unsafe
block.

however, the function was not actually marked unsafe.

* `munmap` should also be `unsafe` for obvious reasons.
* `madvise` should be `unsafe` because of the `MADV_DONTNEED` flag.
* `mlock` was already marked `unsafe`
* `munlock` and `msync` don't strictly need to be `unsafe` despite
taking pointers AFAICT, but are marked `unsafe` for consistency and in
case they add additional flags in the future.

[breaking-change]