### PR TITLE
Use specific version of libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc" }
+libc = "0.2.21"
 bitflags = "0.7"
 cfg-if = "0.1.0"
 void = "1.0.2"


### PR DESCRIPTION
It should be policy for additional functionality to wait for a `libc` release anyways before `nix` can release, so these should just bump the `libc` dependency version anyways.