### PR TITLE
select.rs FdSet: method `contains' should not mutate anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `revents` argument from `PollFd::new()` as it's an output argument and
   will be overwritten regardless of value.
   ([#542](https://github.com/nix-rust/nix/pull/542))
+- Changed type signature of `sys::select::FdSet::contains` to make `self`
+  immutable ([#564](https://github.com/nix-rust/nix/pull/564))
 
 ### Fixed
 - Fixed multiple issues compiling under different archetectures and OSes.

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -43,7 +43,7 @@ impl FdSet {
         self.bits[fd / BITS] &= !(1 << (fd % BITS));
     }
 
-    pub fn contains(&mut self, fd: RawFd) -> bool {
+    pub fn contains(&self, fd: RawFd) -> bool {
         let fd = fd as usize;
         self.bits[fd / BITS] & (1 << (fd % BITS)) > 0
     }


### PR DESCRIPTION
The method does not change anything, so I updated the type signature. Tests pass.