### PR TITLE
Cargo.toml: restore upstream libc remote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc = { git = "https://github.com/Mic92/libc" }
+libc = { git = "https://github.com/rust-lang/libc" }
 bitflags = "0.7"
 cfg-if = "0.1.0"
 void = "1.0.2"


### PR DESCRIPTION
My previous pull request was merged too early and contained
my own libc fork with outstanding pull requests. As the pull requests
are now merged, this commit restores the libc git repo.