### PR TITLE
Add support for powerpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Marked `sys::mman::{ mmap, munmap, madvise, munlock, msync }` as unsafe.
   ([#559](https://github.com/nix-rust/nix/pull/559))
-  
-<!--### Fixed-->
+
+### Fixed
+- Fixed compilation on powerpc
+  ([#569](https://github.com/nix-rust/nix/pull/569))
 
 ## [0.8.0] 2017-03-02
 

--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -54,6 +54,16 @@ mod arch {
     pub static MEMFD_CREATE: Syscall = 354;
 }
 
+#[cfg(target_arch = "powerpc")]
+mod arch {
+    use libc::c_long;
+
+    pub type Syscall = c_long;
+
+    pub static SYSPIVOTROOT: Syscall = 203;
+    pub static MEMFD_CREATE: Syscall = 360;
+}
+
 extern {
     pub fn syscall(num: Syscall, ...) -> c_int;
 }


### PR DESCRIPTION
Define the architecture-dependent syscall numbers (taken from the
corresponding powerpc's header file). This allows compiling and using
the crate for powerpc targets (like the builtin
powerpc-unknown-linux-gnu).

This should probably fix #534 (as well as my problem).

I'm a bit unsure about the correct way to update the changelog. It seems the entries contain the number of pull request, but how do I get it in advance before sending the pull request?