### PR TITLE
tests should protect concurrent access to signal handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cfg-if = "0.1.0"
 void = "1.0.2"
 
 [dev-dependencies]
+lazy_static = "0.2"
 rand = "0.3.8"
 tempdir = "0.3"
 tempfile = "2"

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate nix;
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate rand;
 extern crate tempdir;


### PR DESCRIPTION
Adds a mutex to protect access to SIGUSR2 signal handlers by the AIO
tests.

Fixes #578