### PR TITLE
readme: Add gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/nix-rust/nix.svg?branch=master)](https://travis-ci.org/nix-rust/nix)
 [![crates.io](http://meritbadge.herokuapp.com/nix)](https://crates.io/crates/nix)
+[![Gitter chat at https://gitter.im/nix-rust/nix](https://badges.gitter.im/nix-rust/nix.svg)](https://gitter.im/nix-rust/nix)
 
 [Documentation (Releases)](https://docs.rs/nix/)
 


### PR DESCRIPTION
I created the `nix-rust` gitter community and a channel for the nix repo. This adds a badge and link to the README.