### PR TITLE
Change sched_setaffinity's PID argument to pid_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#542](https://github.com/nix-rust/nix/pull/542))
 - Changed type signature of `sys::select::FdSet::contains` to make `self`
   immutable ([#564](https://github.com/nix-rust/nix/pull/564))
+- Changed type of `sched::sched_setaffinity`'s `pid` argument to `pid_t`
 
 ### Removed
 - Removed io::Error from nix::Error and conversion from nix::Error to Errno

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -91,9 +91,9 @@ mod ffi {
     }
 }
 
-pub fn sched_setaffinity(pid: isize, cpuset: &CpuSet) -> Result<()> {
+pub fn sched_setaffinity(pid: pid_t, cpuset: &CpuSet) -> Result<()> {
     let res = unsafe {
-        libc::sched_setaffinity(pid as libc::pid_t,
+        libc::sched_setaffinity(pid,
                                 mem::size_of::<CpuSet>() as libc::size_t,
                                 mem::transmute(cpuset))
     };


### PR DESCRIPTION
I might be missing something as to why this argument was made `isize`, but there's nothing obvious from the commit history, and other calls that work with thread IDs in this library return `pid_t`, so hopefully this is a nit and not noise.