### PR TITLE
Add SigAction getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `sys::signal::SigAction::{ flags, mask, handler}`
+  ([#611](https://github.com/nix-rust/nix/pull/609)
 - Added `AioCb::from_boxed_slice`
   ([#582](https://github.com/nix-rust/nix/pull/582)
 - Added `nix::unistd::{openat, fstatat, readlink, readlinkat}`


### PR DESCRIPTION
I want to inspect the old SigAction after installing a new one. This adds getter methods for handler, flags and mask. Returning the old SigAction isn't very useful if we can't read its fields.