### PR TITLE
Added ptrace utilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#556](https://github.com/nix-rust/nix/pull/556)
 - Added `nix::ptr::openpty`
   ([#456](https://github.com/nix-rust/nix/pull/456))
+- Added `nix::ptrace::{ptrace_get_data, ptrace_getsiginfo, ptrace_setsiginfo
+  and nix::Error::UnsupportedOperation}`
+  ([#614](https://github.com/nix-rust/nix/pull/614))
 
 ### Changed
 - Marked `sys::mman::{ mmap, munmap, madvise, munlock, msync }` as unsafe.
@@ -28,6 +31,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#542](https://github.com/nix-rust/nix/pull/542))
 - Changed type signature of `sys::select::FdSet::contains` to make `self`
   immutable ([#564](https://github.com/nix-rust/nix/pull/564))
+
+### Removed
+- Removed io::Error from nix::Error and conversion from nix::Error to Errno
+  ([#614](https://github.com/nix-rust/nix/pull/614))
 
 ### Fixed
 - Fixed multiple issues compiling under different archetectures and OSes.

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -1,5 +1,6 @@
+use std::{mem, ptr};
 use {Errno, Error, Result};
-use libc::{pid_t, c_void, c_long};
+use libc::{pid_t, c_void, c_long, siginfo_t};
 
 #[cfg(all(target_os = "linux",
           any(target_arch = "x86",
@@ -71,11 +72,14 @@ mod ffi {
     }
 }
 
+/// Performs a ptrace request. If the request in question is provided by a specialised function
+/// this function will return an unsupported operation error.
 pub fn ptrace(request: ptrace::PtraceRequest, pid: pid_t, addr: *mut c_void, data: *mut c_void) -> Result<c_long> {
     use self::ptrace::*;
 
     match request {
         PTRACE_PEEKTEXT | PTRACE_PEEKDATA | PTRACE_PEEKUSER => ptrace_peek(request, pid, addr, data),
+        PTRACE_GETSIGINFO | PTRACE_GETEVENTMSG | PTRACE_SETSIGINFO | PTRACE_SETOPTIONS => Err(Error::UnsupportedOperation),
         _ => ptrace_other(request, pid, addr, data)
     }
 }
@@ -91,6 +95,20 @@ fn ptrace_peek(request: ptrace::PtraceRequest, pid: pid_t, addr: *mut c_void, da
     }
 }
 
+/// Function for ptrace requests that return values from the data field. 
+/// Some ptrace get requests populate structs or larger elements than c_long
+/// and therefore use the data field to return values. This function handles these
+/// requests.
+fn ptrace_get_data<T>(request: ptrace::PtraceRequest, pid: pid_t) -> Result<T> {
+    // Creates an uninitialized pointer to store result in 
+    let data: Box<T> = Box::new(unsafe { mem::uninitialized() });
+    let data: *mut c_void = unsafe { mem::transmute(data) };
+    ptrace(request, pid, ptr::null_mut(), data)?;
+    // Convert back into the original data format and return unboxed value
+    let data: Box<T> = unsafe { mem::transmute(data) };
+    Ok(*data)
+}
+
 fn ptrace_other(request: ptrace::PtraceRequest, pid: pid_t, addr: *mut c_void, data: *mut c_void) -> Result<c_long> {
     Errno::result(unsafe { ffi::ptrace(request, pid, addr, data) }).map(|_| 0)
 }
@@ -101,4 +119,29 @@ pub fn ptrace_setoptions(pid: pid_t, options: ptrace::PtraceOptions) -> Result<(
     use std::ptr;
 
     ptrace(PTRACE_SETOPTIONS, pid, ptr::null_mut(), options as *mut c_void).map(drop)
+}
+
+/// Gets a ptrace event as described by `ptrace(PTRACE_GETEVENTMSG,...)`
+pub fn ptrace_getevent(pid: pid_t) -> Result<c_long> {
+    use self::ptrace::*;
+    ptrace_get_data::<c_long>(PTRACE_GETEVENTMSG, pid)
+}
+
+/// Get siginfo as with `ptrace(PTRACE_GETSIGINFO,...)`
+pub fn ptrace_getsiginfo(pid: pid_t) -> Result<siginfo_t> {
+    use self::ptrace::*;
+    ptrace_get_data::<siginfo_t>(PTRACE_GETSIGINFO, pid)
+}
+
+/// Set siginfo as with `ptrace(PTRACE_SETSIGINFO,...)`
+pub fn ptrace_setsiginfo(pid: pid_t, sig: &siginfo_t) -> Result<()> {
+    use self::ptrace::*;
+    let ret = unsafe{
+        Errno::clear();
+        ffi::ptrace(PTRACE_SETSIGINFO, pid, ptr::null_mut(), sig as *const _ as *const c_void)
+    };
+    match Errno::result(ret) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e),
+    }
 }


### PR DESCRIPTION
Some ptrace functions return structures through the data argument. This commit adds utilities to return data through this mechanism and function specialisations for a few of these functions (getting event messages or the siginfo_t struct). Once the next version of libc is released these utilities will be expanded to include the fpregs and user_regs structs.

Due to the need to use unsafe blocks to utilise these ptrace features I feel these are good candidates for inclusion into rust-nix 