### PR TITLE
implement signal BitOr and SigSet::from!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - On Linux and Android, added support for receiving `PTRACE_O_TRACESYSGOOD`
   events from `wait` and `waitpid` using `WaitStatus::PtraceSyscall`
   ([#566](https://github.com/nix-rust/nix/pull/566)).
+- Added `nix::sys::Signal::BitOr<Into<SigSet>>`,
+  `nix::sys::SigSet::BitOr<Into<SigSet>>`, and
+  `nix::sys::SigSet::BitOrAssign<Into<SigSet>>`
+  ([#615](https://github.com/nix-rust/nix/pull/615)
 
 ### Changed
 - Changed `ioctl!(write ...)` into `ioctl!(write_ptr ...)` and `ioctl!(write_int ..)` variants
@@ -57,6 +61,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   "*_buf" variants also now calculate total array size and take slice references for improved type
   safety. The documentation has also been dramatically improved.
   ([#670](https://github.com/nix-rust/nix/pull/670))
+- Added `nix::sys::SigSet::From<Signal>` and refactored some APIs to allow
+  passing `Into<SigSet>` rather than bare `SigSet`s.
+  ([#615](https://github.com/nix-rust/nix/pull/615)
 
 ### Removed
 - Removed `io::Error` from `nix::Error` and the conversion from `nix::Error` to `Errno`

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -54,14 +54,14 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn ppoll(fds: &mut [PollFd], timeout: TimeSpec, sigmask: SigSet) -> Result<libc::c_int> {
+pub fn ppoll<T: Into<SigSet>>(fds: &mut [PollFd], timeout: TimeSpec, sigmask: T) -> Result<libc::c_int> {
 
 
     let res = unsafe {
         libc::ppoll(fds.as_mut_ptr() as *mut libc::pollfd,
                     fds.len() as libc::nfds_t,
                     timeout.as_ref(),
-                    sigmask.as_ref())
+                    sigmask.into().as_ref())
     };
     Errno::result(res)
 }

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -60,10 +60,10 @@ pub fn signalfd<'a, T: Into<&'a SigSet>>(fd: RawFd, mask: T, flags: SfdFlags) ->
 /// # Examples
 ///
 /// ```
-/// # use nix::sys::signalfd::*;
+/// #use nix::sys::signal::*;
+/// #use nix::sys::signalfd::*;
 /// // Set the thread to block the SIGUSR1 signal, otherwise the default handler will be used
-/// let mut mask = SigSet::empty();
-/// mask.add(signal::SIGUSR1);
+/// let mask: SigSet = Signal::SIGUSR1.into();
 /// mask.thread_block().unwrap();
 ///
 /// // Signals are queued up on the file descriptor

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -46,9 +46,9 @@ pub const SIGNALFD_SIGINFO_SIZE: usize = 128;
 /// signalfd (the default handler will be invoked instead).
 ///
 /// See [the signalfd man page for more information](http://man7.org/linux/man-pages/man2/signalfd.2.html)
-pub fn signalfd(fd: RawFd, mask: &SigSet, flags: SfdFlags) -> Result<RawFd> {
+pub fn signalfd<'a, T: Into<&'a SigSet>>(fd: RawFd, mask: T, flags: SfdFlags) -> Result<RawFd> {
     unsafe {
-        Errno::result(libc::signalfd(fd as libc::c_int, mask.as_ref(), flags.bits()))
+        Errno::result(libc::signalfd(fd as libc::c_int, mask.into().as_ref(), flags.bits()))
     }
 }
 

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -8,8 +8,7 @@ fn test_signalfd() {
     let m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Block the SIGUSR1 signal from automatic processing for this thread
-    let mut mask = SigSet::empty();
-    mask.add(signal::SIGUSR1);
+    let mask: SigSet = SigSet::SIGUSR1.into();
     mask.thread_block().unwrap();
 
     let mut fd = SignalFd::new(&mask).unwrap();


### PR DESCRIPTION
This allows for far more idiomatic initialisation of SigSet without
having to declare mut variables, as well as mirroring the vec![]
semantics (though arguably SigSet is closer to a bitfield than a
vector).

    let mut sigset = SigSet::empty();
    sigset.add(Signal::SIGINT);
    // versus
    let sigset = sigset![Signal::SIGINT];

And the BitOr* operations futher make it much easier to idiomatically
work with SigSet and Signal, without having to use sigset![] and
SigSet::extend() everywhere.

    let sigset_a = sigset![Signal::SIGINT];
    let sigset_b = sigset![Signal::SIGTERM];
    let mut sigset = SigSet::empty();
    sigset.extend(&sigset_a);
    sigset.extend(&sigset_b);
    // or
    let sigset = sigset![Signal::SIGINT, Signal::SIGTERM];
    // versus
    let sigset = Signal::SIGINT | Signal::SIGTERM;

Implements #609
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>