### PR TITLE
Integrate the FreeBSD BuildBot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 
     # *BSD
     - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1 # Uses BuildBot instead
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
     # Other architectures

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Tier 1:
   * aarch64-unknown-linux-gnu
   * armv7-unknown-linux-gnueabihf
   * arm-unknown-linux-gnueabi
+  * x86_64-unknown-freebsd
 
 Tier 2:
   * i686-unknown-freebsd
-  * x86_64-unknown-freebsd
   * x86_64-unknown-netbsd
 
 Tier 3:

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
-# Gate on Travis CI
-status = ["continuous-integration/travis-ci/push"]
+# Gate on Travis CI and Buildbot
+status = ["continuous-integration/travis-ci/push",
+          "buildbot/nix-rust/nix fbsd11"]
 
 # Set bors's timeout to 4 hours
 #


### PR DESCRIPTION
* Gate Bors on the FreeBSD 11 build
* Remove the testless FreeBSD build from Travis
* Promote x86_64-unknown-freebsd to Tier 1

Fixes #603