### PR TITLE
Fix sendmsg on macOS when passing a zero entry cmsgs array.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `nix::ptrace` on all Linux-kernel-based platforms
   [#624](https://github.com/nix-rust/nix/pull/624). Previously it was
   only available on x86, x86-64, and ARM, and also not on Android.
+- Fixed `sys::socket::sendmsg` with zero entry `cmsgs` parameter.
+  ([#623](https://github.com/nix-rust/nix/pull/623))
 
 ## [0.8.1] 2017-04-16
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -258,14 +258,12 @@ pub fn sendmsg<'a>(fd: RawFd, iov: &[IoVec<&'a [u8]>], cmsgs: &[ControlMessage<'
         len += cmsg.len();
         capacity += cmsg.space();
     }
-    // Alignment hackery. Note that capacity is guaranteed to be a
-    // multiple of size_t. Note also that the resulting vector claims
-    // to have length == capacity, so it's presently uninitialized.
+    // Note that the resulting vector claims to have length == capacity,
+    // so it's presently uninitialized.
     let mut cmsg_buffer = unsafe {
         let mut vec = Vec::<u8>::with_capacity(len);
-        let ptr = vec.as_mut_ptr();
-        mem::forget(vec);
-        Vec::<u8>::from_raw_parts(ptr as *mut _, len, len)
+        vec.set_len(len);
+        vec
     };
     {
         let mut ptr = &mut cmsg_buffer[..];

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -277,12 +277,18 @@ pub fn sendmsg<'a>(fd: RawFd, iov: &[IoVec<&'a [u8]>], cmsgs: &[ControlMessage<'
         None => (0 as *const _, 0),
     };
 
+    let cmsg_ptr = if capacity > 0 {
+        cmsg_buffer.as_ptr() as *const c_void
+    } else {
+        ptr::null()
+    };
+
     let mhdr = msghdr {
         msg_name: name as *const c_void,
         msg_namelen: namelen,
         msg_iov: iov.as_ptr(),
         msg_iovlen: iov.len() as size_t,
-        msg_control: cmsg_buffer.as_ptr() as *const c_void,
+        msg_control: cmsg_ptr,
         msg_controllen: capacity as size_t,
         msg_flags: 0,
     };


### PR DESCRIPTION
On macOS, trying to call `sendmsg` with a zero entry cmsgs buffer, e.g.:

    sendmsg(fd, [IoVec::from_slice(buf)], &[], MsgFlags::empty(), None)

...fails with `EINVAL`.  This occurs due to the pointer value for zero capacity `Vec`s being 0x1 rather than 0x0, to distinguish allocated-but-zero-size from nullptr.  The [kernel validates](https://github.com/opensource-apple/xnu/blob/dc0628e187c3148723505cf1f1d35bb948d3195b/bsd/kern/uipc_syscalls.c#L1304) both the `msghdr.msg_control` and `msghdr.msg_controllen` fields and rejects `msghdr.msg_control == 0x1` as invalid.

This doesn't show up on Linux because the [kernel validates](https://github.com/torvalds/linux/blob/9705596d08ac87c18aee32cc97f2783b7d14624e/net/core/scm.c#L139) `msghdr.msg_controllen` first and ignores the value of `msghdr.msg_control` if the length was 0.