### PR TITLE
Enable ptrace on all Linux platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `Android` ([#631](https://github.com/nix-rust/nix/pull/631)).
 - `bind` and `errno_location` now work correctly on `Android`
   ([#631](https://github.com/nix-rust/nix/pull/631))
+- Added `nix::ptrace` on all Linux-kernel-based platforms
+  [#624](https://github.com/nix-rust/nix/pull/624). Previously it was
+  only available on x86, x86-64, and ARM, and also not on Android.
 
 ## [0.8.1] 2017-04-16
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -52,11 +52,7 @@ pub mod uio;
 
 pub mod time;
 
-#[cfg(all(target_os = "linux",
-          any(target_arch = "x86",
-              target_arch = "x86_64",
-              target_arch = "arm")),
-          )]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod ptrace;
 
 pub mod select;

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -3,11 +3,6 @@ use {Errno, Error, Result};
 use libc::{c_void, c_long, siginfo_t};
 use ::unistd::Pid;
 
-#[cfg(all(target_os = "linux",
-          any(target_arch = "x86",
-              target_arch = "x86_64",
-              target_arch = "arm")),
-          )]
 pub mod ptrace {
     use libc::c_int;
 

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -13,3 +13,5 @@ mod test_uio;
 #[cfg(target_os = "linux")]
 mod test_epoll;
 mod test_pthread;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod test_ptrace;

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -1,0 +1,14 @@
+use nix::Error;
+use nix::errno::*;
+use nix::unistd::*;
+use nix::sys::ptrace::*;
+use nix::sys::ptrace::ptrace::*;
+use std::ptr;
+
+#[test]
+fn test_ptrace() {
+    // Just make sure ptrace can be called at all, for now.
+    // FIXME: qemu-user doesn't implement ptrace on all arches, so permit ENOSYS
+    let err = ptrace(PTRACE_ATTACH, getpid(), ptr::null_mut(), ptr::null_mut()).unwrap_err();
+    assert!(err == Error::Sys(Errno::EPERM) || err == Error::Sys(Errno::ENOSYS));
+}


### PR DESCRIPTION
Nothing that nix currently binds is architecture-specific, and Android
supports ptrace just as much as non-Android Linux.