### PR TITLE
Use pass by value for write ioctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#614](https://github.com/nix-rust/nix/pull/614))
 
 ### Changed
+- Changed ioctl! write to take argument by value instead as pointer.
+  If you need a pointer as argument, use ioctl! write buf.
+  ([#626](https://github.com/nix-rust/nix/pull/626))
 - Marked `sys::mman::{ mmap, munmap, madvise, munlock, msync }` as unsafe.
   ([#559](https://github.com/nix-rust/nix/pull/559))
 - Minimum supported Rust version is now 1.13

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -158,7 +158,7 @@ macro_rules! ioctl {
         );
     (write $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
         pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                            val: *const $ty)
+                            val: $ty)
                             -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, iow!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::libc::c_ulong, val))
         }


### PR DESCRIPTION
The kernel expects that the values are passed by value and not by pointer for writing ioctls.