### PR TITLE
Make aio, chdir, and wait tests thread safe

### DIFF
--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -8,7 +8,6 @@ use std::io::{Write, Read, Seek, SeekFrom};
 use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::rc::Rc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{thread, time};
 use tempfile::tempfile;
@@ -233,8 +232,6 @@ fn test_write() {
 
 lazy_static! {
     pub static ref SIGNALED: AtomicBool = AtomicBool::new(false);
-    // protects access to SIGUSR2 handlers, not just SIGNALED
-    pub static ref SIGUSR2_MTX: Mutex<()> = Mutex::new(());
 }
 
 extern fn sigfunc(_: c_int) {
@@ -246,7 +243,8 @@ extern fn sigfunc(_: c_int) {
 #[test]
 #[cfg_attr(any(all(target_env = "musl", target_arch = "x86_64"), target_arch = "mips"), ignore)]
 fn test_write_sigev_signal() {
-    let _ = SIGUSR2_MTX.lock().expect("Mutex got poisoned by another test");
+    #[allow(unused_variables)]
+    let m = ::SIGUSR2_MTX.lock().expect("Mutex got poisoned by another test");
     let sa = SigAction::new(SigHandler::Handler(sigfunc),
                             SA_RESETHAND,
                             SigSet::empty());
@@ -376,7 +374,8 @@ fn test_lio_listio_nowait() {
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[cfg_attr(any(target_arch = "mips", target_env = "musl"), ignore)]
 fn test_lio_listio_signal() {
-    let _ = SIGUSR2_MTX.lock().expect("Mutex got poisoned by another test");
+    #[allow(unused_variables)]
+    let m = ::SIGUSR2_MTX.lock().expect("Mutex got poisoned by another test");
     const INITIAL: &'static [u8] = b"abcdef123456";
     const WBUF: &'static [u8] = b"CDEF";
     let rbuf = Rc::new(vec![0; 4].into_boxed_slice());

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -6,6 +6,9 @@ use libc::exit;
 
 #[test]
 fn test_wait_signal() {
+    #[allow(unused_variables)]
+    let m = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");
+
     match fork() {
       Ok(Child) => pause().unwrap_or(()),
       Ok(Parent { child }) => {
@@ -19,6 +22,9 @@ fn test_wait_signal() {
 
 #[test]
 fn test_wait_exit() {
+    #[allow(unused_variables)]
+    let m = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");
+
     match fork() {
       Ok(Child) => unsafe { exit(12); },
       Ok(Parent { child }) => {

--- a/test/test.rs
+++ b/test/test.rs
@@ -25,6 +25,7 @@ mod test_unistd;
 
 use nixtest::assert_size_of;
 use std::os::unix::io::RawFd;
+use std::sync::Mutex;
 use nix::unistd::read;
 
 /// Helper function analogous to std::io::Read::read_exact, but for `RawFD`s
@@ -35,6 +36,17 @@ fn read_exact(f: RawFd, buf: &mut  [u8]) {
         let (_, remaining) = buf.split_at_mut(len);
         len += read(f, remaining).unwrap();
     }
+}
+
+lazy_static! {
+    /// Any test that changes the process's current working directory must grab
+    /// this mutex
+    pub static ref CWD_MTX: Mutex<()> = Mutex::new(());
+    /// Any test that creates child processes must grab this mutex, regardless
+    /// of what it does with those children.
+    pub static ref FORK_MTX: Mutex<()> = Mutex::new(());
+    /// Any test that registers a SIGUSR2 handler must grab this mutex
+    pub static ref SIGUSR2_MTX: Mutex<()> = Mutex::new(());
 }
 
 #[test]

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -16,6 +16,8 @@ use nix::Error::Sys;
 
 #[test]
 fn test_mq_send_and_receive() {
+    #[allow(unused_variables)]
+    let m = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
     const MSG_SIZE: c_long =  32;
     let attr =  MqAttr::new(0, 10, MSG_SIZE, 0);

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -16,45 +16,27 @@ use nix::Error::Sys;
 
 #[test]
 fn test_mq_send_and_receive() {
-    #[allow(unused_variables)]
-    let m = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");
-
     const MSG_SIZE: c_long =  32;
     let attr =  MqAttr::new(0, 10, MSG_SIZE, 0);
-    let mq_name_in_parent = &CString::new(b"/a_nix_test_queue".as_ref()).unwrap();
-    let mqd_in_parent = mq_open(mq_name_in_parent, O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, Some(&attr)).unwrap();
-    let msg_to_send = "msg_1".as_bytes();
+    let mq_name= &CString::new(b"/a_nix_test_queue".as_ref()).unwrap();
 
-    mq_send(mqd_in_parent, msg_to_send, 1).unwrap();
+    let mqd0 = mq_open(mq_name, O_CREAT | O_WRONLY,
+                       S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH,
+                       Some(&attr)).unwrap();
+    let msg_to_send = "msg_1";
+    mq_send(mqd0, msg_to_send.as_bytes(), 1).unwrap();
 
-    let (reader, writer) = pipe().unwrap();
+    let mqd1 = mq_open(mq_name, O_CREAT | O_RDONLY,
+                       S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH,
+                       Some(&attr)).unwrap();
+    let mut buf = [0u8; 32];
+    let mut prio = 0u32;
+    let len = mq_receive(mqd1, &mut buf, &mut prio).unwrap();
+    assert!(prio == 1);
 
-    let pid = fork();
-    match pid {
-        Ok(Child) => {
-            let mq_name_in_child =  &CString::new(b"/a_nix_test_queue".as_ref()).unwrap();
-            let mqd_in_child = mq_open(mq_name_in_child, O_CREAT | O_RDONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, Some(&attr)).unwrap();
-            let mut buf = [0u8; 32];
-            let mut prio = 0u32;
-            mq_receive(mqd_in_child, &mut buf, &mut prio).unwrap();
-            assert!(prio == 1);
-            write(writer, &buf).unwrap();  // pipe result to parent process. Otherwise cargo does not report test failures correctly
-            mq_close(mqd_in_child).unwrap();
-      }
-      Ok(Parent { child }) => {
-          mq_close(mqd_in_parent).unwrap();
-
-          // Wait for the child to exit.
-          waitpid(child, None).unwrap();
-          // Read 1024 bytes.
-          let mut read_buf = [0u8; 32];
-          read(reader, &mut read_buf).unwrap();
-          let message_str = str::from_utf8(&read_buf).unwrap();
-          assert_eq!(&message_str[.. message_str.char_indices().nth(5).unwrap().0], "msg_1");
-      },
-      // panic, fork should never fail unless there is a serious problem with the OS
-      Err(_) => panic!("Error: Fork Failed")
-    }
+    mq_close(mqd1).unwrap();
+    mq_close(mqd0).unwrap();
+    assert_eq!(msg_to_send, str::from_utf8(&buf[0..len]).unwrap());
 }
 
 


### PR DESCRIPTION
Fix thread safety issues in aio, chdir, and wait tests
    
They have four problems:
    
* The chdir tests change the process's cwd, which is global.  Protect them all with a mutex.
    
* The wait tests will reap any subprocess, and several tests create subprocesses.  Protect them all with a mutex so only one subprocess-creating test will run at a time.
    
* When a multithreaded test forks, the child process can sometimes block in the stack unwinding code.  It blocks on a mutex that was held by a different thread in the parent, but that thread doesn't exist in the child, so a deadlock results.  Fix this by immediately calling `std::process:;exit` in the child processes.
    
* My previous attempt at thread safety in the aio tests didn't work, because anonymous MutexGuards drop immediately.  Fix this by naming the SIGUSR2_MTX MutexGuards.

Fixes #251 