### PR TITLE
Add iOS as a Tier 3 platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,23 @@ matrix:
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
       rust: 1.13.0
 
+    # iOS
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
       rust: 1.13.0
@@ -98,6 +115,23 @@ matrix:
       rust: 1.13.0
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
       rust: 1.13.0
+
+    # iOS is still being worked on, so for now don't block on compilation failures
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
 
     # Failures for nightlies may be because of compiler bugs, so don't fail the
     # build if these fail.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ Tier 2:
   * x86_64-unknown-netbsd
 
 Tier 3:
+  * aarch64-apple-ios
   * aarch64-linux-android
   * arm-linux-androideabi
+  * armv7-apple-ios
   * armv7-linux-androideabi
+  * armv7s-apple-ios
+  * i386-apple-ios
   * i686-linux-android
+  * x86_64-apple-ios
   * x86_64-linux-android
 
 ## Usage

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,6 +10,26 @@ main() {
         sort=gsort  # for `sort --sort-version`, from brew's coreutils.
     fi
 
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
     # This fetches latest stable release
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
                        | cut -d/ -f3 \


### PR DESCRIPTION
With this and #639, then we have at least basic testing recurring for all mobile platforms (note that this is more than the `libc` currently tests, so we may have trouble moving the non-x86 targets to Tier2 until that happens).