### PR TITLE
Use single threads for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: required
 env:
   global:
     - CRATE_NAME=nix
-    - CARGO_TEST_THREADS=1
+    - RUST_TEST_THREADS=1
 
 matrix:
   # These are all the build jobs. Adjust as necessary. Comment out what you

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["RUST_TEST_THREADS"]


### PR DESCRIPTION
I actually couldn't find a reference to CARGO_TEST_THREADS in the
current cargo codebase, but RUST_TEST_THREADS is definitely correct.
This should reduce some spurious failures on some platforms.