### PR TITLE
merge socket constants

### DIFF
--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -1,6 +1,5 @@
 pub use self::os::*;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
 mod os {
     use libc::{self, c_int, uint8_t};
 
@@ -8,68 +7,237 @@ mod os {
     pub const AF_LOCAL: c_int = libc::AF_LOCAL;
     pub const AF_INET: c_int  = libc::AF_INET;
     pub const AF_INET6: c_int = libc::AF_INET6;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const AF_NETLINK: c_int = libc::AF_NETLINK;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const AF_PACKET: c_int = libc::AF_PACKET;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub const AF_SYSTEM: c_int = libc::AF_SYSTEM;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub const AF_SYS_CONTROL: c_int = 2;
 
     pub const SOCK_STREAM: c_int = libc::SOCK_STREAM;
     pub const SOCK_DGRAM: c_int = libc::SOCK_DGRAM;
     pub const SOCK_SEQPACKET: c_int = libc::SOCK_SEQPACKET;
     pub const SOCK_RAW: c_int = libc::SOCK_RAW;
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    pub const SOCK_RDM: c_int = libc::SOCK_RDM;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOCK_RDM: c_int = 4;
 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOL_IP: c_int = libc::SOL_IP;
     pub const SOL_SOCKET: c_int = libc::SOL_SOCKET;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOL_TCP: c_int = libc::SOL_TCP;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOL_UDP: c_int = 17;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOL_IPV6: c_int = libc::SOL_IPV6;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SOL_NETLINK: c_int = libc::SOL_NETLINK;
     pub const IPPROTO_IP: c_int = libc::IPPROTO_IP;
     pub const IPPROTO_IPV6: c_int = libc::IPPROTO_IPV6;
     pub const IPPROTO_TCP: c_int = libc::IPPROTO_TCP;
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "dragonfly"))]
     pub const IPPROTO_UDP: c_int = SOL_UDP;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const IPPROTO_UDP: c_int = 17;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub const SYSPROTO_CONTROL: c_int = 2;
 
     pub const SO_ACCEPTCONN: c_int = libc::SO_ACCEPTCONN;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_BINDTODEVICE: c_int = libc::SO_BINDTODEVICE;
     pub const SO_BROADCAST: c_int = libc::SO_BROADCAST;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_BSDCOMPAT: c_int = libc::SO_BSDCOMPAT;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub const SO_BUSY_POLL: c_int = libc::SO_BUSY_POLL;
     pub const SO_DEBUG: c_int = libc::SO_DEBUG;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_DOMAIN: c_int = libc::SO_DOMAIN;
-    pub const SO_ERROR: c_int = libc::SO_ERROR;
     pub const SO_DONTROUTE: c_int = libc::SO_DONTROUTE;
+    #[cfg(not(target_os = "netbsd"))]
+    pub const SO_DONTTRUNC: c_int = 0x2000;
+    pub const SO_ERROR: c_int = libc::SO_ERROR;
     pub const SO_KEEPALIVE: c_int = libc::SO_KEEPALIVE;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_LABEL: c_int = 0x1010;
     pub const SO_LINGER: c_int = libc::SO_LINGER;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_MARK: c_int = libc::SO_MARK;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NREAD: c_int = 0x1020;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NKE: c_int = 0x1021;
+    #[cfg(target_os = "dragonfly")]
+    pub const SO_NOSIGPIPE: c_int = libc::SO_NOSIGPIPE;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NOSIGPIPE: c_int = 0x1022;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NOADDRERR: c_int = 0x1023;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NOTIFYCONFLICT: c_int = 0x1026;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NP_EXTENSIONS: c_int = 0x1083;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_NWRITE: c_int = 0x1024;
     pub const SO_OOBINLINE: c_int = libc::SO_OOBINLINE;
+    #[cfg(target_os = "linux")]
+    pub const SO_ORIGINAL_DST: c_int = 80;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_PASSCRED: c_int = libc::SO_PASSCRED;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_PEEK_OFF: c_int = libc::SO_PEEK_OFF;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_PEERCRED: c_int = libc::SO_PEERCRED;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_PEERLABEL: c_int = 0x1011;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_PRIORITY: c_int = libc::SO_PRIORITY;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_PROTOCOL: c_int = libc::SO_PROTOCOL;
     pub const SO_RCVBUF: c_int = libc::SO_RCVBUF;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_RCVBUFFORCE: c_int = 33;
     pub const SO_RCVLOWAT: c_int = libc::SO_RCVLOWAT;
     pub const SO_SNDLOWAT: c_int = libc::SO_SNDLOWAT;
     pub const SO_RCVTIMEO: c_int = libc::SO_RCVTIMEO;
     pub const SO_SNDTIMEO: c_int = libc::SO_SNDTIMEO;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_RANDOMPORT: c_int = 0x1082;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_RESTRICTIONS: c_int = 0x1081;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_RESTRICT_DENYIN: c_int = 0x00000001;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_RESTRICT_DENYOUT: c_int = 0x00000002;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    #[allow(overflowing_literals)]
+    pub const SO_RESTRICT_DENYSET: c_int = 0x80000000;
     pub const SO_REUSEADDR: c_int = libc::SO_REUSEADDR;
     pub const SO_REUSEPORT: c_int = libc::SO_REUSEPORT;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_REUSESHAREUID: c_int = 0x1025;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_RXQ_OVFL: c_int = libc::SO_RXQ_OVFL;
     pub const SO_SNDBUF: c_int = libc::SO_SNDBUF;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SO_SNDBUFFORCE: c_int = libc::SO_SNDBUFFORCE;
     pub const SO_TIMESTAMP: c_int = libc::SO_TIMESTAMP;
+    #[cfg(not(target_os = "netbsd"))]
+    pub const SO_TIMESTAMP_MONOTONIC: c_int = 0x0800;
     pub const SO_TYPE: c_int = libc::SO_TYPE;
-    pub const SO_BUSY_POLL: c_int = libc::SO_BUSY_POLL;
-    #[cfg(target_os = "linux")]
-    pub const SO_ORIGINAL_DST: c_int = 80;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_USELOOPBACK: c_int = libc::SO_USELOOPBACK;
+    #[cfg(not(target_os = "netbsd"))]
+    pub const SO_WANTMORE: c_int = 0x4000;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const SO_WANTOOBFLAG: c_int = 0x8000;
 
     // Socket options for TCP sockets
     pub const TCP_NODELAY: c_int = libc::TCP_NODELAY;
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "dragonfly"))]
     pub const TCP_MAXSEG: c_int = libc::TCP_MAXSEG;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd"))]
+    pub const TCP_MAXSEG: c_int = 2;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const TCP_CORK: c_int = libc::TCP_CORK;
+    #[cfg(any(target_os = "linux",
+              target_os = "android",
+              target_os = "freebsd",
+              target_os = "dragonfly"))]
     pub const TCP_KEEPIDLE: c_int = libc::TCP_KEEPIDLE;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub const TCP_KEEPALIVE: c_int = libc::TCP_KEEPALIVE;
 
     // Socket options for the IP layer of the socket
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const IP_MULTICAST_IF: c_int = 32;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd",
+              target_os = "dragonfly"))]
+    pub const IP_MULTICAST_IF: c_int = 9;
 
     pub type IpMulticastTtl = uint8_t;
 
@@ -78,8 +246,24 @@ mod os {
     pub const IP_ADD_MEMBERSHIP: c_int = libc::IP_ADD_MEMBERSHIP;
     pub const IP_DROP_MEMBERSHIP: c_int = libc::IP_DROP_MEMBERSHIP;
 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const IPV6_ADD_MEMBERSHIP: c_int = libc::IPV6_ADD_MEMBERSHIP;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const IPV6_DROP_MEMBERSHIP: c_int = libc::IPV6_DROP_MEMBERSHIP;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd",
+              target_os = "dragonfly"))]
+    pub const IPV6_JOIN_GROUP: c_int = libc::IPV6_JOIN_GROUP;
+    #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "openbsd",
+              target_os = "netbsd",
+              target_os = "dragonfly"))]
+    pub const IPV6_LEAVE_GROUP: c_int = libc::IPV6_LEAVE_GROUP;
 
     pub type InAddrT = u32;
 
@@ -93,11 +277,16 @@ mod os {
         pub flags MsgFlags: libc::c_int {
             MSG_OOB,
             MSG_PEEK,
-            MSG_CTRUNC,
-            MSG_TRUNC,
             MSG_DONTWAIT,
+            #[cfg(not(target_os = "dragonfly"))]
+            MSG_CTRUNC,
+            #[cfg(not(target_os = "dragonfly"))]
+            MSG_TRUNC,
+            #[cfg(not(target_os = "dragonfly"))]
             MSG_EOR,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             MSG_ERRQUEUE,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             MSG_CMSG_CLOEXEC,
         }
     }
@@ -108,213 +297,15 @@ mod os {
     pub const SHUT_RDWR: c_int = libc::SHUT_RDWR;
 
     // Ancillary message types
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const SCM_RIGHTS: c_int = libc::SCM_RIGHTS;
-}
-
-// Not all of these constants exist on freebsd
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
-mod os {
     #[cfg(any(target_os = "macos",
+              target_os = "freebsd",
               target_os = "ios",
-              target_os = "freebsd"))]
-    use libc::{self, c_int, uint8_t};
-    #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
-    use libc::{self, c_int, uint8_t};
-
-    pub const AF_UNIX: c_int  = libc::AF_UNIX;
-    pub const AF_LOCAL: c_int = libc::AF_LOCAL;
-    pub const AF_INET: c_int  = libc::AF_INET;
-    pub const AF_INET6: c_int = libc::AF_INET6;
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub const AF_SYSTEM: c_int = libc::AF_SYSTEM;
-
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub const AF_SYS_CONTROL: c_int = 2;
-
-    pub const SOCK_STREAM: c_int = libc::SOCK_STREAM;
-    pub const SOCK_DGRAM: c_int = libc::SOCK_DGRAM;
-    pub const SOCK_SEQPACKET: c_int = libc::SOCK_SEQPACKET;
-    pub const SOCK_RAW: c_int = libc::SOCK_RAW;
-    pub const SOCK_RDM: c_int = libc::SOCK_RDM;
-
-    pub const SOL_SOCKET: c_int = libc::SOL_SOCKET;
-    pub const IPPROTO_IP: c_int = libc::IPPROTO_IP;
-    pub const IPPROTO_IPV6: c_int = libc::IPPROTO_IPV6;
-    pub const IPPROTO_TCP: c_int = libc::IPPROTO_TCP;
-    pub const IPPROTO_UDP: c_int = 17;
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub const SYSPROTO_CONTROL: c_int = 2;
-
-    pub const SO_ACCEPTCONN: c_int          = libc::SO_ACCEPTCONN;
-    pub const SO_BROADCAST: c_int           = libc::SO_BROADCAST;
-    pub const SO_DEBUG: c_int               = libc::SO_DEBUG;
-    #[cfg(not(target_os = "netbsd"))]
-    pub const SO_DONTTRUNC: c_int           = 0x2000;
-    pub const SO_USELOOPBACK: c_int         = libc::SO_USELOOPBACK;
-    pub const SO_ERROR: c_int               = libc::SO_ERROR;
-    pub const SO_DONTROUTE: c_int           = libc::SO_DONTROUTE;
-    pub const SO_KEEPALIVE: c_int           = libc::SO_KEEPALIVE;
-    pub const SO_LABEL: c_int               = 0x1010;
-    pub const SO_LINGER: c_int              = libc::SO_LINGER;
-    pub const SO_NREAD: c_int               = 0x1020;
-    pub const SO_NKE: c_int                 = 0x1021;
-    pub const SO_NOSIGPIPE: c_int           = 0x1022;
-    pub const SO_NOADDRERR: c_int           = 0x1023;
-    pub const SO_NOTIFYCONFLICT: c_int      = 0x1026;
-    pub const SO_NP_EXTENSIONS: c_int       = 0x1083;
-    pub const SO_NWRITE: c_int              = 0x1024;
-    pub const SO_OOBINLINE: c_int           = libc::SO_OOBINLINE;
-    pub const SO_PEERLABEL: c_int           = 0x1011;
-    pub const SO_RCVBUF: c_int              = libc::SO_RCVBUF;
-    pub const SO_RCVLOWAT: c_int            = libc::SO_RCVLOWAT;
-    pub const SO_SNDLOWAT: c_int            = libc::SO_SNDLOWAT;
-    pub const SO_RCVTIMEO: c_int            = libc::SO_RCVTIMEO;
-    pub const SO_SNDTIMEO: c_int            = libc::SO_SNDTIMEO;
-    pub const SO_RANDOMPORT: c_int          = 0x1082;
-    pub const SO_RESTRICTIONS: c_int        = 0x1081;
-    pub const SO_RESTRICT_DENYIN: c_int     = 0x00000001;
-    pub const SO_RESTRICT_DENYOUT: c_int    = 0x00000002;
-    pub const SO_REUSEADDR: c_int           = libc::SO_REUSEADDR;
-    pub const SO_REUSEPORT: c_int           = libc::SO_REUSEPORT;
-    pub const SO_REUSESHAREUID: c_int       = 0x1025;
-    pub const SO_SNDBUF: c_int              = libc::SO_SNDBUF;
-    pub const SO_TIMESTAMP: c_int           = libc::SO_TIMESTAMP;
-    #[cfg(not(target_os = "netbsd"))]
-    pub const SO_TIMESTAMP_MONOTONIC: c_int = 0x0800;
-    pub const SO_TYPE: c_int                = libc::SO_TYPE;
-    #[cfg(not(target_os = "netbsd"))]
-    pub const SO_WANTMORE: c_int            = 0x4000;
-    pub const SO_WANTOOBFLAG: c_int         = 0x8000;
-    #[allow(overflowing_literals)]
-    pub const SO_RESTRICT_DENYSET: c_int    = 0x80000000;
-
-    // Socket options for TCP sockets
-    pub const TCP_NODELAY: c_int = libc::TCP_NODELAY;
-    pub const TCP_MAXSEG: c_int = 2;
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub const TCP_KEEPALIVE: c_int = libc::TCP_KEEPALIVE;
-    #[cfg(target_os = "freebsd")]
-    pub const TCP_KEEPIDLE: c_int = libc::TCP_KEEPIDLE;
-
-    // Socket options for the IP layer of the socket
-    pub const IP_MULTICAST_IF: c_int = 9;
-
-    pub type IpMulticastTtl = uint8_t;
-
-    pub const IP_MULTICAST_TTL: c_int = libc::IP_MULTICAST_TTL;
-    pub const IP_MULTICAST_LOOP: c_int = libc::IP_MULTICAST_LOOP;
-    pub const IP_ADD_MEMBERSHIP: c_int = libc::IP_ADD_MEMBERSHIP;
-    pub const IP_DROP_MEMBERSHIP: c_int = libc::IP_DROP_MEMBERSHIP;
-
-    pub const IPV6_JOIN_GROUP: c_int = libc::IPV6_JOIN_GROUP;
-    pub const IPV6_LEAVE_GROUP: c_int = libc::IPV6_LEAVE_GROUP;
-
-    pub type InAddrT = u32;
-
-    // Declarations of special addresses
-    pub const INADDR_ANY: InAddrT = 0;
-    pub const INADDR_NONE: InAddrT = 0xffffffff;
-    pub const INADDR_BROADCAST: InAddrT = 0xffffffff;
-
-    // Flags for send/recv and their relatives
-    libc_bitflags!{
-        pub flags MsgFlags: libc::c_int {
-            MSG_OOB,
-            MSG_PEEK,
-            MSG_EOR,
-            MSG_TRUNC,
-            MSG_CTRUNC,
-            MSG_DONTWAIT,
-        }
-    }
-
-    // shutdown flags
-    pub const SHUT_RD: c_int = libc::SHUT_RD;
-    pub const SHUT_WR: c_int = libc::SHUT_WR;
-    pub const SHUT_RDWR: c_int = libc::SHUT_RDWR;
-
-    // Ancillary message types
+              target_os = "openbsd",
+              target_os = "netbsd"))]
     pub const SCM_RIGHTS: c_int = 1;
-}
 
-#[cfg(target_os = "dragonfly")]
-mod os {
-    use libc::{c_int, uint8_t};
-
-    pub const AF_UNIX: c_int  = libc::AF_UNIX;
-    pub const AF_LOCAL: c_int = libc::AF_LOCAL;
-    pub const AF_INET: c_int  = libc::AF_INET;
-    pub const AF_INET6: c_int = libc::AF_INET6;
-
-    pub const SOCK_STREAM: c_int = libc::SOCK_STREAM;
-    pub const SOCK_DGRAM: c_int = libc::SOCK_DGRAM;
-    pub const SOCK_SEQPACKET: c_int = libc::SOCK_SEQPACKET;
-    pub const SOCK_RAW: c_int = libc::SOCK_RAW;
-    pub const SOCK_RDM: c_int = libc::SOCK_RDM;
-
-    pub const SOL_SOCKET: c_int = libc::SOL_SOCKET;
-    pub const IPPROTO_IP: c_int = libc::IPPROTO_IP;
-    pub const IPPROTO_IPV6: c_int = libc::IPPROTO_IPV6;
-    pub const IPPROTO_TCP: c_int = libc::IPPROTO_TCP;
-    pub const IPPROTO_UDP: c_int = libc::IPPROTO_UDP;
-
-    pub const SO_ACCEPTCONN: c_int = libc::SO_ACCEPTCONN;
-    pub const SO_BROADCAST: c_int = libc::SO_BROADCAST;
-    pub const SO_DEBUG: c_int = libc::SO_DEBUG;
-    pub const SO_ERROR: c_int = libc::SO_ERROR;
-    pub const SO_DONTROUTE: c_int = libc::SO_DONTROUTE;
-    pub const SO_KEEPALIVE: c_int = libc::SO_KEEPALIVE;
-    pub const SO_LINGER: c_int = libc::SO_LINGER;
-    pub const SO_NOSIGPIPE: c_int = libc::SO_NOSIGPIPE;
-    pub const SO_OOBINLINE: c_int = libc::SO_OOBINLINE;
-    pub const SO_RCVBUF: c_int = libc::SO_RCVBUF;
-    pub const SO_RCVLOWAT: c_int = libc::RCVLOWAT;
-    pub const SO_SNDLOWAT: c_int = libc::SO_SNDLOWAT;
-    pub const SO_RCVTIMEO: c_int = libc::SO_RCVTIMEO;
-    pub const SO_SNDTIMEO: c_int = libc::SO_SNDTIMEO;
-    pub const SO_REUSEADDR: c_int = libc::SO_REUSEADDR;
-    pub const SO_REUSEPORT: c_int = libc::SO_REUSEPORT;
-    pub const SO_SNDBUF: c_int = libc::SO_SNDBUF;
-    pub const SO_TIMESTAMP: c_int = libc::SO_TIMESTAMP;
-    pub const SO_TYPE: c_int = libc::SO_TYPE;
-
-    // Socket options for TCP sockets
-    pub const TCP_NODELAY: c_int = libc::TCP_NODELAY;
-    pub const TCP_MAXSEG: c_int = libc::TCP_MAXSEG;
-    pub const TCP_KEEPIDLE: c_int = libc::TCP_KEEPIDLE;
-
-    // Socket options for the IP layer of the socket
-    pub const IP_MULTICAST_IF: c_int = 9;
-
-    pub type IpMulticastTtl = uint8_t;
-
-    pub const IP_MULTICAST_TTL: c_int = libc::IP_MULTICAST_TTL;
-    pub const IP_MULTICAST_LOOP: c_int = libc::IP_MULTICAST_LOOP;
-    pub const IP_ADD_MEMBERSHIP: c_int = libc::IP_ADD_MEMBERSHIP;
-    pub const IP_DROP_MEMBERSHIP: c_int = libc::IP_DROP_MEMBERSHIP;
-    pub const IPV6_JOIN_GROUP: c_int = libc::IPV6_JOIN_GROUP;
-    pub const IPV6_LEAVE_GROUP: c_int = libc::IPV6_LEAVE_GROUP;
-
-    pub type InAddrT = u32;
-
-    // Declarations of special addresses
-    pub const INADDR_ANY: InAddrT = 0;
-    pub const INADDR_NONE: InAddrT = 0xffffffff;
-    pub const INADDR_BROADCAST: InAddrT = 0xffffffff;
-
-    // Flags for send/recv and their relatives
-    libc_bitflags!{
-        pub flags MsgFlags: libc::c_int {
-            MSG_OOB,
-            MSG_PEEK,
-            MSG_DONTWAIT,
-        }
-    }
-
-    // shutdown flags
-    pub const SHUT_RD: c_int = libc::SHUT_RD;
-    pub const SHUT_WR: c_int = libc::SHUT_WR;
-    pub const SHUT_RDWR: c_int = libc::SHUT_RDWR;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
> Refactor the constant declarations such that all constants are only declared once with a #[cfg] that only enables the constant on the correct platforms.

#637 