### PR TITLE
Improve Wait Documentation

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -7,6 +7,8 @@
 //!
 //! ```rust
 //! use nix::sys::wait::*;
+//! use nix::unistd::Pid;
+//!
 //! let pid = Pid::from_raw(17563);
 //! loop {
 //!     match waitpid(PidGroup::ProcessGroupID(pid), WUNTRACED) {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -7,6 +7,7 @@
 //!
 //! ```rust
 //! use nix::sys::wait::*;
+//! let pid = Pid::from_raw(17563);
 //! loop {
 //!     match waitpid(PidGroup::ProcessGroupID(pid), WUNTRACED) {
 //!         Ok(WaitStatus::Exited(pid, status)) => {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -14,7 +14,7 @@
 //!             break
 //!         },
 //!         Ok(WaitStatus::Stopped(pid, signal)) => {
-//!             println!("Process '{}' stopped with signal '{}'", pid, signal);
+//!             println!("Process '{}' stopped with signal '{:?}'", pid, signal);
 //!         },
 //!         Ok(WaitStatus::Continued(pid)) => {
 //!             println!("Process '{}' continued", pid);

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -48,15 +48,20 @@ libc_bitflags!(
         /// process
         WUNTRACED,
         /// Waits for children that have terminated.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android",
+                  target_os = "freebsd",
+                  target_os = "linux",
+                  target_os = "netbsd"))]
         WEXITED,
         /// Report the status of any continued child process specified by pid whose status has not
         /// been reported since it continued from a job control stop.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         WCONTINUED,
         /// Leave the child in a waitable state; a later wait call can be used to again retrieve
         /// the child status information.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android",
+                  target_os = "freebsd",
+                  target_os = "linux",
+                  target_os = "netbsd"))]
         WNOWAIT,
         /// Don't wait on children of other threads in this group
         #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -1,3 +1,5 @@
+//! This module contains the `wait()` and `waitpid()` functions, which are used
+
 use libc::{self, c_int};
 use {Errno, Result};
 use unistd::Pid;
@@ -14,40 +16,33 @@ libc_bitflags!(
         /// has not yet been reported since they stopped, shall also be reported to the requesting
         /// process
         WUNTRACED,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Waits for children that have terminated.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         WEXITED,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Report the status of any continued child process specified by pid whose status has not
         /// been reported since it continued from a job control stop.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         WCONTINUED,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Leave the child in a waitable state; a later wait call can be used to again retrieve
         /// the child status information.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         WNOWAIT,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Don't wait on children of other threads in this group
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         __WNOTHREAD,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Wait for all children, regardless of type (clone or non-clone)
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         __WALL,
-        #[cfg(any(target_os = "linux",
-                  target_os = "android"))]
         /// Wait for "clone" children only. If omitted then wait for "non-clone" children only.
         /// (A "clone" child is one which delivers no signal, or a signal other than `SIGCHLD` to
         /// its parent upon termination.) This option is ignored if `__WALL` is also specified.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         __WCLONE,
 
     }
 );
 
-#[cfg(any(target_os = "linux",
-          target_os = "android"))]
+#[cfg(any(target_os = "linux",target_os = "android"))]
 const WSTOPPED: WaitPidFlag = WUNTRACED;
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
@@ -61,18 +56,17 @@ pub enum WaitStatus {
     /// Signifies that the process was stopped by a signal, providing the PID and associated
     /// signal.
     Stopped(Pid, Signal),
-    #[cfg(any(target_os = "linux", target_os = "android"))]
     /// Signifies that the process was stopped due to a ptrace event, providing the PID, the
     /// associated signal, and an integer that represents the status of the event.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     PtraceEvent(Pid, Signal, c_int),
     /// Signifies that the process received a `SIGCONT` signal, and thus continued.
     Continued(Pid),
-    /// if `WNOHANG` was set, this value is returned when no children have changed state.
+    /// If `WNOHANG` was set, this value is returned when no children have changed state.
     StillAlive
 }
 
-#[cfg(any(target_os = "linux",
-          target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod status {
     use sys::signal::Signal;
     use libc::c_int;
@@ -114,8 +108,7 @@ mod status {
     }
 }
 
-#[cfg(any(target_os = "macos",
-          target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod status {
     use sys::signal::{Signal,SIGCONT};
 
@@ -236,9 +229,9 @@ fn decode(pid : Pid, status: i32) -> WaitStatus {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 /// Designates whether the supplied `Pid` value is a process ID, process group ID,
 /// specifies any child of the current process's group ID, or any child of the current process.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PidGroup {
     ProcessID(u32),
     ProcessGroupID(u32),

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -1,9 +1,12 @@
-//! This module contains the `wait()` and `waitpid()` functions, which are used to wait on and
-//! obtain status information from child processes. These provide more granular control over
-//! child management than the primitives provided by Rust's standard library, and are critical
-//! in the creation of shells and managing jobs on *nix platforms.
+//! This module contains the `wait()` and `waitpid()` functions.
 //!
-//! # Example
+//! These are used to wait on and obtain status information from child processes, which provide
+//! more granular control over child management than the primitives provided by Rust's standard
+//! library, and are critical in the creation of shells and managing jobs on *nix platforms.
+//!
+//! Manual Page: http://pubs.opengroup.org/onlinepubs/007908799/xsh/wait.html
+//!
+//! # Examples
 //!
 //! ```rust
 //! use nix::sys::wait::*;
@@ -291,8 +294,10 @@ impl From<i32> for PidGroup {
     }
 }
 
-/// Waits for and returns events that are received from the given supplied process or process group
-/// ID, and associated options.
+/// Waits for and returns events that are received, with additional options.
+///
+/// The `pid` value may indicate either a process group ID, or process ID. The options
+/// parameter controls the behavior of the function.
 ///
 /// # Usage Notes
 ///
@@ -305,9 +310,7 @@ impl From<i32> for PidGroup {
 /// - If the value of the PID is `PidGroup::AnyChild`, it will wait on any child process of the
 ///   current process.
 ///
-/// # Possible Error Values
-///
-/// If this function returns an error, the error value will be one of the following:
+/// # Errors
 ///
 /// - **ECHILD**: The process does not exist or is not a child of the current process.
 ///   - This may also happen if a child process has the `SIGCHLD` signal masked or set to
@@ -338,8 +341,16 @@ pub fn waitpid<O>(pid: PidGroup, options: O) -> Result<WaitStatus>
     })
 }
 
-/// Waits on any child of the current process, returning on events that change the status of
-/// of that child. It is directly equivalent to `waitpid(PidGroup::AnyChild, None)`.
+/// Waits for and returns events from any child of the current process.
+///
+/// While waiting on the child, this function will return on events that indicate that the status
+/// of that child has changed. It is directly equivalent to `waitpid(PidGroup::AnyChild, None)`.
+///
+/// # Errors
+///
+/// - **ECHILD**: The process does not exist or is not a child of the current process.
+///   - This may also happen if a child process has the `SIGCHLD` signal masked or set to
+///     `SIG_IGN`.
 pub fn wait() -> Result<WaitStatus> {
     waitpid(PidGroup::AnyChild, None)
 }

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -10,18 +10,18 @@
 //! loop {
 //!     match waitpid(PidGroup::ProcessGroupID(pid), WUNTRACED) {
 //!         Ok(WaitStatus::Exited(pid, status)) => {
-//!             eprintln!("Process '{}' exited with status '{}'", pid, status);
+//!             println!("Process '{}' exited with status '{}'", pid, status);
 //!             break
 //!         },
 //!         Ok(WaitStatus::Stopped(pid, signal)) => {
-//!             eprintln!("Process '{}' stopped with signal '{}'", pid, signal);
+//!             println!("Process '{}' stopped with signal '{}'", pid, signal);
 //!         },
 //!         Ok(WaitStatus::Continued(pid)) => {
-//!             eprintln!("Process '{}' continued", pid);
+//!             println!("Process '{}' continued", pid);
 //!         },
 //!         Ok(_) => (),
 //!         Err(why) => {
-//!             eprintln!("waitpid returned an error code: {}" why);
+//!             println!("waitpid returned an error code: {}" why);
 //!             break
 //!         }
 //!     }
@@ -319,16 +319,16 @@ pub fn waitpid<O>(pid: PidGroup, options: O) -> Result<WaitStatus>
 
     let pid = match pid {
         PidGroup::ProcessID(pid) if pid < Pid::from_raw(-1)      => -pid_t::from(pid),
-        PidGroup::ProcessGroupID(pid) if pid > Pid::from_raw(0)  => -pid_t::from(pid),
+        PidGroup::ProcessGroupID(pid) if pid > Pid::from_raw(0) => -pid_t::from(pid),
         PidGroup::ProcessID(pid) | PidGroup::ProcessGroupID(pid) => pid_t::from(pid),
         PidGroup::AnyGroupChild => 0,
-        PidGroup::AnyChild      => -1,
+        PidGroup::AnyChild => -1,
     };
 
     let res = unsafe { libc::waitpid(pid.into(), &mut status as *mut c_int, options) };
 
     Errno::result(res).map(|res| match res {
-        0   => StillAlive,
+        0 => StillAlive,
         res => decode(Pid::from_raw(res), status),
     })
 }

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -70,9 +70,6 @@ libc_bitflags!(
     }
 );
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-const WSTOPPED: WaitPidFlag = WUNTRACED;
-
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 /// Contains the status returned by the `wait` and `waitpid` functions.
 pub enum WaitStatus {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -21,7 +21,7 @@
 //!         },
 //!         Ok(_) => (),
 //!         Err(why) => {
-//!             println!("waitpid returned an error code: {}" why);
+//!             println!("waitpid returned an error code: {}", why);
 //!             break
 //!         }
 //!     }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Gid {
 ///
 /// Newtype pattern around `pid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, PartialOrd)]
 pub struct Pid(pid_t);
 
 impl Pid {
@@ -236,6 +236,7 @@ pub fn setpgid(pid: Pid, pgid: Pid) -> Result<()> {
     let res = unsafe { libc::setpgid(pid.into(), pgid.into()) };
     Errno::result(res).map(drop)
 }
+
 #[inline]
 pub fn getpgid(pid: Option<Pid>) -> Result<Pid> {
     let res = unsafe { libc::getpgid(pid.unwrap_or(Pid(0)).into()) };

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -13,7 +13,7 @@ fn test_wait_signal() {
       Ok(Child) => pause().unwrap_or(()),
       Ok(Parent { child }) => {
           kill(child, Some(SIGKILL)).ok().expect("Error: Kill Failed");
-          assert_eq!(waitpid(child.into(), None), Ok(WaitStatus::Signaled(child, SIGKILL, false)));
+          assert_eq!(waitpid(PidGroup::ProcessID(child), None), Ok(WaitStatus::Signaled(child, SIGKILL, false)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")
@@ -28,7 +28,7 @@ fn test_wait_exit() {
     match fork() {
       Ok(Child) => unsafe { exit(12); },
       Ok(Parent { child }) => {
-          assert_eq!(waitpid(child.into(), None), Ok(WaitStatus::Exited(child, 12)));
+          assert_eq!(waitpid(PidGroup::ProcessID(child), None), Ok(WaitStatus::Exited(child, 12)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -13,7 +13,7 @@ fn test_wait_signal() {
       Ok(Child) => pause().unwrap_or(()),
       Ok(Parent { child }) => {
           kill(child, Some(SIGKILL)).ok().expect("Error: Kill Failed");
-          assert_eq!(waitpid(child, None), Ok(WaitStatus::Signaled(child, SIGKILL, false)));
+          assert_eq!(waitpid(child.into(), None), Ok(WaitStatus::Signaled(child, SIGKILL, false)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")
@@ -28,7 +28,7 @@ fn test_wait_exit() {
     match fork() {
       Ok(Child) => unsafe { exit(12); },
       Ok(Parent { child }) => {
-          assert_eq!(waitpid(child, None), Ok(WaitStatus::Exited(child, 12)));
+          assert_eq!(waitpid(child.into(), None), Ok(WaitStatus::Exited(child, 12)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -25,7 +25,7 @@ fn test_fork_and_waitpid() {
             // assert that child was created and pid > 0
             let child_raw: ::libc::pid_t = child.into();
             assert!(child_raw > 0);
-            let wait_status = waitpid(child, None);
+            let wait_status = waitpid(child.into(), None);
             match wait_status {
                 // assert that waitpid returned correct status and the pid is the one of the child
                 Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child),
@@ -135,7 +135,7 @@ macro_rules! execve_test_factory(
             },
             Parent { child } => {
                 // Wait for the child to exit.
-                waitpid(child, None).unwrap();
+                waitpid(child.into(), None).unwrap();
                 // Read 1024 bytes.
                 let mut buf = [0u8; 1024];
                 read(reader, &mut buf).unwrap();

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -25,7 +25,7 @@ fn test_fork_and_waitpid() {
             // assert that child was created and pid > 0
             let child_raw: ::libc::pid_t = child.into();
             assert!(child_raw > 0);
-            let wait_status = waitpid(child.into(), None);
+            let wait_status = waitpid(PidGroup::ProcessID(child), None);
             match wait_status {
                 // assert that waitpid returned correct status and the pid is the one of the child
                 Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child),
@@ -135,7 +135,7 @@ macro_rules! execve_test_factory(
             },
             Parent { child } => {
                 // Wait for the child to exit.
-                waitpid(child.into(), None).unwrap();
+                waitpid(PidGroup::ProcessID(child), None).unwrap();
                 // Read 1024 bytes.
                 let mut buf = [0u8; 1024];
                 read(reader, &mut buf).unwrap();


### PR DESCRIPTION
As the title states, improves the documentation for the wait module by providing documentation where there is currently no documentation. Also, changed the signature of `waitpid` to do as the PID parameter currently does (`Into<Option<T>>`), so that you don't have to always type `Some` every time you want to supply a flag -- but you can still provide a `None` value.

Closes #643.