### PR TITLE
Fix double close bugs in test_lseek and test_lseek64

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -24,6 +24,18 @@ mod test_stat;
 mod test_unistd;
 
 use nixtest::assert_size_of;
+use std::os::unix::io::RawFd;
+use nix::unistd::read;
+
+/// Helper function analogous to std::io::Read::read_exact, but for `RawFD`s
+fn read_exact(f: RawFd, buf: &mut  [u8]) {
+    let mut len = 0;
+    while len < buf.len() {
+        // get_mut would be better than split_at_mut, but it requires nightly
+        let (_, remaining) = buf.split_at_mut(len);
+        len += read(f, remaining).unwrap();
+    }
+}
 
 #[test]
 pub fn test_size_of_long() {

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -5,17 +5,7 @@ use nix::fcntl::{O_RDWR, open};
 use nix::pty::*;
 use nix::sys::stat;
 use nix::sys::termios::*;
-use nix::unistd::{read, write, close};
-
-/// Helper function analogous to std::io::Read::read_exact, but for `RawFD`s
-fn read_exact(f: RawFd, buf: &mut  [u8]) {
-    let mut len = 0;
-    while len < buf.len() {
-        // get_mut would be better than split_at_mut, but it requires nightly
-        let (_, remaining) = buf.split_at_mut(len);
-        len += read(f, remaining).unwrap();
-    }
-}
+use nix::unistd::{write, close};
 
 /// Test equivalence of `ptsname` and `ptsname_r`
 #[test]
@@ -115,21 +105,21 @@ fn test_openpty() {
     let string = "foofoofoo\n";
     let mut buf = [0u8; 10];
     write(pty.master, string.as_bytes()).unwrap();
-    read_exact(pty.slave, &mut buf);
+    ::read_exact(pty.slave, &mut buf);
 
     assert_eq!(&buf, string.as_bytes());
 
     // Read the echo as well
     let echoed_string = "foofoofoo\r\n";
     let mut buf = [0u8; 11];
-    read_exact(pty.master, &mut buf);
+    ::read_exact(pty.master, &mut buf);
     assert_eq!(&buf, echoed_string.as_bytes());
 
     let string2 = "barbarbarbar\n";
     let echoed_string2 = "barbarbarbar\r\n";
     let mut buf = [0u8; 14];
     write(pty.slave, string2.as_bytes()).unwrap();
-    read_exact(pty.master, &mut buf);
+    ::read_exact(pty.master, &mut buf);
 
     assert_eq!(&buf, echoed_string2.as_bytes());
 
@@ -160,20 +150,20 @@ fn test_openpty_with_termios() {
     let string = "foofoofoo\n";
     let mut buf = [0u8; 10];
     write(pty.master, string.as_bytes()).unwrap();
-    read_exact(pty.slave, &mut buf);
+    ::read_exact(pty.slave, &mut buf);
 
     assert_eq!(&buf, string.as_bytes());
 
     // read the echo as well
     let echoed_string = "foofoofoo\n";
-    read_exact(pty.master, &mut buf);
+    ::read_exact(pty.master, &mut buf);
     assert_eq!(&buf, echoed_string.as_bytes());
 
     let string2 = "barbarbarbar\n";
     let echoed_string2 = "barbarbarbar\n";
     let mut buf = [0u8; 13];
     write(pty.slave, string2.as_bytes()).unwrap();
-    read_exact(pty.master, &mut buf);
+    ::read_exact(pty.master, &mut buf);
 
     assert_eq!(&buf, echoed_string2.as_bytes());
 


### PR DESCRIPTION
std::fs::File closes the underlying file descriptor on Drop, without
checking for errors.  test_lseek and test_lseek64 also manually close
the file descriptor.  That works for single threaded test runs.  But for
multithreaded runs, it causes EBADF errors in other tests.  Fix the
tests by consuming the File with into_raw_fd(), so its drop method will
never be called.