### PR TITLE
Fix tier3s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     - env: TARGET=arm-unknown-linux-gnueabi
       rust: 1.13.0
     - env: TARGET=arm-unknown-linux-musleabi
-      rust: 1.13.0
+      rust: 1.14.0
     - env: TARGET=armv7-unknown-linux-gnueabihf
       rust: 1.13.0
     - env: TARGET=i686-unknown-linux-gnu
@@ -131,7 +131,7 @@ matrix:
     - env: TARGET=mips64el-unknown-linux-gnuabi64
       rust: 1.13.0
     - env: TARGET=arm-unknown-linux-musleabi
-      rust: 1.13.0
+      rust: 1.14.0
     - env: TARGET=s390x-unknown-linux-gnu
       rust: 1.13.0
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Tier 2:
 
 Tier 3:
   * aarch64-apple-ios
-  * arm-unknown-linux-musleabi
+  * arm-unknown-linux-musleabi (requires Rust >= 1.14)
   * armv7-apple-ios
   * armv7s-apple-ios
   * i386-apple-ios

--- a/src/sys/ioctl/platform/linux.rs
+++ b/src/sys/ioctl/platform/linux.rs
@@ -1,7 +1,7 @@
 pub const NRBITS: u32 = 8;
 pub const TYPEBITS: u32 = 8;
 
-#[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "powerpc64"))]
+#[cfg(any(target_arch = "mips", target_arch = "mips64", target_arch = "powerpc", target_arch = "powerpc64"))]
 mod consts {
     pub const NONE: u8 = 1;
     pub const READ: u8 = 2;
@@ -12,16 +12,19 @@ mod consts {
 
 #[cfg(not(any(target_arch = "powerpc",
               target_arch = "mips",
+              target_arch = "mips64",
               target_arch = "x86",
               target_arch = "arm",
               target_arch = "x86_64",
               target_arch = "powerpc64",
+              target_arch = "s390x",
               target_arch = "aarch64")))]
 use this_arch_not_supported;
 
 // "Generic" ioctl protocol
 #[cfg(any(target_arch = "x86",
           target_arch = "arm",
+          target_arch = "s390x",
           target_arch = "x86_64",
           target_arch = "aarch64"))]
 mod consts {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -32,7 +32,7 @@ pub enum Signal {
     SIGPIPE = libc::SIGPIPE,
     SIGALRM = libc::SIGALRM,
     SIGTERM = libc::SIGTERM,
-    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(target_arch = "mips")))]
+    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64"))))]
     SIGSTKFLT = libc::SIGSTKFLT,
     SIGCHLD = libc::SIGCHLD,
     SIGCONT = libc::SIGCONT,
@@ -58,7 +58,7 @@ pub enum Signal {
 
 pub use self::Signal::*;
 
-#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(target_arch = "mips")))]
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64"))))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -91,7 +91,7 @@ const SIGNALS: [Signal; 31] = [
     SIGIO,
     SIGPWR,
     SIGSYS];
-#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), target_arch = "mips"))]
+#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), any(target_arch = "mips", target_arch = "mips64")))]
 const SIGNALS: [Signal; 30] = [
     SIGHUP,
     SIGINT,

--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -44,6 +44,7 @@ mod arch {
     pub static MEMFD_CREATE: Syscall = 385;
 }
 
+// Rust on mips uses the N32 ABI
 #[cfg(target_arch = "mips")]
 mod arch {
     use libc::c_long;
@@ -52,6 +53,17 @@ mod arch {
 
     pub static SYSPIVOTROOT: Syscall = 216;
     pub static MEMFD_CREATE: Syscall = 354;
+}
+
+// Rust on mips64 uses the N64 ABI
+#[cfg(target_arch = "mips64")]
+mod arch {
+    use libc::c_long;
+
+    pub type Syscall = c_long;
+
+    pub static SYSPIVOTROOT: Syscall = 151;
+    pub static MEMFD_CREATE: Syscall = 314;
 }
 
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]

--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -64,6 +64,16 @@ mod arch {
     pub static MEMFD_CREATE: Syscall = 360;
 }
 
+#[cfg(target_arch = "s390x")]
+mod arch {
+    use libc::c_long;
+
+    pub type Syscall = c_long;
+
+    pub static SYSPIVOTROOT: Syscall = 217;
+    pub static MEMFD_CREATE: Syscall = 350;
+}
+
 extern {
     pub fn syscall(num: Syscall, ...) -> c_int;
 }


### PR DESCRIPTION
This handles the low-hanging fruit. rust-lang/libc#654 needs to land and there's a bit of work necessary for the syscall and ioctl errors.