### PR TITLE
Add support for SO_TIMESTAMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#739](https://github.com/nix-rust/nix/pull/739))
 - Added nix::sys::ptrace::detach. 
   ([#749](https://github.com/nix-rust/nix/pull/749))
+- Added timestamp socket control message variant:
+  `nix::sys::socket::ControlMessage::ScmTimestamp`
+  ([#663](https://github.com/nix-rust/nix/pull/663))
+- Added socket option variant that enables the timestamp socket
+  control message: `nix::sys::socket::sockopt::ReceiveTimestamp`
+  ([#663](https://github.com/nix-rust/nix/pull/663))
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -171,6 +171,7 @@ sockopt_impl!(GetOnly, SockType, libc::SOL_SOCKET, libc::SO_TYPE, super::SockTyp
 sockopt_impl!(GetOnly, AcceptConn, libc::SOL_SOCKET, libc::SO_ACCEPTCONN, bool);
 #[cfg(any(target_os = "linux", target_os = "android"))]
 sockopt_impl!(GetOnly, OriginalDst, libc::SOL_IP, libc::SO_ORIGINAL_DST, libc::sockaddr_in);
+sockopt_impl!(Both, ReceiveTimestamp, libc::SOL_SOCKET, libc::SO_TIMESTAMP, bool);
 
 /*
  *


### PR DESCRIPTION
This was implemented as part of my employment, and I have received permission to submit it upstream under my own name.

I implemented this with a bit of copy+pasting from the SCM_RIGHTS implementation, and it appeared to be functional when originally implemented on top of 13deb619c3e0bdf490511cedd848e60633ca3b2d (tagged v0.8.0).