### PR TITLE
Add waitpid flags for *BSD operating systems

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -13,9 +13,48 @@ mod ffi {
 }
 
 #[cfg(not(any(target_os = "linux",
-              target_os = "android")))]
+              target_os = "android",
+              target_os = "openbsd",
+              target_os = "bitrig",
+              target_os = "dragonfly",
+              target_os = "netbsd",
+              target_os = "freebsd")))]
 libc_bitflags!(
     pub flags WaitPidFlag: c_int {
+        WNOHANG,
+        WUNTRACED,
+    }
+);
+
+#[cfg(target_os = "freebsd")]
+libc_bitflags!(
+    pub flags WaitPidFlag: c_int {
+        WCONTINUED,
+        WNOHANG,
+        WUNTRACED,
+        WTRAPPED,
+        WEXITED,
+        WNOWAIT,
+    }
+);
+
+#[cfg(target_os = "netbsd")]
+libc_bitflags!(
+    pub flags WaitPidFlag: c_int {
+        WCONTINUED,
+        WEXITED,
+        WNOHANG,
+        WNOWAIT,
+        WUNTRACED,
+    }
+);
+
+#[cfg(any(target_os = "openbsd",
+          target_os = "bitrig",
+          target_os = "dragonfly"))]
+libc_bitflags!(
+    pub flags WaitPidFlag: c_int {
+        WCONTINUED,
         WNOHANG,
         WUNTRACED,
     }
@@ -37,7 +76,9 @@ libc_bitflags!(
 );
 
 #[cfg(any(target_os = "linux",
-          target_os = "android"))]
+          target_os = "android",
+          target_os = "netbsd",
+          target_os = "freebsd"))]
 const WSTOPPED: WaitPidFlag = WUNTRACED;
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]


### PR DESCRIPTION
Works on FreeBSD 11, FreeBSD -CURRENT and NetBSD 7. OpenBSD -CURRENT and DragonFly 4.8 don't compile for other reasons, I should probably fix that stuff too…

Prompted by [ion's use of WCONTINUED](https://github.com/redox-os/ion/commit/8fc7729400b7ba8b2bad8e5248be61b9a39472eb#diff-0902043a20bccae7d1c9e1e03e51ff59R163) :)