### PR TITLE
Fix some bugs in the termios tests

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -14,7 +14,8 @@ use {Errno, Result, Error, fcntl};
 
 /// Representation of a master/slave pty pair
 ///
-/// This is returned by `openpty`
+/// This is returned by `openpty`.  Note that this type does *not* implement `Drop`, so the user
+/// must manually close the file descriptors.
 pub struct OpenptyResult {
     pub master: RawFd,
     pub slave: RawFd,


### PR DESCRIPTION
* Make test_tcgetattr deterministic.  The old version behaved
  differently depending on what file descriptors were opened by the
  harness or by other tests, and could race against other tests.

* Close some file descriptor leaks

Fixes #154