### PR TITLE
Fix testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
       rust: 1.13.0
     - env: TARGET=mipsel-unknown-linux-gnu
       rust: 1.13.0
-    - env: TARGET=powerpc-unknown-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
       rust: 1.13.0
     - env: TARGET=powerpc64-unknown-linux-gnu
       rust: 1.13.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,11 @@ matrix:
       rust: beta
 
   allow_failures:
+    # We allow beta to fail here because a bug might crop up in rust that causes it. We will
+    # however be on the lookout for this and file those bugs with upstream.
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: beta
+
     # Planning to add these targets, but they can fail for now
     - env: TARGET=mips64-unknown-linux-gnuabi64
       rust: 1.13.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Tier 1:
   * i686-unknown-linux-musl
   * mips-unknown-linux-gnu
   * mipsel-unknown-linux-gnu
-  * powerpc-unknown-linux-gnu
   * powerpc64-unknown-linux-gnu
   * powerpc64le-unknown-linux-gnu
   * x86_64-apple-darwin
@@ -76,6 +75,7 @@ Tier 2:
   * i386-apple-ios
   * i686-linux-android (requires Rust >= 1.18)
   * i686-unknown-freebsd
+  * powerpc-unknown-linux-gnu
   * x86_64-apple-ios
   * x86_64-linux-android (requires Rust >= 1.18)
   * x86_64-unknown-netbsd


### PR DESCRIPTION
Move `powerpc-unknown-linux-gnu` to Tier 2. And attempt a fix for the epoll tests that seem to fail reliably now.

cc @asomers 