### PR TITLE
fix some tests for Android

### DIFF
--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -3,5 +3,5 @@ use nix::sys::pthread::*;
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();
-    assert!(tid > 0);
+    assert!(tid != 0);
 }

--- a/test/test_net.rs
+++ b/test/test_net.rs
@@ -1,9 +1,9 @@
 use nix::net::if_::*;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 const LOOPBACK: &'static [u8] = b"lo";
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "android", target_os = "linux")))]
 const LOOPBACK: &'static [u8] = b"lo0";
 
 #[test]

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -64,7 +64,12 @@ fn test_wait() {
 
 #[test]
 fn test_mkstemp() {
-    let result = mkstemp("/tmp/nix_tempfile.XXXXXX");
+    #[cfg(target_os = "android")]
+    let tmp = "/data/local/tmp/";
+    #[cfg(not(target_os = "android"))]
+    let tmp = "/tmp/";
+
+    let result = mkstemp((tmp.to_owned() + "nix_tempfile.XXXXXX").as_str());
     match result {
         Ok((fd, path)) => {
             close(fd).unwrap();
@@ -73,7 +78,7 @@ fn test_mkstemp() {
         Err(e) => panic!("mkstemp failed: {}", e)
     }
 
-    let result = mkstemp("/tmp/");
+    let result = mkstemp(tmp);
     match result {
         Ok(_) => {
             panic!("mkstemp succeeded even though it should fail (provided a directory)");


### PR DESCRIPTION
I tested the crate on an Android emulator and quite all the tests passed. Only 6 were failing.

> failures:
> 
> ---- sys::test_pthread::test_pthread_self stdout ----
> 	thread 'sys::test_pthread::test_pthread_self' panicked at 'assertion failed: tid > 0', test/sys/test_pthread.rs:6
> note: Run with `RUST_BACKTRACE=1` for a backtrace.
> 
> ---- sys::test_socket::test_getsockname stdout ----
> 	thread 'sys::test_socket::test_getsockname' panicked at 'bind failed: Sys(EACCES)', /checkout/src/libcore/result.rs:859
> 
> ---- sys::test_socket::test_unixdomain stdout ----
> 	thread 'sys::test_socket::test_unixdomain' panicked at 'bind failed: Sys(EACCES)', /checkout/src/libcore/result.rs:859
> 
> ---- sys::test_termios::test_local_flags stdout ----
> 	thread 'sys::test_termios::test_local_flags' panicked at 'called `Option::unwrap()` on a `None` value', /checkout/src/libcore/option.rs:329
> 
> ---- test_net::test_if_nametoindex stdout ----
> 	thread 'test_net::test_if_nametoindex' panicked at 'assertion failed: if_nametoindex(&LOOPBACK[..]).is_ok()', test/test_net.rs:11
> 
> ---- test_unistd::test_mkstemp stdout ----
> 	thread 'test_unistd::test_mkstemp' panicked at 'mkstemp failed: ENOENT: No such file or directory', test/test_unistd.rs:73

This PR fixes 3 of those:
 - `test_pthread_self`: pthread_t is unsigned, so it can be negative (and it is often the case)
 - `test_if_nametoindex`: constant `LOOPBACK` is the same than on Linux
 - `test_mkstemp`: directory `/tmp` does not exist in Android

Two are still failing (`test_unixdomain` and `test_getsockname`) because we need some special permissions on Android for playing with sockets. On a rooted physical device, they passed. So, if tests for Android are integrated in CI, we should try to embed the tests to run in an APK with requested permissions or find a way to give the permission to a native program.

`test_local_flags` is still failing also because `O_LARGEFILE` is hardcoded and is not the right value in Android. Then `fcntl::OFlag::from_bits(flags).unwrap()` fails because this flag is then not recognised.
I made a PR in `libc` so that we can rely on libc definitions for all `O_*` flags. (rust-lang/libc#683)

Do you prefer to wait for this one to be fixed for this PR to merged as well ?


