### PR TITLE
Remove workaround for `pub extern crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,7 @@ extern crate nix_test as nixtest;
 
 #[macro_use] mod macros;
 
-// In rust 1.8+ this should be `pub extern crate libc` but prior
-// to https://github.com/rust-lang/rust/issues/26775 being resolved
-// it is necessary to get a little creative.
-pub mod libc {
-    extern crate libc;
-    pub use self::libc::*;
-}
+pub extern crate libc;
 
 pub use libc::{c_int, c_void};
 pub use errno::Errno;


### PR DESCRIPTION
On semi-recent Rust versions (I think 1.8+) this now works properly.

Closes #655