### PR TITLE
Remove `homepage` from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
 version     = "0.9.0-pre"
 authors     = ["The nix-rust Project Developers"]
-homepage    = "https://github.com/nix-rust/nix"
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"
 categories  = ["os::unix-apis"]


### PR DESCRIPTION
It's just a (redundant) link to the repo, not a real homepage. According
to the [API
guidelines](https://github.com/brson/rust-api-guidelines#cargotoml-includes-all-common-metadata-c-metadata),
this shouldn't be set in this case.