### PR TITLE
Get rid of a lot of transmutes

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -96,7 +96,7 @@ pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> Result<()> {
     let res = unsafe {
         libc::sched_setaffinity(pid.into(),
                                 mem::size_of::<CpuSet>() as libc::size_t,
-                                mem::transmute(cpuset))
+                                &cpuset.cpu_set)
     };
 
     Errno::result(res).map(drop)

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -111,16 +111,10 @@ pub fn quotactl_sync<P: ?Sized + NixPath>(which: quota::QuotaType, special: Opti
 }
 
 pub fn quotactl_get<P: ?Sized + NixPath>(which: quota::QuotaType, special: &P, id: c_int, dqblk: &mut quota::Dqblk) -> Result<()> {
-    use std::mem;
-    unsafe {
-        quotactl(quota::QuotaCmd(quota::Q_GETQUOTA, which), Some(special), id, mem::transmute(dqblk))
-    }
+    quotactl(quota::QuotaCmd(quota::Q_GETQUOTA, which), Some(special), id, dqblk as *mut _ as *mut c_char)
 }
 
 pub fn quotactl_set<P: ?Sized + NixPath>(which: quota::QuotaType, special: &P, id: c_int, dqblk: &quota::Dqblk) -> Result<()> {
-    use std::mem;
     let mut dqblk_copy = *dqblk;
-    unsafe {
-        quotactl(quota::QuotaCmd(quota::Q_SETQUOTA, which), Some(special), id, mem::transmute(&mut dqblk_copy))
-    }
+    quotactl(quota::QuotaCmd(quota::Q_SETQUOTA, which), Some(special), id, &mut dqblk_copy as *mut _ as *mut c_char)
 }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -364,10 +364,10 @@ impl SigAction {
     pub fn new(handler: SigHandler, flags: SaFlags, mask: SigSet) -> SigAction {
         let mut s = unsafe { mem::uninitialized::<libc::sigaction>() };
         s.sa_sigaction = match handler {
-            SigHandler::SigDfl => unsafe { mem::transmute(libc::SIG_DFL) },
-            SigHandler::SigIgn => unsafe { mem::transmute(libc::SIG_IGN) },
-            SigHandler::Handler(f) => unsafe { mem::transmute(f) },
-            SigHandler::SigAction(f) => unsafe { mem::transmute(f) },
+            SigHandler::SigDfl => libc::SIG_DFL,
+            SigHandler::SigIgn => libc::SIG_IGN,
+            SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
+            SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
         };
         s.sa_flags = match handler {
             SigHandler::SigAction(_) => (flags | SA_SIGINFO).bits(),

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1,7 +1,7 @@
 use super::sa_family_t;
 use {Errno, Error, Result, NixPath};
 use libc;
-use std::{fmt, hash, mem, net, ptr};
+use std::{fmt, hash, mem, net, ptr, slice};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::os::unix::ffi::OsStrExt;
@@ -581,7 +581,7 @@ impl UnixAddr {
     }
 
     fn sun_path(&self) -> &[u8] {
-        unsafe { mem::transmute(&self.0.sun_path[..self.1]) }
+        unsafe { slice::from_raw_parts(self.0.sun_path.as_ptr() as *const u8, self.1) }
     }
 
     /// If this address represents a filesystem path, return that path.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -227,7 +227,7 @@ impl<'a> Iterator for CmsgIterator<'a> {
         if self.buf.len() < sizeof_cmsghdr {
             return None;
         }
-        let cmsg: &cmsghdr = unsafe { mem::transmute(self.buf.as_ptr()) };
+        let cmsg: &'a cmsghdr = unsafe { &*(self.buf.as_ptr() as *const cmsghdr) };
 
         // This check is only in the glibc implementation of CMSG_NXTHDR
         // (although it claims the kernel header checks this), but such

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -205,11 +205,11 @@ impl<T> Get<T> for GetStruct<T> {
     }
 
     unsafe fn ffi_ptr(&mut self) -> *mut c_void {
-        mem::transmute(&mut self.val)
+        &mut self.val as *mut T as *mut c_void
     }
 
     unsafe fn ffi_len(&mut self) -> *mut socklen_t {
-        mem::transmute(&mut self.len)
+        &mut self.len
     }
 
     unsafe fn unwrap(self) -> T {
@@ -228,7 +228,7 @@ impl<'a, T> Set<'a, T> for SetStruct<'a, T> {
     }
 
     unsafe fn ffi_ptr(&self) -> *const c_void {
-        mem::transmute(self.ptr)
+        self.ptr as *const T as *const c_void
     }
 
     unsafe fn ffi_len(&self) -> socklen_t {
@@ -250,11 +250,11 @@ impl Get<bool> for GetBool {
     }
 
     unsafe fn ffi_ptr(&mut self) -> *mut c_void {
-        mem::transmute(&mut self.val)
+        &mut self.val as *mut c_int as *mut c_void
     }
 
     unsafe fn ffi_len(&mut self) -> *mut socklen_t {
-        mem::transmute(&mut self.len)
+        &mut self.len
     }
 
     unsafe fn unwrap(self) -> bool {
@@ -273,7 +273,7 @@ impl<'a> Set<'a, bool> for SetBool {
     }
 
     unsafe fn ffi_ptr(&self) -> *const c_void {
-        mem::transmute(&self.val)
+        &self.val as *const c_int as *const c_void
     }
 
     unsafe fn ffi_len(&self) -> socklen_t {
@@ -295,11 +295,11 @@ impl Get<u8> for GetU8 {
     }
 
     unsafe fn ffi_ptr(&mut self) -> *mut c_void {
-        mem::transmute(&mut self.val)
+        &mut self.val as *mut uint8_t as *mut c_void
     }
 
     unsafe fn ffi_len(&mut self) -> *mut socklen_t {
-        mem::transmute(&mut self.len)
+        &mut self.len
     }
 
     unsafe fn unwrap(self) -> u8 {
@@ -318,7 +318,7 @@ impl<'a> Set<'a, u8> for SetU8 {
     }
 
     unsafe fn ffi_ptr(&self) -> *const c_void {
-        mem::transmute(&self.val)
+        &self.val as *const uint8_t as *const c_void
     }
 
     unsafe fn ffi_len(&self) -> socklen_t {
@@ -340,11 +340,11 @@ impl Get<usize> for GetUsize {
     }
 
     unsafe fn ffi_ptr(&mut self) -> *mut c_void {
-        mem::transmute(&mut self.val)
+        &mut self.val as *mut c_int as *mut c_void
     }
 
     unsafe fn ffi_len(&mut self) -> *mut socklen_t {
-        mem::transmute(&mut self.len)
+        &mut self.len
     }
 
     unsafe fn unwrap(self) -> usize {
@@ -363,7 +363,7 @@ impl<'a> Set<'a, usize> for SetUsize {
     }
 
     unsafe fn ffi_ptr(&self) -> *const c_void {
-        mem::transmute(&self.val)
+        &self.val as *const c_int as *const c_void
     }
 
     unsafe fn ffi_len(&self) -> socklen_t {

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -178,17 +178,17 @@ sockopt_impl!(GetOnly, OriginalDst, libc::SOL_IP, libc::SO_ORIGINAL_DST, libc::s
  *
  */
 
-trait Get<T> {
+unsafe trait Get<T> {
     unsafe fn blank() -> Self;
-    unsafe fn ffi_ptr(&mut self) -> *mut c_void;
-    unsafe fn ffi_len(&mut self) -> *mut socklen_t;
+    fn ffi_ptr(&mut self) -> *mut c_void;
+    fn ffi_len(&mut self) -> *mut socklen_t;
     unsafe fn unwrap(self) -> T;
 }
 
-trait Set<'a, T> {
+unsafe trait Set<'a, T> {
     fn new(val: &'a T) -> Self;
-    unsafe fn ffi_ptr(&self) -> *const c_void;
-    unsafe fn ffi_len(&self) -> socklen_t;
+    fn ffi_ptr(&self) -> *const c_void;
+    fn ffi_len(&self) -> socklen_t;
 }
 
 struct GetStruct<T> {
@@ -196,7 +196,7 @@ struct GetStruct<T> {
     val: T,
 }
 
-impl<T> Get<T> for GetStruct<T> {
+unsafe impl<T> Get<T> for GetStruct<T> {
     unsafe fn blank() -> Self {
         GetStruct {
             len: mem::size_of::<T>() as socklen_t,
@@ -204,11 +204,11 @@ impl<T> Get<T> for GetStruct<T> {
         }
     }
 
-    unsafe fn ffi_ptr(&mut self) -> *mut c_void {
+    fn ffi_ptr(&mut self) -> *mut c_void {
         &mut self.val as *mut T as *mut c_void
     }
 
-    unsafe fn ffi_len(&mut self) -> *mut socklen_t {
+    fn ffi_len(&mut self) -> *mut socklen_t {
         &mut self.len
     }
 
@@ -222,16 +222,16 @@ struct SetStruct<'a, T: 'static> {
     ptr: &'a T,
 }
 
-impl<'a, T> Set<'a, T> for SetStruct<'a, T> {
+unsafe impl<'a, T> Set<'a, T> for SetStruct<'a, T> {
     fn new(ptr: &'a T) -> SetStruct<'a, T> {
         SetStruct { ptr: ptr }
     }
 
-    unsafe fn ffi_ptr(&self) -> *const c_void {
+    fn ffi_ptr(&self) -> *const c_void {
         self.ptr as *const T as *const c_void
     }
 
-    unsafe fn ffi_len(&self) -> socklen_t {
+    fn ffi_len(&self) -> socklen_t {
         mem::size_of::<T>() as socklen_t
     }
 }
@@ -241,7 +241,7 @@ struct GetBool {
     val: c_int,
 }
 
-impl Get<bool> for GetBool {
+unsafe impl Get<bool> for GetBool {
     unsafe fn blank() -> Self {
         GetBool {
             len: mem::size_of::<c_int>() as socklen_t,
@@ -249,11 +249,11 @@ impl Get<bool> for GetBool {
         }
     }
 
-    unsafe fn ffi_ptr(&mut self) -> *mut c_void {
+    fn ffi_ptr(&mut self) -> *mut c_void {
         &mut self.val as *mut c_int as *mut c_void
     }
 
-    unsafe fn ffi_len(&mut self) -> *mut socklen_t {
+    fn ffi_len(&mut self) -> *mut socklen_t {
         &mut self.len
     }
 
@@ -267,16 +267,16 @@ struct SetBool {
     val: c_int,
 }
 
-impl<'a> Set<'a, bool> for SetBool {
+unsafe impl<'a> Set<'a, bool> for SetBool {
     fn new(val: &'a bool) -> SetBool {
         SetBool { val: if *val { 1 } else { 0 } }
     }
 
-    unsafe fn ffi_ptr(&self) -> *const c_void {
+    fn ffi_ptr(&self) -> *const c_void {
         &self.val as *const c_int as *const c_void
     }
 
-    unsafe fn ffi_len(&self) -> socklen_t {
+    fn ffi_len(&self) -> socklen_t {
         mem::size_of::<c_int>() as socklen_t
     }
 }
@@ -286,7 +286,7 @@ struct GetU8 {
     val: uint8_t,
 }
 
-impl Get<u8> for GetU8 {
+unsafe impl Get<u8> for GetU8 {
     unsafe fn blank() -> Self {
         GetU8 {
             len: mem::size_of::<uint8_t>() as socklen_t,
@@ -294,11 +294,11 @@ impl Get<u8> for GetU8 {
         }
     }
 
-    unsafe fn ffi_ptr(&mut self) -> *mut c_void {
+    fn ffi_ptr(&mut self) -> *mut c_void {
         &mut self.val as *mut uint8_t as *mut c_void
     }
 
-    unsafe fn ffi_len(&mut self) -> *mut socklen_t {
+    fn ffi_len(&mut self) -> *mut socklen_t {
         &mut self.len
     }
 
@@ -312,16 +312,16 @@ struct SetU8 {
     val: uint8_t,
 }
 
-impl<'a> Set<'a, u8> for SetU8 {
+unsafe impl<'a> Set<'a, u8> for SetU8 {
     fn new(val: &'a u8) -> SetU8 {
         SetU8 { val: *val as uint8_t }
     }
 
-    unsafe fn ffi_ptr(&self) -> *const c_void {
+    fn ffi_ptr(&self) -> *const c_void {
         &self.val as *const uint8_t as *const c_void
     }
 
-    unsafe fn ffi_len(&self) -> socklen_t {
+    fn ffi_len(&self) -> socklen_t {
         mem::size_of::<c_int>() as socklen_t
     }
 }
@@ -331,7 +331,7 @@ struct GetUsize {
     val: c_int,
 }
 
-impl Get<usize> for GetUsize {
+unsafe impl Get<usize> for GetUsize {
     unsafe fn blank() -> Self {
         GetUsize {
             len: mem::size_of::<c_int>() as socklen_t,
@@ -339,11 +339,11 @@ impl Get<usize> for GetUsize {
         }
     }
 
-    unsafe fn ffi_ptr(&mut self) -> *mut c_void {
+    fn ffi_ptr(&mut self) -> *mut c_void {
         &mut self.val as *mut c_int as *mut c_void
     }
 
-    unsafe fn ffi_len(&mut self) -> *mut socklen_t {
+    fn ffi_len(&mut self) -> *mut socklen_t {
         &mut self.len
     }
 
@@ -357,16 +357,16 @@ struct SetUsize {
     val: c_int,
 }
 
-impl<'a> Set<'a, usize> for SetUsize {
+unsafe impl<'a> Set<'a, usize> for SetUsize {
     fn new(val: &'a usize) -> SetUsize {
         SetUsize { val: *val as c_int }
     }
 
-    unsafe fn ffi_ptr(&self) -> *const c_void {
+    fn ffi_ptr(&self) -> *const c_void {
         &self.val as *const c_int as *const c_void
     }
 
-    unsafe fn ffi_len(&self) -> socklen_t {
+    fn ffi_len(&self) -> socklen_t {
         mem::size_of::<c_int>() as socklen_t
     }
 }


### PR DESCRIPTION
Most could be replaced by simple raw pointer casts (or even perfectly
safe coercions!).

cc #373