### PR TITLE
Let freebsd and openbsd access 'poll'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- Enabled `nix::poll` for 'freebsd' and 'netbsd' targets
 
 ### Changed
+- Enabled `nix::poll` for 'freebsd' and 'netbsd' targets. ([#710](https://github.com/nix-rus/nix/pull/710))
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))
 
 ## [0.9.0] 2017-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Enabled `nix::poll` for 'freebsd' and 'netbsd' targets
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod mqueue;
 
 pub mod pty;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os="freebsd", target_os="netbsd"))]
 pub mod poll;
 
 pub mod net;


### PR DESCRIPTION
Gave freebsd and openbsd access to 'poll'.  Don't see a reason why other bsd's shouldn't be added as well.  Might make more sense to add exclusive `#cfg(not(...)` statements around a few OS's instead of long strings of acceptable targets. 