### PR TITLE
Reorder builds to improve build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ env:
 
 matrix:
   # These are all the build jobs. Adjust as necessary. Comment out what you
-  # don't need
+  # don't need. The iOS/Mac builds are distributed throughout because Travis
+  # likes to have a big backlog on builds on those machines. This way at least
+  # all of the other jobs can finish while waiting on those builds.
   include:
     # Android
     - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
@@ -21,69 +23,62 @@ matrix:
       rust: 1.13.0
     - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
       rust: 1.13.0
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
     - env: TARGET=i686-linux-android DISABLE_TESTS=1
       rust: 1.18.0
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
       rust: 1.18.0
 
-    # iOS
-    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
-      os: osx
-    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
-      os: osx
-    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
-      os: osx
-    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
-      os: osx
-    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
-      os: osx
-
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
       rust: 1.13.0
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
     - env: TARGET=arm-unknown-linux-gnueabi
       rust: 1.13.0
     - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
       rust: 1.14.0
     - env: TARGET=armv7-unknown-linux-gnueabihf
       rust: 1.13.0
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
     - env: TARGET=i686-unknown-linux-gnu
       rust: 1.13.0
     - env: TARGET=i686-unknown-linux-musl
       rust: 1.13.0
     - env: TARGET=mips-unknown-linux-gnu
       rust: 1.13.0
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
     - env: TARGET=mips64-unknown-linux-gnuabi64
       rust: 1.13.0
     - env: TARGET=mips64el-unknown-linux-gnuabi64
       rust: 1.13.0
     - env: TARGET=mipsel-unknown-linux-gnu
       rust: 1.13.0
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+      rust: 1.13.0
+      os: osx
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
       rust: 1.13.0
     - env: TARGET=powerpc64-unknown-linux-gnu
       rust: 1.13.0
     - env: TARGET=powerpc64le-unknown-linux-gnu
       rust: 1.13.0
+    - env: TARGET=i686-apple-darwin
+      rust: 1.13.0
+      os: osx
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
       rust: 1.13.0
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: 1.13.0
     - env: TARGET=x86_64-unknown-linux-musl
       rust: 1.13.0
-
-    # OSX
-    - env: TARGET=i686-apple-darwin
-      rust: 1.13.0
-      os: osx
-    - env: TARGET=x86_64-apple-darwin
-      rust: 1.13.0
-      os: osx
 
     # *BSD
     # FreeBSD i686 and x86_64 use BuildBot instead of Travis
@@ -93,6 +88,10 @@ matrix:
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
       rust: 1.13.0
+
+    - env: TARGET=x86_64-apple-darwin
+      rust: 1.13.0
+      os: osx
 
     # Testing beta on main targets
     - env: TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
The main issue is that all iOS builds are in a block and there are only 5
simultaneous builds allowed by our Travis CI plan. So if there's a backlog
of iOS builders, then the entire build process stalls. So instead of having
them all clumped together, distribute the Mac and iOS builds throughout the
build pipeline.

Addresses part of #669.