### PR TITLE
Support features across more platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#722](https://github.com/nix-rust/nix/pull/722))
 - Added `nix::unistd:fexecve`.
   ([#727](https://github.com/nix-rust/nix/pull/727))
+- Expose `uname()` on all platforms.
+  ([#739](https://github.com/nix-rust/nix/pull/739))
+- Expose `signalfd` module on Android as well.
+  ([#739](https://github.com/nix-rust/nix/pull/739))
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -18,7 +18,8 @@ pub mod memfd;
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+// TODO: Add support for dragonfly, freebsd, and ios/macos.
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod sendfile;
 
 pub mod signal;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -39,7 +39,6 @@ pub mod reboot;
 
 pub mod termios;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod utsname;
 
 pub mod wait;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -24,8 +24,7 @@ pub mod sendfile;
 
 pub mod signal;
 
-// FIXME: Add to Android once libc#671 lands in a release
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod signalfd;
 
 pub mod socket;

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -50,10 +50,21 @@ fn to_str<'a>(s: *const *const c_char) -> &'a str {
 
 #[cfg(test)]
 mod test {
-    use super::uname;
-
+    #[cfg(target_os = "linux")]
     #[test]
-    pub fn test_uname() {
-        assert_eq!(uname().sysname(), "Linux");
+    pub fn test_uname_linux() {
+        assert_eq!(super::uname().sysname(), "Linux");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    pub fn test_uname_darwin() {
+        assert_eq!(super::uname().sysname(), "Darwin");
+    }
+
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    pub fn test_uname_freebsd() {
+        assert_eq!(super::uname().sysname(), "FreeBSD");
     }
 }


### PR DESCRIPTION
 * Exposes `utsname` on all platforms
 * Expose `signalfd` on Android

Closes #607.