### PR TITLE
ptrace: add PTRACE_O_EXITKILL option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#768](https:://github.com/nix-rust/nix/pull/768))
 - Added `nix::unistd::mkfifo`.
   ([#602](https://github.com/nix-rust/nix/pull/774))
+- Added `ptrace::Options::PTRACE_O_EXITKILL` on Linux and Android.
+  ([#771](https://github.com/nix-rust/nix/pull/771))
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -116,6 +116,10 @@ libc_bitflags! {
         /// Stop tracee when a SECCOMP_RET_TRACE rule is triggered. See `man seccomp` for more
         /// details.
         PTRACE_O_TRACESECCOMP;
+        /// Send a SIGKILL to the tracee if the tracer exits.  This is useful
+        /// for ptrace jailers to prevent tracees from escaping their control.
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        PTRACE_O_EXITKILL;
     }
 }
 


### PR DESCRIPTION
It is a somewhat newer option -- it requires Linux 3.8. Is there a
more precise way to specify that?