### PR TITLE
#602 added unistd::mkfifo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#773](https://github.com/nix-rust/nix/pull/773))
 - Add nix::sys::fallocate
   ([#768](https:://github.com/nix-rust/nix/pull/768))
+- Added `nix::unistd::mkfifo`.
+  ([#602](https://github.com/nix-rust/nix/pull/774))
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -86,6 +86,24 @@ fn test_mkstemp_directory() {
 }
 
 #[test]
+fn test_mkfifo() {
+    let tempdir = TempDir::new("nix-test_mkfifo").unwrap();
+    let mkfifo_fifo = tempdir.path().join("mkfifo_fifo");
+
+    mkfifo(&mkfifo_fifo, stat::S_IRUSR).unwrap();
+
+    let stats = stat::stat(&mkfifo_fifo).unwrap();
+    let typ = stat::SFlag::from_bits_truncate(stats.st_mode);
+    assert!(typ == stat::S_IFIFO); 
+}
+
+#[test]
+fn test_mkfifo_directory() {
+    // mkfifo should fail if a directory is given
+    assert!(mkfifo(&env::temp_dir(), stat::S_IRUSR).is_err());
+}
+
+#[test]
 fn test_getpid() {
     let pid: ::libc::pid_t = getpid().into();
     let ppid: ::libc::pid_t = getppid().into();


### PR DESCRIPTION
Since libc has mkfifo already I have just copied mkdir and adapted to mkfifo. I have tested that on MacOS only.