### PR TITLE
Use libc_enum! where possible

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -19,9 +19,12 @@ libc_enum! {
         /// do it like `fsync`
         O_SYNC,
         /// on supported operating systems only, do it like `fdatasync`
-        #[cfg(any(target_os = "openbsd", target_os = "bitrig",
-                target_os = "netbsd", target_os = "macos", target_os = "ios",
-                target_os = "linux"))]
+        #[cfg(any(target_os = "bitrig",
+                  target_os = "ios",
+                  target_os = "linux",
+                  target_os = "macos",
+                  target_os = "netbsd",
+                  target_os = "openbsd"))]
         O_DSYNC
     }
 }

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -13,38 +13,41 @@ use sys::time::TimeSpec;
 
 /// Mode for `AioCb::fsync`.  Controls whether only data or both data and
 /// metadata are synced.
-#[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum AioFsyncMode {
-    /// do it like `fsync`
-    O_SYNC = libc::O_SYNC,
-    /// on supported operating systems only, do it like `fdatasync`
-    #[cfg(any(target_os = "openbsd", target_os = "bitrig",
-              target_os = "netbsd", target_os = "macos", target_os = "ios",
-              target_os = "linux"))]
-    O_DSYNC = libc::O_DSYNC
+libc_enum! {
+    #[repr(i32)]
+    pub enum AioFsyncMode {
+        /// do it like `fsync`
+        O_SYNC,
+        /// on supported operating systems only, do it like `fdatasync`
+        #[cfg(any(target_os = "openbsd", target_os = "bitrig",
+                target_os = "netbsd", target_os = "macos", target_os = "ios",
+                target_os = "linux"))]
+        O_DSYNC
+    }
 }
 
-/// When used with `lio_listio`, determines whether a given `aiocb` should be
-/// used for a read operation, a write operation, or ignored.  Has no effect for
-/// any other aio functions.
-#[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum LioOpcode {
-    LIO_NOP = libc::LIO_NOP,
-    LIO_WRITE = libc::LIO_WRITE,
-    LIO_READ = libc::LIO_READ
+libc_enum! {
+    /// When used with `lio_listio`, determines whether a given `aiocb` should be
+    /// used for a read operation, a write operation, or ignored.  Has no effect for
+    /// any other aio functions.
+    #[repr(i32)]
+    pub enum LioOpcode {
+        LIO_NOP,
+        LIO_WRITE,
+        LIO_READ,
+    }
 }
 
-/// Mode for `lio_listio`.
-#[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum LioMode {
-    /// Requests that `lio_listio` block until all requested operations have
-    /// been completed
-    LIO_WAIT = libc::LIO_WAIT,
-    /// Requests that `lio_listio` return immediately
-    LIO_NOWAIT = libc::LIO_NOWAIT,
+libc_enum! {
+    /// Mode for `lio_listio`.
+    #[repr(i32)]
+    pub enum LioMode {
+        /// Requests that `lio_listio` block until all requested operations have
+        /// been completed
+        LIO_WAIT,
+        /// Requests that `lio_listio` return immediately
+        LIO_NOWAIT,
+    }
 }
 
 /// Return values for `AioCb::cancel and aio_cancel_all`

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -34,7 +34,7 @@ type type_of_data = libc::int64_t;
 type type_of_event_filter = u32;
 #[cfg(not(target_os = "netbsd"))]
 type type_of_event_filter = i16;
-libc_enum!{
+libc_enum! {
     #[cfg_attr(target_os = "netbsd", repr(u32))]
     #[cfg_attr(not(target_os = "netbsd"), repr(i16))]
     pub enum EventFilter {
@@ -59,7 +59,7 @@ libc_enum!{
                   target_os = "ios",
                   target_os = "macos"))]
         EVFILT_USER,
-        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         EVFILT_VM,
         EVFILT_VNODE,
         EVFILT_WRITE,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -59,7 +59,7 @@ libc_enum! {
                   target_os = "ios",
                   target_os = "macos"))]
         EVFILT_USER,
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
         EVFILT_VM,
         EVFILT_VNODE,
         EVFILT_WRITE,

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -5,19 +5,20 @@ use libc;
 use void::Void;
 use std::mem::drop;
 
-/// How exactly should the system be rebooted.
-///
-/// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
-/// enabling/disabling Ctrl-Alt-Delete.
-#[repr(i32)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RebootMode {
-    RB_HALT_SYSTEM = libc::RB_HALT_SYSTEM,
-    RB_KEXEC = libc::RB_KEXEC,
-    RB_POWER_OFF = libc::RB_POWER_OFF,
-    RB_AUTOBOOT = libc::RB_AUTOBOOT,
-    // we do not support Restart2,
-    RB_SW_SUSPEND = libc::RB_SW_SUSPEND,
+libc_enum! {
+    /// How exactly should the system be rebooted.
+    ///
+    /// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
+    /// enabling/disabling Ctrl-Alt-Delete.
+    #[repr(i32)]
+    pub enum RebootMode {
+        RB_HALT_SYSTEM,
+        RB_KEXEC,
+        RB_POWER_OFF,
+        RB_AUTOBOOT,
+        // we do not support Restart2,
+        RB_SW_SUSPEND,
+    }
 }
 
 pub fn reboot(how: RebootMode) -> Result<Void> {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -33,7 +33,8 @@ libc_enum!{
         SIGPIPE,
         SIGALRM,
         SIGTERM,
-        #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64"))))]
+        #[cfg(all(any(target_os = "android", target_os = "emscripten", target_os = "linux"), 
+                  not(any(target_arch = "mips", target_arch = "mips64"))))]
         SIGSTKFLT,
         SIGCHLD,
         SIGCONT,
@@ -48,12 +49,12 @@ libc_enum!{
         SIGPROF,
         SIGWINCH,
         SIGIO,
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
         SIGPWR,
         SIGSYS,
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+        #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
         SIGEMT,
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+        #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
         SIGINFO,
     }
 }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -11,50 +11,51 @@ use std::ptr;
 #[cfg(not(target_os = "openbsd"))]
 pub use self::sigevent::*;
 
-// Currently there is only one definition of c_int in libc, as well as only one
-// type for signal constants.
-// We would prefer to use the libc::c_int alias in the repr attribute. Unfortunately
-// this is not (yet) possible.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(i32)]
-pub enum Signal {
-    SIGHUP = libc::SIGHUP,
-    SIGINT = libc::SIGINT,
-    SIGQUIT = libc::SIGQUIT,
-    SIGILL = libc::SIGILL,
-    SIGTRAP = libc::SIGTRAP,
-    SIGABRT = libc::SIGABRT,
-    SIGBUS = libc::SIGBUS,
-    SIGFPE = libc::SIGFPE,
-    SIGKILL = libc::SIGKILL,
-    SIGUSR1 = libc::SIGUSR1,
-    SIGSEGV = libc::SIGSEGV,
-    SIGUSR2 = libc::SIGUSR2,
-    SIGPIPE = libc::SIGPIPE,
-    SIGALRM = libc::SIGALRM,
-    SIGTERM = libc::SIGTERM,
-    #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64"))))]
-    SIGSTKFLT = libc::SIGSTKFLT,
-    SIGCHLD = libc::SIGCHLD,
-    SIGCONT = libc::SIGCONT,
-    SIGSTOP = libc::SIGSTOP,
-    SIGTSTP = libc::SIGTSTP,
-    SIGTTIN = libc::SIGTTIN,
-    SIGTTOU = libc::SIGTTOU,
-    SIGURG = libc::SIGURG,
-    SIGXCPU = libc::SIGXCPU,
-    SIGXFSZ = libc::SIGXFSZ,
-    SIGVTALRM = libc::SIGVTALRM,
-    SIGPROF = libc::SIGPROF,
-    SIGWINCH = libc::SIGWINCH,
-    SIGIO = libc::SIGIO,
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
-    SIGPWR = libc::SIGPWR,
-    SIGSYS = libc::SIGSYS,
-    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
-    SIGEMT = libc::SIGEMT,
-    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
-    SIGINFO = libc::SIGINFO,
+libc_enum!{
+    // Currently there is only one definition of c_int in libc, as well as only one
+    // type for signal constants.
+    // We would prefer to use the libc::c_int alias in the repr attribute. Unfortunately
+    // this is not (yet) possible.
+    #[repr(i32)]
+    pub enum Signal {
+        SIGHUP,
+        SIGINT,
+        SIGQUIT,
+        SIGILL,
+        SIGTRAP,
+        SIGABRT,
+        SIGBUS,
+        SIGFPE,
+        SIGKILL,
+        SIGUSR1,
+        SIGSEGV,
+        SIGUSR2,
+        SIGPIPE,
+        SIGALRM,
+        SIGTERM,
+        #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64"))))]
+        SIGSTKFLT,
+        SIGCHLD,
+        SIGCONT,
+        SIGSTOP,
+        SIGTSTP,
+        SIGTTIN,
+        SIGTTOU,
+        SIGURG,
+        SIGXCPU,
+        SIGXFSZ,
+        SIGVTALRM,
+        SIGPROF,
+        SIGWINCH,
+        SIGIO,
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
+        SIGPWR,
+        SIGSYS,
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+        SIGEMT,
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+        SIGINFO,
+    }
 }
 
 pub use self::Signal::*;
@@ -241,12 +242,13 @@ libc_bitflags!{
     }
 }
 
-#[repr(i32)]
-#[derive(Clone, Copy, PartialEq)]
-pub enum SigmaskHow {
-    SIG_BLOCK   = libc::SIG_BLOCK,
-    SIG_UNBLOCK = libc::SIG_UNBLOCK,
-    SIG_SETMASK = libc::SIG_SETMASK,
+libc_enum! {
+    #[repr(i32)]
+    pub enum SigmaskHow {
+        SIG_BLOCK,
+        SIG_UNBLOCK,
+        SIG_SETMASK,
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Some enums which use different names for values than libc still set the
discriminators manually.

closes #254