### PR TITLE
Migrate memfd constants to libc

### DIFF
--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -3,10 +3,10 @@ use std::os::unix::io::RawFd;
 use {Errno, Result};
 use std::ffi::CStr;
 
-bitflags!(
+libc_bitflags!(
     pub struct MemFdCreateFlag: libc::c_uint {
-        const MFD_CLOEXEC       = 0x0001;
-        const MFD_ALLOW_SEALING = 0x0002;
+        MFD_CLOEXEC;
+        MFD_ALLOW_SEALING;
     }
 );
 


### PR DESCRIPTION
This will fail because rust-lang/libc#836 is not merged yet, but just getting it staged for when it is.