### PR TITLE
Use sh as interpreter

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 rev=$(git rev-parse --short HEAD)
 


### PR DESCRIPTION
No bash-specific feature is used, so deploy script will work
in every POSIX OS, even when bash isn't installed.