### PR TITLE
Bulletproof the deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 rev=$(git rev-parse --short HEAD)
 
-cd target/doc
+cd target/doc || exit 72
 
 git init
 git config user.name "Carl Lerche"


### PR DESCRIPTION
If the target/doc folder can't be reached, the script should exit
without trying to continue.

This issue has been found using [ShellCheck](https://github.com/koalaman/shellcheck):

```
In deploy.sh line 5:                   
cd target/doc                          
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.    
```

Reference: https://github.com/koalaman/shellcheck/wiki/SC2164