### PR TITLE
Fix nix on Dragonfly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ bitflags = "1.0"
 cfg-if = "0.1.0"
 void = "1.0.2"
 
+[target.'cfg(target_os = "dragonfly")'.build-dependencies]
+gcc = "0.3"
+
 [dev-dependencies]
 lazy_static = "1"
 rand = "0.3.8"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+#[cfg(target_os = "dragonfly")]
+extern crate gcc;
+
+#[cfg(target_os = "dragonfly")]
+fn main() {
+    gcc::Build::new()
+        .file("src/errno_dragonfly.c")
+        .compile("liberrno_dragonfly.a");
+}
+
+#[cfg(not(target_os = "dragonfly"))]
+fn main() {}

--- a/src/errno_dragonfly.c
+++ b/src/errno_dragonfly.c
@@ -1,0 +1,3 @@
+#include <errno.h>
+
+int *errno_location() { return &errno; }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -48,7 +48,6 @@ libc_bitflags!(
         O_DIRECTORY;
         /// Implicitly follow each `write()` with an `fdatasync()`.
         #[cfg(any(target_os = "android",
-                  target_os = "dragonfly",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos",

--- a/src/sys/socket/ffi.rs
+++ b/src/sys/socket/ffi.rs
@@ -5,32 +5,32 @@ pub use libc::{socket, listen, bind, accept, connect, setsockopt, sendto, recvfr
 
 use libc::{c_int, c_void, socklen_t, ssize_t};
 
-#[cfg(not(target_os = "macos"))]
-use libc::size_t;
-
-#[cfg(not(target_os = "linux"))]
-use libc::c_uint;
-
 use sys::uio::IoVec;
 
-#[cfg(target_os = "linux")]
-pub type type_of_cmsg_len = size_t;
-
-#[cfg(not(target_os = "linux"))]
-pub type type_of_cmsg_len = socklen_t;
-
-// OSX always aligns struct cmsghdr as if it were a 32-bit OS
-#[cfg(target_os = "macos")]
-pub type type_of_cmsg_data = c_uint;
-
-#[cfg(not(target_os = "macos"))]
-pub type type_of_cmsg_data = size_t;
-
-#[cfg(target_os = "linux")]
-pub type type_of_msg_iovlen = size_t;
-
-#[cfg(not(target_os = "linux"))]
-pub type type_of_msg_iovlen = c_uint;
+cfg_if! {
+    if #[cfg(target_os = "dragonfly")] {
+        use libc::c_uint;
+        pub type type_of_cmsg_len = socklen_t;
+        pub type type_of_cmsg_data = c_int;
+        pub type type_of_msg_iovlen = c_uint;
+    } else if #[cfg(target_os = "linux")] {
+        use libc::size_t;
+        pub type type_of_cmsg_len = size_t;
+        pub type type_of_cmsg_data = size_t;
+        pub type type_of_msg_iovlen = size_t;
+    } else if #[cfg(target_os = "macos")] {
+        use libc::c_uint;
+        pub type type_of_cmsg_len = socklen_t;
+        // OSX always aligns struct cmsghdr as if it were a 32-bit OS
+        pub type type_of_cmsg_data = c_uint;
+        pub type type_of_msg_iovlen = c_uint;
+    } else {
+        use libc::{c_uint, size_t};
+        pub type type_of_cmsg_len = socklen_t;
+        pub type type_of_cmsg_data = size_t;
+        pub type type_of_msg_iovlen = c_uint;
+    }
+}
 
 // Private because we don't expose any external functions that operate
 // directly on this type; we just use it internally at FFI boundaries.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -630,8 +630,11 @@ pub fn execvp(filename: &CString, args: &[CString]) -> Result<Void> {
 ///
 /// This function is similar to `execve`, except that the program to be executed
 /// is referenced as a file descriptor instead of a path.
-#[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-          target_os = "netbsd", target_os = "openbsd", target_os = "linux"))]
+#[cfg(any(target_os = "android",
+          target_os = "freebsd",
+          target_os = "linux",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
 #[inline]
 pub fn fexecve(fd: RawFd, args: &[CString], env: &[CString]) -> Result<Void> {
     let args_p = to_exec_array(args);

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -1,6 +1,15 @@
 mod test_signal;
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "ios",
-          target_os = "netbsd", target_os = "macos", target_os = "linux"))]
+
+// NOTE: DragonFly lacks a kernel-level implementation of Posix AIO as of
+// this writing. There is an user-level implementation, but whether aio
+// works or not heavily depends on which pthread implementation is chosen
+// by the user at link time. For this reason we do not want to run aio test
+// cases on DragonFly.
+#[cfg(any(target_os = "freebsd",
+          target_os = "ios",
+          target_os = "linux",
+          target_os = "macos",
+          target_os = "netbsd"))]
 mod test_aio;
 #[cfg(target_os = "linux")]
 mod test_signalfd;
@@ -14,5 +23,6 @@ mod test_uio;
 #[cfg(target_os = "linux")]
 mod test_epoll;
 mod test_pthread;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "android",
+          target_os = "linux"))]
 mod test_ptrace;

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -241,16 +241,17 @@ cfg_if!{
     if #[cfg(target_os = "android")] {
         execve_test_factory!(test_execve, execve, &CString::new("/system/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
-    } else if #[cfg(any(target_os = "dragonfly",
-                        target_os = "freebsd",
+    } else if #[cfg(any(target_os = "freebsd",
+                        target_os = "linux",
                         target_os = "netbsd",
-                        target_os = "openbsd",
-                        target_os = "linux", ))] {
+                        target_os = "openbsd"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap().into_raw_fd());
-    } else if #[cfg(any(target_os = "ios", target_os = "macos", ))] {
+    } else if #[cfg(any(target_os = "dragonfly",
+                        target_os = "ios",
+                        target_os = "macos"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
-        // No fexecve() on macos/ios.
+        // No fexecve() on macos/ios and DragonFly.
     }
 }
 


### PR DESCRIPTION
This commit replaces pull request https://github.com/nix-rust/nix/pull/684. It fixes building `nix` on DragonFly. All tests pass. This requires most recent libc to build: https://github.com/rust-lang/libc/pull/851.

