### PR TITLE
unistd: add execveat() on Linux and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `nix::unistd::{getgroups, setgroups, getgrouplist, initgroups}`. ([#733](https://github.com/nix-rust/nix/pull/733))
 - Added `nix::sys::socket::UnixAddr::as_abstract` on Linux and Android.
   ([#785](https://github.com/nix-rust/nix/pull/785))
+- Added `nix::unistd::execveat` on Linux and Android.
+  ([#800](https://github.com/nix-rust/nix/pull/800))
 
 ### Changed
 - Renamed existing `ptrace` wrappers to encourage namespacing ([#692](https://github.com/nix-rust/nix/pull/692))


### PR DESCRIPTION
This adds execveat() to `nix::unistd`. It uses the execveat(2) Linux
kernel syscall, which is available since 3.19.
This is a Linux-specific extension which is not covered by POSIX and
does not have any userland libc wrapper.

Ref: http://man7.org/linux/man-pages/man2/execveat.2.html