### PR TITLE
Upgrade to Bitflags 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,67 +18,67 @@ matrix:
   include:
     # Android
     - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=i686-linux-android DISABLE_TESTS=1
-      rust: 1.18.0
+      rust: 1.20.0
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
-      rust: 1.18.0
+      rust: 1.20.0
 
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=arm-unknown-linux-gnueabi
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-      rust: 1.14.0
+      rust: 1.20.0
     - env: TARGET=armv7-unknown-linux-gnueabihf
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=i686-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=i686-unknown-linux-musl
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=mips-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=i386-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=mips64-unknown-linux-gnuabi64
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=mips64el-unknown-linux-gnuabi64
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=mipsel-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=powerpc64-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=powerpc64le-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=i686-apple-darwin
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.13.0
+      rust: 1.20.0
     - env: TARGET=x86_64-unknown-linux-musl
-      rust: 1.13.0
+      rust: 1.20.0
 
     # *BSD
     # FreeBSD i686 and x86_64 use BuildBot instead of Travis
@@ -87,10 +87,10 @@ matrix:
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-      rust: 1.13.0
+      rust: 1.20.0
 
     - env: TARGET=x86_64-apple-darwin
-      rust: 1.13.0
+      rust: 1.20.0
       os: osx
 
     # Make sure stable is always working too

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude     = [
 
 [dependencies]
 libc = { git = "https://github.com/rust-lang/libc" }
-bitflags = "0.9"
+bitflags = "1.0"
 cfg-if = "0.1.0"
 void = "1.0.2"
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ limitations. Support for platforms is split into two tiers:
              *do not* block the inclusion of new code. Testing may be run, but
              failures in tests don't block the inclusion of new code.
 
-The following targets are all supported by nix on Rust 1.13.0 or newer (unless
+The following targets are all supported by nix on Rust 1.20.0 or newer (unless
 otherwise noted):
 
 Tier 1:
@@ -72,16 +72,16 @@ Tier 2:
   * aarch64-apple-ios
   * aarch64-linux-android
   * arm-linux-androideabi
-  * arm-unknown-linux-musleabi (requires Rust >= 1.14)
+  * arm-unknown-linux-musleabi
   * armv7-apple-ios
   * armv7-linux-androideabi
   * armv7s-apple-ios
   * i386-apple-ios
-  * i686-linux-android (requires Rust >= 1.18)
+  * i686-linux-android
   * powerpc-unknown-linux-gnu
   * s390x-unknown-linux-gnu
   * x86_64-apple-ios
-  * x86_64-linux-android (requires Rust >= 1.18)
+  * x86_64-linux-android
   * x86_64-unknown-netbsd
 
 ## Usage

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -151,7 +151,7 @@ pub fn mq_setattr(mqd: mqd_t, newattr: &MqAttr) -> Result<MqAttr> {
 /// Returns the old attributes
 pub fn mq_set_nonblock(mqd: mqd_t) -> Result<(MqAttr)> {
     let oldattr = try!(mq_getattr(mqd));
-    let newattr = MqAttr::new(O_NONBLOCK.bits() as c_long,
+    let newattr = MqAttr::new(MQ_OFlag::O_NONBLOCK.bits() as c_long,
                               oldattr.mq_attr.mq_maxmsg,
                               oldattr.mq_attr.mq_msgsize,
                               oldattr.mq_attr.mq_curmsgs);

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -86,14 +86,14 @@ pub fn grantpt(fd: &PtyMaster) -> Result<()> {
 ///
 /// ```
 /// use std::path::Path;
-/// use nix::fcntl::{O_RDWR, open};
-/// use nix::pty::*;
-/// use nix::sys::stat;
+/// use nix::fcntl::{OFlag, open};
+/// use nix::pty::{grantpt, posix_openpt, ptsname, unlockpt};
+/// use nix::sys::stat::Mode;
 ///
 /// # #[allow(dead_code)]
 /// # fn run() -> nix::Result<()> {
 /// // Open a new PTY master
-/// let master_fd = posix_openpt(O_RDWR)?;
+/// let master_fd = posix_openpt(OFlag::O_RDWR)?;
 ///
 /// // Allow a slave to be generated for it
 /// grantpt(&master_fd)?;
@@ -104,7 +104,7 @@ pub fn grantpt(fd: &PtyMaster) -> Result<()> {
 ///
 /// // Try to open the slave
 /// # #[allow(unused_variables)]
-/// let slave_fd = open(Path::new(&slave_name), O_RDWR, stat::Mode::empty())?;
+/// let slave_fd = open(Path::new(&slave_name), OFlag::O_RDWR, Mode::empty())?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -320,8 +320,8 @@ fn test_struct_kevent() {
                                 udata: udata as type_of_udata};
     let actual = KEvent::new(0xdeadbeef,
                              EventFilter::EVFILT_READ,
-                             EV_ONESHOT | EV_ADD,
-                             NOTE_CHILD | NOTE_EXIT,
+                             EventFlag::EV_ONESHOT | EventFlag::EV_ADD,
+                             FilterFlag::NOTE_CHILD | FilterFlag::NOTE_EXIT,
                              0x1337,
                              udata);
     assert!(expected.ident == actual.ident());

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -5,12 +5,12 @@
 //! Enabling and setting a quota:
 //!
 //! ```rust,no_run
-//! # use nix::sys::quota::*;
+//! # use nix::sys::quota::{Dqblk, quotactl_on, quotactl_set, QuotaFmt, QuotaType, QuotaValidFlags};
 //! quotactl_on(QuotaType::USRQUOTA, "/dev/sda1", QuotaFmt::QFMT_VFS_V1, "aquota.user");
 //! let mut dqblk: Dqblk = Default::default();
 //! dqblk.set_blocks_hard_limit(10000);
 //! dqblk.set_blocks_soft_limit(8000);
-//! quotactl_set(QuotaType::USRQUOTA, "/dev/sda1", 50, &dqblk, QIF_BLIMITS);
+//! quotactl_set(QuotaType::USRQUOTA, "/dev/sda1", 50, &dqblk, QuotaValidFlags::QIF_BLIMITS);
 //! ```
 use std::default::Default;
 use std::{mem, ptr};
@@ -121,7 +121,7 @@ impl Dqblk {
     /// The absolute limit on disk quota blocks allocated.
     pub fn blocks_hard_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_BLIMITS) {
+        if valid_fields.contains(QuotaValidFlags::QIF_BLIMITS) {
             Some(self.0.dqb_bhardlimit)
         } else {
             None
@@ -136,7 +136,7 @@ impl Dqblk {
     /// Preferred limit on disk quota blocks
     pub fn blocks_soft_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_BLIMITS) {
+        if valid_fields.contains(QuotaValidFlags::QIF_BLIMITS) {
             Some(self.0.dqb_bsoftlimit)
         } else {
             None
@@ -151,7 +151,7 @@ impl Dqblk {
     /// Current occupied space (bytes).
     pub fn occupied_space(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_SPACE) {
+        if valid_fields.contains(QuotaValidFlags::QIF_SPACE) {
             Some(self.0.dqb_curspace)
         } else {
             None
@@ -161,7 +161,7 @@ impl Dqblk {
     /// Maximum number of allocated inodes.
     pub fn inodes_hard_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_ILIMITS) {
+        if valid_fields.contains(QuotaValidFlags::QIF_ILIMITS) {
             Some(self.0.dqb_ihardlimit)
         } else {
             None
@@ -176,7 +176,7 @@ impl Dqblk {
     /// Preferred inode limit
     pub fn inodes_soft_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_ILIMITS) {
+        if valid_fields.contains(QuotaValidFlags::QIF_ILIMITS) {
             Some(self.0.dqb_isoftlimit)
         } else {
             None
@@ -191,7 +191,7 @@ impl Dqblk {
     /// Current number of allocated inodes.
     pub fn allocated_inodes(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_INODES) {
+        if valid_fields.contains(QuotaValidFlags::QIF_INODES) {
             Some(self.0.dqb_curinodes)
         } else {
             None
@@ -201,7 +201,7 @@ impl Dqblk {
     /// Time limit for excessive disk use.
     pub fn block_time_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_BTIME) {
+        if valid_fields.contains(QuotaValidFlags::QIF_BTIME) {
             Some(self.0.dqb_btime)
         } else {
             None
@@ -216,7 +216,7 @@ impl Dqblk {
     /// Time limit for excessive files.
     pub fn inode_time_limit(&self) -> Option<u64> {
         let valid_fields = QuotaValidFlags::from_bits_truncate(self.0.dqb_valid);
-        if valid_fields.contains(QIF_ITIME) {
+        if valid_fields.contains(QuotaValidFlags::QIF_ITIME) {
             Some(self.0.dqb_itime)
         } else {
             None

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -373,8 +373,8 @@ impl SigAction {
             SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
         };
         s.sa_flags = match handler {
-            SigHandler::SigAction(_) => (flags | SA_SIGINFO).bits(),
-            _ => (flags - SA_SIGINFO).bits(),
+            SigHandler::SigAction(_) => (flags | SaFlags::SA_SIGINFO).bits(),
+            _ => (flags - SaFlags::SA_SIGINFO).bits(),
         };
         s.sa_mask = mask.sigset;
 
@@ -393,7 +393,7 @@ impl SigAction {
         match self.sigaction.sa_sigaction {
             libc::SIG_DFL => SigHandler::SigDfl,
             libc::SIG_IGN => SigHandler::SigIgn,
-            f if self.flags().contains(SA_SIGINFO) =>
+            f if self.flags().contains(SaFlags::SA_SIGINFO) =>
                 SigHandler::SigAction( unsafe { mem::transmute(f) } ),
             f => SigHandler::Handler( unsafe { mem::transmute(f) } ),
         }
@@ -713,14 +713,14 @@ mod tests {
 
         let handler_sig = SigHandler::Handler(test_sigaction_handler);
 
-        let flags = SA_ONSTACK | SA_RESTART | SA_SIGINFO;
+        let flags = SaFlags::SA_ONSTACK | SaFlags::SA_RESTART | SaFlags::SA_SIGINFO;
 
         let mut mask = SigSet::empty();
         mask.add(SIGUSR1);
 
         let action_sig = SigAction::new(handler_sig, flags, mask);
 
-        assert_eq!(action_sig.flags(), SA_ONSTACK | SA_RESTART);
+        assert_eq!(action_sig.flags(), SaFlags::SA_ONSTACK | SaFlags::SA_RESTART);
         assert_eq!(action_sig.handler(), handler_sig);
 
         mask = action_sig.mask();

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -67,7 +67,7 @@ pub fn signalfd(fd: RawFd, mask: &SigSet, flags: SfdFlags) -> Result<RawFd> {
 /// mask.thread_block().unwrap();
 ///
 /// // Signals are queued up on the file descriptor
-/// let mut sfd = SignalFd::with_flags(&mask, SFD_NONBLOCK).unwrap();
+/// let mut sfd = SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK).unwrap();
 ///
 /// match sfd.read_signal() {
 ///     // we caught a signal
@@ -155,14 +155,14 @@ mod tests {
     #[test]
     fn create_signalfd_with_opts() {
         let mask = SigSet::empty();
-        let fd = SignalFd::with_flags(&mask, SFD_CLOEXEC | SFD_NONBLOCK);
+        let fd = SignalFd::with_flags(&mask, SfdFlags::SFD_CLOEXEC | SfdFlags::SFD_NONBLOCK);
         assert!(fd.is_ok());
     }
 
     #[test]
     fn read_empty_signalfd() {
         let mask = SigSet::empty();
-        let mut fd = SignalFd::with_flags(&mask, SFD_NONBLOCK).unwrap();
+        let mut fd = SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK).unwrap();
 
         let res = fd.read_signal();
         assert!(res.unwrap().is_none());

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -571,16 +571,16 @@ pub fn socket<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: SockType
               target_os = "netbsd",
               target_os = "openbsd"))]
     {
-        use fcntl::{fcntl, FD_CLOEXEC, O_NONBLOCK};
+        use fcntl::{fcntl, FdFlag, OFlag};
         use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 
         if !feat_atomic {
-            if flags.contains(SOCK_CLOEXEC) {
-                try!(fcntl(res, F_SETFD(FD_CLOEXEC)));
+            if flags.contains(SockFlag::SOCK_CLOEXEC) {
+                try!(fcntl(res, F_SETFD(FdFlag::FD_CLOEXEC)));
             }
 
-            if flags.contains(SOCK_NONBLOCK) {
-                try!(fcntl(res, F_SETFL(O_NONBLOCK)));
+            if flags.contains(SockFlag::SOCK_NONBLOCK) {
+                try!(fcntl(res, F_SETFL(OFlag::O_NONBLOCK)));
             }
         }
     }
@@ -616,18 +616,18 @@ pub fn socketpair<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: Sock
               target_os = "netbsd",
               target_os = "openbsd"))]
     {
-        use fcntl::{fcntl, FD_CLOEXEC, O_NONBLOCK};
+        use fcntl::{fcntl, FdFlag, OFlag};
         use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 
         if !feat_atomic {
-            if flags.contains(SOCK_CLOEXEC) {
-                try!(fcntl(fds[0], F_SETFD(FD_CLOEXEC)));
-                try!(fcntl(fds[1], F_SETFD(FD_CLOEXEC)));
+            if flags.contains(SockFlag::SOCK_CLOEXEC) {
+                try!(fcntl(fds[0], F_SETFD(FdFlag::FD_CLOEXEC)));
+                try!(fcntl(fds[1], F_SETFD(FdFlag::FD_CLOEXEC)));
             }
 
-            if flags.contains(SOCK_NONBLOCK) {
-                try!(fcntl(fds[0], F_SETFL(O_NONBLOCK)));
-                try!(fcntl(fds[1], F_SETFL(O_NONBLOCK)));
+            if flags.contains(SockFlag::SOCK_NONBLOCK) {
+                try!(fcntl(fds[0], F_SETFL(OFlag::O_NONBLOCK)));
+                try!(fcntl(fds[1], F_SETFL(OFlag::O_NONBLOCK)));
             }
         }
     }
@@ -698,15 +698,15 @@ fn accept4_polyfill(sockfd: RawFd, flags: SockFlag) -> Result<RawFd> {
               target_os = "netbsd",
               target_os = "openbsd"))]
     {
-        use fcntl::{fcntl, FD_CLOEXEC, O_NONBLOCK};
+        use fcntl::{fcntl, FdFlag, OFlag};
         use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 
-        if flags.contains(SOCK_CLOEXEC) {
-            try!(fcntl(res, F_SETFD(FD_CLOEXEC)));
+        if flags.contains(SockFlag::SOCK_CLOEXEC) {
+            try!(fcntl(res, F_SETFD(FdFlag::FD_CLOEXEC)));
         }
 
-        if flags.contains(SOCK_NONBLOCK) {
-            try!(fcntl(res, F_SETFL(O_NONBLOCK)));
+        if flags.contains(SockFlag::SOCK_NONBLOCK) {
+            try!(fcntl(res, F_SETFL(OFlag::O_NONBLOCK)));
         }
     }
 

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -37,10 +37,10 @@
 //! An example showing some of the basic operations for interacting with the control flags:
 //!
 //! ```
-//! # use self::nix::sys::termios::{CS5, CSIZE, Termios};
+//! # use self::nix::sys::termios::{ControlFlags, Termios};
 //! # let mut termios = unsafe { Termios::default_uninit() };
-//! termios.control_flags & CSIZE == CS5;
-//! termios.control_flags |= CS5;
+//! termios.control_flags & ControlFlags::CSIZE == ControlFlags::CS5;
+//! termios.control_flags |= ControlFlags::CS5;
 //! ```
 
 use {Errno, Result};

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -2,7 +2,7 @@ use libc::c_int;
 use nix::{Error, Result};
 use nix::errno::*;
 use nix::sys::aio::*;
-use nix::sys::signal::*;
+use nix::sys::signal::{SaFlags, SigAction, sigaction, SigevNotify, SigHandler, Signal, SigSet};
 use nix::sys::time::{TimeSpec, TimeValLike};
 use std::io::{Write, Read, Seek, SeekFrom};
 use std::ops::Deref;
@@ -325,7 +325,7 @@ fn test_write_sigev_signal() {
     #[allow(unused_variables)]
     let m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
     let sa = SigAction::new(SigHandler::Handler(sigfunc),
-                            SA_RESETHAND,
+                            SaFlags::SA_RESETHAND,
                             SigSet::empty());
     SIGNALED.store(false, Ordering::Relaxed);
     unsafe { sigaction(Signal::SIGUSR2, &sa) }.unwrap();
@@ -462,7 +462,7 @@ fn test_lio_listio_signal() {
     const EXPECT: &'static [u8] = b"abCDEF123456";
     let mut f = tempfile().unwrap();
     let sa = SigAction::new(SigHandler::Handler(sigfunc),
-                            SA_RESETHAND,
+                            SaFlags::SA_RESETHAND,
                             SigSet::empty());
     let sigev_notify = SigevNotify::SigevSignal { signal: Signal::SIGUSR2,
                                                   si_value: 0 };

--- a/test/sys/test_epoll.rs
+++ b/test/sys/test_epoll.rs
@@ -1,5 +1,4 @@
-use nix::sys::epoll::{EpollCreateFlags, EpollOp, EpollEvent};
-use nix::sys::epoll::{EPOLLIN, EPOLLERR};
+use nix::sys::epoll::{EpollCreateFlags, EpollFlags, EpollOp, EpollEvent};
 use nix::sys::epoll::{epoll_create1, epoll_ctl};
 use nix::{Error, Errno};
 
@@ -18,7 +17,7 @@ pub fn test_epoll_errno() {
 #[test]
 pub fn test_epoll_ctl() {
     let efd = epoll_create1(EpollCreateFlags::empty()).unwrap();
-    let mut event = EpollEvent::new(EPOLLIN | EPOLLERR, 1);
+    let mut event = EpollEvent::new(EpollFlags::EPOLLIN | EpollFlags::EPOLLERR, 1);
     epoll_ctl(efd, EpollOp::EpollCtlAdd, 1, &mut event).unwrap();
     epoll_ctl(efd, EpollOp::EpollCtlDel, 1, None).unwrap();
 }

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -1,7 +1,7 @@
 use nix::Error;
 use nix::errno::Errno;
 use nix::unistd::getpid;
-use nix::sys::ptrace;
+use nix::sys::ptrace::{self, Options};
 
 use std::mem;
 
@@ -16,7 +16,7 @@ fn test_ptrace() {
 // Just make sure ptrace_setoptions can be called at all, for now.
 #[test]
 fn test_ptrace_setoptions() {
-    let err = ptrace::setoptions(getpid(), ptrace::PTRACE_O_TRACESYSGOOD).unwrap_err();
+    let err = ptrace::setoptions(getpid(), Options::PTRACE_O_TRACESYSGOOD).unwrap_err();
     assert!(err != Error::UnsupportedOperation);
 }
 

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -122,8 +122,7 @@ pub fn test_scm_rights() {
     use nix::unistd::{pipe, read, write, close};
     use nix::sys::socket::{socketpair, sendmsg, recvmsg,
                            AddressFamily, SockType, SockFlag,
-                           ControlMessage, CmsgSpace, MsgFlags,
-                           MSG_TRUNC, MSG_CTRUNC};
+                           ControlMessage, CmsgSpace, MsgFlags};
 
     let (fd1, fd2) = socketpair(AddressFamily::Unix, SockType::Stream, None, SockFlag::empty())
                      .unwrap();
@@ -154,7 +153,7 @@ pub fn test_scm_rights() {
                 panic!("unexpected cmsg");
             }
         }
-        assert!(!msg.flags.intersects(MSG_TRUNC | MSG_CTRUNC));
+        assert!(!msg.flags.intersects(MsgFlags::MSG_TRUNC | MsgFlags::MSG_CTRUNC));
         close(fd2).unwrap();
     }
 
@@ -178,8 +177,7 @@ pub fn test_sendmsg_empty_cmsgs() {
     use nix::unistd::close;
     use nix::sys::socket::{socketpair, sendmsg, recvmsg,
                            AddressFamily, SockType, SockFlag,
-                           CmsgSpace, MsgFlags,
-                           MSG_TRUNC, MSG_CTRUNC};
+                           CmsgSpace, MsgFlags};
 
     let (fd1, fd2) = socketpair(AddressFamily::Unix, SockType::Stream, None, SockFlag::empty())
                      .unwrap();
@@ -199,7 +197,7 @@ pub fn test_sendmsg_empty_cmsgs() {
         for _ in msg.cmsgs() {
             panic!("unexpected cmsg");
         }
-        assert!(!msg.flags.intersects(MSG_TRUNC | MSG_CTRUNC));
+        assert!(!msg.flags.intersects(MsgFlags::MSG_TRUNC | MsgFlags::MSG_CTRUNC));
         close(fd2).unwrap();
     }
 }

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -199,7 +199,6 @@ fn test_process_vm_readv() {
     use nix::unistd::ForkResult::*;
     use nix::sys::signal::*;
     use nix::sys::wait::*;
-    use std::str;
 
     #[allow(unused_variables)]
     let m = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -54,8 +54,7 @@ fn test_waitstatus_pid() {
 // FIXME: qemu-user doesn't implement ptrace on most arches
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod ptrace {
-    use nix::sys::ptrace;
-    use nix::sys::ptrace::*;
+    use nix::sys::ptrace::{self, Options, Event};
     use nix::sys::signal::*;
     use nix::sys::wait::*;
     use nix::unistd::*;
@@ -74,7 +73,7 @@ mod ptrace {
         // Wait for the raised SIGTRAP
         assert_eq!(waitpid(child, None), Ok(WaitStatus::Stopped(child, SIGTRAP)));
         // We want to test a syscall stop and a PTRACE_EVENT stop
-        assert!(ptrace::setoptions(child, PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXIT).is_ok());
+        assert!(ptrace::setoptions(child, Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEEXIT).is_ok());
 
         // First, stop on the next system call, which will be exit()
         assert!(ptrace::syscall(child).is_ok());

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,4 +1,4 @@
-use nix::fcntl::{openat, open, OFlag, O_RDONLY, readlink, readlinkat};
+use nix::fcntl::{openat, open, OFlag, readlink, readlinkat};
 use nix::sys::stat::Mode;
 use nix::unistd::{close, read};
 use tempdir::TempDir;
@@ -17,7 +17,7 @@ fn test_openat() {
                      Mode::empty()).unwrap();
     let fd = openat(dirfd,
                     tmp.path().file_name().unwrap(),
-                    O_RDONLY,
+                    OFlag::O_RDONLY,
                     Mode::empty()).unwrap();
 
     let mut buf = [0u8; 1024];

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::os::unix::prelude::*;
 use tempfile::tempfile;
 
-use nix::fcntl::{O_RDWR, open};
+use nix::fcntl::{OFlag, open};
 use nix::pty::*;
 use nix::sys::stat;
 use nix::sys::termios::*;
@@ -14,7 +14,7 @@ use nix::unistd::{write, close};
 #[test]
 fn test_explicit_close() {
     let mut f = {
-        let m = posix_openpt(O_RDWR).unwrap();
+        let m = posix_openpt(OFlag::O_RDWR).unwrap();
         close(m.into_raw_fd()).unwrap();
         tempfile().unwrap()
     };
@@ -31,7 +31,7 @@ fn test_ptsname_equivalence() {
     let m = ::PTSNAME_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Open a new PTTY master
-    let master_fd = posix_openpt(O_RDWR).unwrap();
+    let master_fd = posix_openpt(OFlag::O_RDWR).unwrap();
     assert!(master_fd.as_raw_fd() > 0);
 
     // Get the name of the slave
@@ -49,7 +49,7 @@ fn test_ptsname_copy() {
     let m = ::PTSNAME_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Open a new PTTY master
-    let master_fd = posix_openpt(O_RDWR).unwrap();
+    let master_fd = posix_openpt(OFlag::O_RDWR).unwrap();
     assert!(master_fd.as_raw_fd() > 0);
 
     // Get the name of the slave
@@ -66,7 +66,7 @@ fn test_ptsname_copy() {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptsname_r_copy() {
     // Open a new PTTY master
-    let master_fd = posix_openpt(O_RDWR).unwrap();
+    let master_fd = posix_openpt(OFlag::O_RDWR).unwrap();
     assert!(master_fd.as_raw_fd() > 0);
 
     // Get the name of the slave
@@ -84,11 +84,11 @@ fn test_ptsname_unique() {
     let m = ::PTSNAME_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Open a new PTTY master
-    let master1_fd = posix_openpt(O_RDWR).unwrap();
+    let master1_fd = posix_openpt(OFlag::O_RDWR).unwrap();
     assert!(master1_fd.as_raw_fd() > 0);
 
     // Open a second PTTY master
-    let master2_fd = posix_openpt(O_RDWR).unwrap();
+    let master2_fd = posix_openpt(OFlag::O_RDWR).unwrap();
     assert!(master2_fd.as_raw_fd() > 0);
 
     // Get the name of the slave
@@ -108,7 +108,7 @@ fn test_open_ptty_pair() {
     let m = ::PTSNAME_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Open a new PTTY master
-    let master_fd = posix_openpt(O_RDWR).expect("posix_openpt failed");
+    let master_fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
     assert!(master_fd.as_raw_fd() > 0);
 
     // Allow a slave to be generated for it
@@ -119,7 +119,7 @@ fn test_open_ptty_pair() {
     let slave_name = unsafe { ptsname(&master_fd) }.expect("ptsname failed");
 
     // Open the slave device
-    let slave_fd = open(Path::new(&slave_name), O_RDWR, stat::Mode::empty()).unwrap();
+    let slave_fd = open(Path::new(&slave_name), OFlag::O_RDWR, stat::Mode::empty()).unwrap();
     assert!(slave_fd > 0);
 }
 
@@ -176,7 +176,7 @@ fn test_openpty_with_termios() {
         termios
     };
     // Make sure newlines are not transformed so the data is preserved when sent.
-    termios.output_flags.remove(ONLCR);
+    termios.output_flags.remove(OutputFlags::ONLCR);
 
     let pty = openpty(None, &termios).unwrap();
     // Must be valid file descriptors

--- a/test/test_ptymaster_drop.rs
+++ b/test/test_ptymaster_drop.rs
@@ -1,6 +1,6 @@
 extern crate nix;
 
-use nix::fcntl::O_RDWR;
+use nix::fcntl::OFlag;
 use nix::pty::*;
 use nix::unistd::close;
 use std::os::unix::io::AsRawFd;
@@ -15,7 +15,7 @@ use std::os::unix::io::AsRawFd;
 // why.  It doesn't happen on any other target, and it doesn't happen on my PC.
 #[cfg_attr(all(target_env = "musl", target_arch = "x86"), ignore)]
 fn test_double_close() {
-    let m = posix_openpt(O_RDWR).unwrap();
+    let m = posix_openpt(OFlag::O_RDWR).unwrap();
     close(m.as_raw_fd()).unwrap();
     drop(m);            // should panic here
 }


### PR DESCRIPTION
The libc_bitflags! macro was replaced with a non-recursive one supporting
only public structs. I could not figure out how to make the old macro work
with the upgrade, so I reworked part of the bitflags! macro directly to suit
our needs, much as the original recursive macro was made. There are no uses
of this macro for non-public structs, so this is not a problem for internal code.

Closes #766.