### PR TITLE
Implement nix wrapper for libc::signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#997](https://github.com/nix-rust/nix/pull/997))
 - Added `ptrace::{getregs, setregs}`.
   ([#1010](https://github.com/nix-rust/nix/pull/1010))
+- Added `nix::sys::signal::signal`.
+  ([#817](https://github.com/nix-rust/nix/pull/817))
 
 ### Changed
 ### Fixed

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -107,6 +107,10 @@ impl ErrnoSentinel for *mut c_void {
     fn sentinel() -> Self { (-1 as isize) as *mut c_void }
 }
 
+impl ErrnoSentinel for libc::sighandler_t {
+    fn sentinel() -> Self { libc::SIG_ERR }
+}
+
 impl error::Error for Errno {
     fn description(&self) -> &str {
         self.desc()


### PR DESCRIPTION
This implements `nix::sys::signal::signal` and adds corresponding documentation and tests.

Closes #476