### PR TITLE
Cargo.toml: don't exclude test files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ license     = "MIT"
 categories  = ["os::unix-apis"]
 exclude     = [
   ".gitignore",
-  ".travis.yml",
-  "test/**/*"
+  ".travis.yml"
 ]
 
 [dependencies]


### PR DESCRIPTION
Those are pretty useful for distributions to verify that crate actually work.