### PR TITLE
Add step function to ptrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.10.0] 2018-01-26
 
 ### Added
+- Added specialized wrapper: `sys::ptrace::step` 
+  ([#852](https://github.com/nix-rust/nix/pull/852))
 - Added `AioCb::from_ptr` and `AioCb::from_mut_ptr`
   ([#820](https://github.com/nix-rust/nix/pull/820))
 - Added specialized wrappers: `sys::ptrace::{traceme, syscall, cont, attach}`. Using the matching routines

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -292,10 +292,17 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 /// use nix::sys::ptrace::step;
 /// use nix::unistd::Pid;
 /// use nix::sys::signal::Signal; 
+/// use nix::sys::wait::*;
 /// fn main() {
-///     let dummy_pid = Pid::from_raw(0); 
-///
-///     let _ = step(dummy_pid, Some(Signal::SIGSTOP));
+///     // If a process changes state to the stopped state because of a SIGUSR1 
+///     // signal, this will step the process forward and forward the user 
+///     // signal to the stopped process
+///     match waitpid(Pid::from_raw(-1), None) {
+///         Ok(WaitStatus::Stopped(pid, Signal::SIGUSR1)) => {
+///             let _ = step(pid, Signal::SIGUSR1);
+///         }
+///         _ => {},
+///     }
 /// }
 /// ```
 pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -284,7 +284,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 /// `ptrace(PTRACE_SINGLESTEP, ...)`
 ///
 /// Advances the execution of the process with PID `pid` by a single step optionally delivering a
-/// single specified by `sig`.
+/// signal specified by `sig`.
 ///
 /// # Example
 /// ```rust

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -280,3 +280,17 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
     }
 }
 
+/// Move the stopped tracee process forward by a single step as with 
+/// `ptrace(PTRACE_SINGLESTEP, ...)`
+///
+/// Advances the execution of the process with PID `pid` by a single step optionally delivering a
+/// single specified by `sig`.
+pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
+    let data = match sig.into() {
+        Some(s) => s as i32 as *mut c_void,
+        None => ptr::null_mut(),
+    };
+    unsafe {
+        ptrace_other(Request::PTRACE_SINGLESTEP, pid, ptr::null_mut(), data).map(|_| ())
+    }
+}

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -285,6 +285,19 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 ///
 /// Advances the execution of the process with PID `pid` by a single step optionally delivering a
 /// single specified by `sig`.
+///
+/// # Example
+/// ```rust
+/// extern crate nix;
+/// use nix::sys::ptrace::step;
+/// use nix::unistd::Pid;
+/// use nix::sys::signal::Signal; 
+/// fn main() {
+///     let dummy_pid = Pid::from_raw(0); 
+///
+///     let _ = step(dummy_pid, Some(Signal::SIGSTOP));
+/// }
+/// ```
 pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
     let data = match sig.into() {
         Some(s) => s as i32 as *mut c_void,


### PR DESCRIPTION
Added step function to ptrace, this follows the same form as the PTRACE_CONTINUE by advanced the tracee by a single step!

Found when I was updating to nix 0.10.0 that this function had been missed out. Minor addition as `SINGLESTEP` works the same as `CONTINUE`