### PR TITLE
Re-add ifaddrs module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,15 @@ pub mod errno;
 #[deny(missing_docs)]
 pub mod features;
 pub mod fcntl;
+#[deny(missing_docs)]
+#[cfg(any(target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "ios",
+          target_os = "linux",
+          target_os = "macos",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
+pub mod ifaddrs;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod mount;
 #[cfg(any(target_os = "dragonfly",


### PR DESCRIPTION
Mistakingly removed in d1be45d8405.

Fixes #855.