### PR TITLE
Fix Broken SockFlag::SOCK_NONBLOCK and SockFlag::SOCK_CLOEXEC on MacOS/iOS

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -86,32 +86,44 @@ pub enum SockProtocol {
     KextControl = libc::SYSPROTO_CONTROL,
 }
 
-libc_bitflags!{
-    /// Additional socket options
-    pub struct SockFlag: c_int {
-        /// Set non-blocking mode on the new socket
-        #[cfg(any(target_os = "android",
-                  target_os = "dragonfly",
-                  target_os = "freebsd",
-                  target_os = "linux",
-                  target_os = "netbsd",
-                  target_os = "openbsd"))]
-        SOCK_NONBLOCK;
-        /// Set close-on-exec on the new descriptor
-        #[cfg(any(target_os = "android",
-                  target_os = "dragonfly",
-                  target_os = "freebsd",
-                  target_os = "linux",
-                  target_os = "netbsd",
-                  target_os = "openbsd"))]
-        SOCK_CLOEXEC;
-        /// Return `EPIPE` instead of raising `SIGPIPE`
-        #[cfg(target_os = "netbsd")]
-        SOCK_NOSIGPIPE;
-        /// For domains `AF_INET(6)`, only allow `connect(2)`, `sendto(2)`, or `sendmsg(2)`
-        /// to the DNS port (typically 53)
-        #[cfg(target_os = "openbsd")]
-        SOCK_DNS;
+cfg_if! {
+    if #[cfg(any(target_os = "macos",
+                 target_os = "ios"))] {
+        bitflags! {
+            pub struct SockFlag: c_int {
+                const SOCK_NONBLOCK = libc::O_NONBLOCK;
+                const SOCK_CLOEXEC = libc::O_CLOEXEC;
+            }
+        }
+    } else {
+        libc_bitflags!{
+            /// Additional socket options
+            pub struct SockFlag: c_int {
+                /// Set non-blocking mode on the new socket
+                #[cfg(any(target_os = "android",
+                          target_os = "dragonfly",
+                          target_os = "freebsd",
+                          target_os = "linux",
+                          target_os = "netbsd",
+                          target_os = "openbsd"))]
+                SOCK_NONBLOCK;
+                /// Set close-on-exec on the new descriptor
+                #[cfg(any(target_os = "android",
+                          target_os = "dragonfly",
+                          target_os = "freebsd",
+                          target_os = "linux",
+                          target_os = "netbsd",
+                          target_os = "openbsd"))]
+                SOCK_CLOEXEC;
+                /// Return `EPIPE` instead of raising `SIGPIPE`
+                #[cfg(target_os = "netbsd")]
+                SOCK_NOSIGPIPE;
+                /// For domains `AF_INET(6)`, only allow `connect(2)`, `sendto(2)`, or `sendmsg(2)`
+                /// to the DNS port (typically 53)
+                #[cfg(target_os = "openbsd")]
+                SOCK_DNS;
+            }
+        }
     }
 }
 
@@ -709,7 +721,9 @@ pub fn socket<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: SockType
     #[cfg(any(target_os = "android",
               target_os = "dragonfly",
               target_os = "freebsd",
+              target_os = "ios",
               target_os = "linux",
+              target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
     {


### PR DESCRIPTION
`SockFlag::SOCK_NONBLOCK` and `SockFlag::SOCK_CLOEXEC` in 0.9.0 broke macOS/iOS support in 0.10.0 (f067e73bdbb589a0e3c991eab2c26de8bb00e924)

This commit solves the issue and also provides test cases to test for continued support.

ref #244 #861