### PR TITLE
Add `getpwnam` and related functions

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2473,15 +2473,14 @@ impl User {
     /// assert!(res.name == "root");
     /// ```
     pub fn from_uid(uid: Uid, bufsize: Option<usize>) -> Option<Result<Self>> {
-        let mut cbuf = vec![0 as c_char; bufsize.unwrap_or(PWGRP_BUFSIZE)];
-        let mut pwd: libc::passwd =  unsafe { mem::zeroed() };
+        let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
+        let mut pwd: libc::passwd =  unsafe { mem::uninitialized() };
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getpwuid_r(uid.0, &mut pwd,
-                             cbuf.as_mut_ptr(),
-                             cbuf.len(), &mut res)
+            libc::getpwuid_r(uid.0, &mut pwd, cbuf.as_mut_ptr(),
+                             cbuf.capacity(), &mut res)
         };
 
         if error == 0 {
@@ -2509,14 +2508,14 @@ impl User {
     /// assert!(res.name == "root");
     /// ```
     pub fn from_name(name: &str, bufsize: Option<usize>) -> Option<Result<Self>> {
-        let mut cbuf = vec![0 as c_char; bufsize.unwrap_or(PWGRP_BUFSIZE)];
-        let mut pwd: libc::passwd =  unsafe { mem::zeroed() };
+        let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
+        let mut pwd: libc::passwd =  unsafe { mem::uninitialized() };
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getpwnam_r(CString::new(name).unwrap().as_ptr(),
-                             &mut pwd, cbuf.as_mut_ptr(), cbuf.len(), &mut res)
+            libc::getpwnam_r(CString::new(name).unwrap().as_ptr(), &mut pwd,
+                             cbuf.as_mut_ptr(), cbuf.capacity(), &mut res)
         };
 
         if error == 0 {
@@ -2556,7 +2555,7 @@ impl From<*mut libc::group> for Group {
 
 impl Group {
     unsafe fn members(mem: *mut *mut c_char) -> Vec<String> {
-        let mut ret = vec![];
+        let mut ret = Vec::new();
 
         for i in 0.. {
             let u = mem.offset(i);
@@ -2587,15 +2586,14 @@ impl Group {
     /// assert!(res.name == "root");
     /// ```
     pub fn from_gid(gid: Gid, bufsize: Option<usize>) -> Option<Result<Self>> {
-        let mut cbuf = vec![0 as c_char; bufsize.unwrap_or(PWGRP_BUFSIZE)];
+        let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
         let mut grp: libc::group =  unsafe { mem::uninitialized() };
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getgrgid_r(gid.0, &mut grp,
-                             cbuf.as_mut_ptr(),
-                             cbuf.len(), &mut res)
+            libc::getgrgid_r(gid.0, &mut grp, cbuf.as_mut_ptr(),
+                             cbuf.capacity(), &mut res)
         };
 
         if error == 0 {
@@ -2625,14 +2623,14 @@ impl Group {
     /// assert!(res.name == "root");
     /// ```
     pub fn from_name(name: &str, bufsize: Option<usize>) -> Option<Result<Self>> {
-        let mut cbuf = vec![0 as c_char; bufsize.unwrap_or(PWGRP_BUFSIZE)];
+        let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
         let mut grp: libc::group =  unsafe { mem::uninitialized() };
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getgrnam_r(CString::new(name).unwrap().as_ptr(),
-                             &mut grp, cbuf.as_mut_ptr(), cbuf.len(), &mut res)
+            libc::getgrnam_r(CString::new(name).unwrap().as_ptr(), &mut grp,
+                             cbuf.as_mut_ptr(), cbuf.capacity(), &mut res)
         };
 
         if error == 0 {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2410,6 +2410,10 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+#[cfg(not(any(target_os = "android",
+              target_os = "ios",
+              target_os = "macos",
+              target_env = "musl")))]
 /// Default buffer size for system user and group querying functions
 const PWGRP_BUFSIZE: usize = 1024;
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2482,9 +2482,10 @@ impl User {
               libc::size_t,
               *mut *mut libc::passwd) -> libc::c_int
     {
+        let buflimit = 16384;
         let bufsize = match sysconf(SysconfVar::GETPW_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
-            Ok(None) | Err(_) => 1024 as usize,
+            Ok(None) | Err(_) => buflimit as usize,
         };
 
         let mut cbuf = Vec::with_capacity(bufsize);
@@ -2506,7 +2507,7 @@ impl User {
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic.
-                reserve_double_buffer_size(&mut cbuf, bufsize)?;
+                reserve_double_buffer_size(&mut cbuf, buflimit)?;
             } else {
                 return Err(Error::Sys(Errno::last()));
             }
@@ -2600,9 +2601,10 @@ impl Group {
               libc::size_t,
               *mut *mut libc::group) -> libc::c_int
     {
+        let buflimit = 16384;
         let bufsize = match sysconf(SysconfVar::GETGR_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
-            Ok(None) | Err(_) => 1024 as usize,
+            Ok(None) | Err(_) => buflimit as usize,
         };
 
         let mut cbuf = Vec::with_capacity(bufsize);
@@ -2624,7 +2626,7 @@ impl Group {
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic.
-                reserve_double_buffer_size(&mut cbuf, bufsize)?;
+                reserve_double_buffer_size(&mut cbuf, buflimit)?;
             } else {
                 return Err(Error::Sys(Errno::last()));
             }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2474,13 +2474,18 @@ impl User {
     /// ```
     pub fn from_uid(uid: Uid, bufsize: Option<usize>) -> Option<Result<Self>> {
         let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
-        let mut pwd: libc::passwd =  unsafe { mem::uninitialized() };
+        let mut pwd = mem::MaybeUninit::<libc::passwd>::uninit();
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getpwuid_r(uid.0, &mut pwd, cbuf.as_mut_ptr(),
-                             cbuf.capacity(), &mut res)
+            libc::getpwuid_r(
+                uid.0,
+                pwd.as_mut_ptr(),
+                cbuf.as_mut_ptr(),
+                cbuf.capacity(),
+                &mut res
+            )
         };
 
         if error == 0 {
@@ -2509,13 +2514,18 @@ impl User {
     /// ```
     pub fn from_name(name: &str, bufsize: Option<usize>) -> Option<Result<Self>> {
         let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
-        let mut pwd: libc::passwd =  unsafe { mem::uninitialized() };
+        let mut pwd = mem::MaybeUninit::<libc::passwd>::uninit();
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getpwnam_r(CString::new(name).unwrap().as_ptr(), &mut pwd,
-                             cbuf.as_mut_ptr(), cbuf.capacity(), &mut res)
+            libc::getpwnam_r(
+                CString::new(name).unwrap().as_ptr(),
+                pwd.as_mut_ptr(),
+                cbuf.as_mut_ptr(),
+                cbuf.capacity(),
+                &mut res
+            )
         };
 
         if error == 0 {
@@ -2587,13 +2597,18 @@ impl Group {
     /// ```
     pub fn from_gid(gid: Gid, bufsize: Option<usize>) -> Option<Result<Self>> {
         let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
-        let mut grp: libc::group =  unsafe { mem::uninitialized() };
+        let mut grp = mem::MaybeUninit::<libc::group>::uninit();
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getgrgid_r(gid.0, &mut grp, cbuf.as_mut_ptr(),
-                             cbuf.capacity(), &mut res)
+            libc::getgrgid_r(
+                gid.0,
+                grp.as_mut_ptr(),
+                cbuf.as_mut_ptr(),
+                cbuf.capacity(),
+                &mut res
+            )
         };
 
         if error == 0 {
@@ -2624,13 +2639,18 @@ impl Group {
     /// ```
     pub fn from_name(name: &str, bufsize: Option<usize>) -> Option<Result<Self>> {
         let mut cbuf = Vec::with_capacity(bufsize.unwrap_or(PWGRP_BUFSIZE));
-        let mut grp: libc::group =  unsafe { mem::uninitialized() };
+        let mut grp = mem::MaybeUninit::<libc::group>::uninit();
         let mut res = ptr::null_mut();
 
         let error = unsafe {
             Errno::clear();
-            libc::getgrnam_r(CString::new(name).unwrap().as_ptr(), &mut grp,
-                             cbuf.as_mut_ptr(), cbuf.capacity(), &mut res)
+            libc::getgrnam_r(
+                CString::new(name).unwrap().as_ptr(),
+                grp.as_mut_ptr(),
+                cbuf.as_mut_ptr(),
+                cbuf.capacity(),
+                &mut res
+            )
         };
 
         if error == 0 {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2463,7 +2463,7 @@ impl User {
                                 *mut libc::c_char,
                                 libc::size_t,
                                 *mut *mut libc::passwd) -> libc::c_int)
-       -> Option<Result<Self>>
+       -> Result<Option<Self>>
     {
         let bufsize = match sysconf(SysconfVar::GETPW_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
@@ -2482,10 +2482,10 @@ impl User {
 
             if error == 0 {
                 if res.is_null() {
-                    return None;
+                    return Ok(None);
                 } else {
                     let pwd = unsafe { pwd.assume_init() };
-                    return Some(Ok(User::from(&pwd)));
+                    return Ok(Some(User::from(&pwd)));
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic of `Vec` by requiring
@@ -2493,7 +2493,7 @@ impl User {
                 unsafe { cbuf.set_len(cbuf.capacity()); }
                 cbuf.reserve(1);
             } else {
-                return Some(Err(Error::Sys(Errno::last())));
+                return Err(Error::Sys(Errno::last()));
             }
         }
     }
@@ -2507,11 +2507,11 @@ impl User {
     ///
     /// ```
     /// use nix::unistd::{Uid, User};
-    /// // Returns an Option<Result<User>>, thus the double unwrap.
+    /// // Returns an Result<Option<User>>, thus the double unwrap.
     /// let res = User::from_uid(Uid::from_raw(0)).unwrap().unwrap();
     /// assert!(res.name == "root");
     /// ```
-    pub fn from_uid(uid: Uid) -> Option<Result<Self>> {
+    pub fn from_uid(uid: Uid) -> Result<Option<Self>> {
         User::from_anything(|pwd, cbuf, cap, res| {
             unsafe { libc::getpwuid_r(uid.0, pwd, cbuf, cap, res) }
         })
@@ -2526,11 +2526,11 @@ impl User {
     ///
     /// ```
     /// use nix::unistd::User;
-    /// // Returns an Option<Result<User>>, thus the double unwrap.
+    /// // Returns an Result<Option<User>>, thus the double unwrap.
     /// let res = User::from_name("root").unwrap().unwrap();
     /// assert!(res.name == "root");
     /// ```
-    pub fn from_name(name: &str) -> Option<Result<Self>> {
+    pub fn from_name(name: &str) -> Result<Option<Self>> {
         let name = CString::new(name).unwrap();
         User::from_anything(|pwd, cbuf, cap, res| {
             unsafe { libc::getpwnam_r(name.as_ptr(), pwd, cbuf, cap, res) }
@@ -2582,7 +2582,7 @@ impl Group {
                                 *mut libc::c_char,
                                 libc::size_t,
                                 *mut *mut libc::group) -> libc::c_int)
-       -> Option<Result<Self>>
+       -> Result<Option<Self>>
     {
         let bufsize = match sysconf(SysconfVar::GETGR_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
@@ -2601,10 +2601,10 @@ impl Group {
 
             if error == 0 {
                 if res.is_null() {
-                    return None;
+                    return Ok(None);
                 } else {
                     let grp = unsafe { grp.assume_init() };
-                    return Some(Ok(Group::from(&grp)));
+                    return Ok(Some(Group::from(&grp)));
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic of `Vec` by requiring
@@ -2612,7 +2612,7 @@ impl Group {
                 unsafe { cbuf.set_len(cbuf.capacity()); }
                 cbuf.reserve(1);
             } else {
-                return Some(Err(Error::Sys(Errno::last())));
+                return Err(Error::Sys(Errno::last()));
             }
         }
     }
@@ -2628,11 +2628,11 @@ impl Group {
     #[cfg_attr(not(target_os = "linux"), doc = " ```no_run")]
     #[cfg_attr(target_os = "linux", doc = " ```")]
     /// use nix::unistd::{Gid, Group};
-    /// // Returns an Option<Result<Group>>, thus the double unwrap.
+    /// // Returns an Result<Option<Group>>, thus the double unwrap.
     /// let res = Group::from_gid(Gid::from_raw(0)).unwrap().unwrap();
     /// assert!(res.name == "root");
     /// ```
-    pub fn from_gid(gid: Gid) -> Option<Result<Self>> {
+    pub fn from_gid(gid: Gid) -> Result<Option<Self>> {
         Group::from_anything(|grp, cbuf, cap, res| {
             unsafe { libc::getgrgid_r(gid.0, grp, cbuf, cap, res) }
         })
@@ -2649,11 +2649,11 @@ impl Group {
     #[cfg_attr(not(target_os = "linux"), doc = " ```no_run")]
     #[cfg_attr(target_os = "linux", doc = " ```")]
     /// use nix::unistd::Group;
-    /// // Returns an Option<Result<Group>>, thus the double unwrap.
+    /// // Returns an Result<Option<Group>>, thus the double unwrap.
     /// let res = Group::from_name("root").unwrap().unwrap();
     /// assert!(res.name == "root");
     /// ```
-    pub fn from_name(name: &str) -> Option<Result<Self>> {
+    pub fn from_name(name: &str) -> Result<Option<Self>> {
         let name = CString::new(name).unwrap();
         Group::from_anything(|grp, cbuf, cap, res| {
             unsafe { libc::getgrnam_r(name.as_ptr(), grp, cbuf, cap, res) }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -541,7 +541,7 @@ pub fn symlinkat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
 
 // Double the buffer capacity up to limit. In case it already has
 // reached the limit, return Errno::ERANGE.
-fn reserve_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
+fn reserve_double_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
     use std::cmp::min;
 
     if buf.len() >= limit {
@@ -597,7 +597,7 @@ pub fn getcwd() -> Result<PathBuf> {
             }
 
             // Trigger the internal buffer resizing logic.
-            reserve_buffer_size(&mut buf, PATH_MAX as usize)?;
+            reserve_double_buffer_size(&mut buf, PATH_MAX as usize)?;
         }
     }
 }
@@ -2502,7 +2502,7 @@ impl User {
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic.
-                reserve_buffer_size(&mut cbuf, bufsize)?;
+                reserve_double_buffer_size(&mut cbuf, bufsize)?;
             } else {
                 return Err(Error::Sys(Errno::last()));
             }
@@ -2620,7 +2620,7 @@ impl Group {
                 }
             } else if Errno::last() == Errno::ERANGE {
                 // Trigger the internal buffer resizing logic.
-                reserve_buffer_size(&mut cbuf, bufsize)?;
+                reserve_double_buffer_size(&mut cbuf, bufsize)?;
             } else {
                 return Err(Error::Sys(Errno::last()));
             }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2459,11 +2459,12 @@ impl From<&libc::passwd> for User {
 }
 
 impl User {
-    fn from_anything(f: impl Fn(*mut libc::passwd,
-                                *mut libc::c_char,
-                                libc::size_t,
-                                *mut *mut libc::passwd) -> libc::c_int)
-       -> Result<Option<Self>>
+    fn from_anything<F>(f: F) -> Result<Option<Self>>
+    where
+        F: Fn(*mut libc::passwd,
+              *mut libc::c_char,
+              libc::size_t,
+              *mut *mut libc::passwd) -> libc::c_int
     {
         let bufsize = match sysconf(SysconfVar::GETPW_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
@@ -2578,11 +2579,12 @@ impl Group {
         ret
     }
 
-    fn from_anything(f: impl Fn(*mut libc::group,
-                                *mut libc::c_char,
-                                libc::size_t,
-                                *mut *mut libc::group) -> libc::c_int)
-       -> Result<Option<Self>>
+    fn from_anything<F>(f: F) -> Result<Option<Self>>
+    where
+        F: Fn(*mut libc::group,
+              *mut libc::c_char,
+              libc::size_t,
+              *mut *mut libc::group) -> libc::c_int
     {
         let bufsize = match sysconf(SysconfVar::GETGR_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -30,7 +30,7 @@ pub use self::usergroupiter::*;
 ///
 /// Newtype pattern around `uid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Uid(uid_t);
 
 impl Uid {
@@ -79,7 +79,7 @@ pub const ROOT: Uid = Uid(0);
 ///
 /// Newtype pattern around `gid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Gid(gid_t);
 
 impl Gid {
@@ -2423,7 +2423,7 @@ const PWGRP_BUFSIZE: usize = 1024;
 /// fields are based on the user's locale, which could be non-UTF8, while other fields are
 /// guaranteed to conform to [`NAME_REGEX`](https://serverfault.com/a/73101/407341), which only
 /// contains ASCII.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct User {
     /// Username
     pub name: String,

--- a/test/test.rs
+++ b/test/test.rs
@@ -120,6 +120,8 @@ lazy_static! {
     pub static ref PTSNAME_MTX: Mutex<()> = Mutex::new(());
     /// Any test that alters signal handling must grab this mutex.
     pub static ref SIGNAL_MTX: Mutex<()> = Mutex::new(());
+    /// Any test that uses the `Users` or `Groups` iterators must grab this mutex.
+    pub static ref USER_GRP_ITER_MTX: Mutex<()> = Mutex::new(());
 }
 
 /// RAII object that restores a test's original directory on drop

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -600,6 +600,62 @@ fn test_symlinkat() {
     );
 }
 
+#[test]
+fn test_getpwuid() {
+    let res = User::query( UserQuery::Uid(Uid::from_raw(1)) ).unwrap();
+    assert!(res.unwrap().uid == Uid::from_raw(1));
+}
+
+#[test]
+fn test_getgrgid() {
+    let res = Group::query( GroupQuery::Gid(Gid::from_raw(1)) ).unwrap();
+    assert!(res.unwrap().gid == Gid::from_raw(1));
+}
+
+#[cfg(not(any(target_os = "android",
+              target_os = "ios",
+              target_os = "macos",
+              target_env = "musl")))]
+
+#[test]
+fn test_users_iterator() {
+    let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
+
+    let entries = Users::new();
+    let users: Vec<Result<User, _>> = entries.collect();
+    let entries2 = Users::new();
+    let users2: Vec<Result<User, _>> = entries2.collect();
+    assert!(users == users2 && users.len() > 0);
+}
+
+#[cfg(not(any(target_os = "android",
+              target_os = "ios",
+              target_os = "macos",
+              target_env = "musl")))]
+
+#[test]
+fn test_groups_iterator() {
+    let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
+
+    let entries = Groups::new();
+    let groups: Vec<Result<Group, _>> = entries.collect();
+    let entries2 = Groups::new();
+    let groups2: Vec<Result<Group, _>> = entries2.collect();
+    assert!(groups == groups2 && groups.len() > 0);
+}
+
+#[cfg(not(any(target_os = "android",
+              target_os = "ios",
+              target_os = "macos",
+              target_env = "musl")))]
+#[test]
+/// This test sees what happens when we use a ridiculously small buffer.
+fn test_users_iterator_smallbuf() {
+    let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
+
+    let bufsize = 2;
+    assert!(Users::with_bufsize(bufsize).next().unwrap().is_err());
+}
 
 #[test]
 fn test_unlinkat_dir_noremovedir() {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -602,14 +602,14 @@ fn test_symlinkat() {
 
 #[test]
 fn test_getpwuid() {
-    let res = User::query( UserQuery::Uid(Uid::from_raw(1)) ).unwrap();
-    assert!(res.unwrap().uid == Uid::from_raw(1));
+    let res = User::from_uid(Uid::from_raw(0), None).unwrap();
+    assert!(res.unwrap().uid == Uid::from_raw(0));
 }
 
 #[test]
 fn test_getgrgid() {
-    let res = Group::query( GroupQuery::Gid(Gid::from_raw(1)) ).unwrap();
-    assert!(res.unwrap().gid == Gid::from_raw(1));
+    let res = Group::from_gid(Gid::from_raw(0), None).unwrap();
+    assert!(res.unwrap().gid == Gid::from_raw(0));
 }
 
 #[cfg(not(any(target_os = "android",
@@ -621,9 +621,9 @@ fn test_getgrgid() {
 fn test_users_iterator() {
     let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
 
-    let entries = Users::new();
+    let entries = Users::default();
     let users: Vec<Result<User, _>> = entries.collect();
-    let entries2 = Users::new();
+    let entries2 = Users::default();
     let users2: Vec<Result<User, _>> = entries2.collect();
     assert!(users == users2 && users.len() > 0);
 }
@@ -637,9 +637,9 @@ fn test_users_iterator() {
 fn test_groups_iterator() {
     let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
 
-    let entries = Groups::new();
+    let entries = Groups::default();
     let groups: Vec<Result<Group, _>> = entries.collect();
-    let entries2 = Groups::new();
+    let entries2 = Groups::default();
     let groups2: Vec<Result<Group, _>> = entries2.collect();
     assert!(groups == groups2 && groups.len() > 0);
 }
@@ -654,7 +654,7 @@ fn test_users_iterator_smallbuf() {
     let _m = ::USER_GRP_ITER_MTX.lock().expect("Mutex got poisoned by another test");
 
     let bufsize = 2;
-    assert!(Users::with_bufsize(bufsize).next().unwrap().is_err());
+    assert!(Users::with_capacity(bufsize).next().unwrap().is_err());
 }
 
 #[test]

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -600,18 +600,6 @@ fn test_symlinkat() {
     );
 }
 
-#[test]
-fn test_getpwuid() {
-    let res = User::from_uid(Uid::from_raw(0), None).unwrap();
-    assert!(res.unwrap().uid == Uid::from_raw(0));
-}
-
-#[test]
-fn test_getgrgid() {
-    let res = Group::from_gid(Gid::from_raw(0), None).unwrap();
-    assert!(res.unwrap().gid == Gid::from_raw(0));
-}
-
 #[cfg(not(any(target_os = "android",
               target_os = "ios",
               target_os = "macos",


### PR DESCRIPTION
This PR closes #862.

Implemented functions:
* As `User::query`:
  * getpwnam
  * getpwuid
* As `Group::query`:
  * getgrgid
  * getgrnam
* As `Users` iterator:
  * getpwent
  * setpwent
  * endpwent
* As `Groups` iterator:
  * getgrent
  * setgrent
  * endgrent


~I wanted to implement `getgrent`, `setgrent` and `endgrent`, but they are missing from `libc`. (See https://github.com/rust-lang/libc/issues/923 )~