### PR TITLE
Add SockProtocol::Htons(u16) for RAW sockets

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -253,6 +253,9 @@ sockopt_impl!(Both, IpTransparent, libc::SOL_IP, libc::IP_TRANSPARENT, bool);
 sockopt_impl!(Both, BindAny, libc::SOL_SOCKET, libc::SO_BINDANY, bool);
 #[cfg(target_os = "freebsd")]
 sockopt_impl!(Both, BindAny, libc::IPPROTO_IP, libc::IP_BINDANY, bool);
+/// SO_PROTOCOL (since Linux 2.6.32)
+#[cfg(any(target_os = "android", target_os = "linux"))]
+sockopt_impl!(GetOnly, Protocol, libc::SOL_SOCKET, libc::SO_PROTOCOL, u32);
 
 /*
  *

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -255,3 +255,22 @@ pub fn test_syscontrol() {
     // requires root privileges
     // connect(fd, &sockaddr).expect("connect failed");
 }
+
+/// Test that SockProtocol::Htons returns htons(u16) conversion correctly
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+pub fn test_socketprotocol_htons() {
+  use libc::{c_int};
+  use nix::sys::socket::{SockProtocol};
+
+  /* ETH_P_ALL */
+  let ntons: c_int = SockProtocol::Htons(3).into();
+  assert_eq!(ntons, 768);
+
+  let ntons: c_int = SockProtocol::Htons(0xFFFF).into();
+  assert_eq!(ntons, 0xFFFF);
+
+  let ntons: c_int = SockProtocol::Htons(0xCAFE).into();
+  assert_eq!(ntons, 0xFECA);
+}
+


### PR DESCRIPTION
This PR closes #854.

* Maintains backwards compatibility with existing API.
* Tests htons conversion

Welcome to comments and suggestions. Thanks.

/cc @mexus @Susurrus 