### PR TITLE
macOS: Add getsockopt for (libc::SYSPROTO_CONTROL, libc::UTUN_OPT_IFNAME)

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -283,6 +283,8 @@ sockopt_impl!(Both, IpTransparent, libc::SOL_IP, libc::IP_TRANSPARENT, bool);
 sockopt_impl!(Both, BindAny, libc::SOL_SOCKET, libc::SO_BINDANY, bool);
 #[cfg(target_os = "freebsd")]
 sockopt_impl!(Both, BindAny, libc::IPPROTO_IP, libc::IP_BINDANY, bool);
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+sockopt_impl!(GetOnly, UTunIfname, libc::SYSPROTO_CONTROL, libc::UTUN_OPT_IFNAME, Vec<u8>, libc::IFNAMSIZ);
 
 /*
  *


### PR DESCRIPTION
Adds `getsockopt` implementation for (`libc::SYSPROTO_CONTROL`, `libc::UTUN_OPT_IFNAME`).

- [X] Implementation (requires #866)
- [X] Tests (hard to test on CI because it requires root to initiate the UTUN)

## Usage
`getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, name, len)` is used to get the interface name of the `connect`ed tunnel adapter. Usually returns `utun` followed by the interface number.