### PR TITLE
Don't derive Clone for sys::aio::Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#837](https://github.com/nix-rust/nix/pull/837))
 
 ### Removed
+- Don't derive Clone for sys::aio::buffer
+  ([#868](https://github.com/nix-rust/nix/pull/868))
 
 ## [0.10.0] 2018-01-26
 

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -92,7 +92,7 @@ pub enum AioCancelStat {
 
 /// Owns (uniquely or shared) a memory buffer to keep it from `Drop`ing while
 /// the kernel has a pointer to it.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Buffer<'a> {
     /// No buffer to own.
     ///
@@ -186,7 +186,7 @@ impl<'a> AioCb<'a> {
     /// # Examples
     ///
     /// Create an `AioCb` from a raw file descriptor and use it for an
-    /// [`fsync`](#method.from_bytes_mut) operation.
+    /// [`fsync`](#method.fsync) operation.
     ///
     /// ```
     /// # extern crate tempfile;
@@ -355,11 +355,11 @@ impl<'a> AioCb<'a> {
     pub fn from_bytes(fd: RawFd, offs: off_t, buf: Bytes,
                       prio: libc::c_int, sigev_notify: SigevNotify,
                       opcode: LioOpcode) -> AioCb<'a> {
-        // Small BytesMuts are stored inline.  Inline storage is a no-no,
+        // Small Bytes are stored inline.  Inline storage is a no-no,
         // because we store a pointer to the buffer in the AioCb before
         // returning the Buffer by move.  If the buffer is too small, reallocate
         // it to force out-of-line storage
-        // TODO: Add an is_inline() method to BytesMut, and a way to explicitly
+        // TODO: Add an is_inline() method to Bytes, and a way to explicitly
         // force out-of-line allocation.
         let buf2 = if buf.len() < 64 {
             // Reallocate to force out-of-line allocation


### PR DESCRIPTION
It's deceptive, because BytesMut::clone doesn't do what you expect.  It
actually copies the object to new storage, which could cause problems if
the Buffer gets Clone'd while the aio operation is still active in the
kernel.

Also, fix some comments.