### PR TITLE
Change SigAction::flags to use from_bits_truncated

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -389,7 +389,7 @@ impl SigAction {
     }
 
     pub fn flags(&self) -> SaFlags {
-        SaFlags::from_bits(self.sigaction.sa_flags).unwrap()
+        SaFlags::from_bits_truncate(self.sigaction.sa_flags)
     }
 
     pub fn mask(&self) -> SigSet {

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -7,6 +7,20 @@ fn test_kill_none() {
 }
 
 #[test]
+fn test_old_sigaction_flags() {
+    extern "C" fn handler(_: ::libc::c_int) {}
+    let act = SigAction::new(
+        SigHandler::Handler(handler),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+    let oact = unsafe { sigaction(SIGINT, &act) }.unwrap();
+    let _flags = oact.flags();
+    let oact = unsafe { sigaction(SIGINT, &act) }.unwrap();
+    let _flags = oact.flags();
+}
+
+#[test]
 fn test_sigprocmask_noop() {
     sigprocmask(SigmaskHow::SIG_BLOCK, None, None)
         .expect("this should be an effective noop");


### PR DESCRIPTION
On Linux, if the signal trampoline code is in the C library, sigaction
sets the SA_RESTORER flag (0x04000000) in the sa_flags field of old
sigaction (see sigreturn(2)).

This is not intended for application use and is missing from SaFlags,
therefore from_bits fails and unwrapping panics the user program.

This fix just drops the bits that are not defined in SaFlags.