### PR TITLE
add SO_MARK SetSockOpt for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `SO_MARK` on Linux.
+- ([#873](https://github.com/nix-rust/nix/pull/873))
 - Added `getsid` in `::nix::unistd`
   ([#850](https://github.com/nix-rust/nix/pull/850))
 - Added `alarm`. ([#830](https://github.com/nix-rust/nix/pull/830))


### PR DESCRIPTION
SO_MARK allows traffic to be filtered by a "tag" using fwmark (see: https://www.linux.org/docs/man8/tc-fw.html).

Tested on Linux as root - the test will skip over when not being run as root, as I noticed a few other tests do this in the suite already.