### PR TITLE
impl FromStr for sys::Signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#857](https://github.com/nix-rust/nix/pull/857))
 - Added `request_code_write_int!` on FreeBSD/DragonFlyBSD
   ([#833](https://github.com/nix-rust/nix/pull/833))
+- Added `FromStr` and `Display` impls for `nix::sys::Signal`
+  ([#884](https://github.com/nix-rust/nix/pull/884))
 
 ### Changed
 - Display and Debug for SysControlAddr now includes all fields.


### PR DESCRIPTION
This implements both ALLCAPS and lowercase full name (including SIG) and short
name.

This matches what `kill` accepts in many shells, and it also allows the `Debug`
representation of `Signal`, which means it can be round-tripped, if desired.