### PR TITLE
Remove IFF_NOTRAILERS for openbsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#833](https://github.com/nix-rust/nix/pull/833))
 - Enabled more `ptrace::Request` definitions for uncommon Linux platforms
   ([#892](https://github.com/nix-rust/nix/pull/892))
+- Remove `IFF_NOTRAILERS` on OpenBSD, as it has been removed in OpenBSD 6.3
+  ([#893](https://github.com/nix-rust/nix/pull/893))
 
 ### Fixed
 - Properly exposed 460800 and 921600 baud rates on NetBSD

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -44,7 +44,6 @@ libc_bitflags!(
                   target_os = "linux",
                   target_os = "macos",
                   target_os = "netbsd",
-                  target_os = "openbsd",
                   target_os = "solaris"))]
         IFF_NOTRAILERS;
         /// Interface manages own routes.


### PR DESCRIPTION
nix currently doesn't compile on openbsd because `IFF_NOTRAILERS` isn't found. This PR fixes the openbsd build again (tested on 6.3). It seems it was changed in this commit:

https://github.com/openbsd/src/commit/beb8b0dd5985e55a615b52e593da6e75bab33f3f