### PR TITLE
Switch to Into<Option<Pid>> for Pid arguments in unistd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#833](https://github.com/nix-rust/nix/pull/833))
 
 ### Changed
+- `setpgid`, `getpgid` and `getsid` now take `Into<Option<Pid>>`
+  arguments. It is now possible to specify these optional Pid
+  arguments as plain `Pid`s or as `None`.
+  ([#896](https://github.com/nix-rust/nix/pull/896))
 - Display and Debug for SysControlAddr now includes all fields.
   ([#837](https://github.com/nix-rust/nix/pull/837))
 - `ioctl!` has been replaced with a family of `ioctl_*!` macros.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -240,20 +240,30 @@ pub fn getppid() -> Pid {
 /// Set a process group ID (see
 /// [setpgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html)).
 ///
-/// Set the process group id (PGID) of a particular process.  If a pid of zero
-/// is specified, then the pid of the calling process is used.  Process groups
-/// may be used to group together a set of processes in order for the OS to
-/// apply some operations across the group.
+/// Set the process group id (PGID) of a particular process.  If None
+/// or a pid of zero is specified, then the pid of the calling process
+/// is used.  Process groups may be used to group together a set of
+/// processes in order for the OS to apply some operations across the
+/// group.
 ///
 /// `setsid()` may be used to create a new process group.
 #[inline]
-pub fn setpgid(pid: Pid, pgid: Pid) -> Result<()> {
+pub fn setpgid<P: Into<Option<Pid>>>(pid: P, pgid: P) -> Result<()> {
+    let pid = pid.into().unwrap_or(Pid(0));
+    let pgid = pgid.into().unwrap_or(Pid(0));
     let res = unsafe { libc::setpgid(pid.into(), pgid.into()) };
     Errno::result(res).map(drop)
 }
+
+/// Get the process group ID for a process (see
+/// [getpgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgid.html)).
+///
+/// Return the process group ID (PGID) of a particular process. If
+/// None or a pid of zero is specified, then the PGID of the calling
+/// process is returned.
 #[inline]
-pub fn getpgid(pid: Option<Pid>) -> Result<Pid> {
-    let res = unsafe { libc::getpgid(pid.unwrap_or(Pid(0)).into()) };
+pub fn getpgid<P: Into<Option<Pid>>>(pid: P) -> Result<Pid> {
+    let res = unsafe { libc::getpgid(pid.into().unwrap_or(Pid(0)).into()) };
     Errno::result(res).map(Pid)
 }
 
@@ -268,13 +278,12 @@ pub fn setsid() -> Result<Pid> {
 /// [getsid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsid.html).
 ///
 /// Obtain the process group ID of the process that is the session leader of the process specified
-/// by pid. If pid is zero, it specifies the calling process.
+/// by pid. If passed None or pid is or zero, it specifies the calling process.
 #[inline]
-pub fn getsid(pid: Option<Pid>) -> Result<Pid> {
-    let res = unsafe { libc::getsid(pid.unwrap_or(Pid(0)).into()) };
+pub fn getsid<P: Into<Option<Pid>>>(pid: P) -> Result<Pid> {
+    let res = unsafe { libc::getsid(pid.into().unwrap_or(Pid(0)).into()) };
     Errno::result(res).map(Pid)
 }
-
 
 /// Get the terminal foreground process group (see
 /// [tcgetpgrp(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetpgrp.html)).

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -112,8 +112,24 @@ fn test_getpid() {
 fn test_getsid() {
     let none_sid: ::libc::pid_t = getsid(None).unwrap().into();
     let pid_sid: ::libc::pid_t = getsid(Some(getpid())).unwrap().into();
+    let plain_sid: ::libc::pid_t = getsid(getpid()).unwrap().into();
+    let zero_sid: ::libc::pid_t = getsid(Pid::from_raw(0)).unwrap().into();
     assert!(none_sid > 0);
     assert!(none_sid == pid_sid);
+    assert!(none_sid == plain_sid);
+    assert!(none_sid == zero_sid);
+}
+
+#[test]
+fn test_getpgid() {
+    let none_pgid: ::libc::pid_t = getpgid(None).unwrap().into();
+    let pid_pgid: ::libc::pid_t = getpgid(Some(getpid())).unwrap().into();
+    let plain_pgid: ::libc::pid_t = getpgid(getpid()).unwrap().into();
+    let zero_pgid: ::libc::pid_t = getpgid(Pid::from_raw(0)).unwrap().into();
+    assert!(none_pgid > 0);
+    assert!(none_pgid == pid_pgid);
+    assert!(none_pgid == plain_pgid);
+    assert!(none_pgid == zero_pgid);
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
This PR adjusts the unistd functions `setpgid`, `getpgid` and `getsid` to take `Into<Option<Pid>>` arguments, which (as of Rust 1.12) allows users to pass plain `Pid`s without wrapping them in `Some`.

Additionally, this allows users to pass `None` as both the `pid` and the `pgrp` argument in `setpgrp`, defaulting them to 0, as specified by POSIX.

I hope this is useful! If you like this, please let me know if I should go on an `Into<Option>` spree on the rest of the code (: