### PR TITLE
Remove emulation of FD_CLOEXEC/O_NONBLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#892](https://github.com/nix-rust/nix/pull/892))
 - Remove `IFF_NOTRAILERS` on OpenBSD, as it has been removed in OpenBSD 6.3
   ([#893](https://github.com/nix-rust/nix/pull/893))
+- Emulation of `FD_CLOEXEC` and `O_NONBLOCK` was removed from `socket()`, `accept4()`, and
+  `socketpair()`.
+  ([#907](https://github.com/nix-rust/nix/pull/907))
 
 ### Fixed
 - Fixed possible panics when using `SigAction::flags` on Linux
@@ -68,6 +71,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#872](https://github.com/nix-rust/nix/pull/872))
 - Removed `sys::aio::lio_listio`.  Use `sys::aio::LioCb::listio` instead.
   ([#872](https://github.com/nix-rust/nix/pull/872))
+- Removed emulated `accept4()` from macos, ios, and netbsd targets
+  ([#907](https://github.com/nix-rust/nix/pull/907))
 
 ## [0.10.0] 2018-01-26
 

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -255,3 +255,65 @@ pub fn test_syscontrol() {
     // requires root privileges
     // connect(fd, &sockaddr).expect("connect failed");
 }
+
+/// Test non-blocking mode on new sockets via SockFlag::O_NONBLOCK
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "linux",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
+#[test]
+pub fn test_sockflag_nonblock() {
+    use libc;
+    use nix::fcntl::{fcntl};
+    use nix::fcntl::FcntlArg::{F_GETFL};
+    use nix::sys::socket::{socket, AddressFamily, SockType, SockFlag};
+
+    /* first, try without SockFlag::SOCK_NONBLOCK */
+    let sock = socket(AddressFamily::Unix, SockType::Stream, SockFlag::empty(), None)
+                 .expect("socket failed");
+
+    let fcntl_res = fcntl(sock, F_GETFL).expect("fcntl failed");
+
+    assert!(fcntl_res & libc::O_NONBLOCK == 0);
+
+    /* next, try with SockFlag::SOCK_NONBLOCK */
+    let sock = socket(AddressFamily::Unix, SockType::Stream, SockFlag::SOCK_NONBLOCK, None)
+                 .expect("socket failed");
+
+    let fcntl_res = fcntl(sock, F_GETFL).expect("fcntl failed");
+
+    assert!(fcntl_res & libc::O_NONBLOCK == libc::O_NONBLOCK);
+}
+
+/// Test close-on-exec on new sockets via SockFlag::SOCK_CLOEXEC
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "linux",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
+#[test]
+pub fn test_sockflag_cloexec() {
+    use libc;
+    use nix::fcntl::{fcntl};
+    use nix::fcntl::FcntlArg::{F_GETFD};
+    use nix::sys::socket::{socket, AddressFamily, SockType, SockFlag};
+
+    /* first, test without SockFlag::SOCK_CLOEXEC */
+    let sock = socket(AddressFamily::Unix, SockType::Stream, SockFlag::empty(), None)
+                 .expect("socket failed");
+
+    let fcntl_res = fcntl(sock, F_GETFD).expect("fcntl failed");
+
+    assert!(fcntl_res & libc::FD_CLOEXEC == 0);
+
+    /* next, test without SockFlag::SOCK_CLOEXEC */
+    let sock = socket(AddressFamily::Unix, SockType::Stream, SockFlag::SOCK_CLOEXEC, None)
+                 .expect("socket failed");
+
+    let fcntl_res = fcntl(sock, F_GETFD).expect("fcntl failed");
+
+    assert!(fcntl_res & libc::FD_CLOEXEC == libc::FD_CLOEXEC);
+}


### PR DESCRIPTION
Rather than using the native implementation of these constants
on supported platforms, the native implementation was instead
emulated. This was also hidden from the user even though this
could result in data races and the functionality being broken.

Native functionality is, however, not support on macos/ios.
Rather than enable this emulation solely for this platform, it
should be removed as this is a dangerous abstraction.

This is a replacement for #863. There is much previous discussion there which I recommend you read to familiarize yourself with this decision.

I'm looking to push this through rather quickly as it's the last thing blocking our next 0.11.0 release.

cc @aomser @kristate