### PR TITLE
Specify bytes version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,7 @@ void = "1.0.2"
 cc = "1"
 
 [dev-dependencies]
-# The examples use a new feature of Bytes which should be available in 0.4.7
-# https://github.com/carllerche/bytes/pull/192
-bytes = { git = "https://github.com/carllerche/bytes", rev = "ae1b454" }
+bytes = "0.4.8"
 lazy_static = "1"
 rand = "0.4"
 tempdir = "0.3"

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -20,6 +20,8 @@ The release is prepared as follows:
   - In `Cargo.toml`, change the libc dependency to the latest version.
   - In `README.md`, update the version in the Usage section to the new
     version.
+- Confirm that everything's ready for a release by running
+  `cargo publish --dry-run`
 - Make a pull request.
 - Once the PR is merged, tag the merge commit, e.g. `git tag v0.8.3
   $MERGE_COMMIT_SHA1`.


### PR DESCRIPTION
Needed to do this for the v0.11.0 release, but I missed it on my first pass through. Also updated the release notes to hopefully prevent this error in the future.