### PR TITLE
Fix compilation on aarch64-unknown-linux-musl

### DIFF
--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -48,7 +48,7 @@ libc_bitflags!{
         /// Put the mapping into the first 2GB of the process address space.
         #[cfg(any(all(any(target_os = "android", target_os = "linux"),
                       any(target_arch = "x86", target_arch = "x86_64")),
-                  all(target_os = "linux", target_env = "musl", any(target_arch = "x86", target_pointer_width = "64")),
+                  all(target_os = "linux", target_env = "musl", any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "freebsd", target_pointer_width = "64")))]
         MAP_32BIT;
         /// Used for stacks; indicates to the kernel that the mapping should extend downward in memory.


### PR DESCRIPTION
trust/cross don't support this architecture, so it's non-trivial to add CI testing for this to nix, but this fixed it locally for me. Since it's not a supported platform, I haven't added anything to the CHANGELOG, since this could break before the next release.