### PR TITLE
Get `SO_PEERCRED` working on all Linux targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added a `sysinfo` wrapper.
   ([#922](https://github.com/nix-rust/nix/pull/922))
+- Support the `SO_PEERCRED` socket option and the `UnixCredentials` type on all Linux and Android targets.
+  ([#921](https://github.com/nix-rust/nix/pull/921))
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -173,7 +173,7 @@ libc_bitflags!{
 }
 
 cfg_if! {
-    if #[cfg(all(target_os = "linux", not(target_arch = "arm")))] {
+    if #[cfg(any(target_os = "android", target_os = "linux"))] {
         /// Unix credentials of the sending process.
         ///
         /// This struct is used with the `SO_PEERCRED` ancillary message for UNIX sockets.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -225,7 +225,7 @@ sockopt_impl!(Both, Broadcast, libc::SOL_SOCKET, libc::SO_BROADCAST, bool);
 sockopt_impl!(Both, OobInline, libc::SOL_SOCKET, libc::SO_OOBINLINE, bool);
 sockopt_impl!(GetOnly, SocketError, libc::SOL_SOCKET, libc::SO_ERROR, i32);
 sockopt_impl!(Both, KeepAlive, libc::SOL_SOCKET, libc::SO_KEEPALIVE, bool);
-#[cfg(all(target_os = "linux", not(target_arch="arm")))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 sockopt_impl!(GetOnly, PeerCredentials, libc::SOL_SOCKET, libc::SO_PEERCRED, super::UnixCredentials);
 #[cfg(any(target_os = "ios",
           target_os = "macos"))]
@@ -478,7 +478,7 @@ unsafe impl<'a> Set<'a, usize> for SetUsize {
 
 #[cfg(test)]
 mod test {
-    #[cfg(all(target_os = "linux", not(target_arch = "arm")))]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     #[test]
     fn can_get_peercred_on_unix_socket() {
         use super::super::*;


### PR DESCRIPTION
These were disabled for ARM way back in 0db6ed1a28b4fb4d408cd9b7c4dba0a79bccf1f7 and 09c00ed7d9d92db2a79baa3ed212e7e239edceb9. Try to enable them for all arches and Android as well, since the removal wasn't really explained and I see no reason why this shouldn't work.