### PR TITLE
Fix control message *decoding* and add support for `ScmCredentials`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#922](https://github.com/nix-rust/nix/pull/922))
 - Support the `SO_PEERCRED` socket option and the `UnixCredentials` type on all Linux and Android targets.
   ([#921](https://github.com/nix-rust/nix/pull/921))
+- Added support for `SCM_CREDENTIALS`, allowing to send process credentials over Unix sockets.
+  ([#923](https://github.com/nix-rust/nix/pull/923))
 
 ### Changed
 

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -255,6 +255,8 @@ sockopt_impl!(Both, BindAny, libc::SOL_SOCKET, libc::SO_BINDANY, bool);
 sockopt_impl!(Both, BindAny, libc::IPPROTO_IP, libc::IP_BINDANY, bool);
 #[cfg(target_os = "linux")]
 sockopt_impl!(Both, Mark, libc::SOL_SOCKET, libc::SO_MARK, u32);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+sockopt_impl!(Both, PassCred, libc::SOL_SOCKET, libc::SO_PASSCRED, bool);
 
 /*
  *

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -48,6 +48,11 @@ impl Uid {
     pub fn is_root(&self) -> bool {
         *self == ROOT
     }
+
+    /// Get the raw `uid_t` wrapped by `self`.
+    pub fn as_raw(&self) -> uid_t {
+        self.0
+    }
 }
 
 impl From<Uid> for uid_t {
@@ -87,6 +92,11 @@ impl Gid {
     pub fn effective() -> Self {
         getegid()
     }
+
+    /// Get the raw `gid_t` wrapped by `self`.
+    pub fn as_raw(&self) -> gid_t {
+        self.0
+    }
 }
 
 impl From<Gid> for gid_t {
@@ -122,6 +132,11 @@ impl Pid {
     /// Returns PID of parent of calling process
     pub fn parent() -> Self {
         getppid()
+    }
+
+    /// Get the raw `pid_t` wrapped by `self`.
+    pub fn as_raw(&self) -> pid_t {
+        self.0
     }
 }
 


### PR DESCRIPTION
While https://github.com/nix-rust/nix/pull/918 fixed the *encoding*, the *decoding* done by the `CmsgIterator` still remained broken when multiple messages are received. However, since nix didn't support any control message that could reliably be sent twice in one `sendmsg` call, this couldn't be tested properly.

This PR addresses this by adding `SCM_CREDENTIALS` support and testing all of this by passing both an `SCM_CREDENTIALS` and a `SCM_RIGHTS` message at the same time.

I've also verified that the resulting encoding is the same as for roughly equivalent C code.