### PR TITLE
Enable the select tests on powerpc and mips

### DIFF
--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -273,14 +273,7 @@ mod tests {
         assert_eq!(set.highest(), Some(7));
     }
 
-    // powerpc-unknown-linux-gnu currently fails on the first `assert_eq` because
-    // `select()` returns a 0 instead of a 1. Since this test has only been run on
-    // qemu, it's unclear if this is a OS or qemu bug. Just disable it on that arch
-    // for now.
-    // FIXME: Fix tests for powerpc and mips
-    // FIXME: Add a link to an upstream qemu bug if there is one
     #[test]
-    #[cfg_attr(any(target_arch = "powerpc", target_arch = "mips"), ignore)]
     fn test_select() {
         let (r1, w1) = pipe().unwrap();
         write(w1, b"hi!").unwrap();
@@ -301,7 +294,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(any(target_arch = "powerpc", target_arch = "mips"), ignore)]
     fn test_select_nfds() {
         let (r1, w1) = pipe().unwrap();
         write(w1, b"hi!").unwrap();
@@ -322,7 +314,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(any(target_arch = "powerpc", target_arch = "mips"), ignore)]
     fn test_select_nfds2() {
         let (r1, w1) = pipe().unwrap();
         write(w1, b"hi!").unwrap();


### PR DESCRIPTION
They pass at least on my machine with QEMU, so the underlying bugs might
have been fixed.