### PR TITLE
Enable most AIO tests on musl targets and clean them up

### DIFF
--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -424,7 +424,7 @@ extern fn sigfunc(_: c_int) {
 // Test an aio operation with completion delivered by a signal
 // FIXME: This test is ignored on mips because of failures in qemu in CI
 #[test]
-#[cfg_attr(any(all(target_env = "musl", target_arch = "x86_64"), target_arch = "mips", target_arch = "mips64"), ignore)]
+#[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
 fn test_write_sigev_signal() {
     let _m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
     let sa = SigAction::new(SigHandler::Handler(sigfunc),
@@ -560,7 +560,7 @@ fn test_liocb_listio_nowait() {
 // FIXME: This test is ignored on mips/mips64 because of failures in qemu in CI.
 #[test]
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-#[cfg_attr(any(target_arch = "mips", target_arch = "mips64", target_env = "musl"), ignore)]
+#[cfg_attr(any(all(target_arch = "x86", target_env = "musl"), target_arch = "mips", target_arch = "mips64"), ignore)]
 fn test_liocb_listio_signal() {
     let _m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
     const INITIAL: &[u8] = b"abcdef123456";

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -46,7 +46,6 @@ fn test_accessors() {
 // our bindings.  So it's sufficient to check that AioCb.cancel returned any
 // AioCancelStat value.
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_cancel() {
     let wbuf: &[u8] = b"CDEF";
 
@@ -71,7 +70,6 @@ fn test_cancel() {
 
 // Tests using aio_cancel_all for all outstanding IOs.
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_aio_cancel_all() {
     let wbuf: &[u8] = b"CDEF";
 
@@ -95,7 +93,6 @@ fn test_aio_cancel_all() {
 }
 
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_fsync() {
     const INITIAL: &[u8] = b"abcdef123456";
     let mut f = tempfile().unwrap();
@@ -131,7 +128,6 @@ fn test_fsync_error() {
 }
 
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_aio_suspend() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEFG";
@@ -174,7 +170,6 @@ fn test_aio_suspend() {
 // Test a simple aio operation with no completion notification.  We must poll
 // for completion
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_read() {
     const INITIAL: &[u8] = b"abcdef123456";
     let mut rbuf = vec![0; 4];
@@ -220,7 +215,6 @@ fn test_read_error() {
 
 // Tests from_mut_slice
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_read_into_mut_slice() {
     const INITIAL: &[u8] = b"abcdef123456";
     let mut rbuf = vec![0; 4];
@@ -246,7 +240,6 @@ fn test_read_into_mut_slice() {
 
 // Tests from_ptr
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_read_into_pointer() {
     const INITIAL: &[u8] = b"abcdef123456";
     let mut rbuf = vec![0; 4];
@@ -274,11 +267,9 @@ fn test_read_into_pointer() {
     assert_eq!(rbuf, EXPECT);
 }
 
-// Test reading into an immutable buffer.  It should fail
-// FIXME: This test fails to panic on Linux/musl
+// Test reading into an immutable buffer. It should fail with a panic.
 #[test]
 #[should_panic(expected = "Can't read into an immutable buffer")]
-#[cfg_attr(target_env = "musl", ignore)]
 fn test_read_immutable_buffer() {
     let rbuf: &[u8] = b"CDEF";
     let f = tempfile().unwrap();
@@ -291,11 +282,9 @@ fn test_read_immutable_buffer() {
     aiocb.read().unwrap();
 }
 
-
 // Test a simple aio operation with no completion notification.  We must poll
 // for completion.  Unlike test_aio_read, this test uses AioCb::from_slice
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_write() {
     const INITIAL: &[u8] = b"abcdef123456";
     let wbuf = "CDEF".to_string().into_bytes();
@@ -324,7 +313,6 @@ fn test_write() {
 
 // Tests `AioCb::from_boxed_slice` with `Bytes`
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_write_bytes() {
     const INITIAL: &[u8] = b"abcdef123456";
     let wbuf = Box::new(Bytes::from(&b"CDEF"[..]));
@@ -354,7 +342,6 @@ fn test_write_bytes() {
 
 // Tests `AioCb::from_boxed_mut_slice` with `BytesMut`
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_read_bytes_mut_small() {
     const INITIAL: &[u8] = b"abcdef";
     let rbuf = Box::new(BytesMut::from(vec![0; 4]));
@@ -379,7 +366,6 @@ fn test_read_bytes_mut_small() {
 
 // Tests `AioCb::from_ptr`
 #[test]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_write_from_pointer() {
     const INITIAL: &[u8] = b"abcdef123456";
     let wbuf = "CDEF".to_string().into_bytes();
@@ -479,7 +465,6 @@ fn test_write_sigev_signal() {
 // time listio returns.
 #[test]
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_liocb_listio_wait() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEF";
@@ -526,7 +511,6 @@ fn test_liocb_listio_wait() {
 // mechanism to check for the individual AioCb's completion.
 #[test]
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
-#[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
 fn test_liocb_listio_nowait() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEF";
@@ -631,11 +615,9 @@ fn test_liocb_listio_signal() {
 }
 
 // Try to use LioCb::listio to read into an immutable buffer.  It should fail
-// FIXME: This test fails to panic on Linux/musl
 #[test]
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[should_panic(expected = "Can't read into an immutable buffer")]
-#[cfg_attr(target_env = "musl", ignore)]
 fn test_liocb_listio_read_immutable() {
     let rbuf: &[u8] = b"abcd";
     let f = tempfile().unwrap();

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -618,6 +618,8 @@ fn test_liocb_listio_signal() {
 #[test]
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 #[should_panic(expected = "Can't read into an immutable buffer")]
+// FIXME: This test fails on Travis with "failed to initiate panic, error 5"
+#[cfg_attr(target_env = "musl", ignore)]
 fn test_liocb_listio_read_immutable() {
     let rbuf: &[u8] = b"abcd";
     let f = tempfile().unwrap();


### PR DESCRIPTION
I've run them a bunch of times on my machine and haven't witnessed any spurious failures so far.

The exception are the signal event tests, which I've kept ignored. They deadlock on some target combinations - apparently the signal handler never runs. This is not a QEMU bug since it also happens on `i686-unknown-linux-musl`.