### PR TITLE
Add wrappers for futimens(2) and utimesat(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#916](https://github.com/nix-rust/nix/pull/916))
 - Added `kmod` module that allows loading and unloading kernel modules on Linux.
   ([#930](https://github.com/nix-rust/nix/pull/930))
+- Added `futimens` and `utimesat` wrappers.
+  ([#944](https://github.com/nix-rust/nix/pull/944))
 
 ### Changed
 - Increased required Rust version to 1.22.1/


### PR DESCRIPTION
Hello again!

Let's see how this looks like. I don't think there is any other way of doing this via the standard library, though I see there is a `filetime` crate in the Rust nursery to add this missing functionality. Not sure what your policy for adding features into `nix` is.