### PR TITLE
Add a wrapper for utimes(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#916](https://github.com/nix-rust/nix/pull/916))
 - Added `kmod` module that allows loading and unloading kernel modules on Linux.
   ([#930](https://github.com/nix-rust/nix/pull/930))
-- Added `futimens` and `utimesat` wrappers.
-  ([#944](https://github.com/nix-rust/nix/pull/944))
+- Added `futimens` and `utimesat` wrappers ([#944](https://github.com/nix-rust/nix/pull/944))
+  and a `utimes` wrapper ([#946](https://github.com/nix-rust/nix/pull/946)).
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -6,9 +6,9 @@ use std::time::{Duration, UNIX_EPOCH};
 use libc::{S_IFMT, S_IFLNK};
 
 use nix::fcntl;
-use nix::sys::stat::{self, fchmod, fchmodat, fstat, futimens, lstat, stat, utimensat};
+use nix::sys::stat::{self, fchmod, fchmodat, fstat, futimens, lstat, stat, utimes, utimensat};
 use nix::sys::stat::{FileStat, Mode, FchmodatFlags, UtimensatFlags};
-use nix::sys::time::{TimeSpec, TimeValLike};
+use nix::sys::time::{TimeSpec, TimeVal, TimeValLike};
 use nix::unistd::chdir;
 use nix::Result;
 use tempfile;
@@ -166,6 +166,16 @@ fn assert_times_eq(exp_atime_sec: u64, exp_mtime_sec: u64, attr: &fs::Metadata) 
     assert_eq!(
         Duration::new(exp_mtime_sec, 0),
         attr.modified().unwrap().duration_since(UNIX_EPOCH).unwrap());
+}
+
+#[test]
+fn test_utimes() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let fullpath = tempdir.path().join("file");
+    drop(File::create(&fullpath).unwrap());
+
+    utimes(&fullpath, &TimeVal::seconds(9990), &TimeVal::seconds(5550));
+    assert_times_eq(9990, 5550, &fs::metadata(&fullpath).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
PR #944 added wrappers for the more-modern futimens(2) and utimesat(2),
but unfortunately these APIs are not available on old-ish systems.

In particular, macOS Sierra and below don't implement them, making the
new APIs unusable.  Whether we should care about such "old" systems is
debatable, but the problem is that, at the moment, this is the only
macOS version usable on Travis to test kexts and, thus, to test FUSE
file systems.