### PR TITLE
socket: add AF_UNSPEC to AddressFamily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#930](https://github.com/nix-rust/nix/pull/930))
 - Added `futimens` and `utimesat` wrappers ([#944](https://github.com/nix-rust/nix/pull/944))
   and a `utimes` wrapper ([#946](https://github.com/nix-rust/nix/pull/946)).
+- Added `AF_UNSPEC` wrapper to `AddressFamily` ([#948](https://github.com/nix-rust/nix/pull/948))
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -209,6 +209,9 @@ pub enum AddressFamily {
               target_os = "netbsd",
               target_os = "openbsd"))]
     Natm = libc::AF_NATM,
+    /// Unspecified address family, (see [`getaddrinfo(3)`](http://man7.org/linux/man-pages/man3/getaddrinfo.3.html))
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    Unspec = libc::AF_UNSPEC,
 }
 
 impl AddressFamily {


### PR DESCRIPTION
Hi!

I work on a [crate](https://github.com/levex/network-bridge-rs) where it would make sense to use `AF_UNSPEC` in place of `AF_INET`, since that's the API most bridge libraries use. Unfortunately, it seems that `nix` is missing a representation for `AF_UNSPEC`. This PR adds `Unspec` to `AddressFamily`, so we can now represent `AF_UNSPEC`.