### PR TITLE
Make sys::stat::mode_t public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `futimens` and `utimesat` wrappers ([#944](https://github.com/nix-rust/nix/pull/944))
   and a `utimes` wrapper ([#946](https://github.com/nix-rust/nix/pull/946)).
 - Added `AF_UNSPEC` wrapper to `AddressFamily` ([#948](https://github.com/nix-rust/nix/pull/948))
+- Added the `mode_t` public alias within `sys::stat`.
+  ([#954](https://github.com/nix-rust/nix/pull/954))
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -1,10 +1,10 @@
-pub use libc::dev_t;
+pub use libc::{dev_t, mode_t};
 pub use libc::stat as FileStat;
 
 use {Result, NixPath};
 use errno::Errno;
 use fcntl::AtFlags;
-use libc::{self, mode_t};
+use libc;
 use std::mem;
 use std::os::raw;
 use std::os::unix::io::RawFd;


### PR DESCRIPTION
This allows using e.g. sys::stat::Mode::from_bits() without having to
pull the mode_t type from libc (which is ugly if a project is trying
to use nix exclusively to avoid libc's unsafety).

This change mimics dev_t which was already exposed as public.