### PR TITLE
Add a truncate(2) wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `AF_UNSPEC` wrapper to `AddressFamily` ([#948](https://github.com/nix-rust/nix/pull/948))
 - Added the `mode_t` public alias within `sys::stat`.
   ([#954](https://github.com/nix-rust/nix/pull/954))
+- Added a `truncate` wrapper.
+  ([#956](https://github.com/nix-rust/nix/pull/956))
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -989,6 +989,20 @@ fn pipe2_setflags(fd1: RawFd, fd2: RawFd, flags: OFlag) -> Result<()> {
 /// Truncate a file to a specified length
 ///
 /// See also
+/// [truncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html)
+pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
+    let res = try!(path.with_nix_path(|cstr| {
+        unsafe {
+            libc::truncate(cstr.as_ptr(), len)
+        }
+    }));
+
+    Errno::result(res).map(drop)
+}
+
+/// Truncate a file to a specified length
+///
+/// See also
 /// [ftruncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html)
 pub fn ftruncate(fd: RawFd, len: off_t) -> Result<()> {
     Errno::result(unsafe { libc::ftruncate(fd, len) }).map(drop)


### PR DESCRIPTION
This also adds a test for truncate (obviously) but, while doing so, also
adds a test for the already-existing ftruncate.