### PR TITLE
Added AddressType type to ptrace::linux + peek/poke user fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#955](https://github.com/nix-rust/nix/pull/955))
 - Added support for `ptrace` on BSD operating systems ([#949](https://github.com/nix-rust/nix/pull/949))
 - Added `ptrace` functions for reads and writes to tracee memory and ptrace kill 
-  ([#949](https://github.com/nix-rust/nix/pull/949))
+  ([#949](https://github.com/nix-rust/nix/pull/949)) ([#958](https://github.com/nix-rust/nix/pull/958))
 - Added a `acct` wrapper module for enabling and disabling process accounting
   ([#952](https://github.com/nix-rust/nix/pull/952))
 

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -174,10 +174,9 @@ libc_bitflags! {
 pub unsafe fn ptrace(request: Request, pid: Pid, addr: AddressType, data: *mut c_void) -> Result<c_long> {
     use self::Request::*;
     match request {
-        PTRACE_PEEKTEXT | PTRACE_PEEKDATA | PTRACE_PEEKUSER | PTRACE_GETSIGINFO | 
+        PTRACE_PEEKTEXT | PTRACE_PEEKDATA | PTRACE_GETSIGINFO | 
             PTRACE_GETEVENTMSG | PTRACE_SETSIGINFO | PTRACE_SETOPTIONS | 
-            PTRACE_POKETEXT | PTRACE_POKEDATA | PTRACE_POKEUSER | 
-            PTRACE_KILL => Err(Error::UnsupportedOperation),
+            PTRACE_POKETEXT | PTRACE_POKEDATA | PTRACE_KILL => Err(Error::UnsupportedOperation),
         _ => ptrace_other(request, pid, addr, data)
     }
 }


### PR DESCRIPTION
This was added to the BSD ptrace API and probably should have been added to the linux API to make it easier to write code for both platforms without the user having to reexport the types to their own crate.

I went to use the latest nix myself and found that having this added would improve usability for nix users.

Could potentially add a type for what they return (BSDs: `c_int`, linux: `c_long`). Data input might be trickier as linux is `*mut c_void` and BSD just takes data as `c_int`.