### PR TITLE
Added direct support for fchown() and dup3()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#949](https://github.com/nix-rust/nix/pull/949)) ([#958](https://github.com/nix-rust/nix/pull/958))
 - Added a `acct` wrapper module for enabling and disabling process accounting
   ([#952](https://github.com/nix-rust/nix/pull/952))
+- Added a `fchown` wrapper.
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Increased required Rust version to 1.22.1/
   ([#900](https://github.com/nix-rust/nix/pull/900))
+- Changed the `dup3` wrapper to perform a direct call to the system call `dup3` instead of
+  emulating it via `dup2` and `fcntl` which could cause a race condition. The `dup3` system call
+  is supported on the following platforms: Emscripten, FreeBSD, Fuchsia, Linux, NetBSD, OpenBSD,
+  Solaris.
 
 ### Fixed
 - Made `preadv` take immutable slice of IoVec.
@@ -42,6 +46,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#918](https://github.com/nix-rust/nix/pull/918))
 
 ### Removed
+- Removed the `dup3` wrapper on OSX, which was emulated via `dup2` and `fcntl`, which could cause
+  a race condition. The `dup3` system call is not supported on OSX.
 
 ## [0.11.0] 2018-06-01
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -623,6 +623,20 @@ pub fn fchownat<P: ?Sized + NixPath>(
     Errno::result(res).map(|_| ())
 }
 
+/// Change the ownership of the file specified by the file descriptor `fd` to be owned by the
+/// specified `owner` (user) and `group` (see
+/// [fchown(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchown.html)).
+///
+/// The owner/group for the provided path name will not be modified if `None` is
+/// provided for that argument.  Ownership change will be attempted for the path
+/// only if `Some` owner/group is provided.
+pub fn fchown(fd: RawFd, owner: Option<Uid>, group: Option<Gid>) -> Result<()> {
+    let (uid, gid) = chown_raw_ids(owner, group);
+    let res = unsafe { libc::fchown(fd, uid, gid) };
+
+    Errno::result(res).map(drop)
+}
+
 fn to_exec_array(args: &[CString]) -> Vec<*const c_char> {
     let mut args_p: Vec<*const c_char> = args.iter().map(|s| s.as_ptr()).collect();
     args_p.push(ptr::null());


### PR DESCRIPTION
- Added direct support for `dup3`.
- Removed emulation of `dup3`.
- Added support for `fchown`.

Fixes #939.