### PR TITLE
Require Rust 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,63 +22,63 @@ matrix:
     # Additionally they're moved to the front of the line to get them in the Travis
     # OS X build queue first.
     - env: TARGET="aarch64-apple-ios;armv7-apple-ios;armv7s-apple-ios;i386-apple-ios;x86_64-apple-ios" DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
       os: osx
 
     # Mac builds
     # These are also moved to be first because they wait in a long queue with Travis
     - env: TARGET=i686-apple-darwin
-      rust: 1.22.1
+      rust: 1.24.1
       os: osx
     - env: TARGET=x86_64-apple-darwin
-      rust: 1.22.1
+      rust: 1.24.1
       os: osx
 
     # Android
     - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=i686-linux-android DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
 
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=arm-unknown-linux-gnueabi
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=armv7-unknown-linux-gnueabihf
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=i686-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=i686-unknown-linux-musl
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=mips-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=mips64-unknown-linux-gnuabi64
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=mips64el-unknown-linux-gnuabi64
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=mipsel-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=powerpc64-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=powerpc64le-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.22.1
+      rust: 1.24.1
     - env: TARGET=x86_64-unknown-linux-musl
-      rust: 1.22.1
+      rust: 1.24.1
 
     # *BSD
     # FreeBSD i686 and x86_64 use BuildBot instead of Travis
@@ -87,7 +87,7 @@ matrix:
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-      rust: 1.22.1
+      rust: 1.24.1
 
     # Make sure stable is always working too
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#952](https://github.com/nix-rust/nix/pull/952))
 
 ### Changed
-- Increased required Rust version to 1.22.1/
+- Increased required Rust version to 1.24.1
   ([#900](https://github.com/nix-rust/nix/pull/900))
+  ([#966](https://github.com/nix-rust/nix/pull/966))
 
 ### Fixed
 - Made `preadv` take immutable slice of IoVec.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cc = "1"
 
 [dev-dependencies]
 bytes = "0.4.8"
-lazy_static = "1"
+lazy_static = "1.2"
 rand = "0.5"
 tempfile = "3"
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ limitations. Support for platforms is split into three tiers:
              *do not* block the inclusion of new code. Testing may be run, but
              failures in tests don't block the inclusion of new code.
 
-The following targets are all supported by nix on Rust 1.22.1 or newer (unless
+The following targets are all supported by nix on Rust 1.24.1 or newer (unless
 otherwise noted):
 
 Tier 1:


### PR DESCRIPTION
`lazy_static` as of 1.2 requires Rust 1.24.1, so make that our minimum required. This was discovered when I looked into the failures of #965.

@asomers if you agree with this change, could you update the buildbots here too?
