### PR TITLE
Add a wrapper for lutimes(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#916](https://github.com/nix-rust/nix/pull/916))
 - Added `kmod` module that allows loading and unloading kernel modules on Linux.
   ([#930](https://github.com/nix-rust/nix/pull/930))
-- Added `futimens` and `utimesat` wrappers ([#944](https://github.com/nix-rust/nix/pull/944))
+- Added `futimens` and `utimesat` wrappers ([#944](https://github.com/nix-rust/nix/pull/944)),
+  an `lutimes` wrapper ([#967](https://github.com/nix-rust/nix/pull/967)),
   and a `utimes` wrapper ([#946](https://github.com/nix-rust/nix/pull/946)).
 - Added `AF_UNSPEC` wrapper to `AddressFamily` ([#948](https://github.com/nix-rust/nix/pull/948))
 - Added the `mode_t` public alias within `sys::stat`.


### PR DESCRIPTION
PR #944 added wrappers for the more-modern futimens(2) and utimesat(2),
but unfortunately these APIs are not available on old-ish systems.

In particular, macOS Sierra and below don't implement them, making the
new APIs unusable.  Whether we should care about such "old" systems is
debatable, but the problem is that, at the moment, this is the only
macOS version usable on Travis to test kexts and, thus, to test FUSE
file systems.

This should have been part of PR #946, which added a wrapper for
utimes(2) following this same rationale, but missed lutimes(2) because
I simply didn't notice it existed.