### PR TITLE
Make sys::time::{time_t, suseconds_t} public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#949](https://github.com/nix-rust/nix/pull/949)) ([#958](https://github.com/nix-rust/nix/pull/958))
 - Added a `acct` wrapper module for enabling and disabling process accounting
   ([#952](https://github.com/nix-rust/nix/pull/952))
+- Added the `time_t` and `suseconds_t` public aliases within `sys::time`.
+  ([#968](https://github.com/nix-rust/nix/pull/968))
 
 ### Changed
 - Increased required Rust version to 1.22.1/

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -1,5 +1,6 @@
 use std::{cmp, fmt, ops};
-use libc::{c_long, time_t, suseconds_t, timespec, timeval};
+use libc::{c_long, timespec, timeval};
+pub use libc::{time_t, suseconds_t};
 
 pub trait TimeValLike: Sized {
     #[inline]


### PR DESCRIPTION
This allows handling the return values of other public functions
(such as TimeVal's tv_sec and tv_usec) without having to pull in
these types from libc (which is ugly if a project is trying to
use nix exclusively to avoid libc's unsafety).