### PR TITLE
Add ENOTSUP to Linux and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   socket types on Linux and Android ([#1031](https://github.com/nix-rust/nix/pull/1031))
 - Add killpg
   ([#1034](https://github.com/nix-rust/nix/pull/1034))
+- Added ENOTSUP errno support for Linux and Android.
+  ([#969](https://github.com/nix-rust/nix/pull/969))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -675,6 +675,7 @@ mod consts {
 
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+    pub const ENOTSUP:     Errno = Errno::EOPNOTSUPP;
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;


### PR DESCRIPTION
While ENOTSUP is defined as equal to EOPNOTSUPP on these platforms,
exposing the ENOTSUP symbol (as libc does) allows for writing portable
code that may want to reference this error code.