### PR TITLE
Error as i32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#968](https://github.com/nix-rust/nix/pull/968))
 - Added `unistd::execvpe` for Haiku, Linux and OpenBSD
   ([#975](https://github.com/nix-rust/nix/pull/975))
+- Added `Error::as_errno`.
+  ([#977](https://github.com/nix-rust/nix/pull/977))
 
 ### Changed
 - Increased required Rust version to 1.24.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,23 @@ pub enum Error {
 }
 
 impl Error {
+    /// Convert this `Error` to an [`Errno`](enum.Errno.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use nix::Error;
+    /// # use nix::errno::Errno;
+    /// let e = Error::from(Errno::EPERM);
+    /// assert_eq!(Some(Errno::EPERM), e.as_errno());
+    /// ```
+    pub fn as_errno(&self) -> Option<Errno> {
+        if let &Error::Sys(ref e) = self {
+            Some(*e)
+        } else {
+            None
+        }
+    }
 
     /// Create a nix Error from a given errno
     pub fn from_errno(errno: Errno) -> Error {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -4,13 +4,12 @@ use nix::unistd::ForkResult::*;
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::wait::*;
 use nix::sys::stat::{self, Mode, SFlag};
-use std::{env, iter, thread, time};
+use std::{env, iter};
 use std::ffi::CString;
-use std::fs::{self, File, metadata};
+use std::fs::{self, File};
 use std::io::Write;
 use std::os::unix::prelude::*;
-use std::process::Command;
-use tempfile::{self, tempfile, NamedTempFile};
+use tempfile::{self, tempfile};
 use libc::{self, _exit, off_t};
 
 #[test]
@@ -387,6 +386,10 @@ fn test_lseek64() {
 #[cfg(not(target_os = "freebsd"))]
 #[test]
 fn test_acct() {
+    use tempfile::NamedTempFile;
+    use std::process::Command;
+    use std::{thread, time};
+
     skip_if_not_root!("test_acct");
     let file = NamedTempFile::new().unwrap();
     let path = file.path().to_str().unwrap();
@@ -396,7 +399,7 @@ fn test_acct() {
     acct::disable().unwrap();
 
     loop {
-        let len = metadata(path).unwrap().len();
+        let len = fs::metadata(path).unwrap().len();
         if len > 0 { break; }
         thread::sleep(time::Duration::from_millis(10));
     }


### PR DESCRIPTION
 Add Error::as_errno

This method is useful when it can be statically determined that a nix::Error be an errno, which I find to be very common.

Also, fix some recently introduced compiler warnings.