### PR TITLE
dragonfly: fix errno problem

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "dragonfly"))]
 use libc;
 use libc::c_int;
+use libc::c_void;
 use std::{fmt, io, error};
 use {Error, Result};
 
@@ -103,8 +104,8 @@ impl ErrnoSentinel for i64 {
     fn sentinel() -> Self { -1 }
 }
 
-impl ErrnoSentinel for *mut libc::c_void {
-    fn sentinel() -> Self { (-1 as isize) as *mut libc::c_void }
+impl ErrnoSentinel for *mut c_void {
+    fn sentinel() -> Self { (-1 as isize) as *mut c_void }
 }
 
 impl error::Error for Errno {


### PR DESCRIPTION
Most of the problems (i.e. the missing errnos are fixed by https://github.com/rust-lang/libc/pull/1145, but there's one more issue with the DragonflyBSD build. This commit fixes a missing `use`.

Note that this needs to wait until the PR linked is merged into `rust-lang/libc master`, should happen soon as it is already `r+`.

Fixes: #974 
Signed-off-by: Levente Kurusa <lkurusa@acm.org>