### PR TITLE
Prefer `map(drop)` to `map(|_| ())`

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1138,7 +1138,7 @@ impl<'a> LioCb<'a> {
         let p = self.list.as_ptr();
         Errno::result(unsafe {
             libc::lio_listio(mode as i32, p, self.list.len() as i32, sigevp)
-        }).map(|_| ())
+        }).map(drop)
     }
 
     /// Resubmits any incomplete operations with [`lio_listio`].
@@ -1229,7 +1229,7 @@ impl<'a> LioCb<'a> {
         let p = self.list.as_ptr();
         Errno::result(unsafe {
             libc::lio_listio(mode as i32, p, self.list.len() as i32, sigevp)
-        }).map(|_| ())
+        }).map(drop)
     }
 
     /// Collect final status for an individual `AioCb` submitted as part of an

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -72,21 +72,21 @@ unsafe fn ptrace_other(
 /// Indicates that this process is to be traced by its parent.
 /// This is the only ptrace request to be issued by the tracee.
 pub fn traceme() -> Result<()> {
-    unsafe { ptrace_other(Request::PT_TRACE_ME, Pid::from_raw(0), ptr::null_mut(), 0).map(|_| ()) }
+    unsafe { ptrace_other(Request::PT_TRACE_ME, Pid::from_raw(0), ptr::null_mut(), 0).map(drop) }
 }
 
 /// Attach to a running process, as with `ptrace(PT_ATTACH, ...)`
 ///
 /// Attaches to the process specified in pid, making it a tracee of the calling process.
 pub fn attach(pid: Pid) -> Result<()> {
-    unsafe { ptrace_other(Request::PT_ATTACH, pid, ptr::null_mut(), 0).map(|_| ()) }
+    unsafe { ptrace_other(Request::PT_ATTACH, pid, ptr::null_mut(), 0).map(drop) }
 }
 
 /// Detaches the current running process, as with `ptrace(PT_DETACH, ...)`
 ///
 /// Detaches from the process specified in pid allowing it to run freely
 pub fn detach(pid: Pid) -> Result<()> {
-    unsafe { ptrace_other(Request::PT_DETACH, pid, ptr::null_mut(), 0).map(|_| ()) }
+    unsafe { ptrace_other(Request::PT_DETACH, pid, ptr::null_mut(), 0).map(drop) }
 }
 
 /// Restart the stopped tracee process, as with `ptrace(PTRACE_CONT, ...)`
@@ -100,7 +100,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
     };
     unsafe {
         // Ignore the useless return value
-        ptrace_other(Request::PT_CONTINUE, pid, 1 as AddressType, data).map(|_| ())
+        ptrace_other(Request::PT_CONTINUE, pid, 1 as AddressType, data).map(drop)
     }
 }
 
@@ -109,7 +109,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 /// This request is equivalent to `ptrace(PT_CONTINUE, ..., SIGKILL);` 
 pub fn kill(pid: Pid) -> Result<()> {
     unsafe {
-        ptrace_other(Request::PT_KILL, pid, 0 as AddressType, 0).map(|_| ())
+        ptrace_other(Request::PT_KILL, pid, 0 as AddressType, 0).map(drop)
     }
 }
 
@@ -152,7 +152,7 @@ pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
         Some(s) => s as c_int,
         None => 0,
     };
-    unsafe { ptrace_other(Request::PT_STEP, pid, ptr::null_mut(), data).map(|_| ()) }
+    unsafe { ptrace_other(Request::PT_STEP, pid, ptr::null_mut(), data).map(drop) }
 }
 
 /// Reads a word from a processes memory at the given address
@@ -166,5 +166,5 @@ pub fn read(pid: Pid, addr: AddressType) -> Result<c_int> {
 
 /// Writes a word into the processes memory at the given address
 pub fn write(pid: Pid, addr: AddressType, data: c_int) -> Result<()> {
-    unsafe { ptrace_other(Request::PT_WRITE_D, pid, addr, data).map(|_| ()) }
+    unsafe { ptrace_other(Request::PT_WRITE_D, pid, addr, data).map(drop) }
 }

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -223,7 +223,7 @@ pub fn setoptions(pid: Pid, options: Options) -> Result<()> {
                      ptr::null_mut::<c_void>(),
                      options.bits() as *mut c_void)
     };
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Gets a ptrace event as described by `ptrace(PTRACE_GETEVENTMSG,...)`
@@ -262,7 +262,7 @@ pub fn traceme() -> Result<()> {
             Pid::from_raw(0),
             ptr::null_mut(),
             ptr::null_mut(),
-        ).map(|_| ()) // ignore the useless return value
+        ).map(drop) // ignore the useless return value
     }
 }
 
@@ -276,7 +276,7 @@ pub fn syscall(pid: Pid) -> Result<()> {
             pid,
             ptr::null_mut(),
             ptr::null_mut(),
-        ).map(|_| ()) // ignore the useless return value
+        ).map(drop) // ignore the useless return value
     }
 }
 
@@ -290,7 +290,7 @@ pub fn attach(pid: Pid) -> Result<()> {
             pid,
             ptr::null_mut(),
             ptr::null_mut(),
-        ).map(|_| ()) // ignore the useless return value
+        ).map(drop) // ignore the useless return value
     }
 }
 
@@ -304,7 +304,7 @@ pub fn detach(pid: Pid) -> Result<()> {
             pid,
             ptr::null_mut(),
             ptr::null_mut()
-        ).map(|_| ())
+        ).map(drop)
     }
 }
 
@@ -318,7 +318,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
         None => ptr::null_mut(),
     };
     unsafe {
-        ptrace_other(Request::PTRACE_CONT, pid, ptr::null_mut(), data).map(|_| ()) // ignore the useless return value
+        ptrace_other(Request::PTRACE_CONT, pid, ptr::null_mut(), data).map(drop) // ignore the useless return value
     }
 }
 
@@ -327,7 +327,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 /// This request is equivalent to `ptrace(PTRACE_CONT, ..., SIGKILL);`
 pub fn kill(pid: Pid) -> Result<()> {
     unsafe {
-        ptrace_other(Request::PTRACE_KILL, pid, ptr::null_mut(), ptr::null_mut()).map(|_| ())
+        ptrace_other(Request::PTRACE_KILL, pid, ptr::null_mut(), ptr::null_mut()).map(drop)
     }
 }
 
@@ -362,7 +362,7 @@ pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
         None => ptr::null_mut(),
     };
     unsafe {
-        ptrace_other(Request::PTRACE_SINGLESTEP, pid, ptr::null_mut(), data).map(|_| ())
+        ptrace_other(Request::PTRACE_SINGLESTEP, pid, ptr::null_mut(), data).map(drop)
     }
 }
 
@@ -375,6 +375,6 @@ pub fn read(pid: Pid, addr: AddressType) -> Result<c_long> {
 /// Writes a word into the processes memory at the given address
 pub fn write(pid: Pid, addr: AddressType, data: *mut c_void) -> Result<()> {
     unsafe {
-        ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(|_| ())
+        ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(drop)
     }
 }

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -94,7 +94,7 @@ impl SignalFd {
     }
 
     pub fn set_mask(&mut self, mask: &SigSet) -> Result<()> {
-        signalfd(self.0, mask, SfdFlags::empty()).map(|_| ())
+        signalfd(self.0, mask, SfdFlags::empty()).map(drop)
     }
 
     pub fn read_signal(&mut self) -> Result<Option<siginfo>> {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -131,7 +131,7 @@ pub fn fstatat<P: ?Sized + NixPath>(dirfd: RawFd, pathname: &P, f: AtFlags) -> R
 pub fn fchmod(fd: RawFd, mode: Mode) -> Result<()> {
     let res = unsafe { libc::fchmod(fd, mode.bits() as mode_t) };
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Flags for `fchmodat` function.
@@ -177,7 +177,7 @@ pub fn fchmodat<P: ?Sized + NixPath>(
         )
     })?;
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Change the access and modification times of a file.
@@ -196,7 +196,7 @@ pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -
         libc::utimes(cstr.as_ptr(), &times[0])
     })?;
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Change the access and modification times of a file without following symlinks.
@@ -216,7 +216,7 @@ pub fn lutimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) 
         libc::lutimes(cstr.as_ptr(), &times[0])
     })?;
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Change the access and modification times of the file specified by a file descriptor.
@@ -229,7 +229,7 @@ pub fn futimens(fd: RawFd, atime: &TimeSpec, mtime: &TimeSpec) -> Result<()> {
     let times: [libc::timespec; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = unsafe { libc::futimens(fd, &times[0]) };
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Flags for `utimensat` function.
@@ -277,5 +277,5 @@ pub fn utimensat<P: ?Sized + NixPath>(
         )
     })?;
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -929,7 +929,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetispeed(inner_termios, baud.into() as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
 
         /// Set output baud rate (see
@@ -940,7 +940,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetospeed(inner_termios, baud.into() as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
 
         /// Set both the input and output baud rates (see
@@ -952,7 +952,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetspeed(inner_termios, baud.into() as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
     } else {
         /// Get input baud rate (see
@@ -981,7 +981,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetispeed(inner_termios, baud as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
 
         /// Set output baud rate (see
@@ -992,7 +992,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetospeed(inner_termios, baud as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
 
         /// Set both the input and output baud rates (see
@@ -1004,7 +1004,7 @@ cfg_if!{
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
             let res = unsafe { libc::cfsetspeed(inner_termios, baud as libc::speed_t) };
             termios.update_wrapper();
-            Errno::result(res).map(|_| ())
+            Errno::result(res).map(drop)
         }
     }
 }
@@ -1060,13 +1060,13 @@ pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
 /// *any* of the parameters were successfully set, not only if all were set successfully.
 pub fn tcsetattr(fd: RawFd, actions: SetArg, termios: &Termios) -> Result<()> {
     let inner_termios = termios.get_libc_termios();
-    Errno::result(unsafe { libc::tcsetattr(fd, actions as c_int, &*inner_termios) }).map(|_| ())
+    Errno::result(unsafe { libc::tcsetattr(fd, actions as c_int, &*inner_termios) }).map(drop)
 }
 
 /// Block until all output data is written (see
 /// [tcdrain(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcdrain.html)).
 pub fn tcdrain(fd: RawFd) -> Result<()> {
-    Errno::result(unsafe { libc::tcdrain(fd) }).map(|_| ())
+    Errno::result(unsafe { libc::tcdrain(fd) }).map(drop)
 }
 
 /// Suspend or resume the transmission or reception of data (see
@@ -1075,7 +1075,7 @@ pub fn tcdrain(fd: RawFd) -> Result<()> {
 /// `tcflow()` suspends of resumes the transmission or reception of data for the given port
 /// depending on the value of `action`.
 pub fn tcflow(fd: RawFd, action: FlowArg) -> Result<()> {
-    Errno::result(unsafe { libc::tcflow(fd, action as c_int) }).map(|_| ())
+    Errno::result(unsafe { libc::tcflow(fd, action as c_int) }).map(drop)
 }
 
 /// Discard data in the output or input queue (see
@@ -1084,7 +1084,7 @@ pub fn tcflow(fd: RawFd, action: FlowArg) -> Result<()> {
 /// `tcflush()` will discard data for a terminal port in the input queue, output queue, or both
 /// depending on the value of `action`.
 pub fn tcflush(fd: RawFd, action: FlushArg) -> Result<()> {
-    Errno::result(unsafe { libc::tcflush(fd, action as c_int) }).map(|_| ())
+    Errno::result(unsafe { libc::tcflush(fd, action as c_int) }).map(drop)
 }
 
 /// Send a break for a specific duration (see
@@ -1093,7 +1093,7 @@ pub fn tcflush(fd: RawFd, action: FlushArg) -> Result<()> {
 /// When using asynchronous data transmission `tcsendbreak()` will transmit a continuous stream
 /// of zero-valued bits for an implementation-defined duration.
 pub fn tcsendbreak(fd: RawFd, duration: c_int) -> Result<()> {
-    Errno::result(unsafe { libc::tcsendbreak(fd, duration) }).map(|_| ())
+    Errno::result(unsafe { libc::tcsendbreak(fd, duration) }).map(drop)
 }
 
 /// Get the session controlled by the given terminal (see

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -630,7 +630,7 @@ pub fn fchownat<P: ?Sized + NixPath>(
                        atflag.bits() as libc::c_int)
     })?;
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 fn to_exec_array(args: &[CString]) -> Vec<*const c_char> {
@@ -1318,7 +1318,7 @@ pub fn setgroups(groups: &[Gid]) -> Result<()> {
         libc::setgroups(groups.len() as setgroups_ngroups_t, groups.as_ptr() as *const gid_t)
     };
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Calculate the supplementary group access list.
@@ -1444,7 +1444,7 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
     let gid: gid_t = group.into();
     let res = unsafe { libc::initgroups(user.as_ptr(), gid as initgroups_group_t) };
 
-    Errno::result(res).map(|_| ())
+    Errno::result(res).map(drop)
 }
 
 /// Suspend the thread until a signal is received.


### PR DESCRIPTION
I previously advocated for the latter syntax on stylistic grounds.  But
it generates less efficient code, because it creates a new lambda
function for each usage.  The optimizer does not combine them.  This
change saves about 6KB of code.