### PR TITLE
Add `mman::mprotect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1010](https://github.com/nix-rust/nix/pull/1010))
 - Added `nix::sys::signal::signal`.
   ([#817](https://github.com/nix-rust/nix/pull/817))
+- Added an `mprotect` wrapper.
+  ([#991](https://github.com/nix-rust/nix/pull/991))
 
 ### Changed
 ### Fixed

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -258,6 +258,35 @@ pub unsafe fn madvise(addr: *mut c_void, length: size_t, advise: MmapAdvise) -> 
     Errno::result(libc::madvise(addr, length, advise as i32)).map(drop)
 }
 
+/// Set protection of memory mapping.
+///
+/// See [`mprotect(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mprotect.html) for
+/// details.
+///
+/// # Safety
+///
+/// Calls to `mprotect` are inherently unsafe, as changes to memory protections can lead to
+/// SIGSEGVs.
+///
+/// ```
+/// # use nix::libc::size_t;
+/// # use nix::sys::mman::{mmap, mprotect, MapFlags, ProtFlags};
+/// # use std::ptr;
+/// const ONE_K: size_t = 1024;
+/// let mut slice: &mut [u8] = unsafe {
+///     let mem = mmap(ptr::null_mut(), ONE_K, ProtFlags::PROT_NONE,
+///                    MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE, -1, 0).unwrap();
+///     mprotect(mem, ONE_K, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE).unwrap();
+///     std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+/// };
+/// assert_eq!(slice[0], 0x00);
+/// slice[0] = 0xFF;
+/// assert_eq!(slice[0], 0xFF);
+/// ```
+pub unsafe fn mprotect(addr: *mut c_void, length: size_t, prot: ProtFlags) -> Result<()> {
+    Errno::result(libc::mprotect(addr, length, prot.bits())).map(drop)
+}
+
 pub unsafe fn msync(addr: *mut c_void, length: size_t, flags: MsFlags) -> Result<()> {
     Errno::result(libc::msync(addr, length, flags.bits())).map(drop)
 }


### PR DESCRIPTION
It doesn't look like there's an existing test suite for `mmap` and friends, so this is regrettably untested.