### PR TITLE
Make nix build again on OpenBSD 6.4-current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 ### Fixed
+- `lutimes` never worked on OpenBSD as it is not implemented on OpenBSD. It has
+  been removed. ([#1000](https://github.com/nix-rust/nix/pull/1000))
+- `fexecve` never worked on NetBSD or on OpenBSD as it is not implemented on
+  either OS. It has been removed. ([#1000](https://github.com/nix-rust/nix/pull/1000))
+
 ### Removed
 
 ## [0.12.0] 2018-11-28

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -209,7 +209,12 @@ pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -
 /// # References
 ///
 /// [lutimes(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lutimes.html).
-#[cfg(not(target_os = "android"))]
+#[cfg(any(target_os = "linux",
+          target_os = "haiku",
+          target_os = "ios",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "netbsd"))]
 pub fn lutimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -> Result<()> {
     let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = path.with_nix_path(|cstr| unsafe {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -760,11 +760,12 @@ pub fn execvpe(filename: &CString, args: &[CString], env: &[CString]) -> Result<
 ///
 /// This function is similar to `execve`, except that the program to be executed
 /// is referenced as a file descriptor instead of a path.
+// Note for NetBSD and OpenBSD: although rust-lang/libc includes it (under
+// unix/bsd/netbsdlike/) fexecve is not currently implemented on NetBSD nor on
+// OpenBSD.
 #[cfg(any(target_os = "android",
-          target_os = "freebsd",
           target_os = "linux",
-          target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "freebsd"))]
 #[inline]
 pub fn fexecve(fd: RawFd, args: &[CString], env: &[CString]) -> Result<Void> {
     let args_p = to_exec_array(args);

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -1,18 +1,23 @@
 extern crate nix;
 extern crate tempfile;
 
-use nix::sys::aio::*;
-use nix::sys::signal::*;
-use std::os::unix::io::AsRawFd;
-use tempfile::tempfile;
-
 // Test dropping an AioCb that hasn't yet finished.
 // This must happen in its own process, because on OSX this test seems to hose
 // the AIO subsystem and causes subsequent tests to fail
 #[test]
 #[should_panic(expected = "Dropped an in-progress AioCb")]
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(target_env = "musl"),
+          any(target_os = "linux",
+              target_os = "ios",
+              target_os = "macos",
+              target_os = "freebsd",
+              target_os = "netbsd")))]
 fn test_drop() {
+    use nix::sys::aio::*;
+    use nix::sys::signal::*;
+    use std::os::unix::io::AsRawFd;
+    use tempfile::tempfile;
+
     const WBUF: &[u8] = b"CDEF";
 
     let f = tempfile().unwrap();

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -7,7 +7,14 @@ use std::time::{Duration, UNIX_EPOCH};
 use libc::{S_IFMT, S_IFLNK};
 
 use nix::fcntl;
-use nix::sys::stat::{self, fchmod, fchmodat, futimens, lutimes, stat, utimes, utimensat};
+use nix::sys::stat::{self, fchmod, fchmodat, futimens, stat, utimes, utimensat};
+#[cfg(any(target_os = "linux",
+          target_os = "haiku",
+          target_os = "ios",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "netbsd"))]
+use nix::sys::stat::lutimes;
 use nix::sys::stat::{Mode, FchmodatFlags, UtimensatFlags};
 
 #[cfg(not(any(target_os = "netbsd")))]
@@ -196,6 +203,12 @@ fn test_utimes() {
 }
 
 #[test]
+#[cfg(any(target_os = "linux",
+          target_os = "haiku",
+          target_os = "ios",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "netbsd"))]
 fn test_lutimes() {
     let tempdir = tempfile::tempdir().unwrap();
     let target = tempdir.path().join("target");

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -230,16 +230,20 @@ cfg_if!{
         execve_test_factory!(test_execve, execve, &CString::new("/system/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
     } else if #[cfg(any(target_os = "freebsd",
-                        target_os = "linux",
-                        target_os = "openbsd"))] {
+                        target_os = "linux"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap().into_raw_fd());
     } else if #[cfg(any(target_os = "dragonfly",
                         target_os = "ios",
                         target_os = "macos",
-                        target_os = "netbsd"))] {
+                        target_os = "netbsd",
+                        target_os = "openbsd"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
-        // No fexecve() on DragonFly, ios, macos, and NetBSD.
+        // No fexecve() on DragonFly, ios, macos, NetBSD, OpenBSD.
+        //
+        // Note for NetBSD and OpenBSD: although rust-lang/libc includes it
+        // (under unix/bsd/netbsdlike/) fexecve is not currently implemented on
+        // NetBSD nor on OpenBSD.
     }
 }
 


### PR DESCRIPTION
First of all, I'm not a rust developer so please be gentle :)

I'm using https://github.com/jwilm/alacritty on OpenBSD. I'm trying to track the latest versions of both OpenBSD and alacritty so I'm recompiling alacritty fairly often. However the latest version of alacritty updated some of it's nix dependencies to v0.12.0 and that doesn't build on OpenBSD anymore:

```bash
user1 ~/ALACRITTY/nix $ sysctl kern.version
kern.version=OpenBSD 6.4-current (GENERIC.MP) #529: Tue Dec 18 22:36:49 MST 2018
    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC.MP

user1 ~/ALACRITTY/nix $ rustc -vV
rustc 1.31.0
binary: rustc
commit-hash: unknown
commit-date: unknown
host: x86_64-unknown-openbsd
release: 1.31.0
LLVM version: 6.0

user1 ~/ALACRITTY/nix $ cargo build
    Updating crates.io index
    Updating git repository `https://github.com/rust-lang/libc/`
   Compiling libc v0.2.45 (https://github.com/rust-lang/libc/#027d4834)
   Compiling nix v0.12.0 (/home/user1/ALACRITTY/nix)
   Compiling bitflags v1.0.4
   Compiling cfg-if v0.1.6
   Compiling void v1.0.2
error[E0425]: cannot find function `lutimes` in module `libc`
   --> src/sys/stat.rs:216:15
    |
216 |         libc::lutimes(cstr.as_ptr(), &times[0])
    |               ^^^^^^^ did you mean `futimes`?
help: possible candidate is found in another module, you can import it into scope
    |
1   | use sys::stat::lutimes;
    |

error: aborting due to previous error
```
In order to build nix v0.12.0 on OpenBSD 6.4-current the change in 85ae87c is sufficient, however in order to get the tests to build the 2 additional commits I've included in this PR are required. However even with 680ff30 & 6bdd9f2 the tests build but there is 1 failure:

```bash
user1 ~/ALACRITTY/nix $ cargo build
   Compiling libc v0.2.45 (https://github.com/rust-lang/libc/#027d4834)
   Compiling nix v0.12.0 (/home/user1/ALACRITTY/nix)
   Compiling void v1.0.2
   Compiling cfg-if v0.1.6
   Compiling bitflags v1.0.4
    Finished dev [unoptimized + debuginfo] target(s) in 15.14s

user1 ~/ALACRITTY/nix $ cargo test
   Compiling semver-parser v0.7.0
   Compiling libc v0.2.45
   Compiling rand_core v0.3.0
   Compiling byteorder v1.2.7
   Compiling remove_dir_all v0.5.1
   Compiling lazy_static v1.2.0
   Compiling rand_xorshift v0.1.0
   Compiling rand_hc v0.1.0
   Compiling rand_isaac v0.1.1
   Compiling rand_core v0.2.2
   Compiling semver v0.9.0
   Compiling iovec v0.1.2
   Compiling rand v0.5.5
   Compiling rustc_version v0.2.3
   Compiling bytes v0.4.11
   Compiling rand_chacha v0.1.0
   Compiling rand_pcg v0.1.1
   Compiling rand v0.6.1
   Compiling tempfile v3.0.5
   Compiling nix v0.12.0 (/home/user1/ALACRITTY/nix)
warning: unused import: `nix::sys::signal::*`
 --> test/sys/test_aio_drop.rs:6:5
  |
6 | use nix::sys::signal::*;
  |     ^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
< ..................................... >
test sys::time::test::test_timeval_fmt ... ok
test sys::time::test::test_timeval_neg ... ok

test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/test-6e77230ab75553a1

running 88 tests
test sys::test_ioctl::bsd::test_op_read_64 ... ok
test sys::test_ioctl::bsd::test_op_none ... ok
< ..................................... >
test test_unistd::test_alarm ... ok
test test_unistd::test_canceling_alarm ... ok

failures:

---- sys::test_socket::test_scm_rights stdout ----
thread 'sys::test_socket::test_scm_rights' panicked at 'slice index starts at 24 but ends at 20', libcore/slice/mod.rs:2340:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    sys::test_socket::test_scm_rights

test result: FAILED. 87 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test test'

user1 ~/ALACRITTY/nix $ RUST_BACKTRACE=1 cargo test
< ..................................... >

failures:

---- sys::test_socket::test_scm_rights stdout ----
thread 'sys::test_socket::test_scm_rights' panicked at 'slice index starts at 24 but ends at 20', libcore/slice/mod.rs:2340:5
stack backtrace:
   0: __register_frame_info
   1: __register_frame_info
   2: __register_frame_info
   3: __register_frame_info
   4: __register_frame_info
   5: __register_frame_info
   6: __register_frame_info
   7: __register_frame_info
   8: __register_frame_info
   9: __register_frame_info
  10: __register_frame_info
  11: __register_frame_info
  12: __register_frame_info
  13: __register_frame_info
  14: __register_frame_info
  15: __register_frame_info
  16: __register_frame_info
  17: __register_frame_info
  18: __register_frame_info
  19: __register_frame_info
  20: __register_frame_info
  21: __register_frame_info
  22: __register_frame_info
  23: __register_frame_info
  24: pthread_create


failures:
    sys::test_socket::test_scm_rights

test result: FAILED. 87 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test test'
```

I could add a conditional compilation attribute for `test_scm_rights` but I'm not sure if it's the best option, maybe someone with actual rust skills wants to fix it.

Apart from that 1 failed test nix works fine for me and I can build and use alacritty.