### PR TITLE
Allow cargo test to complete on OpenBSD 6.4/AMD64

### DIFF
--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -209,7 +209,7 @@ pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -
 /// # References
 ///
 /// [lutimes(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lutimes.html).
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "openbsd")))]
 pub fn lutimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -> Result<()> {
     let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = path.with_nix_path(|cstr| unsafe {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -763,8 +763,7 @@ pub fn execvpe(filename: &CString, args: &[CString], env: &[CString]) -> Result<
 #[cfg(any(target_os = "android",
           target_os = "freebsd",
           target_os = "linux",
-          target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "netbsd"))]
 #[inline]
 pub fn fexecve(fd: RawFd, args: &[CString], env: &[CString]) -> Result<Void> {
     let args_p = to_exec_array(args);

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -1,18 +1,18 @@
 extern crate nix;
 extern crate tempfile;
 
-use nix::sys::aio::*;
-use nix::sys::signal::*;
-use std::os::unix::io::AsRawFd;
-use tempfile::tempfile;
-
 // Test dropping an AioCb that hasn't yet finished.
 // This must happen in its own process, because on OSX this test seems to hose
 // the AIO subsystem and causes subsequent tests to fail
 #[test]
 #[should_panic(expected = "Dropped an in-progress AioCb")]
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(any(target_env = "musl", target_os = "openbsd")))]
 fn test_drop() {
+    use nix::sys::aio::*;
+    use nix::sys::signal::*;
+    use std::os::unix::io::AsRawFd;
+    use tempfile::tempfile;
+
     const WBUF: &[u8] = b"CDEF";
 
     let f = tempfile().unwrap();

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -117,6 +117,7 @@ pub fn test_socketpair() {
     assert_eq!(&buf[..], b"hello");
 }
 
+#[cfg(not(any(target_os = "openbsd")))]
 #[test]
 pub fn test_scm_rights() {
     use nix::sys::uio::IoVec;

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -7,7 +7,11 @@ use std::time::{Duration, UNIX_EPOCH};
 use libc::{S_IFMT, S_IFLNK};
 
 use nix::fcntl;
-use nix::sys::stat::{self, fchmod, fchmodat, futimens, lutimes, stat, utimes, utimensat};
+use nix::sys::stat::{self, fchmod, fchmodat, futimens, stat, utimes, utimensat};
+
+#[cfg(not(any(target_os = "openbsd")))]
+use nix::sys::stat::lutimes;
+
 use nix::sys::stat::{Mode, FchmodatFlags, UtimensatFlags};
 
 #[cfg(not(any(target_os = "netbsd")))]
@@ -196,6 +200,7 @@ fn test_utimes() {
 }
 
 #[test]
+#[cfg(not(any(target_os = "openbsd")))]
 fn test_lutimes() {
     let tempdir = tempfile::tempdir().unwrap();
     let target = tempdir.path().join("target");

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -230,16 +230,16 @@ cfg_if!{
         execve_test_factory!(test_execve, execve, &CString::new("/system/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
     } else if #[cfg(any(target_os = "freebsd",
-                        target_os = "linux",
-                        target_os = "openbsd"))] {
+                        target_os = "linux"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
         execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap().into_raw_fd());
     } else if #[cfg(any(target_os = "dragonfly",
                         target_os = "ios",
                         target_os = "macos",
-                        target_os = "netbsd"))] {
+                        target_os = "netbsd",
+                        target_os = "openbsd"))] {
         execve_test_factory!(test_execve, execve, &CString::new("/bin/sh").unwrap());
-        // No fexecve() on DragonFly, ios, macos, and NetBSD.
+        // No fexecve() on DragonFly, ios, macos, NetBSD or OpenBSD.
     }
 }
 


### PR DESCRIPTION
disable some features that aren't included in OpenBSD.