### PR TITLE
Switch FreeBSD CI builds from BuildBot to cirrus-ci.com

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+
+# Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the
+# same VM.  The binary will be built in 32-bit mode, but will execute on a
+# 64-bit kernel and in a 64-bit environment.  Our tests don't execute any of
+# the system's binaries, so the environment shouldn't matter.
+task:
+  name: FreeBSD 11.2
+  # Install Rust
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --default-toolchain 1.24.1
+    - $HOME/.cargo/bin/rustup target add i686-unknown-freebsd
+  amd64_test_script:
+    - . $HOME/.cargo/env
+    - cargo test
+  i386_test_script:
+    - . $HOME/.cargo/env
+    - cargo test --target i686-unknown-freebsd

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,6 @@
 # Gate on Travis CI and Buildbot
 status = ["continuous-integration/travis-ci/push",
-          "buildbot/nix-rust/nix amd64_fbsd11",
-          "buildbot/nix-rust/nix i386_fbsd11"]
+	  "FreeBSD 11.2"]
 
 # Set bors's timeout to 4 hours
 #


### PR DESCRIPTION
This change does the following:
1) Adds a CI build on cirrus-ci.com
2) Switches FreeBSD's CI from a jail to a full VM
3) Switches FreeBSD i386's CI from a 32-bit jail to simply using a
   cross-compiled binary on a 64-bit VM.
4) Switches FreeBSD i386's CI from using stable rust to 1.24.1 (back
   when I added buildbot, rustup didn't support i686-unknown-freebsd)
5) Switches bors to gate on cirrus-ci rather than buildbot

This change does _not_ disable buildbot.  That must happen outside of
git.

Fixes #996