### PR TITLE
Fix for #317 - Some event flags renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add IP_RECVIF & IP_RECVDSTADDR. Enable IP_PKTINFO and IP6_PKTINFO on netbsd/openbsd.
   ([#1002](https://github.com/nix-rust/nix/pull/1002))
 ### Changed
+- `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))
 ### Fixed
 ### Removed
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -27,19 +27,19 @@ pub struct PollFd {
 impl PollFd {
     /// Creates a new `PollFd` specifying the events of interest
     /// for a given file descriptor.
-    pub fn new(fd: RawFd, events: EventFlags) -> PollFd {
+    pub fn new(fd: RawFd, events: PollFlags) -> PollFd {
         PollFd {
             pollfd: libc::pollfd {
                 fd: fd,
                 events: events.bits(),
-                revents: EventFlags::empty().bits(),
+                revents: PollFlags::empty().bits(),
             },
         }
     }
 
     /// Returns the events that occured in the last call to `poll` or `ppoll`.
-    pub fn revents(&self) -> Option<EventFlags> {
-        EventFlags::from_bits(self.pollfd.revents)
+    pub fn revents(&self) -> Option<PollFlags> {
+        PollFlags::from_bits(self.pollfd.revents)
     }
 }
 
@@ -48,11 +48,11 @@ impl fmt::Debug for PollFd {
         let pfd = self.pollfd;
         let mut ds = f.debug_struct("PollFd");
         ds.field("fd", &pfd.fd);
-        match EventFlags::from_bits(pfd.events) {
+        match PollFlags::from_bits(pfd.events) {
             None => ds.field("events", &pfd.events),
             Some(ef) => ds.field("events", &ef),
         };
-        match EventFlags::from_bits(pfd.revents) {
+        match PollFlags::from_bits(pfd.revents) {
             None => ds.field("revents", &pfd.revents),
             Some(ef) => ds.field("revents", &ef),
         };
@@ -62,7 +62,7 @@ impl fmt::Debug for PollFd {
 
 libc_bitflags! {
     /// These flags define the different events that can be monitored by `poll` and `ppoll`
-    pub struct EventFlags: libc::c_short {
+    pub struct PollFlags: libc::c_short {
         /// There is data to read.
         POLLIN;
         /// There is some exceptional condition on the file descriptor.

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,34 +1,34 @@
-use nix::poll::{EventFlags, poll, PollFd};
+use nix::poll::{PollFlags, poll, PollFd};
 use nix::unistd::{write, pipe, close};
 
 #[test]
 fn test_poll() {
     let (r, w) = pipe().unwrap();
-    let mut fds = [PollFd::new(r, EventFlags::POLLIN)];
+    let mut fds = [PollFd::new(r, PollFlags::POLLIN)];
 
     // Poll an idle pipe.  Should timeout
     let nfds = poll(&mut fds, 100).unwrap();
     assert_eq!(nfds, 0);
-    assert!(!fds[0].revents().unwrap().contains(EventFlags::POLLIN));
+    assert!(!fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 
     write(w, b".").unwrap();
 
     // Poll a readable pipe.  Should return an event.
     let nfds = poll(&mut fds, 100).unwrap();
     assert_eq!(nfds, 1);
-    assert!(fds[0].revents().unwrap().contains(EventFlags::POLLIN));
+    assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 }
 
 #[test]
 fn test_poll_debug() {
-    assert_eq!(format!("{:?}", PollFd::new(0, EventFlags::empty())),
+    assert_eq!(format!("{:?}", PollFd::new(0, PollFlags::empty())),
                "PollFd { fd: 0, events: (empty), revents: (empty) }");
-    assert_eq!(format!("{:?}", PollFd::new(1, EventFlags::POLLIN)),
+    assert_eq!(format!("{:?}", PollFd::new(1, PollFlags::POLLIN)),
                "PollFd { fd: 1, events: POLLIN, revents: (empty) }");
 
     // Testing revents requires doing some I/O
     let (r, w) = pipe().unwrap();
-    let mut fds = [PollFd::new(r, EventFlags::POLLIN)];
+    let mut fds = [PollFd::new(r, PollFlags::POLLIN)];
     write(w, b" ").unwrap();
     close(w).unwrap();
     poll(&mut fds, -1).unwrap();
@@ -52,17 +52,17 @@ fn test_ppoll() {
 
     let timeout = TimeSpec::milliseconds(1);
     let (r, w) = pipe().unwrap();
-    let mut fds = [PollFd::new(r, EventFlags::POLLIN)];
+    let mut fds = [PollFd::new(r, PollFlags::POLLIN)];
 
     // Poll an idle pipe.  Should timeout
     let nfds = ppoll(&mut fds, timeout, SigSet::empty()).unwrap();
     assert_eq!(nfds, 0);
-    assert!(!fds[0].revents().unwrap().contains(EventFlags::POLLIN));
+    assert!(!fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 
     write(w, b".").unwrap();
 
     // Poll a readable pipe.  Should return an event.
     let nfds = ppoll(&mut fds, timeout, SigSet::empty()).unwrap();
     assert_eq!(nfds, 1);
-    assert!(fds[0].revents().unwrap().contains(EventFlags::POLLIN));
+    assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 }


### PR DESCRIPTION
I tried to grep and replace for #317. Please let me know if I need to fix something else as well but in my search I saw that most were fixed earlier.