### PR TITLE
Add killpg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Android and Linux. ([#1016](https://github.com/nix-rust/nix/pull/1016))
 - Add `ALG_SET_IV`, `ALG_SET_OP` and `ALG_SET_AEAD_ASSOCLEN` control messages and `AF_ALG`
   socket types on Linux and Android ([#1031](https://github.com/nix-rust/nix/pull/1031))
+- Add killpg
+  ([#1034](https://github.com/nix-rust/nix/pull/1034))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -680,6 +680,22 @@ pub fn kill<T: Into<Option<Signal>>>(pid: ::unistd::Pid, signal: T) -> Result<()
     Errno::result(res).map(drop)
 }
 
+/// Send a signal to a process group [(see
+/// killpg(3))](http://pubs.opengroup.org/onlinepubs/9699919799/functions/killpg.html).
+///
+/// If `pgrp` less then or equal 1, the behavior is platform-specific.
+/// If `signal` is `None`, `killpg` will only preform error checking and won't
+/// send any signal.
+pub fn killpg<T: Into<Option<Signal>>>(pgrp: ::unistd::Pid, signal: T) -> Result<()> {
+    let res = unsafe { libc::killpg(pgrp.into(),
+                                  match signal.into() {
+                                      Some(s) => s as libc::c_int,
+                                      None => 0,
+                                  }) };
+
+    Errno::result(res).map(drop)
+}
+
 pub fn raise(signal: Signal) -> Result<()> {
     let res = unsafe { libc::raise(signal as libc::c_int) };
 

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -10,6 +10,12 @@ fn test_kill_none() {
 }
 
 #[test]
+fn test_killpg_none() {
+    killpg(getpgrp(), None)
+        .expect("Should be able to send signal to my process group.");
+}
+
+#[test]
 fn test_old_sigaction_flags() {
     extern "C" fn handler(_: ::libc::c_int) {}
     let act = SigAction::new(


### PR DESCRIPTION
It's seem that #644 is inactively about 1 year. But I really want this API that can land in nix.

Actually I not really understand how to check the availability of an API for other platform except Linux. But I saw that this API in `libc` is wrapping inside a `#[cfg(unix)]`. So I don't need to add any `#[cfg]` on this API, am I right?

Resolved #644 