### PR TITLE
Implement extra traits for all types

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --default-toolchain 1.24.1
+    - sh rustup.sh -y --default-toolchain 1.25.0
     - $HOME/.cargo/bin/rustup target add i686-unknown-freebsd
   amd64_test_script:
     - . $HOME/.cargo/env

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,71 +18,71 @@ matrix:
     # week.  Additionally they're moved to the front of the line to get them in
     # the Travis OS X build queue first.
     - env: TARGET="aarch64-apple-ios;armv7-apple-ios;armv7s-apple-ios;i386-apple-ios;x86_64-apple-ios" DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
       os: osx
 
     # Mac builds
     # These are also moved to be first because they wait in a long queue with
     # Travis
     - env: TARGET=i686-apple-darwin
-      rust: 1.24.1
+      rust: 1.25.0
       os: osx
     - env: TARGET=x86_64-apple-darwin
-      rust: 1.24.1
+      rust: 1.25.0
       os: osx
 
     # Android
     - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=i686-linux-android DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
 
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=arm-unknown-linux-gnueabi
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=armv7-unknown-linux-gnueabihf
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=i686-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=i686-unknown-linux-musl
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=mips-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=mips64-unknown-linux-gnuabi64
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=mips64el-unknown-linux-gnuabi64
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=mipsel-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=powerpc64-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=powerpc64le-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.24.1
+      rust: 1.25.0
     - env: TARGET=x86_64-unknown-linux-musl
-      rust: 1.24.1
+      rust: 1.25.0
 
     # *BSD
     # FreeBSD i686 and x86_64 use Cirrus instead of Travis
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-      rust: 1.24.1
+      rust: 1.25.0
 
     # Make sure stable is always working too
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `MSG_WAITALL` to `MsgFlags` in `sys::socket`.
   ([#1079](https://github.com/nix-rust/nix/pull/1079))
+- Implemented `Clone`, `Copy`, `Debug`, `Eq`, `Hash`, and `PartialEq` for most
+  types that support them. ([#1035](https://github.com/nix-rust/nix/pull/1035))
 
 ### Changed
 - Support for `ifaddrs` now present when building for Android.
   ([#1077](https://github.com/nix-rust/nix/pull/1077))
+- Minimum supported Rust version is now 1.25.0 
+  ([#1035](https://github.com/nix-rust/nix/pull/1035))
 
 ### Fixed
 ### Removed
@@ -35,8 +39,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   native equivalents like `u32.`
   ([#1072](https://github.com/nix-rust/nix/pull/1072/commits))
 
-- Minimum supported Rust version is now 1.25.0 
-  ([#1035](https://github.com/nix-rust/nix/pull/1035))
 ### Fixed
 - Fix the build on Android and Linux/mips with recent versions of libc.
   ([#1072](https://github.com/nix-rust/nix/pull/1072/commits))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   native equivalents like `u32.`
   ([#1072](https://github.com/nix-rust/nix/pull/1072/commits))
 
+- Minimum supported Rust version is now 1.25.0 
+  ([#1035](https://github.com/nix-rust/nix/pull/1035))
 ### Fixed
 - Fix the build on Android and Linux/mips with recent versions of libc.
   ([#1072](https://github.com/nix-rust/nix/pull/1072/commits))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc" }
+libc = { git = "https://github.com/rust-lang/libc", features = [ "extra_traits" ] }
 bitflags = "1.0"
 cfg-if = "0.1.0"
 void = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ limitations. Support for platforms is split into three tiers:
              *do not* block the inclusion of new code. Testing may be run, but
              failures in tests don't block the inclusion of new code.
 
-The following targets are all supported by nix on Rust 1.24.1 or newer (unless
-otherwise noted):
+The following targets are supported by `nix`:
 
 Tier 1:
   * aarch64-unknown-linux-gnu
@@ -83,6 +82,8 @@ Tier 2:
   * x86_64-unknown-netbsd
 
 ## Usage
+
+`nix` requires Rust 1.25.0 or newer.
 
 To use `nix`, first add this to your `Cargo.toml`:
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -214,7 +214,7 @@ libc_bitflags!(
     }
 );
 
-#[allow(missing_debug_implementations)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub enum FcntlArg<'a> {
     F_DUPFD(RawFd),
     F_DUPFD_CLOEXEC(RawFd),
@@ -277,8 +277,7 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
     Errno::result(res)
 }
 
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FlockArg {
     LockShared,
     LockExclusive,

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -15,7 +15,7 @@ use sys::socket::SockAddr;
 use net::if_::*;
 
 /// Describes a single address for an interface as returned by `getifaddrs`.
-#[derive(Clone, Eq, Hash, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InterfaceAddress {
     /// Name of the network interface
     pub interface_name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// error has a corresponding errno (usually the one from the
 /// underlying OS) to which it can be mapped in addition to
 /// implementing other common traits.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     Sys(Errno),
     InvalidPath,

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -29,20 +29,9 @@ libc_bitflags!{
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct MqAttr {
     mq_attr: libc::mq_attr,
-}
-
-impl PartialEq<MqAttr> for MqAttr {
-    fn eq(&self, other: &MqAttr) -> bool {
-        let self_attr = self.mq_attr;
-        let other_attr = other.mq_attr;
-        self_attr.mq_flags == other_attr.mq_flags && self_attr.mq_maxmsg == other_attr.mq_maxmsg &&
-        self_attr.mq_msgsize == other_attr.mq_msgsize &&
-        self_attr.mq_curmsgs == other_attr.mq_curmsgs
-    }
 }
 
 impl MqAttr {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -4,7 +4,6 @@ use sys::time::TimeSpec;
 #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
 use sys::signal::SigSet;
 use std::os::unix::io::RawFd;
-use std::fmt;
 
 use libc;
 use Result;
@@ -19,7 +18,7 @@ use errno::Errno;
 /// After a call to `poll` or `ppoll`, the events that occured can be
 /// retrieved by calling [`revents()`](#method.revents) on the `PollFd`.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct PollFd {
     pollfd: libc::pollfd,
 }
@@ -40,23 +39,6 @@ impl PollFd {
     /// Returns the events that occured in the last call to `poll` or `ppoll`.
     pub fn revents(&self) -> Option<PollFlags> {
         PollFlags::from_bits(self.pollfd.revents)
-    }
-}
-
-impl fmt::Debug for PollFd {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let pfd = self.pollfd;
-        let mut ds = f.debug_struct("PollFd");
-        ds.field("fd", &pfd.fd);
-        match PollFlags::from_bits(pfd.events) {
-            None => ds.field("events", &pfd.events),
-            Some(ef) => ds.field("events", &ef),
-        };
-        match PollFlags::from_bits(pfd.revents) {
-            None => ds.field("revents", &pfd.revents),
-            Some(ef) => ds.field("revents", &ef),
-        };
-        ds.finish()
     }
 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -18,8 +18,7 @@ use errno::Errno;
 ///
 /// This is returned by `openpty`.  Note that this type does *not* implement `Drop`, so the user
 /// must manually close the file descriptors.
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct OpenptyResult {
     /// The master port in a virtual pty pair
     pub master: RawFd,
@@ -45,7 +44,7 @@ pub struct ForkptyResult {
 /// While this datatype is a thin wrapper around `RawFd`, it enforces that the available PTY
 /// functions are given the correct file descriptor. Additionally this type implements `Drop`,
 /// so that when it's consumed or goes out of scope, it's automatically cleaned-up.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PtyMaster(RawFd);
 
 impl AsRawFd for PtyMaster {

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -39,8 +39,7 @@ libc_bitflags!{
 pub type CloneCb<'a> = Box<FnMut() -> isize + 'a>;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct CpuSet {
     cpu_set: libc::cpu_set_t,
 }

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -80,7 +80,7 @@ libc_enum! {
 /// Return values for [`AioCb::cancel`](struct.AioCb.html#method.cancel) and
 /// [`aio_cancel_all`](fn.aio_cancel_all.html)
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AioCancelStat {
     /// All outstanding requests were canceled
     AioCanceled = libc::AIO_CANCELED,
@@ -1021,13 +1021,7 @@ pub fn aio_suspend(list: &[&AioCb], timeout: Option<TimeSpec>) -> Result<()> {
 impl<'a> Debug for AioCb<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("AioCb")
-            .field("aio_fildes", &self.aiocb.aio_fildes)
-            .field("aio_offset", &self.aiocb.aio_offset)
-            .field("aio_buf", &self.aiocb.aio_buf)
-            .field("aio_nbytes", &self.aiocb.aio_nbytes)
-            .field("aio_lio_opcode", &self.aiocb.aio_lio_opcode)
-            .field("aio_reqprio", &self.aiocb.aio_reqprio)
-            .field("aio_sigevent", &SigEvent::from(&self.aiocb.aio_sigevent))
+            .field("aiocb", &self.aiocb)
             .field("mutable", &self.mutable)
             .field("in_progress", &self.in_progress)
             .finish()

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -42,8 +42,7 @@ libc_bitflags!{
     }
 }
 
-#[allow(missing_debug_implementations)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(C)]
 pub struct EpollEvent {
     event: libc::epoll_event,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -12,9 +12,8 @@ use std::ptr;
 use std::mem;
 
 // Redefine kevent in terms of programmer-friendly enums and bitfields.
-#[derive(Clone, Copy)]
 #[repr(C)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct KEvent {
     kevent: libc::kevent,
 }

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -96,8 +96,7 @@ libc_bitflags!(
 /// Wrapper type for `if_dqblk`
 // FIXME: Change to repr(transparent)
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Dqblk(libc::dqblk);
 
 impl Default for Dqblk {

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -11,8 +11,7 @@ pub use libc::FD_SETSIZE;
 
 // FIXME: Change to repr(transparent) once it's stable
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FdSet(libc::fd_set);
 
 impl FdSet {

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -38,7 +38,7 @@ cfg_if! {
                  target_os = "macos"))] {
         use sys::uio::IoVec;
 
-        #[allow(missing_debug_implementations)]
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
         struct SendfileHeaderTrailer<'a>(
             libc::sf_hdtr,
             Option<Vec<IoVec<&'a [u8]>>>,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -265,8 +265,7 @@ const SIGNALS: [Signal; 31] = [
 
 pub const NSIG: libc::c_int = 32;
 
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SignalIterator {
     next: usize,
 }
@@ -328,8 +327,7 @@ libc_enum! {
     }
 }
 
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SigSet {
     sigset: libc::sigset_t
 }
@@ -427,7 +425,7 @@ impl AsRef<libc::sigset_t> for SigSet {
 
 /// A signal handler.
 #[allow(unknown_lints)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SigHandler {
     /// Default signal handling.
     SigDfl,
@@ -441,8 +439,7 @@ pub enum SigHandler {
 }
 
 /// Action to take on receipt of a signal. Corresponds to `sigaction`.
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SigAction {
     sigaction: libc::sigaction
 }
@@ -683,7 +680,7 @@ pub type type_of_thread_id = libc::pid_t;
 // sigval is actually a union of a int and a void*.  But it's never really used
 // as a pointer, because neither libc nor the kernel ever dereference it.  nix
 // therefore presents it as an intptr_t, which is how kevent uses it.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SigevNotify {
     /// No notification will be delivered
     SigevNone,
@@ -710,7 +707,6 @@ mod sigevent {
     use libc;
     use std::mem;
     use std::ptr;
-    use std::fmt::{self, Debug};
     use super::SigevNotify;
     #[cfg(any(target_os = "freebsd", target_os = "linux"))]
     use super::type_of_thread_id;
@@ -718,7 +714,7 @@ mod sigevent {
     /// Used to request asynchronous notification of the completion of certain
     /// events, such as POSIX AIO and timers.
     #[repr(C)]
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct SigEvent {
         sigevent: libc::sigevent
     }
@@ -785,28 +781,6 @@ mod sigevent {
 
         pub fn sigevent(&self) -> libc::sigevent {
             self.sigevent
-        }
-    }
-
-    impl Debug for SigEvent {
-        #[cfg(any(target_os = "freebsd", target_os = "linux"))]
-        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-            fmt.debug_struct("SigEvent")
-                .field("sigev_notify", &self.sigevent.sigev_notify)
-                .field("sigev_signo", &self.sigevent.sigev_signo)
-                .field("sigev_value", &self.sigevent.sigev_value.sival_ptr)
-                .field("sigev_notify_thread_id",
-                        &self.sigevent.sigev_notify_thread_id)
-                .finish()
-        }
-
-        #[cfg(not(any(target_os = "freebsd", target_os = "linux")))]
-        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-            fmt.debug_struct("SigEvent")
-                .field("sigev_notify", &self.sigevent.sigev_notify)
-                .field("sigev_signo", &self.sigevent.sigev_signo)
-                .field("sigev_value", &self.sigevent.sigev_value.sival_ptr)
-                .finish()
         }
     }
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -551,7 +551,7 @@ impl UnixAddr {
                                      ret.sun_path.as_mut_ptr().offset(1) as *mut u8,
                                      path.len());
 
-            Ok(UnixAddr(ret, path.len() + 1))
+            Ok(UnixAddr(ret, ret.sun_path.len()))
         }
     }
 
@@ -1126,9 +1126,11 @@ mod datalink {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(target_os = "dragonfly",
+    #[cfg(any(target_os = "android",
+              target_os = "dragonfly",
               target_os = "freebsd",
               target_os = "ios",
+              target_os = "linux",
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
@@ -1173,5 +1175,19 @@ mod tests {
             },
             _ => { unreachable!() }
         };
+    }
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[test]
+    fn test_abstract_sun_path() {
+        let name = String::from("nix\0abstract\0test");
+        let addr = UnixAddr::new_abstract(name.as_bytes()).unwrap();
+
+        let sun_path1 = addr.sun_path();
+        let sun_path2 = [0u8, 110, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(sun_path1.len(), sun_path2.len());
+        for i in 0..sun_path1.len() {
+            assert_eq!(sun_path1[i], sun_path2[i]);
+        }
     }
 }

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -173,7 +173,7 @@ macro_rules! sockopt_impl {
     };
 
     (GetOnly, $name:ident, $level:path, $flag:path, $ty:ty, $getter:ty) => {
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct $name;
 
         getsockopt_impl!($name, $level, $flag, $ty, $getter);
@@ -184,14 +184,14 @@ macro_rules! sockopt_impl {
     };
 
     (SetOnly, $name:ident, $level:path, $flag:path, $ty:ty, $setter:ty) => {
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct $name;
 
         setsockopt_impl!($name, $level, $flag, $ty, $setter);
     };
 
     (Both, $name:ident, $level:path, $flag:path, $ty:ty, $getter:ty, $setter:ty) => {
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct $name;
 
         setsockopt_impl!($name, $level, $flag, $ty, $setter);

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -57,8 +57,7 @@ libc_bitflags!(
 /// For more information see the [`statvfs(3)` man pages](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html).
 // FIXME: Replace with repr(transparent)
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Statvfs(libc::statvfs);
 
 impl Statvfs {

--- a/src/sys/sysinfo.rs
+++ b/src/sys/sysinfo.rs
@@ -6,8 +6,7 @@ use Result;
 use errno::Errno;
 
 /// System info structure returned by `sysinfo`.
-#[derive(Copy, Clone)]
-#[allow(missing_debug_implementations)] // libc::sysinfo doesn't impl Debug
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SysInfo(libc::sysinfo);
 
 impl SysInfo {

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -176,8 +176,7 @@ use ::unistd::Pid;
 /// This is a wrapper around the `libc::termios` struct that provides a safe interface for the
 /// standard fields. The only safe way to obtain an instance of this struct is to extract it from
 /// an open port using `tcgetattr()`.
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Termios {
     inner: RefCell<libc::termios>,
     /// Input mode flags (see `termios.c_iflag` documentation)

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -45,7 +45,7 @@ pub trait TimeValLike: Sized {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TimeSpec(timespec);
 
 const NANOS_PER_SEC: i64 = 1_000_000_000;
@@ -66,25 +66,6 @@ impl AsRef<timespec> for TimeSpec {
         &self.0
     }
 }
-
-impl fmt::Debug for TimeSpec {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("TimeSpec")
-            .field("tv_sec", &self.tv_sec())
-            .field("tv_nsec", &self.tv_nsec())
-            .finish()
-    }
-}
-
-impl PartialEq for TimeSpec {
-    // The implementation of cmp is simplified by assuming that the struct is
-    // normalized.  That is, tv_nsec must always be within [0, 1_000_000_000)
-    fn eq(&self, other: &TimeSpec) -> bool {
-        self.tv_sec() == other.tv_sec() && self.tv_nsec() == other.tv_nsec()
-    }
-}
-
-impl Eq for TimeSpec {}
 
 impl Ord for TimeSpec {
     // The implementation of cmp is simplified by assuming that the struct is
@@ -259,7 +240,7 @@ impl fmt::Display for TimeSpec {
 
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TimeVal(timeval);
 
 const MICROS_PER_SEC: i64 = 1_000_000;
@@ -277,25 +258,6 @@ impl AsRef<timeval> for TimeVal {
         &self.0
     }
 }
-
-impl fmt::Debug for TimeVal {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("TimeVal")
-            .field("tv_sec", &self.tv_sec())
-            .field("tv_usec", &self.tv_usec())
-            .finish()
-    }
-}
-
-impl PartialEq for TimeVal {
-    // The implementation of cmp is simplified by assuming that the struct is
-    // normalized.  That is, tv_usec must always be within [0, 1_000_000)
-    fn eq(&self, other: &TimeVal) -> bool {
-        self.tv_sec() == other.tv_sec() && self.tv_usec() == other.tv_usec()
-    }
-}
-
-impl Eq for TimeVal {}
 
 impl Ord for TimeVal {
     // The implementation of cmp is simplified by assuming that the struct is

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -88,8 +88,7 @@ pub fn pread(fd: RawFd, buf: &mut [u8], offset: off_t) -> Result<usize>{
 /// and [`process_vm_writev`](fn.process_vm_writev.html).
 #[cfg(target_os = "linux")]
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RemoteIoVec {
     /// The starting address of this slice (`iov_base`).
     pub base: usize,
@@ -160,7 +159,7 @@ pub fn process_vm_readv(pid: ::unistd::Pid, local_iov: &[IoVec<&mut [u8]>], remo
 }
 
 #[repr(C)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IoVec<T>(libc::iovec, PhantomData<T>);
 
 impl<T> IoVec<T> {

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -4,8 +4,7 @@ use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UtsName(libc::utsname);
 
 impl UtsName {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -55,7 +55,7 @@ libc_bitflags!(
 /// Note that there are two Linux-specific enum variants, `PtraceEvent`
 /// and `PtraceSyscall`. Portable code should avoid exhaustively
 /// matching on `WaitStatus`.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum WaitStatus {
     /// The process exited normally (as with `exit()` or returning from
     /// `main`) with the given exit code. This case matches the C macro

--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -6,8 +6,7 @@ use errno::Errno;
 use std::mem;
 use sys::signal::SigSet;
 
-#[derive(Clone, Copy)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UContext {
     context: libc::ucontext_t,
 }

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -87,16 +87,27 @@ pub fn test_addr_equality_path() {
     assert_eq!(calculate_hash(&addr1), calculate_hash(&addr2));
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+pub fn test_abstract_sun_path_too_long() {
+    let name = String::from("nix\0abstract\0tesnix\0abstract\0tesnix\0abstract\0tesnix\0abstract\0tesnix\0abstract\0testttttnix\0abstract\0test\0make\0sure\0this\0is\0long\0enough");
+    let addr = UnixAddr::new_abstract(name.as_bytes());
+    assert!(addr.is_err());
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 pub fn test_addr_equality_abstract() {
     let name = String::from("nix\0abstract\0test");
     let addr1 = UnixAddr::new_abstract(name.as_bytes()).unwrap();
     let mut addr2 = addr1.clone();
-    addr2.0.sun_path[18] = 127;
 
     assert_eq!(addr1, addr2);
     assert_eq!(calculate_hash(&addr1), calculate_hash(&addr2));
+
+    addr2.0.sun_path[18] = 127;
+    assert_ne!(addr1, addr2);
+    assert_ne!(calculate_hash(&addr1), calculate_hash(&addr2));
 }
 
 // Test getting/setting abstract addresses (without unix socket creation)
@@ -105,20 +116,22 @@ pub fn test_addr_equality_abstract() {
 pub fn test_abstract_uds_addr() {
     let empty = String::new();
     let addr = UnixAddr::new_abstract(empty.as_bytes()).unwrap();
-    assert_eq!(addr.as_abstract(), Some(empty.as_bytes()));
+    let sun_path = [0u8; 107];
+    assert_eq!(addr.as_abstract(), Some(&sun_path[..]));
 
     let name = String::from("nix\0abstract\0test");
     let addr = UnixAddr::new_abstract(name.as_bytes()).unwrap();
-    assert_eq!(addr.as_abstract(), Some(name.as_bytes()));
+    let sun_path = [
+        110u8, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    assert_eq!(addr.as_abstract(), Some(&sun_path[..]));
     assert_eq!(addr.path(), None);
 
     // Internally, name is null-prefixed (abstract namespace)
-    let internal: &[u8] = unsafe {
-        slice::from_raw_parts(addr.0.sun_path.as_ptr() as *const u8, addr.1)
-    };
-    let mut abstract_name = name.clone();
-    abstract_name.insert(0, '\0');
-    assert_eq!(internal, abstract_name.as_bytes());
+    assert_eq!(addr.0.sun_path[0], 0);
 }
 
 #[test]

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -55,8 +55,8 @@ fn test_mq_getattr() {
     };
     let mqd = r.unwrap();
 
-    let read_attr = mq_getattr(mqd);
-    assert!(read_attr.unwrap() == initial_attr);
+    let read_attr = mq_getattr(mqd).unwrap();
+    assert_eq!(read_attr, initial_attr);
     mq_close(mqd).unwrap();
 }
 
@@ -79,21 +79,21 @@ fn test_mq_setattr() {
     let mqd = r.unwrap();
 
     let new_attr =  MqAttr::new(0, 20, MSG_SIZE * 2, 100);
-    let old_attr = mq_setattr(mqd, &new_attr);
-    assert!(old_attr.unwrap() == initial_attr);
+    let old_attr = mq_setattr(mqd, &new_attr).unwrap();
+    assert_eq!(old_attr, initial_attr);
 
-    let new_attr_get = mq_getattr(mqd);
+    let new_attr_get = mq_getattr(mqd).unwrap();
     // The following tests make sense. No changes here because according to the Linux man page only
     // O_NONBLOCK can be set (see tests below)
-    assert!(new_attr_get.unwrap() != new_attr);
+    assert_ne!(new_attr_get, new_attr);
 
     let new_attr_non_blocking =  MqAttr::new(MQ_OFlag::O_NONBLOCK.bits() as c_long, 10, MSG_SIZE, 0);
     mq_setattr(mqd, &new_attr_non_blocking).unwrap();
-    let new_attr_get = mq_getattr(mqd);
+    let new_attr_get = mq_getattr(mqd).unwrap();
 
     // now the O_NONBLOCK flag has been set
-    assert!(new_attr_get.unwrap() != initial_attr);
-    assert!(new_attr_get.unwrap() == new_attr_non_blocking);
+    assert_ne!(new_attr_get, initial_attr);
+    assert_eq!(new_attr_get, new_attr_non_blocking);
     mq_close(mqd).unwrap();
 }
 

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,5 +1,5 @@
 use nix::poll::{PollFlags, poll, PollFd};
-use nix::unistd::{write, pipe, close};
+use nix::unistd::{write, pipe};
 
 #[test]
 fn test_poll() {
@@ -17,24 +17,6 @@ fn test_poll() {
     let nfds = poll(&mut fds, 100).unwrap();
     assert_eq!(nfds, 1);
     assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
-}
-
-#[test]
-fn test_poll_debug() {
-    assert_eq!(format!("{:?}", PollFd::new(0, PollFlags::empty())),
-               "PollFd { fd: 0, events: (empty), revents: (empty) }");
-    assert_eq!(format!("{:?}", PollFd::new(1, PollFlags::POLLIN)),
-               "PollFd { fd: 1, events: POLLIN, revents: (empty) }");
-
-    // Testing revents requires doing some I/O
-    let (r, w) = pipe().unwrap();
-    let mut fds = [PollFd::new(r, PollFlags::POLLIN)];
-    write(w, b" ").unwrap();
-    close(w).unwrap();
-    poll(&mut fds, -1).unwrap();
-    assert_eq!(format!("{:?}", fds[0]),
-               format!("PollFd {{ fd: {}, events: POLLIN, revents: POLLIN | POLLHUP }}", r));
-    close(r).unwrap();
 }
 
 // ppoll(2) is the same as poll except for how it handles timeouts and signals.


### PR DESCRIPTION
Now that I've gotten all the extra traits implemented for `libc`, they can be easily derived for `nix`'s types. Note that this requires a bump to the minimum supported Rust version, but it's still at least 2 versions behind, so it fits in with policy.

One thing I did notice is that we have an inconsistent approach to our newtypes, where some use a struct and some a tuple struct. We should be consistent here, and should probably use a tuple struct since the name of the single field is irrelevant. This style is already suggested in our `CONVENTIONS.md` doc, so this should be uncontroversial. I'll file a PR after this is merged adding that.