### PR TITLE
allow importing macros without helpers in the 2018 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed multiple bugs when using `sendmsg` and `recvmsg` with ancillary control messages
   ([#1020](https://github.com/nix-rust/nix/pull/1020))
+- Macros exported by `nix` may now be imported via `use` on the Rust 2018
+  edition without importing helper macros.
+  ([#1041](https://github.com/nix-rust/nix/pull/1041))
+
+  For example, in Rust 2018, the `ioctl_read_bad!` macro can now be imported
+  without importing the `convert_ioctl_res!` macro.
+
+  ```rust
+  use nix::ioctl_read_bad;
+
+  ioctl_read_bad!(tcgets, libc::TCGETS, libc::termios);
+  ```
 
 ### Removed
 - `Daemon`, `NOTE_REAP`, and `NOTE_EXIT_REPARENTED` are now deprecated on OSX

--- a/src/sys/ioctl/bsd.rs
+++ b/src/sys/ioctl/bsd.rs
@@ -44,7 +44,7 @@ macro_rules! ioc {
 /// ioctl_write_int_bad!(kvm_create_vm, request_code_none!(KVMIO, 0x03));
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_none {
     ($g:expr, $n:expr) => (ioc!($crate::sys::ioctl::VOID, $g, $n, 0))
 }
@@ -55,7 +55,7 @@ macro_rules! request_code_none {
 ///
 /// You should only use this macro directly if the `ioctl` you're working
 /// with is "bad" and you cannot use `ioctl_write_int!()` directly.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_write_int {
     ($g:expr, $n:expr) => (ioc!($crate::sys::ioctl::VOID, $g, $n, ::std::mem::size_of::<$crate::libc::c_int>()))
 }
@@ -70,7 +70,7 @@ macro_rules! request_code_write_int {
 /// The read/write direction is relative to userland, so this
 /// command would be userland is reading and the kernel is
 /// writing.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_read {
     ($g:expr, $n:expr, $len:expr) => (ioc!($crate::sys::ioctl::OUT, $g, $n, $len))
 }
@@ -85,7 +85,7 @@ macro_rules! request_code_read {
 /// The read/write direction is relative to userland, so this
 /// command would be userland is writing and the kernel is
 /// reading.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_write {
     ($g:expr, $n:expr, $len:expr) => (ioc!($crate::sys::ioctl::IN, $g, $n, $len))
 }
@@ -96,7 +96,7 @@ macro_rules! request_code_write {
 ///
 /// You should only use this macro directly if the `ioctl` you're working
 /// with is "bad" and you cannot use `ioctl_readwrite!()` directly.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_readwrite {
     ($g:expr, $n:expr, $len:expr) => (ioc!($crate::sys::ioctl::INOUT, $g, $n, $len))
 }

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -287,7 +287,7 @@ macro_rules! convert_ioctl_res {
 /// ioctl_none!(log_status, b'V', 70);
 /// fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_none {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr) => (
         $(#[$attr])*
@@ -328,7 +328,7 @@ macro_rules! ioctl_none {
 /// }
 /// ```
 // TODO: add an example using request_code_*!()
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_none_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr) => (
         $(#[$attr])*
@@ -365,7 +365,7 @@ macro_rules! ioctl_none_bad {
 /// ioctl_read!(spi_read_mode, SPI_IOC_MAGIC, SPI_IOC_TYPE_MODE, u8);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_read {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -402,7 +402,7 @@ macro_rules! ioctl_read {
 /// ioctl_read_bad!(tcgets, libc::TCGETS, libc::termios);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_read_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -439,7 +439,7 @@ macro_rules! ioctl_read_bad {
 /// ioctl_write_ptr!(s_audio, b'V', 34, v4l2_audio);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_write_ptr {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -476,7 +476,7 @@ macro_rules! ioctl_write_ptr {
 /// ioctl_write_ptr_bad!(tcsets, libc::TCSETS, libc::termios);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_write_ptr_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -517,7 +517,7 @@ cfg_if!{
         /// ioctl_write_int!(vt_activate, b'v', 4);
         /// # fn main() {}
         /// ```
-        #[macro_export]
+        #[macro_export(local_inner_macros)]
         macro_rules! ioctl_write_int {
             ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr) => (
                 $(#[$attr])*
@@ -558,7 +558,7 @@ cfg_if!{
         /// ioctl_write_int!(hci_dev_up, HCI_IOC_MAGIC, HCI_IOC_HCIDEVUP);
         /// # fn main() {}
         /// ```
-        #[macro_export]
+        #[macro_export(local_inner_macros)]
         macro_rules! ioctl_write_int {
             ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr) => (
                 $(#[$attr])*
@@ -603,7 +603,7 @@ cfg_if!{
 /// ioctl_write_int_bad!(kvm_create_vm, request_code_none!(KVMIO, 0x03));
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_write_int_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr) => (
         $(#[$attr])*
@@ -640,7 +640,7 @@ macro_rules! ioctl_write_int_bad {
 /// ioctl_readwrite!(enum_audio, b'V', 65, v4l2_audio);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_readwrite {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -668,7 +668,7 @@ macro_rules! ioctl_readwrite {
 ///
 /// For a more in-depth explanation of ioctls, see [`::sys::ioctl`](sys/ioctl/index.html).
 // TODO: Find an example for ioctl_readwrite_bad
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_readwrite_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -697,7 +697,7 @@ macro_rules! ioctl_readwrite_bad {
 ///
 /// For a more in-depth explanation of ioctls, see [`::sys::ioctl`](sys/ioctl/index.html).
 // TODO: Find an example for ioctl_read_buf
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_read_buf {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -736,7 +736,7 @@ macro_rules! ioctl_read_buf {
 /// ioctl_write_buf!(spi_transfer, SPI_IOC_MAGIC, SPI_IOC_TYPE_MESSAGE, spi_ioc_transfer);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_write_buf {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*
@@ -765,7 +765,7 @@ macro_rules! ioctl_write_buf {
 ///
 /// For a more in-depth explanation of ioctls, see [`::sys::ioctl`](sys/ioctl/index.html).
 // TODO: Find an example for readwrite_buf
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! ioctl_readwrite_buf {
     ($(#[$attr:meta])* $name:ident, $ioty:expr, $nr:expr, $ty:ty) => (
         $(#[$attr])*


### PR DESCRIPTION
~This PR adds the `$crate::` prefix to all uses of helper macros, which will allow users of the 2018 edition to import the macros without needing to also import their helpers.~

See https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macros-with-crate-prefix for more info.

~While this is a cleaner solution than using `#[macro_export(local_inner_macros)]`, it also requires bumping the minimum supported compiler version to 1.30. If this is acceptable, I'll add a commit to update the Travis configuration and docs.~

This PR now uses `local_inner_macros` to preserve compatibility with the current minimum Rust version.