### PR TITLE
Uncomment to_std and from_std methods for IpAddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#969](https://github.com/nix-rust/nix/pull/969))
 - Add several errno constants from OpenBSD 6.2
   ([#1036](https://github.com/nix-rust/nix/pull/1036))
+- Added `from_std` and `to_std` methods for `sys::socket::IpAddr`
+  ([#1043](https://github.com/nix-rust/nix/pull/1043))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -418,20 +418,19 @@ impl IpAddr {
         IpAddr::V6(Ipv6Addr::new(a, b, c, d, e, f, g, h))
     }
 
-    /*
     pub fn from_std(std: &net::IpAddr) -> IpAddr {
         match *std {
             net::IpAddr::V4(ref std) => IpAddr::V4(Ipv4Addr::from_std(std)),
             net::IpAddr::V6(ref std) => IpAddr::V6(Ipv6Addr::from_std(std)),
         }
     }
+
     pub fn to_std(&self) -> net::IpAddr {
         match *self {
             IpAddr::V4(ref ip) => net::IpAddr::V4(ip.to_std()),
             IpAddr::V6(ref ip) => net::IpAddr::V6(ip.to_std()),
         }
     }
-    */
 }
 
 impl fmt::Display for IpAddr {


### PR DESCRIPTION
These were commented out in 2b60633c8bdd5359c317bb74e698777106befb85, apparently because `std::net::IpAddr` had been removed from the standard library. However, `IpAddr` has since been re-added to the standard library (https://github.com/rust-lang/rust/pull/23711) and stabilized (https://github.com/rust-lang/rust/pull/31438), so it seems there is no reason to keep them commented out.