### PR TITLE
Add unistd::{seteuid,setegid}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1036](https://github.com/nix-rust/nix/pull/1036))
 - Added `from_std` and `to_std` methods for `sys::socket::IpAddr`
   ([#1043](https://github.com/nix-rust/nix/pull/1043))
+- Added `nix::unistd:seteuid` and `nix::unistd::setegid` for those platforms that do
+  not support `setresuid` nor `setresgid` respectively.
+  ([#1044](https://github.com/nix-rust/nix/pull/1044))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1236,6 +1236,26 @@ pub fn getegid() -> Gid {
     Gid(unsafe { libc::getegid() })
 }
 
+/// Set the effective user ID
+///
+/// See also [seteuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/seteuid.html)
+#[inline]
+pub fn seteuid(euid: Uid) -> Result<()> {
+    let res = unsafe { libc::seteuid(euid.into()) };
+
+    Errno::result(res).map(drop)
+}
+
+/// Set the effective group ID
+///
+/// See also [setegid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setegid.html)
+#[inline]
+pub fn setegid(egid: Gid) -> Result<()> {
+    let res = unsafe { libc::setegid(egid.into()) };
+
+    Errno::result(res).map(drop)
+}
+
 /// Set the user ID
 ///
 /// See also [setuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setuid.html)
@@ -1246,7 +1266,7 @@ pub fn setuid(uid: Uid) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
-/// Set the user ID
+/// Set the group ID
 ///
 /// See also [setgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setgid.html)
 #[inline]


### PR DESCRIPTION
This is for the benefit of those platforms that do not provide setresuid
nor setresgid, like macOS.