### PR TITLE
Implement `sched_yield`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1045](https://github.com/nix-rust/nix/pull/1045))
 - Add `forkpty`
   ([#1042](https://github.com/nix-rust/nix/pull/1042))
+- Add `sched_yield`
+  ([#1050](https://github.com/nix-rust/nix/pull/1050))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -85,6 +85,17 @@ pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+/// Explicitly yield the processor to other threads.
+///
+/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
+pub fn sched_yield() -> Result<()> {
+    let res = unsafe {
+        libc::sched_yield()
+    };
+
+    Errno::result(res).map(drop)
+}
+
 pub fn clone(mut cb: CloneCb,
              stack: &mut [u8],
              flags: CloneFlags,


### PR DESCRIPTION
This adds the `sched_yield` function, which is part of POSIX:

http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html

and widely implemented on Unix-family platforms.