### PR TITLE
Implement unlinkat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1045](https://github.com/nix-rust/nix/pull/1045))
 - Add `forkpty`
   ([#1042](https://github.com/nix-rust/nix/pull/1042))
+- Add `unlinkat`
+  ([#TBD](https://github.com/nix-rust/nix/pull/TBD))
 
 ### Changed
 - `PollFd` event flags renamed to `PollFlags` ([#1024](https://github.com/nix-rust/nix/pull/1024/))

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -12,6 +12,7 @@ use sys::uio::IoVec;  // For vmsplice
 
 libc_bitflags!{
     pub struct AtFlags: c_int {
+        AT_REMOVEDIR;
         AT_SYMLINK_NOFOLLOW;
         #[cfg(any(target_os = "android", target_os = "linux"))]
         AT_NO_AUTOMOUNT;


### PR DESCRIPTION
This adds the unlinkat function, which is part of POSIX:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html
and widely implmented on Unix-family platforms.