### PR TITLE
Implement unlinkat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1089](https://github.com/nix-rust/nix/pull/1089))
 - Added `AF_VSOCK` to `AddressFamily`.
   ([#1091](https://github.com/nix-rust/nix/pull/1091))
+- Add `unlinkat`
+  ([#1058](https://github.com/nix-rust/nix/pull/1058))
 
 ### Changed
 - Support for `ifaddrs` now present when building for Android.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -23,6 +23,7 @@ pub use self::posix_fadvise::*;
 
 libc_bitflags!{
     pub struct AtFlags: c_int {
+        AT_REMOVEDIR;
         AT_SYMLINK_NOFOLLOW;
         #[cfg(any(target_os = "android", target_os = "linux"))]
         AT_NO_AUTOMOUNT;


### PR DESCRIPTION
This adds the unlinkat function, which is part of POSIX:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html
and widely implmented on Unix-family platforms.