### PR TITLE
Merge r196b05b5c from master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+
+# Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the
+# same VM.  The binary will be built in 32-bit mode, but will execute on a
+# 64-bit kernel and in a 64-bit environment.  Our tests don't execute any of
+# the system's binaries, so the environment shouldn't matter.
+task:
+  name: FreeBSD 11.2
+  # Install Rust
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --default-toolchain 1.20.0
+    - $HOME/.cargo/bin/rustup target add i686-unknown-freebsd
+  amd64_test_script:
+    - . $HOME/.cargo/env
+    - cargo test
+  i386_test_script:
+    - . $HOME/.cargo/env
+    - cargo test --target i686-unknown-freebsd

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,8 @@ branches:
   only:
     # release tags
     - /^v\d+\.\d+\.\d+.*$/
+    # release branches
+    - /^r\d+\.\d+\.\d+.*$/
     - master
     # bors-ng branches; see https://bors-ng.github.io/getting-started/
     - trying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [0.11.1] 2019-05-21
+### Fixed
+- Fixed build on Linux/arm and Linux/s390x with the latest Rust libc
+  ([52102cb](https://github.com/nix-rust/nix/commit/52102cb76398c4dfb9ea141b98c5b01a2e050973))
+
 ## [0.11.0] 2018-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ cc = "1"
 
 [dev-dependencies]
 bytes = "0.4.8"
-lazy_static = "1"
+# lazy_static 1.2.0 needs Rust 1.24.1 or newer
+lazy_static = ">= 1.0, < 1.2"
 rand = "0.4"
 tempdir = "0.3"
 tempfile = "2"

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -38,7 +38,6 @@ libc_enum!{
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
                                                target_arch = "mips64",
-                                               target_arch = "s390x",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_GETREGS,
@@ -46,7 +45,6 @@ libc_enum!{
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
                                                target_arch = "mips64",
-                                               target_arch = "s390x",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_SETREGS,
@@ -54,7 +52,6 @@ libc_enum!{
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
                                                target_arch = "mips64",
-                                               target_arch = "s390x",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_GETFPREGS,
@@ -62,7 +59,6 @@ libc_enum!{
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
                                                target_arch = "mips64",
-                                               target_arch = "s390x",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_SETFPREGS,
@@ -71,14 +67,12 @@ libc_enum!{
         #[cfg(all(target_os = "linux", any(target_env = "musl",
                                            target_arch = "mips",
                                            target_arch = "mips64",
-                                           target_arch = "arm",
                                            target_arch = "x86",
                                            target_arch = "x86_64")))]
         PTRACE_GETFPXREGS,
         #[cfg(all(target_os = "linux", any(target_env = "musl",
                                            target_arch = "mips",
                                            target_arch = "mips64",
-                                           target_arch = "arm",
                                            target_arch = "x86",
                                            target_arch = "x86_64")))]
         PTRACE_SETFPXREGS,


### PR DESCRIPTION
commit 196b05b5c7be39b73dcadca5457948d807fdf913 (fpxregs)
Author: Alan Somers <asomers@gmail.com>
Date:   Fri May 17 14:59:36 2019 -0600

    Fix build on arm and s390x after recent libc changes

    libc just removed some symbols on linux/arm32 and linux/s390x that never
    should've been defined in the first place.

    https://github.com/rust-lang/libc/commit/24f8972b8d2d915b1687fc8197e1ed95e349a82e
    https://github.com/rust-lang/libc/commit/d2695436ba5072078796c76f727a296e0f43caa6