### PR TITLE
Update fcntl.rs

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -105,7 +105,7 @@ libc_bitflags!(
         O_RDONLY;
         /// Allow both reading and writing.
         ///
-        /// This should not be combined with `O_WRONLY` or `O_RDWR`.
+        /// This should not be combined with `O_WRONLY` or `O_RDONLY`.
         O_RDWR;
         /// Similar to `O_DSYNC` but applies to `read`s instead.
         #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "openbsd"))]


### PR DESCRIPTION
Just a minor typo in the docs of `O_RDWR`. It read:

```
/// Allow both reading and writing.
///
/// This should not be combined with `O_WRONLY` or `O_RDWR`.
O_RDWR;
```

but I believe it should read

```
/// Allow both reading and writing.
///
/// This should not be combined with `O_WRONLY` or `O_RDONLY`.
O_RDWR;
```

instead :-)