### PR TITLE
Allow import of Linux macros in Rust2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Macros exported by `nix` may now be imported via `use` on the Rust 2018
+  edition without importing helper macros on Linux targets.
+  ([#1066](https://github.com/nix-rust/nix/pull/1066))
+
+  For example, in Rust 2018, the `ioctl_read_bad!` macro can now be imported
+  without importing the `convert_ioctl_res!` macro.
+
+  ```rust
+  use nix::ioctl_read_bad;
+
+  ioctl_read_bad!(tcgets, libc::TCGETS, libc::termios);
+  ```
+
 ### Changed
 ### Fixed
 ### Removed
@@ -56,7 +69,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed multiple bugs when using `sendmsg` and `recvmsg` with ancillary control messages
   ([#1020](https://github.com/nix-rust/nix/pull/1020))
 - Macros exported by `nix` may now be imported via `use` on the Rust 2018
-  edition without importing helper macros.
+  edition without importing helper macros for BSD targets.
   ([#1041](https://github.com/nix-rust/nix/pull/1041))
 
   For example, in Rust 2018, the `ioctl_read_bad!` macro can now be imported

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -93,7 +93,7 @@ macro_rules! ioc {
 /// ioctl_write_int_bad!(kvm_create_vm, request_code_none!(KVMIO, 0x03));
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_none {
     ($ty:expr, $nr:expr) => (ioc!($crate::sys::ioctl::NONE, $ty, $nr, 0))
 }
@@ -108,7 +108,7 @@ macro_rules! request_code_none {
 /// The read/write direction is relative to userland, so this
 /// command would be userland is reading and the kernel is
 /// writing.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_read {
     ($ty:expr, $nr:expr, $sz:expr) => (ioc!($crate::sys::ioctl::READ, $ty, $nr, $sz))
 }
@@ -123,7 +123,7 @@ macro_rules! request_code_read {
 /// The read/write direction is relative to userland, so this
 /// command would be userland is writing and the kernel is
 /// reading.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_write {
     ($ty:expr, $nr:expr, $sz:expr) => (ioc!($crate::sys::ioctl::WRITE, $ty, $nr, $sz))
 }
@@ -134,7 +134,7 @@ macro_rules! request_code_write {
 ///
 /// You should only use this macro directly if the `ioctl` you're working
 /// with is "bad" and you cannot use `ioctl_readwrite!()` directly.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! request_code_readwrite {
     ($ty:expr, $nr:expr, $sz:expr) => (ioc!($crate::sys::ioctl::READ | $crate::sys::ioctl::WRITE, $ty, $nr, $sz))
 }


### PR DESCRIPTION
Finish off the work started in 8c9ac5a70 allowing the use of macros
without needing to import local inner macros for Linux targets.