### PR TITLE
Use ptrace::Event in WaitStatus::PtraceEvent

### DIFF
--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -1,6 +1,7 @@
 //! For detailed description of the ptrace requests, consult `man ptrace`.
 
 use std::{mem, ptr};
+use std::convert::TryFrom;
 use {Error, Result};
 use errno::Errno;
 use libc::{self, c_void, c_long, siginfo_t};
@@ -140,9 +141,11 @@ libc_enum!{
     }
 }
 
-impl Event {
+impl TryFrom<libc::c_int> for Event {
+    type Error = Error;
+
     #[inline]
-    pub fn from_c_int(evnum: libc::c_int) -> Result<Event> {
+    fn try_from(evnum: libc::c_int) -> Result<Event> {
         if 0 < evnum && (evnum as usize) < Event::COUNT {
             Ok(unsafe { mem::transmute(evnum) })
         } else {

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -140,6 +140,17 @@ libc_enum!{
     }
 }
 
+impl Event {
+    #[inline]
+    pub fn from_c_int(evnum: libc::c_int) -> Result<Event> {
+        if 0 < evnum && evnum < 7 {
+            Ok(unsafe { mem::transmute(evnum) })
+        } else {
+            Err(Error::invalid_argument())
+        }
+    }
+}
+
 libc_bitflags! {
     /// Ptrace options used in conjunction with the PTRACE_SETOPTIONS request.
     /// See `man ptrace` for more details.

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -143,7 +143,7 @@ libc_enum!{
 impl Event {
     #[inline]
     pub fn from_c_int(evnum: libc::c_int) -> Result<Event> {
-        if 0 < evnum && evnum < 7 {
+        if 0 < evnum && (evnum as usize) < Event::COUNT {
             Ok(unsafe { mem::transmute(evnum) })
         } else {
             Err(Error::invalid_argument())

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -571,12 +571,14 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// # extern crate nix;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
 /// # use nix::sys::signal::{self, Signal, SigHandler};
+/// # use std::convert::TryInto;
+///
 /// lazy_static! {
 ///    static ref SIGNALED: AtomicBool = AtomicBool::new(false);
 /// }
 ///
 /// extern fn handle_sigint(signal: libc::c_int) {
-///     let signal = signal.try_into().unwrap();
+///     let signal: Signal = signal.try_into().unwrap();
 ///     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 /// }
 ///

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -263,8 +263,6 @@ const SIGNALS: [Signal; 31] = [
     SIGEMT,
     SIGINFO];
 
-pub const NSIG: libc::c_int = 32;
-
 #[derive(Clone, Copy)]
 #[allow(missing_debug_implementations)]
 pub struct SignalIterator {
@@ -295,7 +293,7 @@ impl Signal {
     // implemented, we'll replace this function.
     #[inline]
     pub fn from_c_int(signum: libc::c_int) -> Result<Signal> {
-        if 0 < signum && signum < NSIG {
+        if 0 < signum && (signum as usize) < Signal::COUNT {
             Ok(unsafe { mem::transmute(signum) })
         } else {
             Err(Error::invalid_argument())

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -2,6 +2,7 @@ use libc::{self, c_int};
 use Result;
 use errno::Errno;
 use unistd::Pid;
+use std::convert::TryInto;
 
 use sys::signal::Signal;
 
@@ -129,7 +130,7 @@ fn signaled(status: i32) -> bool {
 }
 
 fn term_signal(status: i32) -> Result<Signal> {
-    Signal::from_c_int(unsafe { libc::WTERMSIG(status) })
+    unsafe { libc::WTERMSIG(status) }.try_into()
 }
 
 fn dumped_core(status: i32) -> bool {
@@ -141,7 +142,7 @@ fn stopped(status: i32) -> bool {
 }
 
 fn stop_signal(status: i32) -> Result<Signal> {
-    Signal::from_c_int(unsafe { libc::WSTOPSIG(status) })
+    unsafe { libc::WSTOPSIG(status) }.try_into()
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -155,7 +156,7 @@ fn syscall_stop(status: i32) -> bool {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn stop_event(status: i32) -> Result<Event> {
-    Event::from_c_int(status >> 16)
+    (status >> 16).try_into()
 }
 
 fn continued(status: i32) -> bool {

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -3,6 +3,7 @@ use nix::Error;
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::convert::TryInto;
 
 #[test]
 fn test_kill_none() {
@@ -75,7 +76,7 @@ lazy_static! {
 }
 
 extern fn test_sigaction_handler(signal: libc::c_int) {
-    let signal = signal.try_into().unwrap();
+    let signal: Signal = signal.try_into().unwrap();
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -75,7 +75,7 @@ lazy_static! {
 }
 
 extern fn test_sigaction_handler(signal: libc::c_int) {
-    let signal = Signal::from_c_int(signal).unwrap();
+    let signal = signal.try_into().unwrap();
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 #[test]
 fn test_signalfd() {
     use nix::sys::signalfd::SignalFd;
@@ -20,6 +22,6 @@ fn test_signalfd() {
 
     // And now catch that same signal.
     let res = fd.read_signal().unwrap().unwrap();
-    let signo = (res.ssi_signo as i32).try_into().unwrap();
+    let signo: Signal = (res.ssi_signo as i32).try_into().unwrap();
     assert_eq!(signo, signal::SIGUSR1);
 }

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -20,6 +20,6 @@ fn test_signalfd() {
 
     // And now catch that same signal.
     let res = fd.read_signal().unwrap().unwrap();
-    let signo = Signal::from_c_int(res.ssi_signo as i32).unwrap();
+    let signo = (res.ssi_signo as i32).try_into().unwrap();
     assert_eq!(signo, signal::SIGUSR1);
 }

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -86,7 +86,7 @@ mod ptrace {
         assert_eq!(waitpid(child, None), Ok(WaitStatus::PtraceSyscall(child)));
         // Then get the ptrace event for the process exiting
         assert!(ptrace::cont(child, None).is_ok());
-        assert_eq!(waitpid(child, None), Ok(WaitStatus::PtraceEvent(child, SIGTRAP, Event::PTRACE_EVENT_EXIT as i32)));
+        assert_eq!(waitpid(child, None), Ok(WaitStatus::PtraceEvent(child, SIGTRAP, Event::PTRACE_EVENT_EXIT)));
         // Finally get the normal wait() result, now that the process has exited
         assert!(ptrace::cont(child, None).is_ok());
         assert_eq!(waitpid(child, None), Ok(WaitStatus::Exited(child, 0)));


### PR DESCRIPTION
The purpose of this PR is to replace `c_int` with the enum `ptrace::Event` in the variant `WaitStatus::PtraceEvent(Pid, Signal, c_int)`.

There was no way to convert `c_int` values into `ptrace::Event` values, so I copied the `from_c_int` function that was defined in the `Signal` enum, and modified the `libc_enum!` macro to automatically count the number of variants to use that as an upper bound of valid integers.

However, I don't think this use of `mem::transmute` is safe, because the libc values are not guaranteed to be sequential AFAIK. Should I replace this with a simple match?

I also replaced both `from_c_int` with impls of `TryFrom<c_int>`, as suggested in a comment in the source.