### PR TITLE
Fix libc deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = "0.2.55"
+libc = "0.2.57"
 bitflags = "1.0"
 cfg-if = "0.1.0"
 void = "1.0.2"

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -27,7 +27,6 @@ use libc;
 use libc::{
     c_char,
     c_int,
-    uint32_t
 };
 use std::ffi::{OsString,OsStr,CStr};
 use std::os::unix::ffi::OsStrExt;
@@ -40,7 +39,7 @@ use errno::Errno;
 
 libc_bitflags! {
     /// Configuration options for [`inotify_add_watch`](fn.inotify_add_watch.html).
-    pub struct AddWatchFlags: uint32_t {
+    pub struct AddWatchFlags: u32 {
         IN_ACCESS;
         IN_MODIFY;
         IN_ATTRIB;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -139,7 +139,15 @@ libc_enum!{
         #[cfg(any(target_os = "android", target_os = "linux"))]
         MADV_UNMERGEABLE,
         /// Preserve the memory of each page but offline the original page.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android",
+            all(target_os = "linux", any(
+                target_arch = "aarch64",
+                target_arch = "arm",
+                target_arch = "ppc",
+                target_arch = "s390x",
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "sparc64"))))]
         MADV_SOFT_OFFLINE,
         /// Enable Transparent Huge Pages (THP) for pages in the given range.
         #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -307,7 +307,6 @@ pub const SIGIOT : Signal = SIGABRT;
 pub const SIGPOLL : Signal = SIGIO;
 pub const SIGUNUSED : Signal = SIGSYS;
 
-#[cfg(not(target_os = "android"))]
 libc_bitflags!{
     pub struct SaFlags: libc::c_int {
         SA_NOCLDSTOP;
@@ -317,35 +316,6 @@ libc_bitflags!{
         SA_RESETHAND;
         SA_RESTART;
         SA_SIGINFO;
-    }
-}
-
-// On 64-bit android, sa_flags is c_uint while on 32-bit android, it is
-// c_ulong.
-// FIXME: https://github.com/rust-lang/libc/pull/511
-#[cfg(all(target_os = "android", target_pointer_width = "32"))]
-libc_bitflags!{
-    pub struct SaFlags: libc::c_ulong {
-        SA_NOCLDSTOP as libc::c_ulong;
-        SA_NOCLDWAIT as libc::c_ulong;
-        SA_NODEFER as libc::c_ulong;
-        SA_ONSTACK as libc::c_ulong;
-        SA_RESETHAND as libc::c_ulong;
-        SA_RESTART as libc::c_ulong;
-        SA_SIGINFO as libc::c_ulong;
-    }
-}
-
-#[cfg(all(target_os = "android", target_pointer_width = "64"))]
-libc_bitflags!{
-    pub struct SaFlags: libc::c_uint {
-        SA_NOCLDSTOP as libc::c_uint;
-        SA_NOCLDWAIT as libc::c_uint;
-        SA_NODEFER as libc::c_uint;
-        SA_ONSTACK as libc::c_uint;
-        SA_RESETHAND as libc::c_uint;
-        SA_RESTART as libc::c_uint;
-        SA_SIGINFO as libc::c_uint;
     }
 }
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1096,7 +1096,7 @@ pub mod alg {
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub mod sys_control {
     use ::sys::socket::addr::AddressFamily;
-    use libc::{self, c_uchar, uint16_t, uint32_t};
+    use libc::{self, c_uchar};
     use std::{fmt, mem};
     use std::hash::{Hash, Hasher};
     use std::os::unix::io::RawFd;
@@ -1104,7 +1104,7 @@ pub mod sys_control {
 
     #[repr(C)]
     pub struct ctl_ioc_info {
-        pub ctl_id: uint32_t,
+        pub ctl_id: u32,
         pub ctl_name: [c_uchar; MAX_KCTL_NAME],
     }
 
@@ -1141,7 +1141,7 @@ pub mod sys_control {
             let addr = libc::sockaddr_ctl {
                 sc_len: mem::size_of::<libc::sockaddr_ctl>() as c_uchar,
                 sc_family: AddressFamily::System as c_uchar,
-                ss_sysaddr: libc::AF_SYS_CONTROL as uint16_t,
+                ss_sysaddr: libc::AF_SYS_CONTROL as u16,
                 sc_id: id,
                 sc_unit: unit,
                 sc_reserved: [0; 5]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -2,7 +2,7 @@ use super::{GetSockOpt, SetSockOpt};
 use Result;
 use errno::Errno;
 use sys::time::TimeVal;
-use libc::{self, c_int, uint8_t, c_void, socklen_t};
+use libc::{self, c_int, c_void, socklen_t};
 use std::mem;
 use std::os::unix::io::RawFd;
 use std::ffi::{OsStr, OsString};
@@ -485,19 +485,19 @@ unsafe impl<'a> Set<'a, bool> for SetBool {
 /// Getter for an `u8` value.
 struct GetU8 {
     len: socklen_t,
-    val: uint8_t,
+    val: u8,
 }
 
 unsafe impl Get<u8> for GetU8 {
     unsafe fn blank() -> Self {
         GetU8 {
-            len: mem::size_of::<uint8_t>() as socklen_t,
+            len: mem::size_of::<u8>() as socklen_t,
             val: mem::zeroed(),
         }
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        &mut self.val as *mut uint8_t as *mut c_void
+        &mut self.val as *mut u8 as *mut c_void
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -505,23 +505,23 @@ unsafe impl Get<u8> for GetU8 {
     }
 
     unsafe fn unwrap(self) -> u8 {
-        assert!(self.len as usize == mem::size_of::<uint8_t>(), "invalid getsockopt implementation");
+        assert!(self.len as usize == mem::size_of::<u8>(), "invalid getsockopt implementation");
         self.val as u8
     }
 }
 
 /// Setter for an `u8` value.
 struct SetU8 {
-    val: uint8_t,
+    val: u8,
 }
 
 unsafe impl<'a> Set<'a, u8> for SetU8 {
     fn new(val: &'a u8) -> SetU8 {
-        SetU8 { val: *val as uint8_t }
+        SetU8 { val: *val as u8 }
     }
 
     fn ffi_ptr(&self) -> *const c_void {
-        &self.val as *const uint8_t as *const c_void
+        &self.val as *const u8 as *const c_void
     }
 
     fn ffi_len(&self) -> socklen_t {

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -1,5 +1,14 @@
 use nix::sys::pthread::*;
+use std::ptr;
 
+#[cfg(target_env = "musl")]
+#[test]
+fn test_pthread_self() {
+    let tid = pthread_self();
+    assert!(tid != ptr::null_mut());
+}
+
+#[cfg(not(target_env = "musl"))]
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();


### PR DESCRIPTION
The `libc` crate now uses rust types in some places where previously types like `libc::uint8_t` had been defined. This PR adjusts nix's code to reflect these simplifications.