### PR TITLE
ifaddrs: add ifaddrs support for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1079](https://github.com/nix-rust/nix/pull/1079))
 
 ### Changed
+- Support for `ifaddrs` now present when building for Android.
+  ([#1077](https://github.com/nix-rust/nix/pull/1077))
+
 ### Fixed
 ### Removed
 

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -32,7 +32,7 @@ pub struct InterfaceAddress {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))] {
+    if #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "fuchsia", target_os = "linux"))] {
         fn get_ifu_from_sockaddr(info: &libc::ifaddrs) -> *const libc::sockaddr {
             info.ifa_ifu
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ pub mod errno;
 pub mod features;
 pub mod fcntl;
 #[deny(missing_docs)]
-#[cfg(any(target_os = "dragonfly",
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",


### PR DESCRIPTION
Support under bionic/android is the same as under Linux for what is exposed
by this code.