### PR TITLE
socket: expose MSG_WAITALL in MsgFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added `MSG_WAITALL` to `MsgFlags` in `sys::socket`.
+  ([#1079](https://github.com/nix-rust/nix/pull/1079))
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -132,6 +132,10 @@ libc_bitflags!{
         /// [`recv()`](fn.recv.html)
         /// or similar function shall still return this data.
         MSG_PEEK;
+        /// Receive operation blocks until the full amount of data can be
+        /// returned. The function may return smaller amount of data if a signal
+        /// is caught, an error or disconnect occurs.
+        MSG_WAITALL;
         /// Enables nonblocking operation; if the operation would block,
         /// `EAGAIN` or `EWOULDBLOCK` is returned.  This provides similar
         /// behavior to setting the `O_NONBLOCK` flag


### PR DESCRIPTION
MSG_WAITALL can be useful with recv() to wait the full amount of data requested.