### PR TITLE
Allow signal injection in ptrace::syscall and ptrace::detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `sched_getaffinity`.
   ([#1148](https://github.com/nix-rust/nix/pull/1148))
 
+- Added optional `Signal` argument to `ptrace::{detach, syscall}` for signal
+  injection. ([#1083](https://github.com/nix-rust/nix/pull/1083))
+
 ### Changed
 - `sys::socket::recvfrom` now returns
   `Result<(usize, Option<SockAddr>)>` instead of `Result<(usize, SockAddr)>`.

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -77,16 +77,23 @@ pub fn traceme() -> Result<()> {
 
 /// Attach to a running process, as with `ptrace(PT_ATTACH, ...)`
 ///
-/// Attaches to the process specified in pid, making it a tracee of the calling process.
+/// Attaches to the process specified by `pid`, making it a tracee of the calling process.
 pub fn attach(pid: Pid) -> Result<()> {
     unsafe { ptrace_other(Request::PT_ATTACH, pid, ptr::null_mut(), 0).map(drop) }
 }
 
 /// Detaches the current running process, as with `ptrace(PT_DETACH, ...)`
 ///
-/// Detaches from the process specified in pid allowing it to run freely
-pub fn detach(pid: Pid) -> Result<()> {
-    unsafe { ptrace_other(Request::PT_DETACH, pid, ptr::null_mut(), 0).map(drop) }
+/// Detaches from the process specified by `pid` allowing it to run freely, optionally delivering a
+/// signal specified by `sig`.
+pub fn detach<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
+    let data = match sig.into() {
+        Some(s) => s as c_int,
+        None => 0,
+    };
+    unsafe {
+        ptrace_other(Request::PT_DETACH, pid, ptr::null_mut(), data).map(drop)
+    }
 }
 
 /// Restart the stopped tracee process, as with `ptrace(PTRACE_CONT, ...)`

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -82,7 +82,7 @@ mod ptrace {
         assert!(ptrace::setoptions(child, Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEEXIT).is_ok());
 
         // First, stop on the next system call, which will be exit()
-        assert!(ptrace::syscall(child).is_ok());
+        assert!(ptrace::syscall(child, None).is_ok());
         assert_eq!(waitpid(child, None), Ok(WaitStatus::PtraceSyscall(child)));
         // Then get the ptrace event for the process exiting
         assert!(ptrace::cont(child, None).is_ok());


### PR DESCRIPTION
Fixes #1049

Should I add tests for this functionality?

By the way, I noticed that the BSD module doesn't have `ptrace::syscall`. I couldn't find a reason behind this in #949. Should we add it?