### PR TITLE
Add From and TryFrom impls in libc_enum macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `mkdirat`.
   ([#1084](https://github.com/nix-rust/nix/pull/1084))
 - `From` and `TryFrom` impls for many enums that correspond to libc constants.
+  ([#1088](https://github.com/nix-rust/nix/pull/1088))
 
 ### Changed
 - Support for `ifaddrs` now present when building for Android.
@@ -24,7 +25,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 - `Signal::from_c_int`. Use `Signal::try_from` instead.
+  ([#1088](https://github.com/nix-rust/nix/pull/1088))
 - `From<speed_t>` impl for `BaudRate`. Use `BaudRate::try_from` instead.
+  ([#1088](https://github.com/nix-rust/nix/pull/1088))
 
 ## [0.14.1] - 2019-06-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1069](https://github.com/nix-rust/nix/pull/1069))
 - Add `mkdirat`.
   ([#1084](https://github.com/nix-rust/nix/pull/1084))
+- `From` and `TryFrom` impls for many enums that correspond to libc constants.
 
 ### Changed
 - Support for `ifaddrs` now present when building for Android.
@@ -22,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 ### Removed
+- `Signal::from_c_int`. Use `Signal::try_from` instead.
+- `From<speed_t>` impl for `BaudRate`. Use `BaudRate::try_from` instead.
 
 ## [0.14.1] - 2019-06-06
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ bitflags = "1.0"
 cfg-if = "0.1.0"
 void = "1.0.2"
 
+[build-dependencies]
+version_check = "0.9.1"
+
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,14 @@
 #[cfg(target_os = "dragonfly")]
 extern crate cc;
+extern crate version_check as rustc;
 
-#[cfg(target_os = "dragonfly")]
 fn main() {
+    #[cfg(target_os = "dragonfly")]
     cc::Build::new()
         .file("src/errno_dragonfly.c")
         .compile("liberrno_dragonfly.a");
-}
 
-#[cfg(not(target_os = "dragonfly"))]
-fn main() {}
+    if rustc::is_min_version("1.34.0").unwrap_or(false) {
+        println!("cargo:rustc-cfg=try_from");
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -60,8 +60,8 @@ macro_rules! libc_bitflags {
 
 /// The `libc_enum!` macro helps with a common use case of defining an enum exclusively using
 /// values from the `libc` crate. The type after the enum name specifies the type of the constants
-/// in libc. The macro will generate impls of From and TryFrom to convert between numeric and enum
-/// values.
+/// in `libc`. The macro will generate impls of `From` and `TryFrom` to convert between numeric and
+/// enum values.
 ///
 /// `TryFrom` is only implemented for Rust >= 1.34.0, where the trait is stable. An equivalent
 /// `try_from` inherent method is made available regardless of the Rust version. `TryInto` should

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -93,10 +93,10 @@ macro_rules! libc_enum {
     // pub
     (
         $(#[$enum_attr:meta])*
-        pub enum $($def:tt)*
+        pub $(($($scope:tt)*))* enum $($def:tt)*
     ) => {
         libc_enum! {
-            @(pub)
+            @(pub $(($($scope)*))*)
             $(#[$enum_attr])*
             enum $($def)*
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,8 +59,11 @@ macro_rules! libc_bitflags {
 }
 
 /// The `libc_enum!` macro helps with a common use case of defining an enum exclusively using
-/// values from the `libc` crate. This macro supports both `pub` and private `enum`s.
+/// values from the `libc` crate. The type after the enum name specifies the type of the constants
+/// in libc. The macro will generate impls of From and TryFrom to convert between numeric and enum
+/// values.
 ///
+/// Documentation for each variant must be provided before any cfg attributes.
 ///
 /// # Example
 /// ```
@@ -70,12 +73,16 @@ macro_rules! libc_bitflags {
 ///         PROT_READ,
 ///         PROT_WRITE,
 ///         PROT_EXEC,
+///         /// Documentation before cfg attribute.
 ///         #[cfg(any(target_os = "linux", target_os = "android"))]
 ///         PROT_GROWSDOWN,
 ///         #[cfg(any(target_os = "linux", target_os = "android"))]
 ///         PROT_GROWSUP,
 ///     }
 /// }
+///
+/// let flag: c_int = ProtFlags::PROT_NONE.into();
+/// let flag: ProtFlags = ProtFlags::try_from(::libc::PROT_NONE).unwrap();
 /// ```
 macro_rules! libc_enum {
     // pub

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,8 +68,7 @@ macro_rules! libc_bitflags {
 /// # Example
 /// ```
 /// libc_enum! {
-///     #[repr(c_int)]
-///     pub enum ProtFlags {
+///     pub enum ProtFlags: c_int {
 ///         PROT_NONE,
 ///         PROT_READ,
 ///         PROT_WRITE,
@@ -84,34 +83,32 @@ macro_rules! libc_bitflags {
 macro_rules! libc_enum {
     // pub
     (
-        $(#[doc = $doc:tt])*
-        #[repr($prim:tt)]
-        pub enum $name:ident $($def:tt)*
+        $(#[$enum_attr:meta])*
+        pub enum $($def:tt)*
     ) => {
         libc_enum! {
             @(pub)
-            $(#[doc = $doc])*
-            enum $name : $prim $($def)*
+            $(#[$enum_attr])*
+            enum $($def)*
         }
     };
 
     // non-pub
     (
-        $(#[doc = $doc:tt])*
-        #[repr($prim:tt)]
-        enum $name:ident $($def:tt)*
+        $(#[$enum_attr:meta])*
+        enum $($def:tt)*
     ) => {
         libc_enum! {
             @()
-            $(#[doc = $doc])*
-            enum $name : $prim $($def)*
+            $(#[$enum_attr])*
+            enum $($def)*
         }
     };
 
     (
         @($($vis:tt)*)
         $(#[$enum_attr:meta])*
-        enum $enum:ident : $prim:tt {
+        enum $enum:ident : $prim:ty {
             $(
                 $(#[doc = $var_doc:tt])*
                 $(#[cfg($var_cfg:meta)])*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,8 +2,6 @@
 /// with values from the libc crate. It is used the same way as the `bitflags!` macro, except
 /// that only the name of the flag value has to be given.
 ///
-/// The `libc` crate must be in scope with the name `libc`.
-///
 /// # Example
 /// ```
 /// libc_bitflags!{
@@ -53,7 +51,7 @@ macro_rules! libc_bitflags {
             pub struct $BitFlags: $T {
                 $(
                     $(#[$inner $($args)*])*
-                    const $Flag = libc::$Flag $(as $cast)*;
+                    const $Flag = ::libc::$Flag $(as $cast)*;
                 )+
             }
         }
@@ -63,7 +61,6 @@ macro_rules! libc_bitflags {
 /// The `libc_enum!` macro helps with a common use case of defining an enum exclusively using
 /// values from the `libc` crate. This macro supports both `pub` and private `enum`s.
 ///
-/// The `libc` crate must be in scope with the name `libc`.
 ///
 /// # Example
 /// ```
@@ -131,7 +128,7 @@ macro_rules! libc_enum {
                 match value {
                     $(
                         $(#[cfg($var_cfg)])*
-                        $enum::$entry => libc::$entry,
+                        $enum::$entry => ::libc::$entry,
                     )*
                 }
             }
@@ -144,7 +141,7 @@ macro_rules! libc_enum {
                 match value {
                     $(
                         $(#[cfg($var_cfg)])*
-                        libc::$entry => Ok($enum::$entry),
+                        ::libc::$entry => Ok($enum::$entry),
                     )*
                     // don't think this Error is the correct one
                     _ => Err(::Error::invalid_argument())

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -39,8 +39,7 @@ use sys::time::TimeSpec;
 libc_enum! {
     /// Mode for `AioCb::fsync`.  Controls whether only data or both data and
     /// metadata are synced.
-    #[repr(i32)]
-    pub enum AioFsyncMode {
+    pub enum AioFsyncMode: i32 {
         /// do it like `fsync`
         O_SYNC,
         /// on supported operating systems only, do it like `fdatasync`
@@ -57,8 +56,7 @@ libc_enum! {
     /// When used with [`lio_listio`](fn.lio_listio.html), determines whether a
     /// given `aiocb` should be used for a read operation, a write operation, or
     /// ignored.  Has no effect for any other aio functions.
-    #[repr(i32)]
-    pub enum LioOpcode {
+    pub enum LioOpcode: i32 {
         LIO_NOP,
         LIO_WRITE,
         LIO_READ,
@@ -67,8 +65,7 @@ libc_enum! {
 
 libc_enum! {
     /// Mode for [`lio_listio`](fn.lio_listio.html)
-    #[repr(i32)]
-    pub enum LioMode {
+    pub enum LioMode: i32 {
         /// Requests that [`lio_listio`](fn.lio_listio.html) block until all
         /// requested operations have been completed
         LIO_WAIT,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -35,8 +35,7 @@ type type_of_event_filter = u32;
 #[cfg(not(target_os = "netbsd"))]
 type type_of_event_filter = i16;
 libc_enum! {
-    #[repr(type_of_event_filter)]
-    pub enum EventFilter {
+    pub enum EventFilter: type_of_event_filter {
         EVFILT_AIO,
         /// Returns whenever there is no remaining data in the write buffer
         #[cfg(target_os = "freebsd")]

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -35,8 +35,7 @@ type type_of_event_filter = u32;
 #[cfg(not(target_os = "netbsd"))]
 type type_of_event_filter = i16;
 libc_enum! {
-    #[cfg_attr(target_os = "netbsd", repr(u32))]
-    #[cfg_attr(not(target_os = "netbsd"), repr(i16))]
+    #[repr(type_of_event_filter)]
     pub enum EventFilter {
         EVFILT_AIO,
         /// Returns whenever there is no remaining data in the write buffer

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -102,12 +102,11 @@ libc_bitflags!{
     }
 }
 
-libc_enum!{
+libc_enum! {
     /// Usage information for a range of memory to allow for performance optimizations by the kernel.
     ///
     /// Used by [`madvise`](./fn.madvise.html).
-    #[repr(i32)]
-    pub enum MmapAdvise {
+    pub enum MmapAdvise: i32 {
         /// No further special treatment. This is the default.
         MADV_NORMAL,
         /// Expect random page references.

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -21,9 +21,8 @@ cfg_if! {
 }
 
 libc_enum! {
-    #[repr(i32)]
     /// Ptrace Request enum defining the action to be taken.
-    pub enum Request {
+    pub enum Request: i32 {
         PT_TRACE_ME,
         PT_READ_I,
         PT_READ_D,

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -26,10 +26,14 @@ cfg_if! {
     }
 }
 
+#[cfg(not(any(target_env = "musl", target_os = "android")))]
+type type_of_request = u32;
+#[cfg(any(target_env = "musl", target_os = "android"))]
+type type_of_request = i32;
+
 libc_enum!{
-    #[cfg_attr(not(any(target_env = "musl", target_os = "android")), repr(u32))]
-    #[cfg_attr(any(target_env = "musl", target_os = "android"), repr(i32))]
     /// Ptrace Request enum defining the action to be taken.
+    #[repr(type_of_request)]
     pub enum Request {
         PTRACE_TRACEME,
         PTRACE_PEEKTEXT,
@@ -110,10 +114,10 @@ libc_enum!{
 }
 
 libc_enum!{
-    #[repr(i32)]
     /// Using the ptrace options the tracer can configure the tracee to stop
     /// at certain events. This enum is used to define those events as defined
     /// in `man ptrace`.
+    #[repr(i32)]
     pub enum Event {
         /// Event that stops before a return from fork or clone.
         PTRACE_EVENT_FORK,

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -31,10 +31,9 @@ type type_of_request = u32;
 #[cfg(any(target_env = "musl", target_os = "android"))]
 type type_of_request = i32;
 
-libc_enum!{
+libc_enum! {
     /// Ptrace Request enum defining the action to be taken.
-    #[repr(type_of_request)]
-    pub enum Request {
+    pub enum Request: type_of_request {
         PTRACE_TRACEME,
         PTRACE_PEEKTEXT,
         PTRACE_PEEKDATA,
@@ -113,12 +112,11 @@ libc_enum!{
     }
 }
 
-libc_enum!{
+libc_enum! {
     /// Using the ptrace options the tracer can configure the tracee to stop
     /// at certain events. This enum is used to define those events as defined
     /// in `man ptrace`.
-    #[repr(i32)]
-    pub enum Event {
+    pub enum Event: i32 {
         /// Event that stops before a return from fork or clone.
         PTRACE_EVENT_FORK,
         /// Event that stops before a return from vfork or clone.

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -27,9 +27,8 @@ impl QuotaCmd {
 }
 
 // linux quota version >= 2
-libc_enum!{
-    #[repr(i32)]
-    enum QuotaSubCmd {
+libc_enum! {
+    enum QuotaSubCmd: i32 {
         Q_SYNC,
         Q_QUOTAON,
         Q_QUOTAOFF,
@@ -38,10 +37,9 @@ libc_enum!{
     }
 }
 
-libc_enum!{
+libc_enum! {
     /// The scope of the quota.
-    #[repr(i32)]
-    pub enum QuotaType {
+    pub enum QuotaType: i32 {
         /// Specify a user quota
         USRQUOTA,
         /// Specify a group quota
@@ -49,10 +47,9 @@ libc_enum!{
     }
 }
 
-libc_enum!{
+libc_enum! {
     /// The type of quota format to use.
-    #[repr(i32)]
-    pub enum QuotaFmt {
+    pub enum QuotaFmt: i32 {
         /// Use the original quota format.
         QFMT_VFS_OLD,
         /// Use the standard VFS v0 quota format.

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -11,8 +11,7 @@ libc_enum! {
     ///
     /// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
     /// enabling/disabling Ctrl-Alt-Delete.
-    #[repr(i32)]
-    pub enum RebootMode {
+    pub enum RebootMode: i32 {
         RB_HALT_SYSTEM,
         RB_KEXEC,
         RB_POWER_OFF,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -6,7 +6,6 @@
 use libc;
 use {Error, Result};
 use errno::Errno;
-use std::convert::{TryInto};
 use std::mem;
 use std::fmt;
 use std::str::FromStr;
@@ -396,7 +395,7 @@ impl SigSet {
         let mut signum: libc::c_int = unsafe { mem::uninitialized() };
         let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, &mut signum) };
 
-        Errno::result(res).map(|_| signum.try_into().unwrap())
+        Errno::result(res).map(|_| Signal::try_from(signum).unwrap())
     }
 }
 
@@ -528,7 +527,7 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// }
 ///
 /// extern fn handle_sigint(signal: libc::c_int) {
-///     let signal: Signal = signal.try_into().unwrap();
+///     let signal: Signal = Signal::try_from(signal).unwrap();
 ///     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 /// }
 ///

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -6,7 +6,7 @@
 use libc;
 use {Error, Result};
 use errno::Errno;
-use std::convert::{TryFrom, TryInto};
+use std::convert::{TryInto};
 use std::mem;
 use std::fmt;
 use std::str::FromStr;
@@ -288,19 +288,6 @@ impl Iterator for SignalIterator {
 impl Signal {
     pub fn iterator() -> SignalIterator {
         SignalIterator{next: 0}
-    }
-}
-
-impl TryFrom<libc::c_int> for Signal {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(signum: libc::c_int) -> Result<Signal> {
-        if 0 < signum && signum < NSIG {
-            Ok(unsafe { mem::transmute(signum) })
-        } else {
-            Err(Error::invalid_argument())
-        }
     }
 }
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -17,13 +17,8 @@ use std::ptr;
 #[cfg(not(target_os = "openbsd"))]
 pub use self::sigevent::*;
 
-libc_enum!{
-    // Currently there is only one definition of c_int in libc, as well as only one
-    // type for signal constants.
-    // We would prefer to use the libc::c_int alias in the repr attribute. Unfortunately
-    // this is not (yet) possible.
-    #[repr(i32)]
-    pub enum Signal {
+libc_enum! {
+    pub enum Signal: libc::c_int {
         SIGHUP,
         SIGINT,
         SIGQUIT,
@@ -308,8 +303,7 @@ libc_bitflags!{
 }
 
 libc_enum! {
-    #[repr(i32)]
-    pub enum SigmaskHow {
+    pub enum SigmaskHow: i32 {
         SIG_BLOCK,
         SIG_UNBLOCK,
         SIG_SETMASK,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -6,6 +6,7 @@
 use libc;
 use {Error, Result};
 use errno::Errno;
+use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::fmt;
 use std::str::FromStr;
@@ -288,12 +289,13 @@ impl Signal {
     pub fn iterator() -> SignalIterator {
         SignalIterator{next: 0}
     }
+}
 
-    // We do not implement the From trait, because it is supposed to be infallible.
-    // With Rust RFC 1542 comes the appropriate trait TryFrom. Once it is
-    // implemented, we'll replace this function.
+impl TryFrom<libc::c_int> for Signal {
+    type Error = Error;
+
     #[inline]
-    pub fn from_c_int(signum: libc::c_int) -> Result<Signal> {
+    fn try_from(signum: libc::c_int) -> Result<Signal> {
         if 0 < signum && signum < NSIG {
             Ok(unsafe { mem::transmute(signum) })
         } else {
@@ -413,7 +415,7 @@ impl SigSet {
         let mut signum: libc::c_int = unsafe { mem::uninitialized() };
         let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, &mut signum) };
 
-        Errno::result(res).map(|_| Signal::from_c_int(signum).unwrap())
+        Errno::result(res).map(|_| signum.try_into().unwrap())
     }
 }
 
@@ -538,12 +540,14 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// # extern crate nix;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
 /// # use nix::sys::signal::{self, Signal, SigHandler};
+/// # use std::convert::TryInto;
+///
 /// lazy_static! {
 ///    static ref SIGNALED: AtomicBool = AtomicBool::new(false);
 /// }
 ///
 /// extern fn handle_sigint(signal: libc::c_int) {
-///     let signal = Signal::from_c_int(signal).unwrap();
+///     let signal: Signal = signal.try_into().unwrap();
 ///     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 /// }
 ///

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -165,7 +165,7 @@ use Result;
 use errno::Errno;
 use libc::{self, c_int, tcflag_t};
 use std::cell::{Ref, RefCell};
-use std::convert::{From, TryInto};
+use std::convert::From;
 use std::mem;
 use std::os::unix::io::RawFd;
 
@@ -844,7 +844,7 @@ cfg_if!{
         /// `cfgetispeed()` extracts the input baud rate from the given `Termios` structure.
         pub fn cfgetispeed(termios: &Termios) -> BaudRate {
             let inner_termios = termios.get_libc_termios();
-            unsafe { libc::cfgetispeed(&*inner_termios) }.try_into().unwrap()
+            BaudRate::try_from(unsafe { libc::cfgetispeed(&*inner_termios) }).unwrap()
         }
 
         /// Get output baud rate (see
@@ -853,7 +853,7 @@ cfg_if!{
         /// `cfgetospeed()` extracts the output baud rate from the given `Termios` structure.
         pub fn cfgetospeed(termios: &Termios) -> BaudRate {
             let inner_termios = termios.get_libc_termios();
-            unsafe { libc::cfgetospeed(&*inner_termios) }.try_into().unwrap()
+            BaudRate::try_from(unsafe { libc::cfgetospeed(&*inner_termios) }).unwrap()
         }
 
         /// Set input baud rate (see

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -295,15 +295,14 @@ type type_of_baud_rate = u64;
 #[cfg(not(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64")))]
 type type_of_baud_rate = u32;
 
-libc_enum!{
+libc_enum! {
     /// Baud rates supported by the system.
     ///
     /// For the BSDs, arbitrary baud rates can be specified by using `u32`s directly instead of this
     /// enum.
     ///
     /// B0 is special and will disable the port.
-    #[repr(type_of_baud_rate)]
-    pub enum BaudRate {
+    pub enum BaudRate: type_of_baud_rate {
         B0,
         B50,
         B75,
@@ -385,8 +384,7 @@ libc_enum! {
     /// Specify when a port configuration change should occur.
     ///
     /// Used as an argument to `tcsetattr()`
-    #[repr(i32)]
-    pub enum SetArg {
+    pub enum SetArg: i32 {
         /// The change will occur immediately
         TCSANOW,
         /// The change occurs after all output has been written
@@ -400,8 +398,7 @@ libc_enum! {
     /// Specify a combination of the input and output buffers to flush
     ///
     /// Used as an argument to `tcflush()`.
-    #[repr(i32)]
-    pub enum FlushArg {
+    pub enum FlushArg: i32 {
         /// Flush data that was received but not read
         TCIFLUSH,
         /// Flush data written but not transmitted
@@ -415,8 +412,7 @@ libc_enum! {
     /// Specify how transmission flow should be altered
     ///
     /// Used as an argument to `tcflow()`.
-    #[repr(i32)]
-    pub enum FlowArg {
+    pub enum FlowArg: i32 {
         /// Suspend transmission
         TCOOFF,
         /// Resume transmission
@@ -431,8 +427,7 @@ libc_enum! {
 // TODO: Make this usable directly as a slice index.
 libc_enum! {
     /// Indices into the `termios.c_cc` array for special characters.
-    #[repr(usize)]
-    pub enum SpecialCharacterIndices {
+    pub enum SpecialCharacterIndices: usize {
         VDISCARD,
         #[cfg(any(target_os = "dragonfly",
                 target_os = "freebsd",

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -290,11 +290,6 @@ impl From<Termios> for libc::termios {
     }
 }
 
-#[cfg(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64"))]
-type type_of_baud_rate = u64;
-#[cfg(not(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64")))]
-type type_of_baud_rate = u32;
-
 libc_enum! {
     /// Baud rates supported by the system.
     ///
@@ -302,7 +297,7 @@ libc_enum! {
     /// enum.
     ///
     /// B0 is special and will disable the port.
-    pub enum BaudRate: type_of_baud_rate {
+    pub enum BaudRate: libc::speed_t {
         B0,
         B50,
         B75,
@@ -815,7 +810,7 @@ cfg_if!{
         /// `cfsetispeed()` sets the intput baud rate in the given `Termios` structure.
         pub fn cfsetispeed<T: Into<u32>>(termios: &mut Termios, baud: T) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetispeed(inner_termios, baud.into() as libc::speed_t) };
+            let res = unsafe { libc::cfsetispeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }
@@ -826,7 +821,7 @@ cfg_if!{
         /// `cfsetospeed()` sets the output baud rate in the given termios structure.
         pub fn cfsetospeed<T: Into<u32>>(termios: &mut Termios, baud: T) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetospeed(inner_termios, baud.into() as libc::speed_t) };
+            let res = unsafe { libc::cfsetospeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }
@@ -838,7 +833,7 @@ cfg_if!{
         /// this is part of the 4.4BSD standard and not part of POSIX.
         pub fn cfsetspeed<T: Into<u32>>(termios: &mut Termios, baud: T) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetspeed(inner_termios, baud.into() as libc::speed_t) };
+            let res = unsafe { libc::cfsetspeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }
@@ -867,7 +862,7 @@ cfg_if!{
         /// `cfsetispeed()` sets the intput baud rate in the given `Termios` structure.
         pub fn cfsetispeed(termios: &mut Termios, baud: BaudRate) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetispeed(inner_termios, baud as libc::speed_t) };
+            let res = unsafe { libc::cfsetispeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }
@@ -878,7 +873,7 @@ cfg_if!{
         /// `cfsetospeed()` sets the output baud rate in the given `Termios` structure.
         pub fn cfsetospeed(termios: &mut Termios, baud: BaudRate) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetospeed(inner_termios, baud as libc::speed_t) };
+            let res = unsafe { libc::cfsetospeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }
@@ -890,7 +885,7 @@ cfg_if!{
         /// this is part of the 4.4BSD standard and not part of POSIX.
         pub fn cfsetspeed(termios: &mut Termios, baud: BaudRate) -> Result<()> {
             let inner_termios = unsafe { termios.get_libc_termios_mut() };
-            let res = unsafe { libc::cfsetspeed(inner_termios, baud as libc::speed_t) };
+            let res = unsafe { libc::cfsetspeed(inner_termios, baud.into()) };
             termios.update_wrapper();
             Errno::result(res).map(drop)
         }

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -2,6 +2,7 @@ use libc::{self, c_int};
 use Result;
 use errno::Errno;
 use unistd::Pid;
+use std::convert::TryInto;
 
 use sys::signal::Signal;
 
@@ -126,7 +127,7 @@ fn signaled(status: i32) -> bool {
 }
 
 fn term_signal(status: i32) -> Result<Signal> {
-    Signal::from_c_int(unsafe { libc::WTERMSIG(status) })
+    unsafe { libc::WTERMSIG(status) }.try_into()
 }
 
 fn dumped_core(status: i32) -> bool {
@@ -138,7 +139,7 @@ fn stopped(status: i32) -> bool {
 }
 
 fn stop_signal(status: i32) -> Result<Signal> {
-    Signal::from_c_int(unsafe { libc::WSTOPSIG(status) })
+    unsafe { libc::WSTOPSIG(status) }.try_into()
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -2,7 +2,6 @@ use libc::{self, c_int};
 use Result;
 use errno::Errno;
 use unistd::Pid;
-use std::convert::TryInto;
 
 use sys::signal::Signal;
 
@@ -127,7 +126,7 @@ fn signaled(status: i32) -> bool {
 }
 
 fn term_signal(status: i32) -> Result<Signal> {
-    unsafe { libc::WTERMSIG(status) }.try_into()
+    Signal::try_from(unsafe { libc::WTERMSIG(status) })
 }
 
 fn dumped_core(status: i32) -> bool {
@@ -139,7 +138,7 @@ fn stopped(status: i32) -> bool {
 }
 
 fn stop_signal(status: i32) -> Result<Signal> {
-    unsafe { libc::WSTOPSIG(status) }.try_into()
+    Signal::try_from(unsafe { libc::WSTOPSIG(status) })
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -3,7 +3,6 @@ use nix::Error;
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::convert::TryInto;
 
 #[test]
 fn test_kill_none() {
@@ -76,7 +75,7 @@ lazy_static! {
 }
 
 extern fn test_sigaction_handler(signal: libc::c_int) {
-    let signal: Signal = signal.try_into().unwrap();
+    let signal: Signal = Signal::try_from(signal).unwrap();
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -3,6 +3,7 @@ use nix::Error;
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::convert::TryInto;
 
 #[test]
 fn test_kill_none() {
@@ -75,7 +76,7 @@ lazy_static! {
 }
 
 extern fn test_sigaction_handler(signal: libc::c_int) {
-    let signal = Signal::from_c_int(signal).unwrap();
+    let signal: Signal = signal.try_into().unwrap();
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 #[test]
 fn test_signalfd() {
     use nix::sys::signalfd::SignalFd;
@@ -20,6 +22,6 @@ fn test_signalfd() {
 
     // And now catch that same signal.
     let res = fd.read_signal().unwrap().unwrap();
-    let signo = Signal::from_c_int(res.ssi_signo as i32).unwrap();
+    let signo: Signal = (res.ssi_signo as i32).try_into().unwrap();
     assert_eq!(signo, signal::SIGUSR1);
 }

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 #[test]
 fn test_signalfd() {
     use nix::sys::signalfd::SignalFd;
@@ -22,6 +20,6 @@ fn test_signalfd() {
 
     // And now catch that same signal.
     let res = fd.read_signal().unwrap().unwrap();
-    let signo: Signal = (res.ssi_signo as i32).try_into().unwrap();
+    let signo: Signal = Signal::try_from(res.ssi_signo as i32).unwrap();
     assert_eq!(signo, signal::SIGUSR1);
 }


### PR DESCRIPTION
This PR adds `From` and `TryFrom` impls in `libc_enum`. The macro was rewritten from scratch, and I think it's considerably simpler now. The syntax changed slightly in order to add the "base" type for which it'll generate conversion impls. It looks more like bitflags now.

To support Rust versions where `TryFrom` isn't stable and keep the current MSRV, there is an inherent `try_from` method. I had to add a build dependency on the `version_check` crate to support conditionally compiling the trait impl.

When `try_from` fails it returns `Error::invalid_argument()`. I copied this over from an existing `Signal::from_c_int` function, but I'm not sure it's the right error to use. Should we add a new `Error` variant?