### PR TITLE
Expose sched_yield on non-linux-like hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#928](https://github.com/nix-rust/nix/pull/928))
 
 ### Fixed
+- Enabled `sched_yield` for all nix hosts.
+  ([#1090](https://github.com/nix-rust/nix/pull/1090))
+
 ### Removed
 
 ## [0.14.1] - 2019-06-06

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,6 @@ pub mod net;
 pub mod poll;
 #[deny(missing_docs)]
 pub mod pty;
-#[cfg(any(target_os = "android",
-          target_os = "linux"))]
 pub mod sched;
 pub mod sys;
 // This can be implemented for other platforms as soon as libc

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,131 +1,144 @@
-use std::mem;
-use std::os::unix::io::RawFd;
-use std::option::Option;
-use libc::{self, c_int, c_void};
-use {Error, Result};
-use errno::Errno;
-use ::unistd::Pid;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use self::sched_linux_like::*;
 
-// For some functions taking with a parameter of type CloneFlags,
-// only a subset of these flags have an effect.
-libc_bitflags!{
-    pub struct CloneFlags: c_int {
-        CLONE_VM;
-        CLONE_FS;
-        CLONE_FILES;
-        CLONE_SIGHAND;
-        CLONE_PTRACE;
-        CLONE_VFORK;
-        CLONE_PARENT;
-        CLONE_THREAD;
-        CLONE_NEWNS;
-        CLONE_SYSVSEM;
-        CLONE_SETTLS;
-        CLONE_PARENT_SETTID;
-        CLONE_CHILD_CLEARTID;
-        CLONE_DETACHED;
-        CLONE_UNTRACED;
-        CLONE_CHILD_SETTID;
-        CLONE_NEWCGROUP;
-        CLONE_NEWUTS;
-        CLONE_NEWIPC;
-        CLONE_NEWUSER;
-        CLONE_NEWPID;
-        CLONE_NEWNET;
-        CLONE_IO;
-    }
-}
+#[cfg(any(target_os = "android", target_os = "linux"))]
+mod sched_linux_like {
+    use errno::Errno;
+    use libc::{self, c_int, c_void};
+    use std::mem;
+    use std::option::Option;
+    use std::os::unix::io::RawFd;
+    use unistd::Pid;
+    use {Error, Result};
 
-pub type CloneCb<'a> = Box<FnMut() -> isize + 'a>;
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct CpuSet {
-    cpu_set: libc::cpu_set_t,
-}
-
-impl CpuSet {
-    pub fn new() -> CpuSet {
-        CpuSet { cpu_set: unsafe { mem::zeroed() } }
-    }
-
-    pub fn is_set(&self, field: usize) -> Result<bool> {
-        if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
-            Err(Error::Sys(Errno::EINVAL))
-        } else {
-            Ok(unsafe { libc::CPU_ISSET(field, &self.cpu_set) })
+    // For some functions taking with a parameter of type CloneFlags,
+    // only a subset of these flags have an effect.
+    libc_bitflags! {
+        pub struct CloneFlags: c_int {
+            CLONE_VM;
+            CLONE_FS;
+            CLONE_FILES;
+            CLONE_SIGHAND;
+            CLONE_PTRACE;
+            CLONE_VFORK;
+            CLONE_PARENT;
+            CLONE_THREAD;
+            CLONE_NEWNS;
+            CLONE_SYSVSEM;
+            CLONE_SETTLS;
+            CLONE_PARENT_SETTID;
+            CLONE_CHILD_CLEARTID;
+            CLONE_DETACHED;
+            CLONE_UNTRACED;
+            CLONE_CHILD_SETTID;
+            CLONE_NEWCGROUP;
+            CLONE_NEWUTS;
+            CLONE_NEWIPC;
+            CLONE_NEWUSER;
+            CLONE_NEWPID;
+            CLONE_NEWNET;
+            CLONE_IO;
         }
     }
 
-    pub fn set(&mut self, field: usize) -> Result<()> {
-        if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
-            Err(Error::Sys(Errno::EINVAL))
-        } else {
-            Ok(unsafe { libc::CPU_SET(field, &mut self.cpu_set) })
+    pub type CloneCb<'a> = Box<FnMut() -> isize + 'a>;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    pub struct CpuSet {
+        cpu_set: libc::cpu_set_t,
+    }
+
+    impl CpuSet {
+        pub fn new() -> CpuSet {
+            CpuSet {
+                cpu_set: unsafe { mem::zeroed() },
+            }
+        }
+
+        pub fn is_set(&self, field: usize) -> Result<bool> {
+            if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
+                Err(Error::Sys(Errno::EINVAL))
+            } else {
+                Ok(unsafe { libc::CPU_ISSET(field, &self.cpu_set) })
+            }
+        }
+
+        pub fn set(&mut self, field: usize) -> Result<()> {
+            if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
+                Err(Error::Sys(Errno::EINVAL))
+            } else {
+                Ok(unsafe { libc::CPU_SET(field, &mut self.cpu_set) })
+            }
+        }
+
+        pub fn unset(&mut self, field: usize) -> Result<()> {
+            if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
+                Err(Error::Sys(Errno::EINVAL))
+            } else {
+                Ok(unsafe { libc::CPU_CLR(field, &mut self.cpu_set) })
+            }
         }
     }
 
-    pub fn unset(&mut self, field: usize) -> Result<()> {
-        if field >= 8 * mem::size_of::<libc::cpu_set_t>() {
-            Err(Error::Sys(Errno::EINVAL))
-        } else {
-            Ok(unsafe { libc::CPU_CLR(field, &mut self.cpu_set) })
+    pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> Result<()> {
+        let res = unsafe {
+            libc::sched_setaffinity(
+                pid.into(),
+                mem::size_of::<CpuSet>() as libc::size_t,
+                &cpuset.cpu_set,
+            )
+        };
+
+        Errno::result(res).map(drop)
+    }
+
+    /// Explicitly yield the processor to other threads.
+    ///
+    /// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
+    pub fn sched_yield() -> Result<()> {
+        let res = unsafe { libc::sched_yield() };
+
+        Errno::result(res).map(drop)
+    }
+
+    pub fn clone(
+        mut cb: CloneCb,
+        stack: &mut [u8],
+        flags: CloneFlags,
+        signal: Option<c_int>,
+    ) -> Result<Pid> {
+        extern "C" fn callback(data: *mut CloneCb) -> c_int {
+            let cb: &mut CloneCb = unsafe { &mut *data };
+            (*cb)() as c_int
         }
-    }
-}
 
-pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> Result<()> {
-    let res = unsafe {
-        libc::sched_setaffinity(pid.into(),
-                                mem::size_of::<CpuSet>() as libc::size_t,
-                                &cpuset.cpu_set)
-    };
+        let res = unsafe {
+            let combined = flags.bits() | signal.unwrap_or(0);
+            let ptr = stack.as_mut_ptr().offset(stack.len() as isize);
+            let ptr_aligned = ptr.offset((ptr as usize % 16) as isize * -1);
+            libc::clone(
+                mem::transmute(
+                    callback as extern "C" fn(*mut Box<::std::ops::FnMut() -> isize>) -> i32,
+                ),
+                ptr_aligned as *mut c_void,
+                combined,
+                &mut cb as *mut _ as *mut c_void,
+            )
+        };
 
-    Errno::result(res).map(drop)
-}
-
-/// Explicitly yield the processor to other threads.
-///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
-pub fn sched_yield() -> Result<()> {
-    let res = unsafe {
-        libc::sched_yield()
-    };
-
-    Errno::result(res).map(drop)
-}
-
-pub fn clone(mut cb: CloneCb,
-             stack: &mut [u8],
-             flags: CloneFlags,
-             signal: Option<c_int>)
-             -> Result<Pid> {
-    extern "C" fn callback(data: *mut CloneCb) -> c_int {
-        let cb: &mut CloneCb = unsafe { &mut *data };
-        (*cb)() as c_int
+        Errno::result(res).map(Pid::from_raw)
     }
 
-    let res = unsafe {
-        let combined = flags.bits() | signal.unwrap_or(0);
-        let ptr = stack.as_mut_ptr().offset(stack.len() as isize);
-        let ptr_aligned = ptr.offset((ptr as usize % 16) as isize * -1);
-        libc::clone(mem::transmute(callback as extern "C" fn(*mut Box<::std::ops::FnMut() -> isize>) -> i32),
-                   ptr_aligned as *mut c_void,
-                   combined,
-                   &mut cb as *mut _ as *mut c_void)
-    };
+    pub fn unshare(flags: CloneFlags) -> Result<()> {
+        let res = unsafe { libc::unshare(flags.bits()) };
 
-    Errno::result(res).map(Pid::from_raw)
-}
+        Errno::result(res).map(drop)
+    }
 
-pub fn unshare(flags: CloneFlags) -> Result<()> {
-    let res = unsafe { libc::unshare(flags.bits()) };
+    pub fn setns(fd: RawFd, nstype: CloneFlags) -> Result<()> {
+        let res = unsafe { libc::setns(fd, nstype.bits()) };
 
-    Errno::result(res).map(drop)
-}
-
-pub fn setns(fd: RawFd, nstype: CloneFlags) -> Result<()> {
-    let res = unsafe { libc::setns(fd, nstype.bits()) };
-
-    Errno::result(res).map(drop)
+        Errno::result(res).map(drop)
+    }
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,3 +1,6 @@
+use libc;
+use {Errno, Result};
+
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::sched_linux_like::*;
 
@@ -93,15 +96,6 @@ mod sched_linux_like {
         Errno::result(res).map(drop)
     }
 
-    /// Explicitly yield the processor to other threads.
-    ///
-    /// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
-    pub fn sched_yield() -> Result<()> {
-        let res = unsafe { libc::sched_yield() };
-
-        Errno::result(res).map(drop)
-    }
-
     pub fn clone(
         mut cb: CloneCb,
         stack: &mut [u8],
@@ -141,4 +135,13 @@ mod sched_linux_like {
 
         Errno::result(res).map(drop)
     }
+}
+
+/// Explicitly yield the processor to other threads.
+///
+/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
+pub fn sched_yield() -> Result<()> {
+    let res = unsafe { libc::sched_yield() };
+
+    Errno::result(res).map(drop)
 }


### PR DESCRIPTION
Currently, `sched` module is compiled only for linux-like hosts. However, the recently added syscall `sched_yield` is universal to all *nixes. This PR pulls all linux-like functionality into a private `sched_linux_like` module which is enabled only for android and linux hosts, while `sched_yield` and `sched` modules are now compiled for all *nixes, thus, correctly exposing `sched_yield` to other non-linux hosts.