### PR TITLE
socket: add support for AF_VSOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1084](https://github.com/nix-rust/nix/pull/1084))
 - Add `posix_fadvise`.
   ([#1089](https://github.com/nix-rust/nix/pull/1089))
+- Added `AF_VSOCK` to `AddressFamily`.
+  ([#1091](https://github.com/nix-rust/nix/pull/1091))
 
 ### Changed
 - Support for `ifaddrs` now present when building for Android.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -33,6 +33,8 @@ pub use self::addr::{
 pub use ::sys::socket::addr::netlink::NetlinkAddr;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use sys::socket::addr::alg::AlgAddr;
+#[cfg(target_os = "linux")]
+pub use sys::socket::addr::vsock::VsockAddr;
 
 pub use libc::{
     cmsghdr,
@@ -1253,6 +1255,11 @@ pub unsafe fn sockaddr_storage_to_addr(
         libc::AF_ALG => {
             use libc::sockaddr_alg;
             Ok(SockAddr::Alg(AlgAddr(*(addr as *const _ as *const sockaddr_alg))))
+        }
+        #[cfg(target_os = "linux")]
+        libc::AF_VSOCK => {
+            use libc::sockaddr_vm;
+            Ok(SockAddr::Vsock(VsockAddr(*(addr as *const _ as *const sockaddr_vm))))
         }
         af => panic!("unexpected address family {}", af),
     }


### PR DESCRIPTION
This patch adds the support of AF_VSOCK in the socket module.
VSOCK is present since Linux 3.9.

