### PR TITLE
Fix warnings on Rust 1.37.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --default-toolchain 1.25.0
+    - sh rustup.sh -y --default-toolchain 1.31.0
     - $HOME/.cargo/bin/rustup target add i686-unknown-freebsd
   amd64_test_script:
     - . $HOME/.cargo/env

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,71 +18,71 @@ matrix:
     # week.  Additionally they're moved to the front of the line to get them in
     # the Travis OS X build queue first.
     - env: TARGET="aarch64-apple-ios;armv7-apple-ios;armv7s-apple-ios;i386-apple-ios;x86_64-apple-ios" DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
       os: osx
 
     # Mac builds
     # These are also moved to be first because they wait in a long queue with
     # Travis
     - env: TARGET=i686-apple-darwin
-      rust: 1.25.0
+      rust: 1.31.0
       os: osx
     - env: TARGET=x86_64-apple-darwin
-      rust: 1.25.0
+      rust: 1.31.0
       os: osx
 
     # Android
     - env: TARGET=aarch64-linux-android DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=i686-linux-android DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=x86_64-linux-android DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
 
     # Linux
     - env: TARGET=aarch64-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=arm-unknown-linux-gnueabi
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=armv7-unknown-linux-gnueabihf
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=i686-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=i686-unknown-linux-musl
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=mips-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=mips64-unknown-linux-gnuabi64
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=mips64el-unknown-linux-gnuabi64
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=mipsel-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=powerpc64-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=powerpc64le-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.25.0
+      rust: 1.31.0
     - env: TARGET=x86_64-unknown-linux-musl
-      rust: 1.25.0
+      rust: 1.31.0
 
     # *BSD
     # FreeBSD i686 and x86_64 use Cirrus instead of Travis
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-      rust: 1.25.0
+      rust: 1.31.0
 
     # Make sure stable is always working too
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
     - rust: nightly
       script:
         - cargo update -Zminimal-versions
-        - cargo build
+        - cargo check
 
 before_install: set -e
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Support for `ifaddrs` now present when building for Android.
   ([#1077](https://github.com/nix-rust/nix/pull/1077))
-- Minimum supported Rust version is now 1.25.0 
+- Minimum supported Rust version is now 1.31.0
   ([#1035](https://github.com/nix-rust/nix/pull/1035))
+  ([#1095](https://github.com/nix-rust/nix/pull/1095))
 - Now functions `statfs()` and `fstatfs()` return result with `Statfs` wrapper
   ([#928](https://github.com/nix-rust/nix/pull/928))
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Tier 2:
 
 ## Usage
 
-`nix` requires Rust 1.25.0 or newer.
+`nix` requires Rust 1.31.0 or newer.
 
 To use `nix`, first add this to your `Cargo.toml`:
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -39,7 +39,7 @@ mod os {
                 b'.' | b'-' => {
                     curr += 1;
                 }
-                b'0'...b'9' => {
+                b'0'..=b'9' => {
                     match curr {
                         0 => digit(&mut major, b),
                         1 => digit(&mut minor, b),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 #![deny(unstable_features)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
+// XXX Allow deprecated items until release 0.16.0.  See issue #1096.
+#![allow(deprecated)]
 
 // External crates
 #[macro_use]

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -44,7 +44,7 @@ mod sched_linux_like {
         }
     }
 
-    pub type CloneCb<'a> = Box<FnMut() -> isize + 'a>;
+    pub type CloneCb<'a> = Box<dyn FnMut() -> isize + 'a>;
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -113,7 +113,7 @@ mod sched_linux_like {
             let ptr_aligned = ptr.offset((ptr as usize % 16) as isize * -1);
             libc::clone(
                 mem::transmute(
-                    callback as extern "C" fn(*mut Box<::std::ops::FnMut() -> isize>) -> i32,
+                    callback as extern "C" fn(*mut Box<dyn FnMut() -> isize>) -> i32,
                 ),
                 ptr_aligned as *mut c_void,
                 combined,

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -102,9 +102,9 @@ pub enum Buffer<'a> {
     /// Keeps a reference to a slice
     Phantom(PhantomData<&'a mut [u8]>),
     /// Generic thing that keeps a buffer from dropping
-    BoxedSlice(Box<Borrow<[u8]>>),
+    BoxedSlice(Box<dyn Borrow<[u8]>>),
     /// Generic thing that keeps a mutable buffer from dropping
-    BoxedMutSlice(Box<BorrowMut<[u8]>>),
+    BoxedMutSlice(Box<dyn BorrowMut<[u8]>>),
 }
 
 impl<'a> Debug for Buffer<'a> {
@@ -116,14 +116,14 @@ impl<'a> Debug for Buffer<'a> {
             Buffer::None => write!(fmt, "None"),
             Buffer::Phantom(p) => p.fmt(fmt),
             Buffer::BoxedSlice(ref bs) => {
-                let borrowed : &Borrow<[u8]> = bs.borrow();
+                let borrowed : &dyn Borrow<[u8]> = bs.borrow();
                 write!(fmt, "BoxedSlice({:?})",
-                    borrowed as *const Borrow<[u8]>)
+                    borrowed as *const dyn Borrow<[u8]>)
             },
             Buffer::BoxedMutSlice(ref bms) => {
-                let borrowed : &BorrowMut<[u8]> = bms.borrow();
+                let borrowed : &dyn BorrowMut<[u8]> = bms.borrow();
                 write!(fmt, "BoxedMutSlice({:?})",
-                    borrowed as *const BorrowMut<[u8]>)
+                    borrowed as *const dyn BorrowMut<[u8]>)
             }
         }
     }
@@ -165,7 +165,7 @@ impl<'a> AioCb<'a> {
     ///
     /// It is an error to call this method while the `AioCb` is still in
     /// progress.
-    pub fn boxed_slice(&mut self) -> Option<Box<Borrow<[u8]>>> {
+    pub fn boxed_slice(&mut self) -> Option<Box<dyn Borrow<[u8]>>> {
         assert!(!self.in_progress, "Can't remove the buffer from an AioCb that's still in-progress.  Did you forget to call aio_return?");
         if let Buffer::BoxedSlice(_) = self.buffer {
             let mut oldbuffer = Buffer::None;
@@ -187,7 +187,7 @@ impl<'a> AioCb<'a> {
     ///
     /// It is an error to call this method while the `AioCb` is still in
     /// progress.
-    pub fn boxed_mut_slice(&mut self) -> Option<Box<BorrowMut<[u8]>>> {
+    pub fn boxed_mut_slice(&mut self) -> Option<Box<dyn BorrowMut<[u8]>>> {
         assert!(!self.in_progress, "Can't remove the buffer from an AioCb that's still in-progress.  Did you forget to call aio_return?");
         if let Buffer::BoxedMutSlice(_) = self.buffer {
             let mut oldbuffer = Buffer::None;
@@ -448,12 +448,12 @@ impl<'a> AioCb<'a> {
     /// ```
     ///
     /// [`from_slice`]: #method.from_slice
-    pub fn from_boxed_slice(fd: RawFd, offs: off_t, buf: Box<Borrow<[u8]>>,
+    pub fn from_boxed_slice(fd: RawFd, offs: off_t, buf: Box<dyn Borrow<[u8]>>,
                       prio: libc::c_int, sigev_notify: SigevNotify,
                       opcode: LioOpcode) -> AioCb<'a> {
         let mut a = AioCb::common_init(fd, prio, sigev_notify);
         {
-            let borrowed : &Borrow<[u8]> = buf.borrow();
+            let borrowed : &dyn Borrow<[u8]> = buf.borrow();
             let slice : &[u8] = borrowed.borrow();
             a.aio_nbytes = slice.len() as size_t;
             a.aio_buf = slice.as_ptr() as *mut c_void;
@@ -516,12 +516,12 @@ impl<'a> AioCb<'a> {
     /// [`from_boxed_slice`]: #method.from_boxed_slice
     /// [`from_mut_slice`]: #method.from_mut_slice
     pub fn from_boxed_mut_slice(fd: RawFd, offs: off_t,
-                                mut buf: Box<BorrowMut<[u8]>>,
+                                mut buf: Box<dyn BorrowMut<[u8]>>,
                                 prio: libc::c_int, sigev_notify: SigevNotify,
                                 opcode: LioOpcode) -> AioCb<'a> {
         let mut a = AioCb::common_init(fd, prio, sigev_notify);
         {
-            let borrowed : &mut BorrowMut<[u8]> = buf.borrow_mut();
+            let borrowed : &mut dyn BorrowMut<[u8]> = buf.borrow_mut();
             let slice : &mut [u8] = borrowed.borrow_mut();
             a.aio_nbytes = slice.len() as size_t;
             a.aio_buf = slice.as_mut_ptr() as *mut c_void;

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -893,7 +893,7 @@ pub fn sendmsg(fd: RawFd, iov: &[IoVec<&[u8]>], cmsgs: &[ControlMessage],
 /// # References
 /// [recvmsg(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html)
 pub fn recvmsg<'a>(fd: RawFd, iov: &[IoVec<&mut [u8]>],
-                   cmsg_buffer: Option<&'a mut CmsgBuffer>,
+                   cmsg_buffer: Option<&'a mut dyn CmsgBuffer>,
                    flags: MsgFlags) -> Result<RecvMsg<'a>>
 {
     let mut address: sockaddr_storage = unsafe { mem::uninitialized() };

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,3 +1,5 @@
+// XXX Allow deprecated items until release 0.16.0.  See issue #1096.
+#![allow(deprecated)]
 extern crate bytes;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 extern crate caps;


### PR DESCRIPTION
* Replace obsolete range syntax "..." with inclusive range "..="
* Use dyn Trait syntax instead of Box<Trait>
* Raise MSRV to 1.27.0 (for dyn Trait syntax)
* Test with nightly again