### PR TITLE
Add Redox support for most of the modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,11 @@ matrix:
       script:
         - cargo update -Zminimal-versions
         - cargo check
+    - language: generic
+      name: redox
+      script:
+        - docker pull redoxos/redoxer
+        - docker run  -v $(pwd):$(pwd) -w $(pwd) redoxos/redoxer sh -c 'rm -rf ~/.redoxer && redoxer test'
 
 before_install: set -e
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,6 @@ name = "test-mount"
 path = "test/test_mount.rs"
 harness = false
 
-[[test]]
+[[target.'cfg(not(target_os = "redox"))'.test]]
 name = "test-ptymaster-drop"
 path = "test/test_ptymaster_drop.rs"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Tier 2:
   * x86_64-linux-android
   * x86_64-unknown-netbsd
 
+Tier 3:
+  * x86_64-unknown-redox
+
 ## Usage
 
 `nix` requires Rust 1.36.0 or newer.

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -2,7 +2,9 @@ use {Error, NixPath, Result};
 use errno::Errno;
 use fcntl::{self, OFlag};
 use libc;
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::{IntoRawFd, RawFd};
+#[cfg(not(target_os = "redox"))]
+use std::os::unix::io::AsRawFd;
 use std::{ffi, ptr};
 use sys;
 
@@ -77,6 +79,7 @@ impl Dir {
 // `Dir` is safe to pass from one thread to another, as it's not reference-counted.
 unsafe impl Send for Dir {}
 
+#[cfg(not(target_os = "redox"))]
 impl AsRawFd for Dir {
     fn as_raw_fd(&self) -> RawFd {
         unsafe { libc::dirfd(self.0.as_ptr()) }
@@ -152,6 +155,7 @@ impl Entry {
               target_os = "l4re",
               target_os = "linux",
               target_os = "macos",
+              target_os = "redox",
               target_os = "solaris"))]
     pub fn ino(&self) -> u64 {
         self.0.d_ino as u64
@@ -166,6 +170,7 @@ impl Entry {
                   target_os = "l4re",
                   target_os = "linux",
                   target_os = "macos",
+                  target_os = "redox",
                   target_os = "solaris")))]
     pub fn ino(&self) -> u64 {
         u64::from(self.0.d_fileno)

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,17 +1,25 @@
+#[cfg(not(target_os = "redox"))]
 use {Error, NixPath, Result};
+#[cfg(not(target_os = "redox"))]
 use errno::Errno;
+#[cfg(not(target_os = "redox"))]
 use fcntl::{self, OFlag};
 use libc;
-use std::os::unix::io::{IntoRawFd, RawFd};
 #[cfg(not(target_os = "redox"))]
-use std::os::unix::io::AsRawFd;
-use std::{ffi, ptr};
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+#[cfg(not(target_os = "redox"))]
+use std::ptr;
+use std::ffi;
+#[cfg(not(target_os = "redox"))]
 use sys;
 
 #[cfg(target_os = "linux")]
 use libc::{dirent64 as dirent, readdir64_r as readdir_r};
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "redox")]
+use libc::dirent;
+
+#[cfg(not(any(target_os = "linux", target_os = "redox")))]
 use libc::{dirent, readdir_r};
 
 /// An open directory.
@@ -28,10 +36,12 @@ use libc::{dirent, readdir_r};
 ///    * returns entries' names as a `CStr` (no allocation or conversion beyond whatever libc
 ///      does).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg(not(target_os = "redox"))]
 pub struct Dir(
     ptr::NonNull<libc::DIR>
 );
 
+#[cfg(not(target_os = "redox"))]
 impl Dir {
     /// Opens the given path as with `fcntl::open`.
     pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag,
@@ -77,6 +87,7 @@ impl Dir {
 // call `readdir` simultaneously from multiple threads.
 //
 // `Dir` is safe to pass from one thread to another, as it's not reference-counted.
+#[cfg(not(target_os = "redox"))]
 unsafe impl Send for Dir {}
 
 #[cfg(not(target_os = "redox"))]
@@ -86,6 +97,7 @@ impl AsRawFd for Dir {
     }
 }
 
+#[cfg(not(target_os = "redox"))]
 impl Drop for Dir {
     fn drop(&mut self) {
         unsafe { libc::closedir(self.0.as_ptr()) };
@@ -93,8 +105,10 @@ impl Drop for Dir {
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
+#[cfg(not(target_os = "redox"))]
 pub struct Iter<'d>(&'d mut Dir);
 
+#[cfg(not(target_os = "redox"))]
 impl<'d> Iterator for Iter<'d> {
     type Item = Result<Entry>;
 
@@ -121,6 +135,7 @@ impl<'d> Iterator for Iter<'d> {
     }
 }
 
+#[cfg(not(target_os = "redox"))]
 impl<'d> Drop for Iter<'d> {
     fn drop(&mut self) {
         unsafe { libc::rewinddir((self.0).0.as_ptr()) }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,25 +1,16 @@
-#[cfg(not(target_os = "redox"))]
 use {Error, NixPath, Result};
-#[cfg(not(target_os = "redox"))]
 use errno::Errno;
-#[cfg(not(target_os = "redox"))]
 use fcntl::{self, OFlag};
 use libc;
-#[cfg(not(target_os = "redox"))]
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
-#[cfg(not(target_os = "redox"))]
 use std::ptr;
 use std::ffi;
-#[cfg(not(target_os = "redox"))]
 use sys;
 
 #[cfg(target_os = "linux")]
 use libc::{dirent64 as dirent, readdir64_r as readdir_r};
 
-#[cfg(target_os = "redox")]
-use libc::dirent;
-
-#[cfg(not(any(target_os = "linux", target_os = "redox")))]
+#[cfg(not(target_os = "linux"))]
 use libc::{dirent, readdir_r};
 
 /// An open directory.
@@ -36,12 +27,10 @@ use libc::{dirent, readdir_r};
 ///    * returns entries' names as a `CStr` (no allocation or conversion beyond whatever libc
 ///      does).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg(not(target_os = "redox"))]
 pub struct Dir(
     ptr::NonNull<libc::DIR>
 );
 
-#[cfg(not(target_os = "redox"))]
 impl Dir {
     /// Opens the given path as with `fcntl::open`.
     pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag,
@@ -87,17 +76,14 @@ impl Dir {
 // call `readdir` simultaneously from multiple threads.
 //
 // `Dir` is safe to pass from one thread to another, as it's not reference-counted.
-#[cfg(not(target_os = "redox"))]
 unsafe impl Send for Dir {}
 
-#[cfg(not(target_os = "redox"))]
 impl AsRawFd for Dir {
     fn as_raw_fd(&self) -> RawFd {
         unsafe { libc::dirfd(self.0.as_ptr()) }
     }
 }
 
-#[cfg(not(target_os = "redox"))]
 impl Drop for Dir {
     fn drop(&mut self) {
         unsafe { libc::closedir(self.0.as_ptr()) };
@@ -105,10 +91,8 @@ impl Drop for Dir {
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
-#[cfg(not(target_os = "redox"))]
 pub struct Iter<'d>(&'d mut Dir);
 
-#[cfg(not(target_os = "redox"))]
 impl<'d> Iterator for Iter<'d> {
     type Item = Result<Entry>;
 
@@ -135,7 +119,6 @@ impl<'d> Iterator for Iter<'d> {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
 impl<'d> Drop for Iter<'d> {
     fn drop(&mut self) {
         unsafe { libc::rewinddir((self.0).0.as_ptr()) }
@@ -170,7 +153,6 @@ impl Entry {
               target_os = "l4re",
               target_os = "linux",
               target_os = "macos",
-              target_os = "redox",
               target_os = "solaris"))]
     pub fn ino(&self) -> u64 {
         self.0.d_ino as u64
@@ -185,7 +167,6 @@ impl Entry {
                   target_os = "l4re",
                   target_os = "linux",
                   target_os = "macos",
-                  target_os = "redox",
                   target_os = "solaris")))]
     pub fn ino(&self) -> u64 {
         u64::from(self.0.d_fileno)

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -38,7 +38,7 @@ cfg_if! {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno()
         }
-    } else if #[cfg(target_os = "linux")] {
+    } else if #[cfg(any(target_os = "linux", target_os = "redox"))] {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno_location()
         }
@@ -332,7 +332,8 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         EUSERS          => "Too many users",
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "netbsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "netbsd", target_os = "redox"))]
         EOPNOTSUPP      => "Operation not supported on transport endpoint",
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -393,10 +394,10 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
         EDOOFUS         => "Programming error",
 
-        #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+        #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "redox"))]
         EMULTIHOP       => "Multihop attempted",
 
-        #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+        #[cfg(any(target_os = "freebsd", target_os = "dragonfly", target_os = "redox"))]
         ENOLINK         => "Link has been severed",
 
         #[cfg(target_os = "freebsd")]
@@ -412,12 +413,13 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EOVERFLOW       => "Value too large to be stored in data type",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "netbsd"))]
+                  target_os = "netbsd", target_os = "redox"))]
         EILSEQ          => "Illegal byte sequence",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -427,12 +429,14 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EBADMSG         => "Bad message",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EPROTO          => "Protocol error",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -455,22 +459,26 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EUSERS          => "Too many users",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EDQUOT          => "Disc quota exceeded",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         ESTALE          => "Stale NFS file handle",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         EREMOTE         => "Too many levels of remote in path",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -510,7 +518,8 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "redox"))]
         ECANCELED       => "Operation canceled",
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -534,19 +543,23 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
         EMULTIHOP       => "Reserved",
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "ios",
+                  target_os = "netbsd", target_os = "redox"))]
         ENODATA         => "No message available on STREAM",
 
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
         ENOLINK         => "Reserved",
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "ios",
+                  target_os = "netbsd", target_os = "redox"))]
         ENOSR           => "No STREAM resources",
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "ios",
+                  target_os = "netbsd", target_os = "redox"))]
         ENOSTR          => "Not a STREAM",
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "netbsd"))]
+        #[cfg(any(target_os = "macos", target_os = "ios",
+                  target_os = "netbsd", target_os = "redox"))]
         ETIME           => "STREAM ioctl timeout",
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -1954,6 +1967,200 @@ mod consts {
             libc::ENOLINK => ENOLINK,
             libc::EPROTO => EPROTO,
             _   => UnknownErrno,
+        }
+    }
+}
+
+#[cfg(target_os = "redox")]
+mod consts {
+    use libc;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(i32)]
+    pub enum Errno {
+        UnknownErrno = 0,
+        EPERM = libc::EPERM,
+        ENOENT = libc::ENOENT,
+        ESRCH = libc::ESRCH,
+        EINTR = libc::EINTR,
+        EIO = libc::EIO,
+        ENXIO = libc::ENXIO,
+        E2BIG = libc::E2BIG,
+        ENOEXEC = libc::ENOEXEC,
+        EBADF = libc::EBADF,
+        ECHILD = libc::ECHILD,
+        EDEADLK = libc::EDEADLK,
+        ENOMEM = libc::ENOMEM,
+        EACCES = libc::EACCES,
+        EFAULT = libc::EFAULT,
+        ENOTBLK = libc::ENOTBLK,
+        EBUSY = libc::EBUSY,
+        EEXIST = libc::EEXIST,
+        EXDEV = libc::EXDEV,
+        ENODEV = libc::ENODEV,
+        ENOTDIR = libc::ENOTDIR,
+        EISDIR = libc::EISDIR,
+        EINVAL = libc::EINVAL,
+        ENFILE = libc::ENFILE,
+        EMFILE = libc::EMFILE,
+        ENOTTY = libc::ENOTTY,
+        ETXTBSY = libc::ETXTBSY,
+        EFBIG = libc::EFBIG,
+        ENOSPC = libc::ENOSPC,
+        ESPIPE = libc::ESPIPE,
+        EROFS = libc::EROFS,
+        EMLINK = libc::EMLINK,
+        EPIPE = libc::EPIPE,
+        EDOM = libc::EDOM,
+        ERANGE = libc::ERANGE,
+        EAGAIN = libc::EAGAIN,
+        EINPROGRESS = libc::EINPROGRESS,
+        EALREADY = libc::EALREADY,
+        ENOTSOCK = libc::ENOTSOCK,
+        EDESTADDRREQ = libc::EDESTADDRREQ,
+        EMSGSIZE = libc::EMSGSIZE,
+        EPROTOTYPE = libc::EPROTOTYPE,
+        ENOPROTOOPT = libc::ENOPROTOOPT,
+        EPROTONOSUPPORT = libc::EPROTONOSUPPORT,
+        ESOCKTNOSUPPORT = libc::ESOCKTNOSUPPORT,
+        EOPNOTSUPP = libc::EOPNOTSUPP,
+        EPFNOSUPPORT = libc::EPFNOSUPPORT,
+        EAFNOSUPPORT = libc::EAFNOSUPPORT,
+        EADDRINUSE = libc::EADDRINUSE,
+        EADDRNOTAVAIL = libc::EADDRNOTAVAIL,
+        ENETDOWN = libc::ENETDOWN,
+        ENETUNREACH = libc::ENETUNREACH,
+        ENETRESET = libc::ENETRESET,
+        ECONNABORTED = libc::ECONNABORTED,
+        ECONNRESET = libc::ECONNRESET,
+        ENOBUFS = libc::ENOBUFS,
+        EISCONN = libc::EISCONN,
+        ENOTCONN = libc::ENOTCONN,
+        ESHUTDOWN = libc::ESHUTDOWN,
+        ETOOMANYREFS = libc::ETOOMANYREFS,
+        ETIMEDOUT = libc::ETIMEDOUT,
+        ECONNREFUSED = libc::ECONNREFUSED,
+        ELOOP = libc::ELOOP,
+        ENAMETOOLONG = libc::ENAMETOOLONG,
+        EHOSTDOWN = libc::EHOSTDOWN,
+        EHOSTUNREACH = libc::EHOSTUNREACH,
+        ENOTEMPTY = libc::ENOTEMPTY,
+        EUSERS = libc::EUSERS,
+        EDQUOT = libc::EDQUOT,
+        ESTALE = libc::ESTALE,
+        EREMOTE = libc::EREMOTE,
+        ENOLCK = libc::ENOLCK,
+        ENOSYS = libc::ENOSYS,
+        EIDRM = libc::EIDRM,
+        ENOMSG = libc::ENOMSG,
+        EOVERFLOW = libc::EOVERFLOW,
+        EILSEQ = libc::EILSEQ,
+        ECANCELED = libc::ECANCELED,
+        EBADMSG = libc::EBADMSG,
+        ENODATA = libc::ENODATA,
+        ENOSR = libc::ENOSR,
+        ENOSTR = libc::ENOSTR,
+        ETIME = libc::ETIME,
+        EMULTIHOP = libc::EMULTIHOP,
+        ENOLINK = libc::ENOLINK,
+        EPROTO = libc::EPROTO,
+    }
+
+    pub const ELAST: Errno = Errno::UnknownErrno;
+    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+
+    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
+
+    pub fn from_i32(e: i32) -> Errno {
+        use self::Errno::*;
+
+        match e {
+            libc::EPERM => EPERM,
+            libc::ENOENT => ENOENT,
+            libc::ESRCH => ESRCH,
+            libc::EINTR => EINTR,
+            libc::EIO => EIO,
+            libc::ENXIO => ENXIO,
+            libc::E2BIG => E2BIG,
+            libc::ENOEXEC => ENOEXEC,
+            libc::EBADF => EBADF,
+            libc::ECHILD => ECHILD,
+            libc::EDEADLK => EDEADLK,
+            libc::ENOMEM => ENOMEM,
+            libc::EACCES => EACCES,
+            libc::EFAULT => EFAULT,
+            libc::ENOTBLK => ENOTBLK,
+            libc::EBUSY => EBUSY,
+            libc::EEXIST => EEXIST,
+            libc::EXDEV => EXDEV,
+            libc::ENODEV => ENODEV,
+            libc::ENOTDIR => ENOTDIR,
+            libc::EISDIR => EISDIR,
+            libc::EINVAL => EINVAL,
+            libc::ENFILE => ENFILE,
+            libc::EMFILE => EMFILE,
+            libc::ENOTTY => ENOTTY,
+            libc::ETXTBSY => ETXTBSY,
+            libc::EFBIG => EFBIG,
+            libc::ENOSPC => ENOSPC,
+            libc::ESPIPE => ESPIPE,
+            libc::EROFS => EROFS,
+            libc::EMLINK => EMLINK,
+            libc::EPIPE => EPIPE,
+            libc::EDOM => EDOM,
+            libc::ERANGE => ERANGE,
+            libc::EAGAIN => EAGAIN,
+            libc::EINPROGRESS => EINPROGRESS,
+            libc::EALREADY => EALREADY,
+            libc::ENOTSOCK => ENOTSOCK,
+            libc::EDESTADDRREQ => EDESTADDRREQ,
+            libc::EMSGSIZE => EMSGSIZE,
+            libc::EPROTOTYPE => EPROTOTYPE,
+            libc::ENOPROTOOPT => ENOPROTOOPT,
+            libc::EPROTONOSUPPORT => EPROTONOSUPPORT,
+            libc::ESOCKTNOSUPPORT => ESOCKTNOSUPPORT,
+            libc::EOPNOTSUPP => EOPNOTSUPP,
+            libc::EPFNOSUPPORT => EPFNOSUPPORT,
+            libc::EAFNOSUPPORT => EAFNOSUPPORT,
+            libc::EADDRINUSE => EADDRINUSE,
+            libc::EADDRNOTAVAIL => EADDRNOTAVAIL,
+            libc::ENETDOWN => ENETDOWN,
+            libc::ENETUNREACH => ENETUNREACH,
+            libc::ENETRESET => ENETRESET,
+            libc::ECONNABORTED => ECONNABORTED,
+            libc::ECONNRESET => ECONNRESET,
+            libc::ENOBUFS => ENOBUFS,
+            libc::EISCONN => EISCONN,
+            libc::ENOTCONN => ENOTCONN,
+            libc::ESHUTDOWN => ESHUTDOWN,
+            libc::ETOOMANYREFS => ETOOMANYREFS,
+            libc::ETIMEDOUT => ETIMEDOUT,
+            libc::ECONNREFUSED => ECONNREFUSED,
+            libc::ELOOP => ELOOP,
+            libc::ENAMETOOLONG => ENAMETOOLONG,
+            libc::EHOSTDOWN => EHOSTDOWN,
+            libc::EHOSTUNREACH => EHOSTUNREACH,
+            libc::ENOTEMPTY => ENOTEMPTY,
+            libc::EUSERS => EUSERS,
+            libc::EDQUOT => EDQUOT,
+            libc::ESTALE => ESTALE,
+            libc::EREMOTE => EREMOTE,
+            libc::ENOLCK => ENOLCK,
+            libc::ENOSYS => ENOSYS,
+            libc::EIDRM => EIDRM,
+            libc::ENOMSG => ENOMSG,
+            libc::EOVERFLOW => EOVERFLOW,
+            libc::EILSEQ => EILSEQ,
+            libc::ECANCELED => ECANCELED,
+            libc::EBADMSG => EBADMSG,
+            libc::ENODATA => ENODATA,
+            libc::ENOSR => ENOSR,
+            libc::ENOSTR => ENOSTR,
+            libc::ETIME => ETIME,
+            libc::EMULTIHOP => EMULTIHOP,
+            libc::ENOLINK => ENOLINK,
+            libc::EPROTO => EPROTO,
+            _ => UnknownErrno,
         }
     }
 }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -163,8 +163,7 @@ libc_bitflags!(
 
 pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<RawFd> {
     let fd = path.with_nix_path(|cstr| {
-        let modebits = c_uint::from(mode.bits());
-        unsafe { libc::open(cstr.as_ptr(), oflag.bits(), modebits) }
+        unsafe { libc::open(cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint) }
     })?;
 
     Errno::result(fd)
@@ -178,8 +177,7 @@ pub fn openat<P: ?Sized + NixPath>(
     mode: Mode,
 ) -> Result<RawFd> {
     let fd = path.with_nix_path(|cstr| {
-        let modebits = c_uint::from(mode.bits());
-        unsafe { libc::openat(dirfd, cstr.as_ptr(), oflag.bits(), modebits) }
+        unsafe { libc::openat(dirfd, cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint) }
     })?;
     Errno::result(fd)
 }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,29 +1,31 @@
-use {Result, NixPath};
 use errno::Errno;
-use libc::{self, c_int, c_uint, c_char, size_t, ssize_t};
-use sys::stat::Mode;
+use libc::{self, c_char, c_int, c_uint, size_t, ssize_t};
+use std::ffi::OsString;
 #[cfg(not(target_os = "redox"))]
 use std::os::raw;
-use std::os::unix::io::RawFd;
-use std::ffi::OsString;
 use std::os::unix::ffi::OsStringExt;
+use std::os::unix::io::RawFd;
+use sys::stat::Mode;
+use {NixPath, Result};
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use std::ptr; // For splice and copy_file_range
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use sys::uio::IoVec;  // For vmsplice
+use sys::uio::IoVec; // For vmsplice
 
-#[cfg(any(target_os = "linux",
-          target_os = "android",
-          target_os = "emscripten",
-          target_os = "fuchsia",
-          any(target_os = "wasi", target_env = "wasi"),
-          target_env = "uclibc",
-          target_env = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    any(target_os = "wasi", target_env = "wasi"),
+    target_env = "uclibc",
+    target_env = "freebsd"
+))]
 pub use self::posix_fadvise::*;
 
 #[cfg(not(target_os = "redox"))]
-libc_bitflags!{
+libc_bitflags! {
     pub struct AtFlags: c_int {
         AT_REMOVEDIR;
         AT_SYMLINK_FOLLOW;
@@ -168,7 +170,13 @@ pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<R
     Errno::result(fd)
 }
 
-pub fn openat<P: ?Sized + NixPath>(dirfd: RawFd, path: &P, oflag: OFlag, mode: Mode) -> Result<RawFd> {
+#[cfg(not(target_os = "redox"))]
+pub fn openat<P: ?Sized + NixPath>(
+    dirfd: RawFd,
+    path: &P,
+    oflag: OFlag,
+    mode: Mode,
+) -> Result<RawFd> {
     let fd = path.with_nix_path(|cstr| {
         let modebits = c_uint::from(mode.bits());
         unsafe { libc::openat(dirfd, cstr.as_ptr(), oflag.bits(), modebits) }
@@ -176,13 +184,21 @@ pub fn openat<P: ?Sized + NixPath>(dirfd: RawFd, path: &P, oflag: OFlag, mode: M
     Errno::result(fd)
 }
 
-pub fn renameat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(old_dirfd: Option<RawFd>, old_path: &P1,
-                                                            new_dirfd: Option<RawFd>, new_path: &P2)
-                                                            -> Result<()> {
+#[cfg(not(target_os = "redox"))]
+pub fn renameat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
+    old_dirfd: Option<RawFd>,
+    old_path: &P1,
+    new_dirfd: Option<RawFd>,
+    new_path: &P2,
+) -> Result<()> {
     let res = old_path.with_nix_path(|old_cstr| {
         new_path.with_nix_path(|new_cstr| unsafe {
-            libc::renameat(at_rawfd(old_dirfd), old_cstr.as_ptr(),
-                           at_rawfd(new_dirfd), new_cstr.as_ptr())
+            libc::renameat(
+                at_rawfd(old_dirfd),
+                old_cstr.as_ptr(),
+                at_rawfd(new_dirfd),
+                new_cstr.as_ptr(),
+            )
         })
     })??;
     Errno::result(res).map(drop)
@@ -194,25 +210,32 @@ fn wrap_readlink_result(mut v: Vec<u8>, len: ssize_t) -> Result<OsString> {
     Ok(OsString::from_vec(v.to_vec()))
 }
 
-fn readlink_maybe_at<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P,
-                                          v: &mut Vec<u8>)
-                                          -> Result<libc::ssize_t> {
-    path.with_nix_path(|cstr| {
-        unsafe {
-            match dirfd  {
-                Some(dirfd) => libc::readlinkat(dirfd, cstr.as_ptr(),
-                                                v.as_mut_ptr() as *mut c_char,
-                                                v.capacity() as size_t),
-                None => libc::readlink(cstr.as_ptr(),
-                                       v.as_mut_ptr() as *mut c_char,
-                                       v.capacity() as size_t),
-            }
+fn readlink_maybe_at<P: ?Sized + NixPath>(
+    dirfd: Option<RawFd>,
+    path: &P,
+    v: &mut Vec<u8>,
+) -> Result<libc::ssize_t> {
+    path.with_nix_path(|cstr| unsafe {
+        match dirfd {
+            #[cfg(target_os = "redox")]
+            Some(_) => unreachable!(),
+            #[cfg(not(target_os = "redox"))]
+            Some(dirfd) => libc::readlinkat(
+                dirfd,
+                cstr.as_ptr(),
+                v.as_mut_ptr() as *mut c_char,
+                v.capacity() as size_t,
+            ),
+            None => libc::readlink(
+                cstr.as_ptr(),
+                v.as_mut_ptr() as *mut c_char,
+                v.capacity() as size_t,
+            ),
         }
     })
 }
 
-fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P)
-                                       -> Result<OsString> {
+fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P) -> Result<OsString> {
     let mut v = Vec::with_capacity(libc::PATH_MAX as usize);
     // simple case: result is strictly less than `PATH_MAX`
     let res = readlink_maybe_at(dirfd, path, &mut v)?;
@@ -224,7 +247,8 @@ fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P)
     // Uh oh, the result is too long...
     // Let's try to ask lstat how many bytes to allocate.
     let reported_size = super::sys::stat::lstat(path)
-        .and_then(|x| Ok(x.st_size)).unwrap_or(0);
+        .and_then(|x| Ok(x.st_size))
+        .unwrap_or(0);
     let mut try_size = if reported_size > 0 {
         // Note: even if `lstat`'s apparently valid answer turns out to be
         // wrong, we will still read the full symlink no matter what.
@@ -241,14 +265,13 @@ fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P)
         debug_assert!(len >= 0);
         if (len as usize) < v.capacity() {
             break wrap_readlink_result(v, res);
-        }
-        else {
+        } else {
             // Ugh! Still not big enough!
             match try_size.checked_shl(1) {
                 Some(next_size) => try_size = next_size,
                 // It's absurd that this would happen, but handle it sanely
                 // anyway.
-                None => break Err(super::Error::Sys(Errno::ENAMETOOLONG))
+                None => break Err(super::Error::Sys(Errno::ENAMETOOLONG)),
             }
         }
     }
@@ -258,9 +281,8 @@ pub fn readlink<P: ?Sized + NixPath>(path: &P) -> Result<OsString> {
     inner_readlink(None, path)
 }
 
-
-pub fn readlinkat<P: ?Sized + NixPath>(dirfd: RawFd, path: &P)
-                                       -> Result<OsString> {
+#[cfg(not(target_os = "redox"))]
+pub fn readlinkat<P: ?Sized + NixPath>(dirfd: RawFd, path: &P) -> Result<OsString> {
     inner_readlink(Some(dirfd), path)
 }
 
@@ -324,7 +346,6 @@ pub enum FcntlArg<'a> {
     F_GETPIPE_SZ,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     F_SETPIPE_SZ(c_int),
-
     // TODO: Rest of flags
 }
 
@@ -488,9 +509,7 @@ pub fn splice(
         .map(|offset| offset as *mut libc::loff_t)
         .unwrap_or(ptr::null_mut());
 
-    let ret = unsafe {
-        libc::splice(fd_in, off_in, fd_out, off_out, len, flags.bits())
-    };
+    let ret = unsafe { libc::splice(fd_in, off_in, fd_out, off_out, len, flags.bits()) };
     Errno::result(ret).map(|r| r as usize)
 }
 
@@ -503,7 +522,12 @@ pub fn tee(fd_in: RawFd, fd_out: RawFd, len: usize, flags: SpliceFFlags) -> Resu
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn vmsplice(fd: RawFd, iov: &[IoVec<&[u8]>], flags: SpliceFFlags) -> Result<usize> {
     let ret = unsafe {
-        libc::vmsplice(fd, iov.as_ptr() as *const libc::iovec, iov.len(), flags.bits())
+        libc::vmsplice(
+            fd,
+            iov.as_ptr() as *const libc::iovec,
+            iov.len(),
+            flags.bits(),
+        )
     };
     Errno::result(ret).map(|r| r as usize)
 }
@@ -544,23 +568,30 @@ libc_bitflags!(
 /// Allows the caller to directly manipulate the allocated disk space for the
 /// file referred to by fd.
 #[cfg(any(target_os = "linux"))]
-pub fn fallocate(fd: RawFd, mode: FallocateFlags, offset: libc::off_t, len: libc::off_t) -> Result<()> {
+pub fn fallocate(
+    fd: RawFd,
+    mode: FallocateFlags,
+    offset: libc::off_t,
+    len: libc::off_t,
+) -> Result<()> {
     let res = unsafe { libc::fallocate(fd, mode.bits(), offset, len) };
     Errno::result(res).map(drop)
 }
 
-#[cfg(any(target_os = "linux",
-          target_os = "android",
-          target_os = "emscripten",
-          target_os = "fuchsia",
-          any(target_os = "wasi", target_env = "wasi"),
-          target_env = "uclibc",
-          target_env = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    any(target_os = "wasi", target_env = "wasi"),
+    target_env = "uclibc",
+    target_env = "freebsd"
+))]
 mod posix_fadvise {
-    use Result;
-    use libc;
     use errno::Errno;
+    use libc;
     use std::os::unix::io::RawFd;
+    use Result;
 
     libc_enum! {
         #[repr(i32)]
@@ -574,10 +605,12 @@ mod posix_fadvise {
         }
     }
 
-    pub fn posix_fadvise(fd: RawFd,
-                         offset: libc::off_t,
-                         len: libc::off_t,
-                         advice: PosixFadviseAdvice) -> Result<libc::c_int> {
+    pub fn posix_fadvise(
+        fd: RawFd,
+        offset: libc::off_t,
+        len: libc::off_t,
+        advice: PosixFadviseAdvice,
+    ) -> Result<libc::c_int> {
         let res = unsafe { libc::posix_fadvise(fd, offset, len, advice as libc::c_int) };
         Errno::result(res)
     }
@@ -591,11 +624,7 @@ mod posix_fadvise {
     any(target_os = "wasi", target_env = "wasi"),
     target_os = "freebsd"
 ))]
-pub fn posix_fallocate(
-    fd: RawFd,
-    offset: libc::off_t,
-    len: libc::off_t
-) -> Result<()> {
+pub fn posix_fallocate(fd: RawFd, offset: libc::off_t, len: libc::off_t) -> Result<()> {
     let res = unsafe { libc::posix_fallocate(fd, offset, len) };
     match Errno::result(res) {
         Err(err) => Err(err),

--- a/src/features.rs
+++ b/src/features.rs
@@ -94,7 +94,10 @@ mod os {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "ios", target_os = "openbsd", target_os = "netbsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd",
+          target_os = "dragonfly", target_os = "ios",
+          target_os = "openbsd", target_os = "netbsd",
+          target_os = "redox"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets
     pub fn socket_atomic_cloexec() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ pub mod mqueue;
 #[cfg(not(target_os = "redox"))]
 pub mod net;
 #[deny(missing_docs)]
-#[cfg(not(target_os = "redox"))]
 pub mod poll;
 #[deny(missing_docs)]
 #[cfg(not(target_os = "redox"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub extern crate libc;
 #[macro_use] mod macros;
 
 // Public crates
+#[cfg(not(target_os = "redox"))]
 pub mod dir;
 pub mod env;
 pub mod errno;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,13 @@ pub mod mount;
           target_os = "netbsd"))]
 pub mod mqueue;
 #[deny(missing_docs)]
+#[cfg(not(target_os = "redox"))]
 pub mod net;
 #[deny(missing_docs)]
+#[cfg(not(target_os = "redox"))]
 pub mod poll;
 #[deny(missing_docs)]
+#[cfg(not(target_os = "redox"))]
 pub mod pty;
 pub mod sched;
 pub mod sys;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -206,6 +206,7 @@ macro_rules! libc_enum {
 
 /// A Rust version of the familiar C `offset_of` macro.  It returns the byte
 /// offset of `field` within struct `ty`
+#[cfg(not(target_os = "redox"))]
 macro_rules! offset_of {
     ($ty:ty, $field:ident) => {
         &(*(ptr::null() as *const $ty)).$field as *const _ as usize

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -64,12 +64,16 @@ libc_bitflags! {
         /// `O_NONBLOCK` is set).
         POLLOUT;
         /// Equivalent to [`POLLIN`](constant.POLLIN.html)
+        #[cfg(not(target_os = "redox"))]
         POLLRDNORM;
+        #[cfg(not(target_os = "redox"))]
         /// Equivalent to [`POLLOUT`](constant.POLLOUT.html)
         POLLWRNORM;
         /// Priority band data can be read (generally unused on Linux).
+        #[cfg(not(target_os = "redox"))]
         POLLRDBAND;
         /// Priority data may be written.
+        #[cfg(not(target_os = "redox"))]
         POLLWRBAND;
         /// Error condition (only returned in
         /// [`PollFd::revents`](struct.PollFd.html#method.revents);

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -221,11 +221,11 @@
 //!
 //! # fn main() {}
 //! ```
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
 #[macro_use]
 mod linux;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
 pub use self::linux::*;
 
 #[cfg(any(target_os = "dragonfly",

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -34,6 +34,7 @@ pub mod ioctl;
 #[cfg(target_os = "linux")]
 pub mod memfd;
 
+#[cfg(not(target_os = "redox"))]
 pub mod mman;
 
 pub mod pthread;
@@ -53,6 +54,7 @@ pub mod quota;
 #[cfg(any(target_os = "linux"))]
 pub mod reboot;
 
+#[cfg(not(target_os = "redox"))]
 pub mod select;
 
 #[cfg(any(target_os = "android",
@@ -67,6 +69,7 @@ pub mod signal;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod signalfd;
 
+#[cfg(not(target_os = "redox"))]
 pub mod socket;
 
 pub mod stat;
@@ -86,6 +89,7 @@ pub mod statvfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod sysinfo;
 
+#[cfg(not(target_os = "redox"))]
 pub mod termios;
 
 pub mod time;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -89,7 +89,6 @@ pub mod statvfs;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod sysinfo;
 
-#[cfg(not(target_os = "redox"))]
 pub mod termios;
 
 pub mod time;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -25,6 +25,7 @@ pub mod eventfd;
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",
+          target_os = "redox",
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd"))]

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -464,7 +464,6 @@ impl SigSet {
 
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
-    #[cfg(not(target_os = "redox"))]
     pub fn wait(&self) -> Result<Signal> {
         let mut signum = mem::MaybeUninit::uninit();
         let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, signum.as_mut_ptr()) };

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use std::os::unix::io::RawFd;
 use std::ptr;
 
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "redox")))]
 pub use self::sigevent::*;
 
 libc_enum!{
@@ -58,9 +58,11 @@ libc_enum!{
         #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
         SIGPWR,
         SIGSYS,
-        #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+        #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                      target_os = "linux", target_os = "redox")))]
         SIGEMT,
-        #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+        #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                      target_os = "linux", target_os = "redox")))]
         SIGINFO,
     }
 }
@@ -103,9 +105,11 @@ impl FromStr for Signal {
             #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
             "SIGPWR" => Signal::SIGPWR,
             "SIGSYS" => Signal::SIGSYS,
-            #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+            #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                          target_os = "linux", target_os = "redox")))]
             "SIGEMT" => Signal::SIGEMT,
-            #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+            #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                          target_os = "linux", target_os = "redox")))]
             "SIGINFO" => Signal::SIGINFO,
             _ => return Err(Error::invalid_argument()),
         })
@@ -154,9 +158,11 @@ impl Signal {
             #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
             Signal::SIGPWR => "SIGPWR",
             Signal::SIGSYS => "SIGSYS",
-            #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+            #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                          target_os = "linux", target_os = "redox")))]
             Signal::SIGEMT => "SIGEMT",
-            #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
+            #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                          target_os = "linux", target_os = "redox")))]
             Signal::SIGINFO => "SIGINFO",
         }
     }
@@ -176,6 +182,37 @@ impl fmt::Display for Signal {
 
 pub use self::Signal::*;
 
+#[cfg(target_os = "redox")]
+const SIGNALS: [Signal; 29] = [
+    SIGHUP,
+    SIGINT,
+    SIGQUIT,
+    SIGILL,
+    SIGTRAP,
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGKILL,
+    SIGUSR1,
+    SIGSEGV,
+    SIGUSR2,
+    SIGPIPE,
+    SIGALRM,
+    SIGTERM,
+    SIGCHLD,
+    SIGCONT,
+    SIGSTOP,
+    SIGTSTP,
+    SIGTTIN,
+    SIGTTOU,
+    SIGURG,
+    SIGXCPU,
+    SIGXFSZ,
+    SIGVTALRM,
+    SIGPROF,
+    SIGWINCH,
+    SIGIO,
+    SIGSYS];
 #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
@@ -241,7 +278,8 @@ const SIGNALS: [Signal; 30] = [
     SIGIO,
     SIGPWR,
     SIGSYS];
-#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "emscripten")))]
+#[cfg(not(any(target_os = "linux", target_os = "android",
+              target_os = "emscripten", target_os = "redox")))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -318,8 +356,13 @@ pub const SIGIOT : Signal = SIGABRT;
 pub const SIGPOLL : Signal = SIGIO;
 pub const SIGUNUSED : Signal = SIGSYS;
 
+#[cfg(not(target_os = "redox"))]
+type SaFlags_t = libc::c_int;
+#[cfg(target_os = "redox")]
+type SaFlags_t = libc::c_ulong;
+
 libc_bitflags!{
-    pub struct SaFlags: libc::c_int {
+    pub struct SaFlags: SaFlags_t {
         SA_NOCLDSTOP;
         SA_NOCLDWAIT;
         SA_NODEFER;
@@ -449,6 +492,7 @@ pub enum SigHandler {
     Handler(extern fn(libc::c_int)),
     /// Use the given signal-catching function, which takes in the signal, information about how
     /// the signal was generated, and a pointer to the threads `ucontext_t`.
+    #[cfg(not(target_os = "redox"))]
     SigAction(extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void))
 }
 
@@ -465,16 +509,31 @@ impl SigAction {
     /// is the `SigAction` variant). `mask` specifies other signals to block during execution of
     /// the signal-catching function.
     pub fn new(handler: SigHandler, flags: SaFlags, mask: SigSet) -> SigAction {
-        let mut s = mem::MaybeUninit::<libc::sigaction>::uninit();
-        unsafe {
-            let p = s.as_mut_ptr();
+        #[cfg(target_os = "redox")]
+        unsafe fn install_sig(p: *mut libc::sigaction, handler: SigHandler) {
+            (*p).sa_handler = match handler {
+                SigHandler::SigDfl => libc::SIG_DFL,
+                SigHandler::SigIgn => libc::SIG_IGN,
+                SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
+            };
+        }
+
+        #[cfg(not(target_os = "redox"))]
+        unsafe fn install_sig(p: *mut libc::sigaction, handler: SigHandler) {
             (*p).sa_sigaction = match handler {
                 SigHandler::SigDfl => libc::SIG_DFL,
                 SigHandler::SigIgn => libc::SIG_IGN,
                 SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
                 SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
             };
+        }
+
+        let mut s = mem::MaybeUninit::<libc::sigaction>::uninit();
+        unsafe {
+            let p = s.as_mut_ptr();
+            install_sig(p, handler);
             (*p).sa_flags = match handler {
+                #[cfg(not(target_os = "redox"))]
                 SigHandler::SigAction(_) => (flags | SaFlags::SA_SIGINFO).bits(),
                 _ => (flags - SaFlags::SA_SIGINFO).bits(),
             };
@@ -496,12 +555,23 @@ impl SigAction {
     }
 
     /// Returns the action's handler.
+    #[cfg(not(target_os = "redox"))]
     pub fn handler(&self) -> SigHandler {
         match self.sigaction.sa_sigaction {
             libc::SIG_DFL => SigHandler::SigDfl,
             libc::SIG_IGN => SigHandler::SigIgn,
             f if self.flags().contains(SaFlags::SA_SIGINFO) =>
                 SigHandler::SigAction( unsafe { mem::transmute(f) } ),
+            f => SigHandler::Handler( unsafe { mem::transmute(f) } ),
+        }
+    }
+
+    /// Returns the action's handler.
+    #[cfg(target_os = "redox")]
+    pub fn handler(&self) -> SigHandler {
+        match self.sigaction.sa_handler {
+            libc::SIG_DFL => SigHandler::SigDfl,
+            libc::SIG_IGN => SigHandler::SigIgn,
             f => SigHandler::Handler( unsafe { mem::transmute(f) } ),
         }
     }
@@ -590,6 +660,7 @@ pub unsafe fn signal(signal: Signal, handler: SigHandler) -> Result<SigHandler> 
         SigHandler::SigDfl => libc::signal(signal, libc::SIG_DFL),
         SigHandler::SigIgn => libc::signal(signal, libc::SIG_IGN),
         SigHandler::Handler(handler) => libc::signal(signal, handler as libc::sighandler_t),
+        #[cfg(not(target_os = "redox"))]
         SigHandler::SigAction(_) => return Err(Error::UnsupportedOperation),
     };
     Errno::result(res).map(|oldhandler| {
@@ -728,7 +799,7 @@ pub enum SigevNotify {
                     si_value: libc::intptr_t },
 }
 
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "redox")))]
 mod sigevent {
     use libc;
     use std::mem;
@@ -944,8 +1015,18 @@ mod tests {
         use libc;
         thread::spawn(|| {
             extern fn test_sigaction_handler(_: libc::c_int) {}
+            #[cfg(not(target_os = "redox"))]
             extern fn test_sigaction_action(_: libc::c_int,
                 _: *mut libc::siginfo_t, _: *mut libc::c_void) {}
+
+            #[cfg(not(target_os = "redox"))]
+            fn test_sigaction_sigaction(flags: SaFlags, mask: SigSet) {
+                let handler_act = SigHandler::SigAction(test_sigaction_action);
+                let action_act = SigAction::new(handler_act, flags, mask);
+                assert_eq!(action_act.handler(), handler_act);
+            }
+            #[cfg(target_os = "redox")]
+            fn test_sigaction_sigaction() {}
 
             let handler_sig = SigHandler::Handler(test_sigaction_handler);
 
@@ -965,9 +1046,7 @@ mod tests {
             assert!(mask.contains(SIGUSR1));
             assert!(!mask.contains(SIGUSR2));
 
-            let handler_act = SigHandler::SigAction(test_sigaction_action);
-            let action_act = SigAction::new(handler_act, flags, mask);
-            assert_eq!(action_act.handler(), handler_act);
+            test_sigaction_sigaction(flags, mask);
 
             let action_dfl = SigAction::new(SigHandler::SigDfl, flags, mask);
             assert_eq!(action_dfl.handler(), SigHandler::SigDfl);

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -464,6 +464,7 @@ impl SigSet {
 
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
+    #[cfg(not(target_os = "redox"))] // RedoxFS does not yet support sigwait
     pub fn wait(&self) -> Result<Signal> {
         let mut signum = mem::MaybeUninit::uninit();
         let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, signum.as_mut_ptr()) };

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -3,6 +3,7 @@ pub use libc::stat as FileStat;
 
 use {Result, NixPath};
 use errno::Errno;
+#[cfg(not(target_os = "redox"))]
 use fcntl::{AtFlags, at_rawfd};
 use libc;
 use std::mem;
@@ -112,6 +113,7 @@ pub fn fstat(fd: RawFd) -> Result<FileStat> {
     Ok(unsafe{dst.assume_init()})
 }
 
+#[cfg(not(target_os = "redox"))]
 pub fn fstatat<P: ?Sized + NixPath>(dirfd: RawFd, pathname: &P, f: AtFlags) -> Result<FileStat> {
     let mut dst = mem::MaybeUninit::uninit();
     let res = pathname.with_nix_path(|cstr| {
@@ -157,6 +159,7 @@ pub enum FchmodatFlags {
 /// # References
 ///
 /// [fchmodat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
+#[cfg(not(target_os = "redox"))]
 pub fn fchmodat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -260,6 +263,7 @@ pub enum UtimensatFlags {
 /// # References
 ///
 /// [utimensat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
+#[cfg(not(target_os = "redox"))]
 pub fn utimensat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -289,6 +289,7 @@ pub fn utimensat<P: ?Sized + NixPath>(
     Errno::result(res).map(drop)
 }
 
+#[cfg(not(target_os = "redox"))]
 pub fn mkdirat<P: ?Sized + NixPath>(fd: RawFd, path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe { libc::mkdirat(fd, cstr.as_ptr(), mode.bits() as mode_t) }

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -10,6 +10,7 @@ use libc::{self, c_ulong};
 use {Result, NixPath};
 use errno::Errno;
 
+#[cfg(not(target_os = "redox"))]
 libc_bitflags!(
     /// File system mount Flags
     #[repr(C)]
@@ -108,6 +109,7 @@ impl Statvfs {
     }
 
     /// Get the mount flags
+    #[cfg(not(target_os = "redox"))]
     pub fn flags(&self) -> FsFlags {
         FsFlags::from_bits_truncate(self.0.f_flag)
     }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -818,6 +818,7 @@ libc_bitflags! {
         PARODD;
         HUPCL;
         CLOCAL;
+        #[cfg(not(target_os = "redox"))]
         CRTSCTS;
         #[cfg(any(target_os = "android", target_os = "linux"))]
         CBAUD;
@@ -868,12 +869,15 @@ libc_bitflags! {
 libc_bitflags! {
     /// Flags for setting any local modes
     pub struct LocalFlags: tcflag_t {
+        #[cfg(not(target_os = "redox"))]
         ECHOKE;
         ECHOE;
         ECHOK;
         ECHO;
         ECHONL;
+        #[cfg(not(target_os = "redox"))]
         ECHOPRT;
+        #[cfg(not(target_os = "redox"))]
         ECHOCTL;
         ISIG;
         ICANON;
@@ -885,8 +889,10 @@ libc_bitflags! {
                   target_os = "openbsd"))]
         ALTWERASE;
         IEXTEN;
+        #[cfg(not(target_os = "redox"))]
         EXTPROC;
         TOSTOP;
+        #[cfg(not(target_os = "redox"))]
         FLUSHO;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
@@ -895,6 +901,7 @@ libc_bitflags! {
                   target_os = "netbsd",
                   target_os = "openbsd"))]
         NOKERNINFO;
+        #[cfg(not(target_os = "redox"))]
         PENDIN;
         NOFLSH;
     }

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -15,6 +15,7 @@ libc_bitflags!(
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
+                  target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
         WEXITED;
@@ -24,6 +25,7 @@ libc_bitflags!(
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
+                  target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
         WSTOPPED;
@@ -33,16 +35,17 @@ libc_bitflags!(
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
+                  target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
         WNOWAIT;
         /// Don't wait on children of other threads in this group
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
         __WNOTHREAD;
         /// Wait on all children, regardless of type
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
         __WALL;
-        #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
         __WCLONE;
     }
 );

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -505,6 +505,7 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 /// }
 /// ```
 #[inline]
+#[cfg(not(target_os = "redox"))]
 pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe { libc::mkfifo(cstr.as_ptr(), mode.bits() as mode_t) }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -505,7 +505,7 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 /// }
 /// ```
 #[inline]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support fifo yet
 pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe { libc::mkfifo(cstr.as_ptr(), mode.bits() as mode_t) }
@@ -1327,6 +1327,7 @@ pub fn fsync(fd: RawFd) -> Result<()> {
 // TODO: exclude only Apple systems after https://github.com/rust-lang/libc/pull/211
 #[cfg(any(target_os = "linux",
           target_os = "android",
+          target_os = "redox",
           target_os = "emscripten"))]
 #[inline]
 pub fn fdatasync(fd: RawFd) -> Result<()> {
@@ -1661,7 +1662,6 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
 ///
 /// See also [pause(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pause.html).
 #[inline]
-#[cfg(not(target_os = "redox"))]
 pub fn pause() {
     unsafe { libc::pause() };
 }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2,14 +2,20 @@
 
 use errno::{self, Errno};
 use {Error, Result, NixPath};
-use fcntl::{AtFlags, at_rawfd, fcntl, FdFlag, OFlag};
+#[cfg(not(target_os = "redox"))]
+use fcntl::{AtFlags, at_rawfd};
+use fcntl::{FdFlag, OFlag, fcntl};
 use fcntl::FcntlArg::F_SETFD;
 use libc::{self, c_char, c_void, c_int, c_long, c_uint, size_t, pid_t, off_t,
            uid_t, gid_t, mode_t, PATH_MAX};
 use std::{fmt, mem, ptr};
 use std::convert::Infallible;
-use std::ffi::{CString, CStr, OsString, OsStr};
-use std::os::unix::ffi::{OsStringExt, OsStrExt};
+use std::ffi::{CString, CStr, OsString};
+#[cfg(not(target_os = "redox"))]
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStringExt;
+#[cfg(not(target_os = "redox"))]
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
 use sys::stat::Mode;
@@ -535,6 +541,7 @@ pub fn mkfifoat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Mode)
 /// directory. This is identical to `libc::symlink(path1, path2)`.
 ///
 /// See also [symlinkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/symlinkat.html).
+#[cfg(not(target_os = "redox"))]
 pub fn symlinkat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
     path1: &P1,
     dirfd: Option<RawFd>,
@@ -674,6 +681,7 @@ pub enum FchownatFlags {
 /// # References
 ///
 /// [fchownat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchownat.html).
+#[cfg(not(target_os = "redox"))]
 pub fn fchownat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -866,6 +874,7 @@ pub fn execveat(dirfd: RawFd, pathname: &CStr, args: &[&CStr],
     note="Deprecated in MacOSX 10.5"
 ))]
 #[cfg_attr(any(target_os = "macos", target_os = "ios"), allow(deprecated))]
+#[cfg(not(target_os = "redox"))]
 pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
     let res = unsafe { libc::daemon(nochdir as c_int, noclose as c_int) };
     Errno::result(res).map(drop)
@@ -878,6 +887,7 @@ pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
 /// On some systems, the host name is limited to as few as 64 bytes.  An error
 /// will be return if the name is not valid or the current process does not have
 /// permissions to update the host name.
+#[cfg(not(target_os = "redox"))]
 pub fn sethostname<S: AsRef<OsStr>>(name: S) -> Result<()> {
     // Handle some differences in type of the len arg across platforms.
     cfg_if! {
@@ -1066,6 +1076,7 @@ pub fn pipe() -> Result<(RawFd, RawFd)> {
           target_os = "emscripten",
           target_os = "freebsd",
           target_os = "linux",
+          target_os = "redox",
           target_os = "netbsd",
           target_os = "openbsd"))]
 pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
@@ -1503,7 +1514,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
 /// #     try_main().unwrap();
 /// # }
 /// ```
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 pub fn setgroups(groups: &[Gid]) -> Result<()> {
     cfg_if! {
         if #[cfg(any(target_os = "dragonfly",
@@ -1547,7 +1558,7 @@ pub fn setgroups(groups: &[Gid]) -> Result<()> {
 /// and `setgroups()`. Additionally, while some implementations will return a
 /// partial list of groups when `NGROUPS_MAX` is exceeded, this implementation
 /// will only ever return the complete list or else an error.
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
     let ngroups_max = match sysconf(SysconfVar::NGROUPS_MAX) {
         Ok(Some(n)) => n as c_int,
@@ -1627,7 +1638,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
 /// #     try_main().unwrap();
 /// # }
 /// ```
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
     cfg_if! {
         if #[cfg(any(target_os = "ios", target_os = "macos"))] {
@@ -1738,6 +1749,7 @@ pub fn sleep(seconds: c_uint) -> c_uint {
     unsafe { libc::sleep(seconds) }
 }
 
+#[cfg(not(target_os = "redox"))]
 pub mod acct {
     use libc;
     use {Result, NixPath};
@@ -1819,7 +1831,7 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 #[repr(i32)]
 pub enum PathconfVar {
     #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "linux",
-              target_os = "netbsd", target_os = "openbsd"))]
+              target_os = "netbsd", target_os = "openbsd", target_os = "redox"))]
     /// Minimum number of bits needed to represent, as a signed integer value,
     /// the maximum size of a regular file allowed in the specified directory.
     FILESIZEBITS = libc::_PC_FILESIZEBITS,
@@ -1843,11 +1855,11 @@ pub enum PathconfVar {
     /// a pipe.
     PIPE_BUF = libc::_PC_PIPE_BUF,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "linux",
-              target_os = "netbsd", target_os = "openbsd"))]
+              target_os = "netbsd", target_os = "openbsd", target_os = "redox"))]
     /// Symbolic links can be created.
     POSIX2_SYMLINKS = libc::_PC_2_SYMLINKS,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     /// Minimum number of bytes of storage actually allocated for any portion of
     /// a file.
     POSIX_ALLOC_SIZE_MIN = libc::_PC_ALLOC_SIZE_MIN,
@@ -1857,19 +1869,20 @@ pub enum PathconfVar {
     /// `POSIX_REC_MIN_XFER_SIZE` and `POSIX_REC_MAX_XFER_SIZE` values.
     POSIX_REC_INCR_XFER_SIZE = libc::_PC_REC_INCR_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     /// Maximum recommended file transfer size.
     POSIX_REC_MAX_XFER_SIZE = libc::_PC_REC_MAX_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     /// Minimum recommended file transfer size.
     POSIX_REC_MIN_XFER_SIZE = libc::_PC_REC_MIN_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     ///  Recommended file transfer buffer alignment.
     POSIX_REC_XFER_ALIGN = libc::_PC_REC_XFER_ALIGN,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "netbsd", target_os = "openbsd"))]
+              target_os = "linux", target_os = "netbsd", target_os = "openbsd",
+              target_os = "redox"))]
     /// Maximum number of bytes in a symbolic link.
     SYMLINK_MAX = libc::_PC_SYMLINK_MAX,
     /// The use of `chown` and `fchown` is restricted to a process with
@@ -1883,17 +1896,18 @@ pub enum PathconfVar {
     /// disable terminal special character handling.
     _POSIX_VDISABLE = libc::_PC_VDISABLE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     /// Asynchronous input or output operations may be performed for the
     /// associated file.
     _POSIX_ASYNC_IO = libc::_PC_ASYNC_IO,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "openbsd"))]
+              target_os = "linux", target_os = "openbsd", target_os = "redox"))]
     /// Prioritized input or output operations may be performed for the
     /// associated file.
     _POSIX_PRIO_IO = libc::_PC_PRIO_IO,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
-              target_os = "linux", target_os = "netbsd", target_os = "openbsd"))]
+              target_os = "linux", target_os = "netbsd", target_os = "openbsd",
+              target_os = "redox"))]
     /// Synchronized input or output operations may be performed for the
     /// associated file.
     _POSIX_SYNC_IO = libc::_PC_SYNC_IO,
@@ -1994,9 +2008,11 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 pub enum SysconfVar {
     /// Maximum number of I/O operations in a single list I/O call supported by
     /// the implementation.
+    #[cfg(not(target_os = "redox"))]
     AIO_LISTIO_MAX = libc::_SC_AIO_LISTIO_MAX,
     /// Maximum number of outstanding asynchronous I/O operations supported by
     /// the implementation.
+    #[cfg(not(target_os = "redox"))]
     AIO_MAX = libc::_SC_AIO_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
@@ -2007,14 +2023,19 @@ pub enum SysconfVar {
     /// Maximum length of argument to the exec functions including environment data.
     ARG_MAX = libc::_SC_ARG_MAX,
     /// Maximum number of functions that may be registered with `atexit`.
+    #[cfg(not(target_os = "redox"))]
     ATEXIT_MAX = libc::_SC_ATEXIT_MAX,
     /// Maximum obase values allowed by the bc utility.
+    #[cfg(not(target_os = "redox"))]
     BC_BASE_MAX = libc::_SC_BC_BASE_MAX,
     /// Maximum number of elements permitted in an array by the bc utility.
+    #[cfg(not(target_os = "redox"))]
     BC_DIM_MAX = libc::_SC_BC_DIM_MAX,
     /// Maximum scale value allowed by the bc utility.
+    #[cfg(not(target_os = "redox"))]
     BC_SCALE_MAX = libc::_SC_BC_SCALE_MAX,
     /// Maximum length of a string constant accepted by the bc utility.
+    #[cfg(not(target_os = "redox"))]
     BC_STRING_MAX = libc::_SC_BC_STRING_MAX,
     /// Maximum number of simultaneous processes per real user ID.
     CHILD_MAX = libc::_SC_CHILD_MAX,
@@ -2022,11 +2043,14 @@ pub enum SysconfVar {
     CLK_TCK = libc::_SC_CLK_TCK,
     /// Maximum number of weights that can be assigned to an entry of the
     /// LC_COLLATE order keyword in the locale definition file
+    #[cfg(not(target_os = "redox"))]
     COLL_WEIGHTS_MAX = libc::_SC_COLL_WEIGHTS_MAX,
     /// Maximum number of timer expiration overruns.
+    #[cfg(not(target_os = "redox"))]
     DELAYTIMER_MAX = libc::_SC_DELAYTIMER_MAX,
     /// Maximum number of expressions that can be nested within parentheses by
     /// the expr utility.
+    #[cfg(not(target_os = "redox"))]
     EXPR_NEST_MAX = libc::_SC_EXPR_NEST_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
@@ -2036,23 +2060,29 @@ pub enum SysconfVar {
     HOST_NAME_MAX = libc::_SC_HOST_NAME_MAX,
     /// Maximum number of iovec structures that one process has available for
     /// use with `readv` or `writev`.
+    #[cfg(not(target_os = "redox"))]
     IOV_MAX = libc::_SC_IOV_MAX,
     /// Unless otherwise noted, the maximum length, in bytes, of a utility's
     /// input line (either standard input or another file), when the utility is
     /// described as processing text files. The length includes room for the
     /// trailing <newline>.
+    #[cfg(not(target_os = "redox"))]
     LINE_MAX = libc::_SC_LINE_MAX,
     /// Maximum length of a login name.
     LOGIN_NAME_MAX = libc::_SC_LOGIN_NAME_MAX,
     /// Maximum number of simultaneous supplementary group IDs per process.
     NGROUPS_MAX = libc::_SC_NGROUPS_MAX,
     /// Initial size of `getgrgid_r` and `getgrnam_r` data buffers
+    #[cfg(not(target_os = "redox"))]
     GETGR_R_SIZE_MAX = libc::_SC_GETGR_R_SIZE_MAX,
     /// Initial size of `getpwuid_r` and `getpwnam_r` data buffers
+    #[cfg(not(target_os = "redox"))]
     GETPW_R_SIZE_MAX = libc::_SC_GETPW_R_SIZE_MAX,
     /// The maximum number of open message queue descriptors a process may hold.
+    #[cfg(not(target_os = "redox"))]
     MQ_OPEN_MAX = libc::_SC_MQ_OPEN_MAX,
     /// The maximum number of message priorities supported by the implementation.
+    #[cfg(not(target_os = "redox"))]
     MQ_PRIO_MAX = libc::_SC_MQ_PRIO_MAX,
     /// A value one greater than the maximum value that the system may assign to
     /// a newly-created file descriptor.
@@ -2067,6 +2097,7 @@ pub enum SysconfVar {
     /// The implementation supports barriers.
     _POSIX_BARRIERS = libc::_SC_BARRIERS,
     /// The implementation supports asynchronous input and output.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_ASYNCHRONOUS_IO = libc::_SC_ASYNCHRONOUS_IO,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
@@ -2079,24 +2110,32 @@ pub enum SysconfVar {
     /// The implementation supports the Process CPU-Time Clocks option.
     _POSIX_CPUTIME = libc::_SC_CPUTIME,
     /// The implementation supports the File Synchronization option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_FSYNC = libc::_SC_FSYNC,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
     /// The implementation supports the IPv6 option.
     _POSIX_IPV6 = libc::_SC_IPV6,
     /// The implementation supports job control.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_JOB_CONTROL = libc::_SC_JOB_CONTROL,
     /// The implementation supports memory mapped Files.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MAPPED_FILES = libc::_SC_MAPPED_FILES,
     /// The implementation supports the Process Memory Locking option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MEMLOCK = libc::_SC_MEMLOCK,
     /// The implementation supports the Range Memory Locking option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MEMLOCK_RANGE = libc::_SC_MEMLOCK_RANGE,
     /// The implementation supports memory protection.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MEMORY_PROTECTION = libc::_SC_MEMORY_PROTECTION,
     /// The implementation supports the Message Passing option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MESSAGE_PASSING = libc::_SC_MESSAGE_PASSING,
     /// The implementation supports the Monotonic Clock option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_MONOTONIC_CLOCK = libc::_SC_MONOTONIC_CLOCK,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
@@ -2104,6 +2143,7 @@ pub enum SysconfVar {
     /// The implementation supports the Prioritized Input and Output option.
     _POSIX_PRIORITIZED_IO = libc::_SC_PRIORITIZED_IO,
     /// The implementation supports the Process Scheduling option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_PRIORITY_SCHEDULING = libc::_SC_PRIORITY_SCHEDULING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
@@ -2125,10 +2165,13 @@ pub enum SysconfVar {
     /// The implementation supports the Regular Expression Handling option.
     _POSIX_REGEXP = libc::_SC_REGEXP,
     /// Each process has a saved set-user-ID and a saved set-group-ID.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_SAVED_IDS = libc::_SC_SAVED_IDS,
     /// The implementation supports semaphores.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_SEMAPHORES = libc::_SC_SEMAPHORES,
     /// The implementation supports the Shared Memory Objects option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_SHARED_MEMORY_OBJECTS = libc::_SC_SHARED_MEMORY_OBJECTS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
@@ -2153,10 +2196,13 @@ pub enum SysconfVar {
               target_os="openbsd"))]
     _POSIX_SS_REPL_MAX = libc::_SC_SS_REPL_MAX,
     /// The implementation supports the Synchronized Input and Output option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_SYNCHRONIZED_IO = libc::_SC_SYNCHRONIZED_IO,
     /// The implementation supports the Thread Stack Address Attribute option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_ATTR_STACKADDR = libc::_SC_THREAD_ATTR_STACKADDR,
     /// The implementation supports the Thread Stack Size Attribute option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_ATTR_STACKSIZE = libc::_SC_THREAD_ATTR_STACKSIZE,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd"))]
@@ -2164,10 +2210,13 @@ pub enum SysconfVar {
     _POSIX_THREAD_CPUTIME = libc::_SC_THREAD_CPUTIME,
     /// The implementation supports the Non-Robust Mutex Priority Inheritance
     /// option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_PRIO_INHERIT = libc::_SC_THREAD_PRIO_INHERIT,
     /// The implementation supports the Non-Robust Mutex Priority Protection option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_PRIO_PROTECT = libc::_SC_THREAD_PRIO_PROTECT,
     /// The implementation supports the Thread Execution Scheduling option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_PRIORITY_SCHEDULING = libc::_SC_THREAD_PRIORITY_SCHEDULING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
@@ -2182,18 +2231,21 @@ pub enum SysconfVar {
     /// The implementation supports the Robust Mutex Priority Protection option.
     _POSIX_THREAD_ROBUST_PRIO_PROTECT = libc::_SC_THREAD_ROBUST_PRIO_PROTECT,
     /// The implementation supports thread-safe functions.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREAD_SAFE_FUNCTIONS = libc::_SC_THREAD_SAFE_FUNCTIONS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
     /// The implementation supports the Thread Sporadic Server option.
     _POSIX_THREAD_SPORADIC_SERVER = libc::_SC_THREAD_SPORADIC_SERVER,
     /// The implementation supports threads.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_THREADS = libc::_SC_THREADS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
     /// The implementation supports timeouts.
     _POSIX_TIMEOUTS = libc::_SC_TIMEOUTS,
     /// The implementation supports timers.
+    #[cfg(not(target_os = "redox"))]
     _POSIX_TIMERS = libc::_SC_TIMERS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
@@ -2258,17 +2310,23 @@ pub enum SysconfVar {
     /// using at least 64 bits.
     _POSIX_V6_LPBIG_OFFBIG = libc::_SC_V6_LPBIG_OFFBIG,
     /// The implementation supports the C-Language Binding option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_C_BIND = libc::_SC_2_C_BIND,
     /// The implementation supports the C-Language Development Utilities option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_C_DEV = libc::_SC_2_C_DEV,
     /// The implementation supports the Terminal Characteristics option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_CHAR_TERM = libc::_SC_2_CHAR_TERM,
     /// The implementation supports the FORTRAN Development Utilities option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_FORT_DEV = libc::_SC_2_FORT_DEV,
     /// The implementation supports the FORTRAN Runtime Utilities option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_FORT_RUN = libc::_SC_2_FORT_RUN,
     /// The implementation supports the creation of locales by the localedef
     /// utility.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_LOCALEDEF = libc::_SC_2_LOCALEDEF,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
@@ -2302,26 +2360,34 @@ pub enum SysconfVar {
     /// The implementation supports the Track Batch Job Request option.
     _POSIX2_PBS_TRACK = libc::_SC_2_PBS_TRACK,
     /// The implementation supports the Software Development Utilities option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_SW_DEV = libc::_SC_2_SW_DEV,
     /// The implementation supports the User Portability Utilities option.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_UPE = libc::_SC_2_UPE,
     /// Integer value indicating version of the Shell and Utilities volume of
     /// POSIX.1 to which the implementation conforms.
+    #[cfg(not(target_os = "redox"))]
     _POSIX2_VERSION = libc::_SC_2_VERSION,
     /// The size of a system page in bytes.
     ///
     /// POSIX also defines an alias named `PAGESIZE`, but Rust does not allow two
     /// enum constants to have the same value, so nix omits `PAGESIZE`.
     PAGE_SIZE = libc::_SC_PAGE_SIZE,
+    #[cfg(not(target_os = "redox"))]
     PTHREAD_DESTRUCTOR_ITERATIONS = libc::_SC_THREAD_DESTRUCTOR_ITERATIONS,
+    #[cfg(not(target_os = "redox"))]
     PTHREAD_KEYS_MAX = libc::_SC_THREAD_KEYS_MAX,
+    #[cfg(not(target_os = "redox"))]
     PTHREAD_STACK_MIN = libc::_SC_THREAD_STACK_MIN,
+    #[cfg(not(target_os = "redox"))]
     PTHREAD_THREADS_MAX = libc::_SC_THREAD_THREADS_MAX,
     RE_DUP_MAX = libc::_SC_RE_DUP_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
     RTSIG_MAX = libc::_SC_RTSIG_MAX,
+    #[cfg(not(target_os = "redox"))]
     SEM_NSEMS_MAX = libc::_SC_SEM_NSEMS_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
@@ -2336,6 +2402,7 @@ pub enum SysconfVar {
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
     SYMLOOP_MAX = libc::_SC_SYMLOOP_MAX,
+    #[cfg(not(target_os = "redox"))]
     TIMER_MAX = libc::_SC_TIMER_MAX,
     TTY_NAME_MAX = libc::_SC_TTY_NAME_MAX,
     TZNAME_MAX = libc::_SC_TZNAME_MAX,
@@ -2366,6 +2433,7 @@ pub enum SysconfVar {
     _XOPEN_REALTIME_THREADS = libc::_SC_XOPEN_REALTIME_THREADS,
     /// The implementation supports the Issue 4, Version 2 Shared Memory Option
     /// Group.
+    #[cfg(not(target_os = "redox"))]
     _XOPEN_SHM = libc::_SC_XOPEN_SHM,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -10,9 +10,9 @@ use libc::{self, c_char, c_void, c_int, c_long, c_uint, size_t, pid_t, off_t,
            uid_t, gid_t, mode_t, PATH_MAX};
 use std::{fmt, mem, ptr};
 use std::convert::Infallible;
-use std::ffi::{CString, CStr, OsString};
+use std::ffi::{CStr, OsString};
 #[cfg(not(target_os = "redox"))]
-use std::ffi::OsStr;
+use std::ffi::{CString, OsStr};
 use std::os::unix::ffi::OsStringExt;
 #[cfg(not(target_os = "redox"))]
 use std::os::unix::ffi::OsStrExt;
@@ -525,7 +525,9 @@ pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 /// [mkfifoat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifoat.html).
 // mkfifoat is not implemented in OSX or android
 #[inline]
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "macos", target_os = "ios",
+    target_os = "android", target_os = "redox")))]
 pub fn mkfifoat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
         libc::mkfifoat(at_rawfd(dirfd), cstr.as_ptr(), mode.bits() as mode_t)
@@ -1205,6 +1207,7 @@ pub enum LinkatFlags {
 ///
 /// # References
 /// See also [linkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/linkat.html)
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support symlinks yet
 pub fn linkat<P: ?Sized + NixPath>(
     olddirfd: Option<RawFd>,
     oldpath: &P,
@@ -1327,7 +1330,6 @@ pub fn fsync(fd: RawFd) -> Result<()> {
 // TODO: exclude only Apple systems after https://github.com/rust-lang/libc/pull/211
 #[cfg(any(target_os = "linux",
           target_os = "android",
-          target_os = "redox",
           target_os = "emscripten"))]
 #[inline]
 pub fn fdatasync(fd: RawFd) -> Result<()> {
@@ -1662,6 +1664,7 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
 ///
 /// See also [pause(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pause.html).
 #[inline]
+#[cfg(not(target_os = "redox"))]
 pub fn pause() {
     unsafe { libc::pause() };
 }
@@ -2581,6 +2584,7 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
 /// fields are based on the user's locale, which could be non-UTF8, while other fields are
 /// guaranteed to conform to [`NAME_REGEX`](https://serverfault.com/a/73101/407341), which only
 /// contains ASCII.
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 #[derive(Debug, Clone, PartialEq)]
 pub struct User {
     /// Username
@@ -2609,6 +2613,7 @@ pub struct User {
     pub expire: libc::time_t
 }
 
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 impl From<&libc::passwd> for User {
     fn from(pw: &libc::passwd) -> User {
         unsafe {
@@ -2632,6 +2637,7 @@ impl From<&libc::passwd> for User {
     }
 }
 
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 impl User {
     fn from_anything<F>(f: F) -> Result<Option<Self>>
     where
@@ -2709,6 +2715,7 @@ impl User {
 }
 
 /// Representation of a Group, based on `libc::group`
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 #[derive(Debug, Clone, PartialEq)]
 pub struct Group {
     /// Group name
@@ -2719,6 +2726,7 @@ pub struct Group {
     pub mem: Vec<String>
 }
 
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 impl From<&libc::group> for Group {
     fn from(gr: &libc::group) -> Group {
         unsafe {
@@ -2731,6 +2739,7 @@ impl From<&libc::group> for Group {
     }
 }
 
+#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
 impl Group {
     unsafe fn members(mem: *mut *mut c_char) -> Vec<String> {
         let mut ret = Vec::new();

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -291,6 +291,7 @@ pub fn setsid() -> Result<Pid> {
 /// Obtain the process group ID of the process that is the session leader of the process specified
 /// by pid. If pid is zero, it specifies the calling process.
 #[inline]
+#[cfg(not(target_os = "redox"))]
 pub fn getsid(pid: Option<Pid>) -> Result<Pid> {
     let res = unsafe { libc::getsid(pid.unwrap_or(Pid(0)).into()) };
     Errno::result(res).map(Pid)
@@ -1149,6 +1150,7 @@ fn pipe2_setflags(fd1: RawFd, fd2: RawFd, flags: OFlag) -> Result<()> {
 ///
 /// See also
 /// [truncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html)
+#[cfg(not(target_os = "redox"))]
 pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
@@ -1263,6 +1265,7 @@ pub enum UnlinkatFlags {
 ///
 /// # References
 /// See also [unlinkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html)
+#[cfg(not(target_os = "redox"))]
 pub fn unlinkat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -1657,6 +1660,7 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
 ///
 /// See also [pause(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pause.html).
 #[inline]
+#[cfg(not(target_os = "redox"))]
 pub fn pause() {
     unsafe { libc::pause() };
 }

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -13,12 +13,17 @@ mod test_signal;
 mod test_aio;
 #[cfg(target_os = "linux")]
 mod test_signalfd;
+#[cfg(not(target_os = "redox"))]
 mod test_socket;
+#[cfg(not(target_os = "redox"))]
 mod test_sockopt;
+#[cfg(not(target_os = "redox"))]
 mod test_select;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_sysinfo;
+#[cfg(not(target_os = "redox"))]
 mod test_termios;
+#[cfg(not(target_os = "redox"))]
 mod test_ioctl;
 mod test_wait;
 mod test_uio;

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -1,13 +1,13 @@
 use nix::sys::pthread::*;
 
-#[cfg(target_env = "musl")]
+#[cfg(any(target_env = "musl", target_os = "redox"))]
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();
     assert!(tid != ::std::ptr::null_mut());
 }
 
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(any(target_env = "musl", target_os = "redox")))]
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -82,7 +82,16 @@ extern fn test_sigaction_handler(signal: libc::c_int) {
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 
-extern fn test_sigaction_action(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {
+#[cfg(not(target_os = "redox"))]
+extern fn test_sigaction_action(_: libc::c_int, _: *mut libc::siginfo_t, _: *mut libc::c_void) {}
+
+#[test]
+#[cfg(not(target_os = "redox"))]
+fn test_signal_sigaction() {
+    let _m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
+
+    let action_handler = SigHandler::SigAction(test_sigaction_action);
+    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Error::UnsupportedOperation);
 }
 
 #[test]
@@ -98,9 +107,6 @@ fn test_signal() {
     raise(Signal::SIGINT).unwrap();
     assert!(SIGNALED.load(Ordering::Relaxed));
     assert_eq!(unsafe { signal(Signal::SIGINT, SigHandler::SigDfl) }.unwrap(), handler);
-
-    let action_handler = SigHandler::SigAction(test_sigaction_action);
-    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Error::UnsupportedOperation);
 
     // Restore default signal handler
     unsafe { signal(Signal::SIGINT, SigHandler::SigDfl) }.unwrap();

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,4 +1,5 @@
 use libc;
+#[cfg(not(target_os = "redox"))]
 use nix::Error;
 use nix::sys::signal::*;
 use nix::unistd::*;

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -53,6 +53,7 @@ fn test_writev() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_readv() {
     let s:String = thread_rng().sample_iter(&Alphanumeric).take(128).collect();
     let to_write = s.as_bytes().to_vec();
@@ -97,6 +98,7 @@ fn test_readv() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_pwrite() {
     use std::io::Read;
 

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -6,7 +6,9 @@ use std::{cmp, iter};
 use std::fs::{OpenOptions};
 use std::os::unix::io::AsRawFd;
 
-use tempfile::{tempfile, tempdir};
+#[cfg(not(target_os = "redox"))]
+use tempfile::tempfile;
+use tempfile::tempdir;
 
 #[test]
 fn test_writev() {

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -6,6 +6,7 @@ use nix::sys::wait::*;
 use libc::_exit;
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_wait_signal() {
     let _ = ::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -134,6 +134,7 @@ cfg_if! {
 }
 
 mod sys;
+#[cfg(not(target_os = "redox"))]
 mod test_dir;
 mod test_fcntl;
 #[cfg(any(target_os = "android",
@@ -145,9 +146,12 @@ mod test_kmod;
           target_os = "linux",
           target_os = "netbsd"))]
 mod test_mq;
+#[cfg(not(target_os = "redox"))]
 mod test_net;
 mod test_nix_path;
+#[cfg(not(target_os = "redox"))]
 mod test_poll;
+#[cfg(not(target_os = "redox"))]
 mod test_pty;
 #[cfg(any(target_os = "android",
           target_os = "linux"))]

--- a/test/test.rs
+++ b/test/test.rs
@@ -33,7 +33,7 @@ cfg_if! {
                 }
             }
         }
-    } else {
+    } else if #[cfg(not(target_os = "redox"))] {
         macro_rules! require_capability {
             ($capname:ident) => {}
         }
@@ -95,7 +95,7 @@ cfg_if! {
                 }
             }
         }
-    } else {
+    } else if #[cfg(not(target_os = "redox"))] {
         macro_rules! skip_if_seccomp {
             ($name:expr) => {}
         }

--- a/test/test.rs
+++ b/test/test.rs
@@ -150,7 +150,6 @@ mod test_mq;
 #[cfg(not(target_os = "redox"))]
 mod test_net;
 mod test_nix_path;
-#[cfg(not(target_os = "redox"))]
 mod test_poll;
 #[cfg(not(target_os = "redox"))]
 mod test_pty;

--- a/test/test.rs
+++ b/test/test.rs
@@ -3,7 +3,7 @@ extern crate bytes;
 extern crate caps;
 #[macro_use]
 extern crate cfg_if;
-#[macro_use]
+#[cfg_attr(not(target_os = "redox"), macro_use)]
 extern crate nix;
 #[macro_use]
 extern crate lazy_static;
@@ -58,6 +58,7 @@ macro_rules! skip_if_jailed {
     }
 }
 
+#[cfg(not(target_os = "redox"))]
 macro_rules! skip_if_not_root {
     ($name:expr) => {
         use nix::unistd::Uid;

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,13 +1,22 @@
+#[cfg(not(target_os = "redox"))]
 use nix::Error;
+#[cfg(not(target_os = "redox"))]
 use nix::errno::*;
+#[cfg(not(target_os = "redox"))]
 use nix::fcntl::{open, OFlag, readlink};
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl::{openat, readlinkat, renameat};
+#[cfg(not(target_os = "redox"))]
 use nix::sys::stat::Mode;
+#[cfg(not(target_os = "redox"))]
 use nix::unistd::{close, read};
+#[cfg(not(target_os = "redox"))]
 use tempfile::{self, NamedTempFile};
+#[cfg(not(target_os = "redox"))]
 use std::fs::File;
+#[cfg(not(target_os = "redox"))]
 use std::io::prelude::*;
+#[cfg(not(target_os = "redox"))]
 use std::os::unix::fs;
 
 #[test]

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,6 +1,8 @@
 use nix::Error;
 use nix::errno::*;
-use nix::fcntl::{openat, open, OFlag, readlink, readlinkat, renameat};
+use nix::fcntl::{open, OFlag, readlink};
+#[cfg(not(target_os = "redox"))]
+use nix::fcntl::{openat, readlinkat, renameat};
 use nix::sys::stat::Mode;
 use nix::unistd::{close, read};
 use tempfile::{self, NamedTempFile};
@@ -9,6 +11,7 @@ use std::io::prelude::*;
 use std::os::unix::fs;
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_openat() {
     const CONTENTS: &[u8] = b"abcd";
     let mut tmp = NamedTempFile::new().unwrap();
@@ -31,6 +34,7 @@ fn test_openat() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_renameat() {
     let old_dir = tempfile::tempdir().unwrap();
     let old_dirfd = open(old_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
@@ -47,6 +51,7 @@ fn test_renameat() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_readlink() {
     let tempdir = tempfile::tempdir().unwrap();
     let src = tempdir.path().join("a");

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -9,7 +9,9 @@ use libc::{S_IFMT, S_IFLNK, mode_t};
 
 use nix::{fcntl, Error};
 use nix::errno::{Errno};
-use nix::sys::stat::{self, fchmod, fchmodat, futimens, stat, utimes, utimensat, mkdirat};
+use nix::sys::stat::{self, fchmod, futimens, stat, utimes};
+#[cfg(not(target_os = "redox"))]
+use nix::sys::stat::{fchmodat, utimensat, mkdirat};
 #[cfg(any(target_os = "linux",
           target_os = "haiku",
           target_os = "ios",
@@ -92,7 +94,7 @@ fn test_stat_and_fstat() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "netbsd")))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 fn test_fstatat() {
     let tempdir = tempfile::tempdir().unwrap();
     let filename = tempdir.path().join("foo.txt");
@@ -155,6 +157,7 @@ fn test_fchmod() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_fchmodat() {
     let _dr = ::DirRestore::new();
     let tempdir = tempfile::tempdir().unwrap();
@@ -243,6 +246,7 @@ fn test_futimens() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_utimensat() {
     let _dr = ::DirRestore::new();
     let tempdir = tempfile::tempdir().unwrap();
@@ -264,6 +268,7 @@ fn test_utimensat() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_mkdirat_success_path() {
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "example_subdir";
@@ -273,6 +278,7 @@ fn test_mkdirat_success_path() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_mkdirat_success_mode() {
     let expected_bits = stat::SFlag::S_IFDIR.bits() | stat::Mode::S_IRWXU.bits();
     let tempdir = tempfile::tempdir().unwrap();
@@ -285,6 +291,7 @@ fn test_mkdirat_success_mode() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_mkdirat_fail() {
     let tempdir = tempfile::tempdir().unwrap();
     let not_dir_filename= "example_not_dir";

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -78,7 +78,7 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
 }
 
 #[test]
-#[cfg(not(any(target_os = "netbsd")))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 fn test_stat_and_fstat() {
     use nix::sys::stat::fstat;
 
@@ -110,7 +110,7 @@ fn test_fstatat() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "netbsd")))]
+#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 fn test_stat_fstat_lstat() {
     use nix::sys::stat::{fstat, lstat};
 
@@ -199,6 +199,7 @@ fn assert_times_eq(exp_atime_sec: u64, exp_mtime_sec: u64, attr: &fs::Metadata) 
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_utimes() {
     let tempdir = tempfile::tempdir().unwrap();
     let fullpath = tempdir.path().join("file");
@@ -234,6 +235,7 @@ fn test_lutimes() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_futimens() {
     let tempdir = tempfile::tempdir().unwrap();
     let fullpath = tempdir.path().join("file");

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1,18 +1,25 @@
-use nix::fcntl::{self, fcntl, FcntlArg, FdFlag, open, OFlag, readlink};
+#[cfg(not(target_os = "redox"))]
+use nix::fcntl::{self, open, readlink};
+use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 use nix::unistd::*;
 use nix::unistd::ForkResult::*;
+#[cfg(not(target_os = "redox"))]
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::wait::*;
 use nix::sys::stat::{self, Mode, SFlag};
 use nix::errno::Errno;
+#[cfg(not(target_os = "redox"))]
 use nix::Error;
 use std::{env, iter};
+#[cfg(not(target_os = "redox"))]
 use std::ffi::CString;
-use std::fs::{self, DirBuilder, File};
+#[cfg(not(target_os = "redox"))]
+use std::fs::DirBuilder;
+use std::fs::{self, File};
 use std::io::Write;
 use std::os::unix::prelude::*;
 use tempfile::{self, tempfile};
-use libc::{self, _exit, off_t};
+use libc::{_exit, off_t};
 
 #[test]
 #[cfg(not(any(target_os = "netbsd")))]
@@ -233,6 +240,7 @@ fn test_initgroups() {
     setgroups(&old_groups).unwrap();
 }
 
+#[cfg(not(target_os = "redox"))]
 macro_rules! execve_test_factory(
     ($test_name:ident, $syscall:ident, $exe: expr $(, $pathname:expr, $flags:expr)*) => (
     #[test]
@@ -466,7 +474,7 @@ cfg_if!{
                 skip_if_jailed!("test_acct");
             }
         }
-    } else {
+    } else if #[cfg(not(target_os = "redox"))] {
         macro_rules! require_acct{
             () => {
                 skip_if_not_root!("test_acct");
@@ -592,9 +600,11 @@ fn test_ftruncate() {
 }
 
 // Used in `test_alarm`.
+#[cfg(not(target_os = "redox"))]
 static mut ALARM_CALLED: bool = false;
 
 // Used in `test_alarm`.
+#[cfg(not(target_os = "redox"))]
 pub extern fn alarm_signal_handler(raw_signal: libc::c_int) {
     assert_eq!(raw_signal, libc::SIGALRM, "unexpected signal: {}", raw_signal);
     unsafe { ALARM_CALLED = true };

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -81,6 +81,7 @@ fn test_mkstemp_directory() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_mkfifo() {
     let tempdir = tempfile::tempdir().unwrap();
     let mkfifo_fifo = tempdir.path().join("mkfifo_fifo");
@@ -93,6 +94,7 @@ fn test_mkfifo() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_mkfifo_directory() {
     // mkfifo should fail if a directory is given
     assert!(mkfifo(&env::temp_dir(), Mode::S_IRUSR).is_err());
@@ -599,6 +601,7 @@ pub extern fn alarm_signal_handler(raw_signal: libc::c_int) {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_alarm() {
     let _m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
 
@@ -628,6 +631,7 @@ fn test_alarm() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_canceling_alarm() {
     let _m = ::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -108,7 +108,9 @@ fn test_mkfifo_directory() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "macos", target_os = "ios",
+    target_os = "android", target_os = "redox")))]
 fn test_mkfifoat_none() {
     let _m = ::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -123,7 +125,9 @@ fn test_mkfifoat_none() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "macos", target_os = "ios",
+    target_os = "android", target_os = "redox")))]
 fn test_mkfifoat() {
     let tempdir = tempfile::tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
@@ -137,7 +141,9 @@ fn test_mkfifoat() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "macos", target_os = "ios",
+    target_os = "android", target_os = "redox")))]
 fn test_mkfifoat_directory_none() {
     let _m = ::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -146,7 +152,9 @@ fn test_mkfifoat_directory_none() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+#[cfg(not(any(
+    target_os = "macos", target_os = "ios",
+    target_os = "android", target_os = "redox")))]
 fn test_mkfifoat_directory() {
     // mkfifoat should fail if a directory is given
     let tempdir = tempfile::tempdir().unwrap();
@@ -680,6 +688,7 @@ fn test_symlinkat() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_linkat_file() {
     let tempdir = tempfile::tempdir().unwrap();
     let oldfilename = "foo.txt";
@@ -700,6 +709,7 @@ fn test_linkat_file() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_linkat_olddirfd_none() {
     let _dr = ::DirRestore::new();
 
@@ -724,6 +734,7 @@ fn test_linkat_olddirfd_none() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_linkat_newdirfd_none() {
     let _dr = ::DirRestore::new();
 
@@ -748,7 +759,7 @@ fn test_linkat_newdirfd_none() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 fn test_linkat_no_follow_symlink() {
     let _m = ::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -785,6 +796,7 @@ fn test_linkat_no_follow_symlink() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_linkat_follow_symlink() {
     let _m = ::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -157,6 +157,7 @@ fn test_getpid() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_getsid() {
     let none_sid: ::libc::pid_t = getsid(None).unwrap().into();
     let pid_sid: ::libc::pid_t = getsid(Some(getpid())).unwrap().into();
@@ -177,7 +178,7 @@ mod linux_android {
 
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
     skip_if_not_root!("test_setgroups");
@@ -200,7 +201,7 @@ fn test_setgroups() {
 
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
-#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
 fn test_initgroups() {
     // Skip this test when not run as root as `initgroups()` and `setgroups()`
     // require root.
@@ -391,6 +392,7 @@ fn test_chown() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_fchownat() {
     let _dr = ::DirRestore::new();
     // Testing for anything other than our own UID/GID is hard.
@@ -472,6 +474,7 @@ cfg_if!{
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_acct() {
     use tempfile::NamedTempFile;
     use std::process::Command;
@@ -550,6 +553,7 @@ fn test_pipe2() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_truncate() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path().join("file");
@@ -634,6 +638,7 @@ fn test_canceling_alarm() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_symlinkat() {
     let _m = ::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -801,6 +806,7 @@ fn test_linkat_follow_symlink() {
 }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_unlinkat_dir_noremovedir() {
     let tempdir = tempfile::tempdir().unwrap();
     let dirname = "foo_dir";
@@ -818,6 +824,7 @@ fn test_unlinkat_dir_noremovedir() {
  }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_unlinkat_dir_removedir() {
     let tempdir = tempfile::tempdir().unwrap();
     let dirname = "foo_dir";
@@ -835,6 +842,7 @@ fn test_unlinkat_dir_removedir() {
  }
 
 #[test]
+#[cfg(not(target_os = "redox"))]
 fn test_unlinkat_file() {
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "foo.txt";


### PR DESCRIPTION
Some things are not implemented yet in redox, so a lot of annotations were added to remove functions when compiling for redox. Those functions will hopefully be added in time, but for now it's better to have partial support than none.

Blocked by https://github.com/rust-lang/libc/pull/1438