### PR TITLE
Add support for UTIME_NOW and UTIME_OMIT to TimeSpec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.60", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", features = [ "extra_traits" ] }
 bitflags = "1.0"
 cfg-if = "0.1.2"
 void = "1.0.2"

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -143,6 +143,25 @@ impl TimeValLike for TimeSpec {
     }
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    target_env = "uclibc"
+))]
+impl TimeSpec {
+    /// Makes a new `TimeSpec` with the special UTIME_NOW constant
+    pub fn utime_now() -> TimeSpec {
+        TimeSpec(timespec { tv_sec: 0, tv_nsec: libc::UTIME_NOW })
+    }
+
+    /// Makes a new `TimeSpec` with the special UTIME_OMIT constant
+    pub fn utime_omit() -> TimeSpec {
+        TimeSpec(timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT })
+    }
+}
+
 impl TimeSpec {
     fn nanos_mod_sec(&self) -> c_long {
         if self.tv_sec() < 0 && self.tv_nsec() > 0 {
@@ -483,6 +502,19 @@ mod test {
         let b = TimeSpec::seconds(-1) + TimeSpec::nanoseconds(-123);
 
         assert_eq!(a, -b);
+    }
+
+    #[test]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_env = "uclibc"
+    ))]
+    pub fn test_timespec_constants() {
+        assert_eq!(TimeSpec::utime_now().tv_nsec(), libc::UTIME_NOW);
+        assert_eq!(TimeSpec::utime_omit().tv_nsec(), libc::UTIME_OMIT);
     }
 
     #[test]

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -144,11 +144,21 @@ impl TimeValLike for TimeSpec {
 }
 
 #[cfg(any(
-    target_os = "linux",
+    target_env = "uclibc",
+    target_env = "wasi",
     target_os = "android",
     target_os = "emscripten",
+    target_os = "freebsd",
     target_os = "fuchsia",
-    target_env = "uclibc"
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "solaris",
+    target_os = "wasi",
 ))]
 impl TimeSpec {
     /// Makes a new `TimeSpec` with the special UTIME_NOW constant
@@ -506,11 +516,21 @@ mod test {
 
     #[test]
     #[cfg(any(
-        target_os = "linux",
+        target_env = "uclibc",
+        target_env = "wasi",
         target_os = "android",
         target_os = "emscripten",
+        target_os = "freebsd",
         target_os = "fuchsia",
-        target_env = "uclibc"
+        target_os = "haiku",
+        target_os = "illumos",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris",
+        target_os = "wasi",
     ))]
     pub fn test_timespec_constants() {
         assert_eq!(TimeSpec::utime_now().tv_nsec(), libc::UTIME_NOW);


### PR DESCRIPTION
From the [documentation](https://linux.die.net/man/3/futimens):

> If the tv_nsec field of one of the timespec structures has the special value UTIME_NOW, then the corresponding file timestamp is set to the current time. If the tv_nsec field of one of the timespec structures has the special value UTIME_OMIT, then the corresponding file timestamp is left unchanged. In both of these cases, the value of the corresponding tv_sec field is ignored. 

Given the current API, there is no way to set tv_nsec to UTIME_NOW, since TimeSpec::nanoseconds mangles the value.