### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [Unreleased] - ReleaseDate
+### Added
+### Changed
+### Fixed
+### Removed
+
+## [0.15.0] - 10 August 2019
 ### Added
 - Added `MSG_WAITALL` to `MsgFlags` in `sys::socket`.
   ([#1079](https://github.com/nix-rust/nix/pull/1079))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
-version     = "0.14.1"
+version     = "0.15.0"
 authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", features = [ "extra_traits" ] }
+libc = { version = "0.2.60", features = [ "extra_traits" ] }
 bitflags = "1.0"
 cfg-if = "0.1.2"
 void = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To use `nix`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nix = "0.14.1"
+nix = "0.15.0"
 ```
 
 Then, add this to your crate root:


### PR DESCRIPTION
It's important to release fairly soon, because rustc 1.38.0 will deprecate std::mem::uninitialized.