### PR TITLE
posix_fallocate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added `posix_fallocate`.
+  ([#1105](https://github.com/nix-rust/nix/pull/1105))
+
 - Implemented `Default` for `FdSet`
   ([#1107](https://github.com/nix-rust/nix/pull/1107))
 
@@ -779,5 +782,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#335](https://github.com/nix-rust/nix/pull/335))
 
 ## [0.5.0] 2016-03-01
-- Added `posix_fallocate`.
-  ([#1105](https://github.com/nix-rust/nix/pull/1105))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -779,3 +779,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#335](https://github.com/nix-rust/nix/pull/335))
 
 ## [0.5.0] 2016-03-01
+- Added `posix_fallocate`.
+  ([#1105](https://github.com/nix-rust/nix/pull/1105))

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -505,3 +505,24 @@ mod posix_fadvise {
         Errno::result(res)
     }
 }
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    any(target_os = "wasi", target_env = "wasi"),
+    target_os = "freebsd"
+))]
+pub fn posix_fallocate(
+    fd: RawFd,
+    offset: libc::off_t,
+    len: libc::off_t
+) -> Result<()> {
+    let res = unsafe { libc::posix_fallocate(fd, offset, len) };
+    match Errno::result(res) {
+        Err(err) => Err(err),
+        Ok(0) => Ok(()),
+        Ok(errno) => Err(crate::Error::Sys(Errno::from_i32(errno))),
+    }
+}

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -256,7 +256,7 @@ mod test_posix_fallocate {
             Ok(_) => {
                 let mut data = [1u8; LEN];
                 assert_eq!(tmp.read(&mut data).expect("read failure"), LEN);
-                assert_eq!(&data as &[u8], &[0u8; LEN] as &[u8]);
+                assert_eq!(&data[..], &[0u8; LEN][..]);
             }
             Err(nix::Error::Sys(Errno::EINVAL)) => {
                 // POSIX requires posix_fallocate to return EINVAL both for

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -231,3 +231,68 @@ mod test_posix_fadvise {
         assert_eq!(errno, Errno::ESPIPE as i32);
     }
 }
+
+#[cfg(any(target_os = "linux",
+          target_os = "android",
+          target_os = "emscripten",
+          target_os = "fuchsia",
+          any(target_os = "wasi", target_env = "wasi"),
+          target_os = "freebsd"))]
+mod test_posix_fallocate {
+
+    use tempfile::NamedTempFile;
+    use std::{io::Read, os::unix::io::{RawFd, AsRawFd}};
+    use nix::errno::Errno;
+    use nix::fcntl::*;
+    use nix::unistd::pipe;
+
+    #[test]
+    fn success() {
+        const LEN: usize = 100;
+        let mut tmp = NamedTempFile::new().unwrap();
+        let fd = tmp.as_raw_fd();
+        let res = posix_fallocate(fd, 0, LEN as libc::off_t);
+        match res {
+            Ok(_) => {
+                let mut data = [1u8; LEN];
+                assert_eq!(tmp.read(&mut data).expect("read failure"), LEN);
+                assert_eq!(&data as &[u8], &[0u8; LEN] as &[u8]);
+            }
+            Err(nix::Error::Sys(Errno::EINVAL)) => {
+                // `posix_fallocate` returned EINVAL.
+                // According to POSIX.1-2008, its implementation shall
+                // return `EINVAL` if `len` is 0, `offset` is negative or
+                // the filesystem does not support this operation.
+                // According to POSIX.1-2001, its implementation shall
+                // return `EINVAL` if `len` is negative, `offset` is
+                // negative or the filesystem does not support this
+                // operation; and may return `EINVAL` if `len` is 0.
+                // However, this test is using `offset=0` and non-zero
+                // `len`.
+                // Suppose that the host platform is POSIX-compliant,
+                // then this can only be due to an underlying filesystem on
+                // `/tmp` that does not support `posix_fallocate`.
+                // This test is passing by giving it the benefit of doubt.
+            }
+            _ => res.unwrap(),
+        }
+    }
+
+    #[test]
+    fn errno() {
+        let (rd, _wr) = pipe().unwrap();
+        let err = posix_fallocate(rd as RawFd, 0, 100).unwrap_err();
+        use nix::Error::Sys;
+        match err {
+            Sys(Errno::EINVAL)
+                | Sys(Errno::ENODEV)
+                | Sys(Errno::ESPIPE)
+                | Sys(Errno::EBADF) => (),
+            errno =>
+                panic!(
+                    "errno does not match posix_fallocate spec, errno={}",
+                    errno,
+                ),
+        }
+    }
+}


### PR DESCRIPTION
This PR add [`posix_fallocate`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_fallocate.html), which is available on
- Linux
- FreeBSD
- Android
- Emscripten
- Fuchsia
- WASI

Here is a question: for some reason, `posix_fallocate` returns `EBADF` instead of `EPIPE` if a FIFO file descriptor is passed in on Linux 4.19.64. In the test `EBADF` is used for now, but I would like to know if such behaviour is expected.