### PR TITLE
Replace most instances of mem::uninitialized with mem::MaybeUninit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,12 @@ matrix:
       rust: 1.36.0
 
     # Make sure stable is always working too
+    # FIXME: Travis's "stable" images are stuck on 1.35.0.  Until that's fixed,
+    # explicitly request 1.37.0, which is as of this writing the latest stable
+    # release.
+    # https://travis-ci.community/t/stable-rust-channel-outdated/4213
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: stable
+      rust: 1.37.0
 
     # Test that we can build with the lowest version of all dependencies.
     # "cargo test" doesn't work because some of our dev-dependencies, like

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -76,12 +76,11 @@ to parameters of functions by [enumerations][enum].
 
 Whenever we need to use a [libc][libc] function to properly initialize a
 variable and said function allows us to use uninitialized memory, we use
-[`std::mem::uninitialized`][std_uninitialized] (or [`core::mem::uninitialized`][core_uninitialized])
-when defining the variable. This allows us to avoid the overhead incurred by
-zeroing or otherwise initializing the variable.
+[`std::mem::MaybeUninit`][std_MaybeUninit] when defining the variable. This
+allows us to avoid the overhead incurred by zeroing or otherwise initializing
+the variable.
 
 [bitflags]: https://crates.io/crates/bitflags/
-[core_uninitialized]: https://doc.rust-lang.org/core/mem/fn.uninitialized.html
 [enum]: https://doc.rust-lang.org/reference.html#enumerations
 [libc]: https://crates.io/crates/libc/
-[std_uninitialized]: https://doc.rust-lang.org/std/mem/fn.uninitialized.html
+[std_MaybeUninit]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -102,16 +102,18 @@ impl<'d> Iterator for Iter<'d> {
             // for the NUL byte. It doesn't look like the std library does this; it just uses
             // fixed-sized buffers (and libc's dirent seems to be sized so this is appropriate).
             // Probably fine here too then.
-            let mut ent: Entry = Entry(::std::mem::uninitialized());
+            let mut ent = std::mem::MaybeUninit::<dirent>::uninit();
             let mut result = ptr::null_mut();
-            if let Err(e) = Errno::result(readdir_r((self.0).0.as_ptr(), &mut ent.0, &mut result)) {
+            if let Err(e) = Errno::result(
+                readdir_r((self.0).0.as_ptr(), ent.as_mut_ptr(), &mut result))
+            {
                 return Some(Err(e));
             }
             if result.is_null() {
                 return None;
             }
-            assert_eq!(result, &mut ent.0 as *mut dirent);
-            Some(Ok(ent))
+            assert_eq!(result, ent.as_mut_ptr());
+            Some(Ok(Entry(ent.assume_init())))
         }
     }
 }
@@ -126,6 +128,7 @@ impl<'d> Drop for Iter<'d> {
 ///
 /// Note that unlike the std version, this may represent the `.` or `..` entries.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
 pub struct Entry(dirent);
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -125,13 +125,15 @@ impl Iterator for InterfaceAddressIterator {
 /// }
 /// ```
 pub fn getifaddrs() -> Result<InterfaceAddressIterator> {
-    let mut addrs: *mut libc::ifaddrs = unsafe { mem::uninitialized() };
-    Errno::result(unsafe { libc::getifaddrs(&mut addrs) }).map(|_| {
-        InterfaceAddressIterator {
-            base: addrs,
-            next: addrs,
-        }
-    })
+    let mut addrs = mem::MaybeUninit::<*mut libc::ifaddrs>::uninit();
+    unsafe {
+        Errno::result(libc::getifaddrs(addrs.as_mut_ptr())).map(|_| {
+            InterfaceAddressIterator {
+                base: addrs.assume_init(),
+                next: addrs.assume_init(),
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -39,13 +39,17 @@ impl MqAttr {
                mq_maxmsg: c_long,
                mq_msgsize: c_long,
                mq_curmsgs: c_long)
-               -> MqAttr {
-        let mut attr = unsafe { mem::uninitialized::<libc::mq_attr>() };
-        attr.mq_flags = mq_flags;
-        attr.mq_maxmsg = mq_maxmsg;
-        attr.mq_msgsize = mq_msgsize;
-        attr.mq_curmsgs = mq_curmsgs;
-        MqAttr { mq_attr: attr }
+               -> MqAttr
+    {
+        let mut attr = mem::MaybeUninit::<libc::mq_attr>::uninit();
+        unsafe {
+            let p = attr.as_mut_ptr();
+            (*p).mq_flags = mq_flags;
+            (*p).mq_maxmsg = mq_maxmsg;
+            (*p).mq_msgsize = mq_msgsize;
+            (*p).mq_curmsgs = mq_curmsgs;
+            MqAttr { mq_attr: attr.assume_init() }
+        }
     }
 
     pub fn flags(&self) -> c_long {
@@ -123,9 +127,9 @@ pub fn mq_send(mqdes: mqd_t, message: &[u8], msq_prio: u32) -> Result<()> {
 ///
 /// See also [`mq_getattr(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_getattr.html)
 pub fn mq_getattr(mqd: mqd_t) -> Result<MqAttr> {
-    let mut attr = unsafe { mem::uninitialized::<libc::mq_attr>() };
-    let res = unsafe { libc::mq_getattr(mqd, &mut attr) };
-    Errno::result(res).map(|_| MqAttr { mq_attr: attr })
+    let mut attr = mem::MaybeUninit::<libc::mq_attr>::uninit();
+    let res = unsafe { libc::mq_getattr(mqd, attr.as_mut_ptr()) };
+    Errno::result(res).map(|_| unsafe{MqAttr { mq_attr: attr.assume_init() }})
 }
 
 /// Set the attributes of the message queue. Only `O_NONBLOCK` can be set, everything else will be ignored
@@ -134,9 +138,11 @@ pub fn mq_getattr(mqd: mqd_t) -> Result<MqAttr> {
 ///
 /// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_setattr.html)
 pub fn mq_setattr(mqd: mqd_t, newattr: &MqAttr) -> Result<MqAttr> {
-    let mut attr = unsafe { mem::uninitialized::<libc::mq_attr>() };
-    let res = unsafe { libc::mq_setattr(mqd, &newattr.mq_attr as *const libc::mq_attr, &mut attr) };
-    Errno::result(res).map(|_| MqAttr { mq_attr: attr })
+    let mut attr = mem::MaybeUninit::<libc::mq_attr>::uninit();
+    let res = unsafe {
+        libc::mq_setattr(mqd, &newattr.mq_attr as *const libc::mq_attr, attr.as_mut_ptr())
+    };
+    Errno::result(res).map(|_| unsafe{ MqAttr { mq_attr: attr.assume_init() }})
 }
 
 /// Convenience function.

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -9,16 +9,17 @@ use sys::time::{TimeSpec, TimeVal};
 
 pub use libc::FD_SETSIZE;
 
-// FIXME: Change to repr(transparent) once it's stable
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FdSet(libc::fd_set);
 
 impl FdSet {
     pub fn new() -> FdSet {
-        let mut fdset = unsafe { mem::uninitialized() };
-        unsafe { libc::FD_ZERO(&mut fdset) };
-        FdSet(fdset)
+        let mut fdset = mem::MaybeUninit::uninit();
+        unsafe {
+            libc::FD_ZERO(fdset.as_mut_ptr());
+            FdSet(fdset.assume_init())
+        }
     }
 
     pub fn insert(&mut self, fd: RawFd) {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -335,17 +335,17 @@ pub struct SigSet {
 
 impl SigSet {
     pub fn all() -> SigSet {
-        let mut sigset: libc::sigset_t = unsafe { mem::uninitialized() };
-        let _ = unsafe { libc::sigfillset(&mut sigset as *mut libc::sigset_t) };
+        let mut sigset = mem::MaybeUninit::uninit();
+        let _ = unsafe { libc::sigfillset(sigset.as_mut_ptr()) };
 
-        SigSet { sigset }
+        unsafe{ SigSet { sigset: sigset.assume_init() } }
     }
 
     pub fn empty() -> SigSet {
-        let mut sigset: libc::sigset_t = unsafe { mem::uninitialized() };
-        let _ = unsafe { libc::sigemptyset(&mut sigset as *mut libc::sigset_t) };
+        let mut sigset = mem::MaybeUninit::uninit();
+        let _ = unsafe { libc::sigemptyset(sigset.as_mut_ptr()) };
 
-        SigSet { sigset }
+        unsafe{ SigSet { sigset: sigset.assume_init() } }
     }
 
     pub fn add(&mut self, signal: Signal) {
@@ -380,9 +380,9 @@ impl SigSet {
 
     /// Gets the currently blocked (masked) set of signals for the calling thread.
     pub fn thread_get_mask() -> Result<SigSet> {
-        let mut oldmask: SigSet = unsafe { mem::uninitialized() };
-        pthread_sigmask(SigmaskHow::SIG_SETMASK, None, Some(&mut oldmask))?;
-        Ok(oldmask)
+        let mut oldmask = mem::MaybeUninit::uninit();
+        do_pthread_sigmask(SigmaskHow::SIG_SETMASK, None, Some(oldmask.as_mut_ptr()))?;
+        Ok(unsafe{ SigSet{sigset: oldmask.assume_init()}})
     }
 
     /// Sets the set of signals as the signal mask for the calling thread.
@@ -402,18 +402,20 @@ impl SigSet {
 
     /// Sets the set of signals as the signal mask, and returns the old mask.
     pub fn thread_swap_mask(&self, how: SigmaskHow) -> Result<SigSet> {
-        let mut oldmask: SigSet = unsafe { mem::uninitialized() };
-        pthread_sigmask(how, Some(self), Some(&mut oldmask))?;
-        Ok(oldmask)
+        let mut oldmask = mem::MaybeUninit::uninit();
+        do_pthread_sigmask(how, Some(self), Some(oldmask.as_mut_ptr()))?;
+        Ok(unsafe{ SigSet{sigset: oldmask.assume_init()}})
     }
 
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
     pub fn wait(&self) -> Result<Signal> {
-        let mut signum: libc::c_int = unsafe { mem::uninitialized() };
-        let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, &mut signum) };
+        let mut signum = mem::MaybeUninit::uninit();
+        let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, signum.as_mut_ptr()) };
 
-        Errno::result(res).map(|_| Signal::from_c_int(signum).unwrap())
+        Errno::result(res).map(|_| unsafe {
+            Signal::from_c_int(signum.assume_init()).unwrap()
+        })
     }
 }
 
@@ -451,20 +453,23 @@ impl SigAction {
     /// is the `SigAction` variant). `mask` specifies other signals to block during execution of
     /// the signal-catching function.
     pub fn new(handler: SigHandler, flags: SaFlags, mask: SigSet) -> SigAction {
-        let mut s = unsafe { mem::uninitialized::<libc::sigaction>() };
-        s.sa_sigaction = match handler {
-            SigHandler::SigDfl => libc::SIG_DFL,
-            SigHandler::SigIgn => libc::SIG_IGN,
-            SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
-            SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
-        };
-        s.sa_flags = match handler {
-            SigHandler::SigAction(_) => (flags | SaFlags::SA_SIGINFO).bits(),
-            _ => (flags - SaFlags::SA_SIGINFO).bits(),
-        };
-        s.sa_mask = mask.sigset;
+        let mut s = mem::MaybeUninit::<libc::sigaction>::uninit();
+        unsafe {
+            let p = s.as_mut_ptr();
+            (*p).sa_sigaction = match handler {
+                SigHandler::SigDfl => libc::SIG_DFL,
+                SigHandler::SigIgn => libc::SIG_IGN,
+                SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
+                SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
+            };
+            (*p).sa_flags = match handler {
+                SigHandler::SigAction(_) => (flags | SaFlags::SA_SIGINFO).bits(),
+                _ => (flags - SaFlags::SA_SIGINFO).bits(),
+            };
+            (*p).sa_mask = mask.sigset;
 
-        SigAction { sigaction: s }
+            SigAction { sigaction: s.assume_init() }
+        }
     }
 
     /// Returns the flags set on the action.
@@ -501,12 +506,13 @@ impl SigAction {
 /// the body of the signal-catching function. Be certain to only make syscalls that are explicitly
 /// marked safe for signal handlers and only share global data using atomics.
 pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigAction> {
-    let mut oldact = mem::uninitialized::<libc::sigaction>();
+    let mut oldact = mem::MaybeUninit::<libc::sigaction>::uninit();
 
-    let res =
-        libc::sigaction(signal as libc::c_int, &sigaction.sigaction as *const libc::sigaction, &mut oldact as *mut libc::sigaction);
+    let res = libc::sigaction(signal as libc::c_int,
+                              &sigaction.sigaction as *const libc::sigaction,
+                              oldact.as_mut_ptr());
 
-    Errno::result(res).map(|_| SigAction { sigaction: oldact })
+    Errno::result(res).map(|_| SigAction { sigaction: oldact.assume_init() })
 }
 
 /// Signal management (see [signal(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))
@@ -582,6 +588,25 @@ pub unsafe fn signal(signal: Signal, handler: SigHandler) -> Result<SigHandler> 
     })
 }
 
+fn do_pthread_sigmask(how: SigmaskHow,
+                       set: Option<&SigSet>,
+                       oldset: Option<*mut libc::sigset_t>) -> Result<()> {
+    if set.is_none() && oldset.is_none() {
+        return Ok(())
+    }
+
+    let res = unsafe {
+        // if set or oldset is None, pass in null pointers instead
+        libc::pthread_sigmask(how as libc::c_int,
+                             set.map_or_else(ptr::null::<libc::sigset_t>,
+                                             |s| &s.sigset as *const libc::sigset_t),
+                             oldset.unwrap_or(ptr::null_mut())
+                             )
+    };
+
+    Errno::result(res).map(drop)
+}
+
 /// Manages the signal mask (set of blocked signals) for the calling thread.
 ///
 /// If the `set` parameter is `Some(..)`, then the signal mask will be updated with the signal set.
@@ -599,21 +624,9 @@ pub unsafe fn signal(signal: Signal, handler: SigHandler) -> Result<SigHandler> 
 /// or [`sigprocmask`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html) man pages.
 pub fn pthread_sigmask(how: SigmaskHow,
                        set: Option<&SigSet>,
-                       oldset: Option<&mut SigSet>) -> Result<()> {
-    if set.is_none() && oldset.is_none() {
-        return Ok(())
-    }
-
-    let res = unsafe {
-        // if set or oldset is None, pass in null pointers instead
-        libc::pthread_sigmask(how as libc::c_int,
-                             set.map_or_else(ptr::null::<libc::sigset_t>,
-                                             |s| &s.sigset as *const libc::sigset_t),
-                             oldset.map_or_else(ptr::null_mut::<libc::sigset_t>,
-                                                |os| &mut os.sigset as *mut libc::sigset_t))
-    };
-
-    Errno::result(res).map(drop)
+                       oldset: Option<&mut SigSet>) -> Result<()>
+{
+    do_pthread_sigmask(how, set, oldset.map(|os| &mut os.sigset as *mut _ ))
 }
 
 /// Examine and change blocked signals.

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -475,9 +475,7 @@ impl Ipv6Addr {
     #[allow(clippy::many_single_char_names)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {
-        let mut in6_addr_var: libc::in6_addr = unsafe{mem::uninitialized()};
-        in6_addr_var.s6_addr = to_u8_array!(a,b,c,d,e,f,g,h);
-        Ipv6Addr(in6_addr_var)
+        Ipv6Addr(libc::in6_addr{s6_addr: to_u8_array!(a,b,c,d,e,f,g,h)})
     }
 
     pub fn from_std(std: &net::Ipv6Addr) -> Ipv6Addr {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -78,49 +78,49 @@ pub fn umask(mode: Mode) -> Mode {
 }
 
 pub fn stat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
-    let mut dst = unsafe { mem::uninitialized() };
+    let mut dst = mem::MaybeUninit::uninit();
     let res = path.with_nix_path(|cstr| {
         unsafe {
-            libc::stat(cstr.as_ptr(), &mut dst as *mut FileStat)
+            libc::stat(cstr.as_ptr(), dst.as_mut_ptr())
         }
     })?;
 
     Errno::result(res)?;
 
-    Ok(dst)
+    Ok(unsafe{dst.assume_init()})
 }
 
 pub fn lstat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
-    let mut dst = unsafe { mem::uninitialized() };
+    let mut dst = mem::MaybeUninit::uninit();
     let res = path.with_nix_path(|cstr| {
         unsafe {
-            libc::lstat(cstr.as_ptr(), &mut dst as *mut FileStat)
+            libc::lstat(cstr.as_ptr(), dst.as_mut_ptr())
         }
     })?;
 
     Errno::result(res)?;
 
-    Ok(dst)
+    Ok(unsafe{dst.assume_init()})
 }
 
 pub fn fstat(fd: RawFd) -> Result<FileStat> {
-    let mut dst = unsafe { mem::uninitialized() };
-    let res = unsafe { libc::fstat(fd, &mut dst as *mut FileStat) };
+    let mut dst = mem::MaybeUninit::uninit();
+    let res = unsafe { libc::fstat(fd, dst.as_mut_ptr()) };
 
     Errno::result(res)?;
 
-    Ok(dst)
+    Ok(unsafe{dst.assume_init()})
 }
 
 pub fn fstatat<P: ?Sized + NixPath>(dirfd: RawFd, pathname: &P, f: AtFlags) -> Result<FileStat> {
-    let mut dst = unsafe { mem::uninitialized() };
+    let mut dst = mem::MaybeUninit::uninit();
     let res = pathname.with_nix_path(|cstr| {
-        unsafe { libc::fstatat(dirfd, cstr.as_ptr(), &mut dst as *mut FileStat, f.bits() as libc::c_int) }
+        unsafe { libc::fstatat(dirfd, cstr.as_ptr(), dst.as_mut_ptr(), f.bits() as libc::c_int) }
     })?;
 
     Errno::result(res)?;
 
-    Ok(dst)
+    Ok(unsafe{dst.assume_init()})
 }
 
 /// Change the file permission bits of the file specified by a file descriptor.

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -55,8 +55,7 @@ libc_bitflags!(
 /// Wrapper around the POSIX `statvfs` struct
 ///
 /// For more information see the [`statvfs(3)` man pages](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html).
-// FIXME: Replace with repr(transparent)
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Statvfs(libc::statvfs);
 
@@ -124,12 +123,12 @@ impl Statvfs {
 pub fn statvfs<P: ?Sized + NixPath>(path: &P) -> Result<Statvfs> {
     unsafe {
         Errno::clear();
-        let mut stat: Statvfs = mem::uninitialized();
+        let mut stat = mem::MaybeUninit::<libc::statvfs>::uninit();
         let res = path.with_nix_path(|path|
-            libc::statvfs(path.as_ptr(), &mut stat.0)
+            libc::statvfs(path.as_ptr(), stat.as_mut_ptr())
         )?;
 
-        Errno::result(res).map(|_| stat)
+        Errno::result(res).map(|_| Statvfs(stat.assume_init()))
     }
 }
 
@@ -137,8 +136,9 @@ pub fn statvfs<P: ?Sized + NixPath>(path: &P) -> Result<Statvfs> {
 pub fn fstatvfs<T: AsRawFd>(fd: &T) -> Result<Statvfs> {
     unsafe {
         Errno::clear();
-        let mut stat: Statvfs = mem::uninitialized();
-        Errno::result(libc::fstatvfs(fd.as_raw_fd(), &mut stat.0)).map(|_| stat)
+        let mut stat = mem::MaybeUninit::<libc::statvfs>::uninit();
+        Errno::result(libc::fstatvfs(fd.as_raw_fd(), stat.as_mut_ptr()))
+            .map(|_| Statvfs(stat.assume_init()))
     }
 }
 

--- a/src/sys/sysinfo.rs
+++ b/src/sys/sysinfo.rs
@@ -7,6 +7,7 @@ use errno::Errno;
 
 /// System info structure returned by `sysinfo`.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
 pub struct SysInfo(libc::sysinfo);
 
 impl SysInfo {
@@ -66,7 +67,7 @@ impl SysInfo {
 ///
 /// [See `sysinfo(2)`](http://man7.org/linux/man-pages/man2/sysinfo.2.html).
 pub fn sysinfo() -> Result<SysInfo> {
-    let mut info: libc::sysinfo = unsafe { mem::uninitialized() };
-    let res = unsafe { libc::sysinfo(&mut info) };
-    Errno::result(res).map(|_| SysInfo(info))
+    let mut info = mem::MaybeUninit::uninit();
+    let res = unsafe { libc::sysinfo(info.as_mut_ptr()) };
+    Errno::result(res).map(|_| unsafe{ SysInfo(info.assume_init()) })
 }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -1045,13 +1045,13 @@ pub fn cfmakesane(termios: &mut Termios) {
 /// this structure *will not* reconfigure the port, instead the modifications should be done to
 /// the `Termios` structure and then the port should be reconfigured using `tcsetattr()`.
 pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
-    let mut termios: libc::termios = unsafe { mem::uninitialized() };
+    let mut termios = mem::MaybeUninit::uninit();
 
-    let res = unsafe { libc::tcgetattr(fd, &mut termios) };
+    let res = unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) };
 
     Errno::result(res)?;
 
-    Ok(termios.into())
+    unsafe { Ok(termios.assume_init().into()) }
 }
 
 /// Set the configuration for a terminal (see

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -3,8 +3,8 @@ use libc::{self, c_char};
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;
 
-#[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
 pub struct UtsName(libc::utsname);
 
 impl UtsName {
@@ -31,9 +31,9 @@ impl UtsName {
 
 pub fn uname() -> UtsName {
     unsafe {
-        let mut ret: UtsName = mem::uninitialized();
-        libc::uname(&mut ret.0);
-        ret
+        let mut ret = mem::MaybeUninit::uninit();
+        libc::uname(ret.as_mut_ptr());
+        UtsName(ret.assume_init())
     }
 }
 

--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -14,11 +14,11 @@ pub struct UContext {
 impl UContext {
     #[cfg(not(target_env = "musl"))]
     pub fn get() -> Result<UContext> {
-        let mut context: libc::ucontext_t = unsafe { mem::uninitialized() };
-        let res = unsafe {
-            libc::getcontext(&mut context as *mut libc::ucontext_t)
-        };
-        Errno::result(res).map(|_| UContext { context: context })
+        let mut context = mem::MaybeUninit::<libc::ucontext_t>::uninit();
+        let res = unsafe { libc::getcontext(context.as_mut_ptr()) };
+        Errno::result(res).map(|_| unsafe {
+            UContext { context: context.assume_init()}
+        })
     }
 
     #[cfg(not(target_env = "musl"))]

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -133,6 +133,10 @@ fn test_fsync_error() {
 
 #[test]
 #[cfg_attr(all(target_env = "musl", target_arch = "x86_64"), ignore)]
+// On Travis, aio_suspend hits an assertion within glibc.  This is either a bug
+// in Travis's version of glibc or Linux.  Either way, we must skip the test.
+// https://github.com/nix-rust/nix/issues/1099
+#[cfg_attr(target_os = "linux", ignore)]
 fn test_aio_suspend() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEFG";

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -46,7 +46,7 @@ fn test_ptrace_getsiginfo() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_setsiginfo() {
-    let siginfo = unsafe { mem::uninitialized() };
+    let siginfo = unsafe { mem::zeroed() };
     if let Err(Error::UnsupportedOperation) = ptrace::setsiginfo(getpid(), &siginfo) {
         panic!("ptrace_setsiginfo returns Error::UnsupportedOperation!");
     }


### PR DESCRIPTION
Only two instances remain:

* For the deprecated sys::socket::CmsgSpace::new.  We should probably
  just remove that method.

* For sys::termios::Termios::default_uninit.  This will require some
  more thought.