### PR TITLE
Fix length of abstract socket address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1107](https://github.com/nix-rust/nix/pull/1107))
 
 ### Fixed
+- Fix length of abstract socket addresses
+  ([#1120](https://github.com/nix-rust/nix/pull/1120))
+
 ### Removed
 
 ## [0.15.0] - 10 August 2019

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -562,7 +562,7 @@ impl UnixAddr {
                                      ret.sun_path.as_mut_ptr().offset(1) as *mut u8,
                                      path.len());
 
-            Ok(UnixAddr(ret, ret.sun_path.len()))
+            Ok(UnixAddr(ret, path.len() + 1))
         }
     }
 
@@ -1300,7 +1300,7 @@ mod tests {
         let addr = UnixAddr::new_abstract(name.as_bytes()).unwrap();
 
         let sun_path1 = addr.sun_path();
-        let sun_path2 = [0u8, 110, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let sun_path2 = [0u8, 110, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116];
         assert_eq!(sun_path1.len(), sun_path2.len());
         for i in 0..sun_path1.len() {
             assert_eq!(sun_path1[i], sun_path2[i]);

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -106,7 +106,7 @@ pub fn test_addr_equality_abstract() {
     assert_eq!(addr1, addr2);
     assert_eq!(calculate_hash(&addr1), calculate_hash(&addr2));
 
-    addr2.0.sun_path[18] = 127;
+    addr2.0.sun_path[17] = 127;
     assert_ne!(addr1, addr2);
     assert_ne!(calculate_hash(&addr1), calculate_hash(&addr2));
 }
@@ -117,16 +117,13 @@ pub fn test_addr_equality_abstract() {
 pub fn test_abstract_uds_addr() {
     let empty = String::new();
     let addr = UnixAddr::new_abstract(empty.as_bytes()).unwrap();
-    let sun_path = [0u8; 107];
+    let sun_path: [u8; 0] = [];
     assert_eq!(addr.as_abstract(), Some(&sun_path[..]));
 
     let name = String::from("nix\0abstract\0test");
     let addr = UnixAddr::new_abstract(name.as_bytes()).unwrap();
     let sun_path = [
-        110u8, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        110u8, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0, 116, 101, 115, 116
     ];
     assert_eq!(addr.as_abstract(), Some(&sun_path[..]));
     assert_eq!(addr.path(), None);


### PR DESCRIPTION
NULL bytes have no special significance in an abstrace address, and the
length of the address is solely decided by the length member. If the
length is set to sun_path.len(), all the NULL bytes will be considered
part of the address.

Tests are updated accordingly.

Closes #1119

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>