### PR TITLE
Where relevant, replace equality checks in assert! with assert_eq!

### DIFF
--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -329,23 +329,17 @@ pub fn ev_set(ev: &mut KEvent,
 fn test_struct_kevent() {
     let udata : intptr_t = 12345;
 
-    let expected = libc::kevent{ident: 0xdead_beef,
-                                filter: libc::EVFILT_READ,
-                                flags: libc::EV_ONESHOT | libc::EV_ADD,
-                                fflags: libc::NOTE_CHILD | libc::NOTE_EXIT,
-                                data: 0x1337,
-                                udata: udata as type_of_udata};
     let actual = KEvent::new(0xdead_beef,
                              EventFilter::EVFILT_READ,
                              EventFlag::EV_ONESHOT | EventFlag::EV_ADD,
                              FilterFlag::NOTE_CHILD | FilterFlag::NOTE_EXIT,
                              0x1337,
                              udata);
-    assert!(expected.ident == actual.ident());
-    assert!(expected.filter == actual.filter() as type_of_event_filter);
-    assert!(expected.flags == actual.flags().bits());
-    assert!(expected.fflags == actual.fflags().bits());
-    assert!(expected.data == actual.data() as type_of_data);
-    assert!(expected.udata == actual.udata() as type_of_udata);
-    assert!(mem::size_of::<libc::kevent>() == mem::size_of::<KEvent>());
+    assert_eq!(0xdead_beef, actual.ident());
+    assert_eq!(libc::EVFILT_READ, actual.filter() as type_of_event_filter);
+    assert_eq!(libc::EV_ONESHOT | libc::EV_ADD, actual.flags().bits());
+    assert_eq!(libc::NOTE_CHILD | libc::NOTE_EXIT, actual.fflags().bits());
+    assert_eq!(0x1337, actual.data() as type_of_data);
+    assert_eq!(udata as type_of_udata, actual.udata() as type_of_udata);
+    assert_eq!(mem::size_of::<libc::kevent>(), mem::size_of::<KEvent>());
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1245,12 +1245,12 @@ pub unsafe fn sockaddr_storage_to_addr(
 
     match c_int::from(addr.ss_family) {
         libc::AF_INET => {
-            assert!(len as usize == mem::size_of::<sockaddr_in>());
+            assert_eq!(len as usize, mem::size_of::<sockaddr_in>());
             let ret = *(addr as *const _ as *const sockaddr_in);
             Ok(SockAddr::Inet(InetAddr::V4(ret)))
         }
         libc::AF_INET6 => {
-            assert!(len as usize == mem::size_of::<sockaddr_in6>());
+            assert_eq!(len as usize, mem::size_of::<sockaddr_in6>());
             Ok(SockAddr::Inet(InetAddr::V6(*(addr as *const _ as *const sockaddr_in6))))
         }
         libc::AF_UNIX => {

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -411,7 +411,7 @@ unsafe impl<T> Get<T> for GetStruct<T> {
     }
 
     unsafe fn unwrap(self) -> T {
-        assert!(self.len as usize == mem::size_of::<T>(), "invalid getsockopt implementation");
+        assert_eq!(self.len as usize, mem::size_of::<T>(), "invalid getsockopt implementation");
         self.val
     }
 }
@@ -458,7 +458,7 @@ unsafe impl Get<bool> for GetBool {
     }
 
     unsafe fn unwrap(self) -> bool {
-        assert!(self.len as usize == mem::size_of::<c_int>(), "invalid getsockopt implementation");
+        assert_eq!(self.len as usize, mem::size_of::<c_int>(), "invalid getsockopt implementation");
         self.val != 0
     }
 }
@@ -505,7 +505,7 @@ unsafe impl Get<u8> for GetU8 {
     }
 
     unsafe fn unwrap(self) -> u8 {
-        assert!(self.len as usize == mem::size_of::<u8>(), "invalid getsockopt implementation");
+        assert_eq!(self.len as usize, mem::size_of::<u8>(), "invalid getsockopt implementation");
         self.val as u8
     }
 }
@@ -552,7 +552,7 @@ unsafe impl Get<usize> for GetUsize {
     }
 
     unsafe fn unwrap(self) -> usize {
-        assert!(self.len as usize == mem::size_of::<c_int>(), "invalid getsockopt implementation");
+        assert_eq!(self.len as usize, mem::size_of::<c_int>(), "invalid getsockopt implementation");
         self.val as usize
     }
 }
@@ -644,7 +644,7 @@ mod test {
 
         let (a, b) = socketpair(AddressFamily::Unix, SockType::Stream, None, SockFlag::empty()).unwrap();
         let a_type = getsockopt(a, super::SockType).unwrap();
-        assert!(a_type == SockType::Stream);
+        assert_eq!(a_type, SockType::Stream);
         close(a).unwrap();
         close(b).unwrap();
     }
@@ -656,7 +656,7 @@ mod test {
 
         let s = socket(AddressFamily::Inet, SockType::Datagram, SockFlag::empty(), None).unwrap();
         let s_type = getsockopt(s, super::SockType).unwrap();
-        assert!(s_type == SockType::Datagram);
+        assert_eq!(s_type, SockType::Datagram);
         close(s).unwrap();
     }
 

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -80,7 +80,7 @@
 //! # let mut t = unsafe { Termios::default_uninit() };
 //! # cfsetspeed(&mut t, BaudRate::B9600);
 //! let speed = cfgetispeed(&t);
-//! assert!(speed == cfgetospeed(&t));
+//! assert_eq!(speed, cfgetospeed(&t));
 //! cfsetispeed(&mut t, speed);
 //! # }
 //! ```
@@ -99,8 +99,8 @@
 //! # fn main() {
 //! # let mut t = unsafe { Termios::default_uninit() };
 //! # cfsetspeed(&mut t, BaudRate::B9600);
-//! assert!(cfgetispeed(&t) == BaudRate::B9600);
-//! assert!(cfgetospeed(&t) == BaudRate::B9600);
+//! assert_eq!(cfgetispeed(&t), BaudRate::B9600);
+//! assert_eq!(cfgetospeed(&t), BaudRate::B9600);
 //! # }
 //! ```
 //!
@@ -118,8 +118,8 @@
 //! # fn main() {
 //! # let mut t = unsafe { Termios::default_uninit() };
 //! # cfsetspeed(&mut t, 9600u32);
-//! assert!(cfgetispeed(&t) == 9600u32);
-//! assert!(cfgetospeed(&t) == 9600u32);
+//! assert_eq!(cfgetispeed(&t), 9600u32);
+//! assert_eq!(cfgetospeed(&t), 9600u32);
 //! # }
 //! ```
 //!
@@ -137,8 +137,8 @@
 //! # fn main() {
 //! # let mut t = unsafe { Termios::default_uninit() };
 //! # cfsetspeed(&mut t, 9600u32);
-//! assert!(cfgetispeed(&t) == BaudRate::B9600.into());
-//! assert!(u32::from(BaudRate::B9600) == 9600u32);
+//! assert_eq!(cfgetispeed(&t), BaudRate::B9600.into());
+//! assert_eq!(u32::from(BaudRate::B9600), 9600u32);
 //! # }
 //! ```
 //!

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -172,8 +172,8 @@ fn test_aio_suspend() {
         }
     }
 
-    assert!(wcb.aio_return().unwrap() as usize == WBUF.len());
-    assert!(rcb.aio_return().unwrap() as usize == rlen);
+    assert_eq!(wcb.aio_return().unwrap() as usize, WBUF.len());
+    assert_eq!(rcb.aio_return().unwrap() as usize, rlen);
 }
 
 // Test a simple aio operation with no completion notification.  We must poll
@@ -196,11 +196,11 @@ fn test_read() {
         aiocb.read().unwrap();
 
         let err = poll_aio(&mut aiocb);
-        assert!(err == Ok(()));
-        assert!(aiocb.aio_return().unwrap() as usize == EXPECT.len());
+        assert_eq!(err, Ok(()));
+        assert_eq!(aiocb.aio_return().unwrap() as usize, EXPECT.len());
     }
 
-    assert!(EXPECT == rbuf.deref().deref());
+    assert_eq!(EXPECT, rbuf.deref().deref());
 }
 
 /// `AioCb::read` should not modify the `AioCb` object if `libc::aio_read`
@@ -242,11 +242,11 @@ fn test_read_into_mut_slice() {
         aiocb.read().unwrap();
 
         let err = poll_aio(&mut aiocb);
-        assert!(err == Ok(()));
-        assert!(aiocb.aio_return().unwrap() as usize == EXPECT.len());
+        assert_eq!(err, Ok(()));
+        assert_eq!(aiocb.aio_return().unwrap() as usize, EXPECT.len());
     }
 
-    assert!(rbuf == EXPECT);
+    assert_eq!(rbuf, EXPECT);
 }
 
 // Tests from_ptr
@@ -272,11 +272,11 @@ fn test_read_into_pointer() {
         aiocb.read().unwrap();
 
         let err = poll_aio(&mut aiocb);
-        assert!(err == Ok(()));
-        assert!(aiocb.aio_return().unwrap() as usize == EXPECT.len());
+        assert_eq!(err, Ok(()));
+        assert_eq!(aiocb.aio_return().unwrap() as usize, EXPECT.len());
     }
 
-    assert!(rbuf == EXPECT);
+    assert_eq!(rbuf, EXPECT);
 }
 
 // Test reading into an immutable buffer.  It should fail
@@ -318,13 +318,13 @@ fn test_write() {
     aiocb.write().unwrap();
 
     let err = poll_aio(&mut aiocb);
-    assert!(err == Ok(()));
-    assert!(aiocb.aio_return().unwrap() as usize == wbuf.len());
+    assert_eq!(err, Ok(()));
+    assert_eq!(aiocb.aio_return().unwrap() as usize, wbuf.len());
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf, EXPECT);
 }
 
 // Tests `AioCb::from_boxed_slice` with `Bytes`
@@ -348,13 +348,13 @@ fn test_write_bytes() {
     aiocb.write().unwrap();
 
     let err = poll_aio(&mut aiocb);
-    assert!(err == Ok(()));
-    assert!(aiocb.aio_return().unwrap() as usize == expected_len);
+    assert_eq!(err, Ok(()));
+    assert_eq!(aiocb.aio_return().unwrap() as usize, expected_len);
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf, EXPECT);
 }
 
 // Tests `AioCb::from_boxed_mut_slice` with `BytesMut`
@@ -406,13 +406,13 @@ fn test_write_from_pointer() {
     aiocb.write().unwrap();
 
     let err = poll_aio(&mut aiocb);
-    assert!(err == Ok(()));
-    assert!(aiocb.aio_return().unwrap() as usize == wbuf.len());
+    assert_eq!(err, Ok(()));
+    assert_eq!(aiocb.aio_return().unwrap() as usize, wbuf.len());
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf, EXPECT);
 }
 
 /// `AioCb::write` should not modify the `AioCb` object if `libc::aio_write`
@@ -473,11 +473,11 @@ fn test_write_sigev_signal() {
         thread::sleep(time::Duration::from_millis(10));
     }
 
-    assert!(aiocb.aio_return().unwrap() as usize == WBUF.len());
+    assert_eq!(aiocb.aio_return().unwrap() as usize, WBUF.len());
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf, EXPECT);
 }
 
 // Test LioCb::listio with LIO_WAIT, so all AIO ops should be complete by the
@@ -516,15 +516,15 @@ fn test_liocb_listio_wait() {
         let err = liocb.listio(LioMode::LIO_WAIT, SigevNotify::SigevNone);
         err.expect("lio_listio");
 
-        assert!(liocb.aio_return(0).unwrap() as usize == WBUF.len());
-        assert!(liocb.aio_return(1).unwrap() as usize == rlen);
+        assert_eq!(liocb.aio_return(0).unwrap() as usize, WBUF.len());
+        assert_eq!(liocb.aio_return(1).unwrap() as usize, rlen);
     }
-    assert!(rbuf.deref().deref() == b"3456");
+    assert_eq!(rbuf.deref().deref(), b"3456");
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf2).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf2 == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf2, EXPECT);
 }
 
 // Test LioCb::listio with LIO_NOWAIT and no SigEvent, so we must use some other
@@ -565,15 +565,15 @@ fn test_liocb_listio_nowait() {
 
         poll_aio(&mut liocb.aiocbs[0]).unwrap();
         poll_aio(&mut liocb.aiocbs[1]).unwrap();
-        assert!(liocb.aiocbs[0].aio_return().unwrap() as usize == WBUF.len());
-        assert!(liocb.aiocbs[1].aio_return().unwrap() as usize == rlen);
+        assert_eq!(liocb.aiocbs[0].aio_return().unwrap() as usize, WBUF.len());
+        assert_eq!(liocb.aiocbs[1].aio_return().unwrap() as usize, rlen);
     }
-    assert!(rbuf.deref().deref() == b"3456");
+    assert_eq!(rbuf.deref().deref(), b"3456");
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf2).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf2 == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf2, EXPECT);
 }
 
 // Test LioCb::listio with LIO_NOWAIT and a SigEvent to indicate when all
@@ -624,15 +624,15 @@ fn test_liocb_listio_signal() {
             thread::sleep(time::Duration::from_millis(10));
         }
 
-        assert!(liocb.aiocbs[0].aio_return().unwrap() as usize == WBUF.len());
-        assert!(liocb.aiocbs[1].aio_return().unwrap() as usize == rlen);
+        assert_eq!(liocb.aiocbs[0].aio_return().unwrap() as usize, WBUF.len());
+        assert_eq!(liocb.aiocbs[1].aio_return().unwrap() as usize, rlen);
     }
-    assert!(rbuf.deref().deref() == b"3456");
+    assert_eq!(rbuf.deref().deref(), b"3456");
 
     f.seek(SeekFrom::Start(0)).unwrap();
     let len = f.read_to_end(&mut rbuf2).unwrap();
-    assert!(len == EXPECT.len());
-    assert!(rbuf2 == EXPECT);
+    assert_eq!(len, EXPECT.len());
+    assert_eq!(rbuf2, EXPECT);
 }
 
 // Try to use LioCb::listio to read into an immutable buffer.  It should fail

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -31,7 +31,7 @@ fn test_mq_send_and_receive() {
     let mut buf = [0u8; 32];
     let mut prio = 0u32;
     let len = mq_receive(mqd1, &mut buf, &mut prio).unwrap();
-    assert!(prio == 1);
+    assert_eq!(prio, 1);
 
     mq_close(mqd1).unwrap();
     mq_close(mqd0).unwrap();
@@ -116,10 +116,10 @@ fn test_mq_set_nonblocking() {
     let mqd = r.unwrap();
     mq_set_nonblock(mqd).unwrap();
     let new_attr = mq_getattr(mqd);
-    assert!(new_attr.unwrap().flags() == MQ_OFlag::O_NONBLOCK.bits() as c_long);
+    assert_eq!(new_attr.unwrap().flags(), MQ_OFlag::O_NONBLOCK.bits() as c_long);
     mq_remove_nonblock(mqd).unwrap();
     let new_attr = mq_getattr(mqd);
-    assert!(new_attr.unwrap().flags() == 0);
+    assert_eq!(new_attr.unwrap().flags(), 0);
     mq_close(mqd).unwrap();
 }
 
@@ -141,12 +141,12 @@ fn test_mq_unlink() {
     let mqd = r.unwrap();
 
     let res_unlink = mq_unlink(mq_name_opened);
-    assert!(res_unlink == Ok(()) );
+    assert_eq!(res_unlink, Ok(()) );
 
     let res_unlink_not_opened = mq_unlink(mq_name_not_opened);
-    assert!(res_unlink_not_opened == Err(Sys(ENOENT)) );
+    assert_eq!(res_unlink_not_opened, Err(Sys(ENOENT)) );
 
     mq_close(mqd).unwrap();
     let res_unlink_after_close = mq_unlink(mq_name_opened);
-    assert!(res_unlink_after_close == Err(Sys(ENOENT)) );
+    assert_eq!(res_unlink_after_close, Err(Sys(ENOENT)) );
 }

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -54,7 +54,7 @@ fn test_ptsname_copy() {
     // Get the name of the slave
     let slave_name1 = unsafe { ptsname(&master_fd) }.unwrap();
     let slave_name2 = unsafe { ptsname(&master_fd) }.unwrap();
-    assert!(slave_name1 == slave_name2);
+    assert_eq!(slave_name1, slave_name2);
     // Also make sure that the string was actually copied and they point to different parts of
     // memory.
     assert!(slave_name1.as_ptr() != slave_name2.as_ptr());
@@ -71,7 +71,7 @@ fn test_ptsname_r_copy() {
     // Get the name of the slave
     let slave_name1 = ptsname_r(&master_fd).unwrap();
     let slave_name2 = ptsname_r(&master_fd).unwrap();
-    assert!(slave_name1 == slave_name2);
+    assert_eq!(slave_name1, slave_name2);
     assert!(slave_name1.as_ptr() != slave_name2.as_ptr());
 }
 

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -46,9 +46,9 @@ fn assert_stat_results(stat_result: Result<FileStat>) {
     assert!(stats.st_dev > 0);      // must be positive integer, exact number machine dependent
     assert!(stats.st_ino > 0);      // inode is positive integer, exact number machine dependent
     assert!(stats.st_mode > 0);     // must be positive integer
-    assert!(stats.st_nlink == 1);   // there links created, must be 1
+    assert_eq!(stats.st_nlink, 1);   // there links created, must be 1
     assert!(valid_uid_gid(stats));  // must be positive integers
-    assert!(stats.st_size == 0);    // size is 0 because we did not write anything to the file
+    assert_eq!(stats.st_size, 0);    // size is 0 because we did not write anything to the file
     assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
     assert!(stats.st_blocks <= 16);  // Up to 16 blocks can be allocated for a blank file
 }
@@ -63,8 +63,8 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
     // st_mode is c_uint (u32 on Android) while S_IFMT is mode_t
     // (u16 on Android), and that will be a compile error.
     // On other platforms they are the same (either both are u16 or u32).
-    assert!((stats.st_mode as usize) & (S_IFMT as usize) == S_IFLNK as usize); // should be a link
-    assert!(stats.st_nlink == 1);   // there links created, must be 1
+    assert_eq!((stats.st_mode as usize) & (S_IFMT as usize), S_IFLNK as usize); // should be a link
+    assert_eq!(stats.st_nlink, 1);   // there links created, must be 1
     assert!(valid_uid_gid(stats));  // must be positive integers
     assert!(stats.st_size > 0);    // size is > 0 because it points to another file
     assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -29,7 +29,7 @@ fn test_fork_and_waitpid() {
             let wait_status = waitpid(child, None);
             match wait_status {
                 // assert that waitpid returned correct status and the pid is the one of the child
-                Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child),
+                Ok(WaitStatus::Exited(pid_t, _)) =>  assert_eq!(pid_t, child),
 
                 // panic, must never happen
                 s @ Ok(_) => panic!("Child exited {:?}, should never happen", s),
@@ -111,7 +111,7 @@ fn test_getsid() {
     let none_sid: ::libc::pid_t = getsid(None).unwrap().into();
     let pid_sid: ::libc::pid_t = getsid(Some(getpid())).unwrap().into();
     assert!(none_sid > 0);
-    assert!(none_sid == pid_sid);
+    assert_eq!(none_sid, pid_sid);
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
`assert_eq!` gives more debug info when the test fails by default than `assert!`. This should help make debugging easier.