### PR TITLE
Relax some dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ cc = "1"
 [dev-dependencies]
 bytes = "0.4.8"
 lazy_static = "1.2"
-rand = ">= 0.6, < 0.7"
-tempfile = ">= 3.0.5, < 3.0.9"
+rand = "0.6"
+tempfile = "3.0.5"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.3.1"


### PR DESCRIPTION
The minimum supported Rust version was bumped in #1108 so these restrictions are no longer necessary.