### PR TITLE
implement mknodat

### DIFF
--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -52,6 +52,27 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
     Errno::result(res).map(drop)
 }
 
+// mknodat not implemented in OSX
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+pub fn mknodat<P: ?Sized + NixPath>(
+    dirfd: Option<RawFd>,
+    path: &P,
+    kind: SFlag,
+    perm: Mode,
+    dev: dev_t,
+) -> Result<()> {
+    let res = path.with_nix_path(|cstr| unsafe {
+        libc::mknodat(
+            at_rawfd(dirfd),
+            cstr.as_ptr(),
+            kind.bits | perm.bits() as mode_t,
+            dev,
+        )
+    })?;
+
+    Errno::result(res).map(drop)
+}
+
 #[cfg(target_os = "linux")]
 pub fn major(dev: dev_t) -> u64 {
     ((dev >> 32) & 0xffff_f000) |


### PR DESCRIPTION
This adds the `mknodat` function, which is part of POSIX [https://pubs.opengroup.org/onlinepubs/9699919799/functions/mknod.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mknod.html)

`mknodat` seems not implemented in OSX, so I add conditional compilation attributes to exclude `ios` and `macos`

I don't find any test code about `mknod`, So tests of `mknodat` are not added either