### PR TITLE
Implement faccessat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `NixPath::is_empty`.
   ([#1107](https://github.com/nix-rust/nix/pull/1107))
 
+- Added `faccessat`
+  ([#1134](https://github.com/nix-rust/nix/pull/1134))
+
 ### Changed
 - `Signal::from_c_int` has been replaced by `Signal::try_from`
   ([#1113](https://github.com/nix-rust/nix/pull/1113))

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2404,3 +2404,21 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
     })?;
     Errno::result(res).map(drop)
 }
+
+/// Checks the file named by `path` for accessibility according to the flags given by `mode`
+/// 
+/// If `dirfd` has a value, then `path` is relative to directory associated with the file descriptor.
+/// 
+/// If `dirfd` is `None`, then `path` is relative to the current working directory.
+/// 
+/// # References
+/// 
+/// [faccessat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html)
+pub fn faccessat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: AccessFlags, flag: AtFlags) -> Result<()> {
+    let res = path.with_nix_path(|cstr| {
+        unsafe {
+            libc::faccessat(at_rawfd(dirfd), cstr.as_ptr(), mode.bits(), flag.bits())
+        }
+    })?;
+    Errno::result(res).map(drop)
+}

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -718,16 +718,13 @@ fn test_faccessat_none_file_exists() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path().join("does_exist.txt");
     let _file = File::create(path.clone()).unwrap();
-    assert_eq!(
-        faccessat(
-            None,
-            &path,
-            AccessFlags::R_OK | AccessFlags::W_OK,
-            AtFlags::empty()
-        )
-        .is_ok(),
-        true
-    );
+    assert!(faccessat(
+        None,
+        &path,
+        AccessFlags::R_OK | AccessFlags::W_OK,
+        AtFlags::empty()
+    )
+    .is_ok());
 }
 
 #[test]
@@ -738,14 +735,11 @@ fn test_faccessat_file_exists() {
     let exist_file = "does_exist.txt";
     let path = tempdir.path().join(exist_file);
     let _file = File::create(path.clone()).unwrap();
-    assert_eq!(
-        faccessat(
-            Some(dirfd),
-            &path,
-            AccessFlags::R_OK | AccessFlags::W_OK,
-            AtFlags::empty()
-        )
-        .is_ok(),
-        true
-    );
+    assert!(faccessat(
+        Some(dirfd),
+        &path,
+        AccessFlags::R_OK | AccessFlags::W_OK,
+        AtFlags::empty()
+    )
+    .is_ok());
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -675,3 +675,73 @@ fn test_access_file_exists() {
     let _file = File::create(path.clone()).unwrap();
     assert!(access(&path, AccessFlags::R_OK | AccessFlags::W_OK).is_ok());
 }
+
+#[test]
+fn test_faccessat_none_not_existing() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let dir = tempdir.path().join("does_not_exist.txt");
+    assert_eq!(
+        faccessat(None, &dir, AccessFlags::F_OK, AtFlags::empty())
+            .err()
+            .unwrap()
+            .as_errno()
+            .unwrap(),
+        Errno::ENOENT
+    );
+}
+
+#[test]
+fn test_faccessat_not_existing() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
+    let not_exist_file = "does_not_exist.txt";
+    assert_eq!(
+        faccessat(
+            Some(dirfd),
+            not_exist_file,
+            AccessFlags::F_OK,
+            AtFlags::empty()
+        )
+        .err()
+        .unwrap()
+        .as_errno()
+        .unwrap(),
+        Errno::ENOENT
+    );
+}
+
+#[test]
+fn test_faccessat_none_file_exists() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("does_exist.txt");
+    let _file = File::create(path.clone()).unwrap();
+    assert_eq!(
+        faccessat(
+            None,
+            &path,
+            AccessFlags::R_OK | AccessFlags::W_OK,
+            AtFlags::empty()
+        )
+        .is_ok(),
+        true
+    );
+}
+
+#[test]
+fn test_faccessat_file_exists() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
+    let exist_file = "does_exist.txt";
+    let path = tempdir.path().join(exist_file);
+    let _file = File::create(path.clone()).unwrap();
+    assert_eq!(
+        faccessat(
+            Some(dirfd),
+            &path,
+            AccessFlags::R_OK | AccessFlags::W_OK,
+            AtFlags::empty()
+        )
+        .is_ok(),
+        true
+    );
+}

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -678,6 +678,7 @@ fn test_access_file_exists() {
 
 #[test]
 fn test_faccessat_none_not_existing() {
+    use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
     let dir = tempdir.path().join("does_not_exist.txt");
     assert_eq!(
@@ -692,6 +693,7 @@ fn test_faccessat_none_not_existing() {
 
 #[test]
 fn test_faccessat_not_existing() {
+    use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let not_exist_file = "does_not_exist.txt";
@@ -712,6 +714,7 @@ fn test_faccessat_not_existing() {
 
 #[test]
 fn test_faccessat_none_file_exists() {
+    use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path().join("does_exist.txt");
     let _file = File::create(path.clone()).unwrap();
@@ -729,6 +732,7 @@ fn test_faccessat_none_file_exists() {
 
 #[test]
 fn test_faccessat_file_exists() {
+    use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let exist_file = "does_exist.txt";


### PR DESCRIPTION
This adds the `faccessat` function, which is part of POSIX [https://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html)

test cases are copied from `access` function