### PR TITLE
Properly initialize msghdr when using musl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix length of abstract socket addresses
   ([#1120](https://github.com/nix-rust/nix/pull/1120))
+- Fix initialization of msghdr in recvmsg/sendmsg when built with musl
+  ([#1136](https://github.com/nix-rust/nix/pull/1136))
 
 ### Removed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -857,7 +857,7 @@ pub fn sendmsg(fd: RawFd, iov: &[IoVec<&[u8]>], cmsgs: &[ControlMessage],
     let mhdr = unsafe {
         // Musl's msghdr has private fields, so this is the only way to
         // initialize it.
-        let mut mhdr = mem::MaybeUninit::<msghdr>::uninit();
+        let mut mhdr = mem::MaybeUninit::<msghdr>::zeroed();
         let p = mhdr.as_mut_ptr();
         (*p).msg_name = name as *mut _;
         (*p).msg_namelen = namelen;
@@ -910,7 +910,7 @@ pub fn recvmsg<'a>(fd: RawFd, iov: &[IoVec<&mut [u8]>],
     let mut mhdr = unsafe {
         // Musl's msghdr has private fields, so this is the only way to
         // initialize it.
-        let mut mhdr = mem::MaybeUninit::<msghdr>::uninit();
+        let mut mhdr = mem::MaybeUninit::<msghdr>::zeroed();
         let p = mhdr.as_mut_ptr();
         (*p).msg_name = address.as_mut_ptr() as *mut c_void;
         (*p).msg_namelen = mem::size_of::<sockaddr_storage>() as socklen_t;


### PR DESCRIPTION
Because of the use of MaybeUninit::uninit, the padding fields in msghdr,
which only present on musl builds, are not initialized. Causing garbage
data to be sent to the kernel. This change ensures the paddings are
always zeroed.