### PR TITLE
Add Signal::as_str() to get representation as static string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added `Signal::as_str()`: returns signal name as `&'static str`
+  (#[1138](https://github.com/nix-rust/nix/pull/1138))
 
 - Added `posix_fallocate`.
   ([#1105](https://github.com/nix-rust/nix/pull/1105))

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -112,9 +112,14 @@ impl FromStr for Signal {
     }
 }
 
-impl AsRef<str> for Signal {
-    fn as_ref(&self) -> &str {
-        match *self {
+impl Signal {
+    /// Returns name of signal.
+    ///
+    /// This function is equivalent to `<Signal as AsRef<str>>::as_ref()`,
+    /// with difference that returned string is `'static`
+    /// and not bound to `self`'s lifetime.
+    pub fn as_str(self) -> &'static str {
+        match self {
             Signal::SIGHUP => "SIGHUP",
             Signal::SIGINT => "SIGINT",
             Signal::SIGQUIT => "SIGQUIT",
@@ -154,6 +159,12 @@ impl AsRef<str> for Signal {
             #[cfg(not(any(target_os = "android", target_os = "emscripten", target_os = "linux")))]
             Signal::SIGINFO => "SIGINFO",
         }
+    }
+}
+
+impl AsRef<str> for Signal {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 


### PR DESCRIPTION
# Motivation
Currently string representation of signal can be obtained with AsRef<str> impl.
But it has downside: returned string's lifetime is bound to lifetime of signal, so &str must be converted to String. This allocation is avoidable, because as_ref() only returns static strings. To fix this problem, my PR adds Signal::as_str() method, which returns static string.