### PR TITLE
Expose getpwuid

### DIFF
--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -474,6 +474,24 @@ cfg_if!{
 }
 
 #[test]
+fn test_passwd() -> nix::Result<()> {
+    let passwd = getpwuid(getuid())?
+        .expect("current user has a passwd entry");
+
+    assert!(!passwd.name()?
+        .to_str()
+        .expect("current user's username is utf-8")
+        .is_empty());
+
+    assert!(passwd.shell()?
+        .to_str()
+        .expect("current user's shell is utf-8")
+        .starts_with('/'));
+
+    Ok(())
+}
+
+#[test]
 fn test_acct() {
     use tempfile::NamedTempFile;
     use std::process::Command;


### PR DESCRIPTION
Implement `getpwuid_r`, which loads the `passwd` entry for a given `Uid`, allowing you to find the user's name, shell, homedir, etc.

I did not know what to do about the string ownership model. It returns us a `struct` full of `*const c_char` pointers, which supposedly point to our buffer. I wrote new code to check these, to some extent, then trust `CStr` to do the rest. I did this because I couldn't find any other code in `nix` that did this (which must exist, someone point it out so I can slap my forehead), and to defer the cost of the checks to the time of use, i.e. so if you only want the `name`, you don't have to pay to check the `shell`.

The code should be safe without the extra checks, if the system follows the rules, and I have no reason to believe otherwise; perhaps just deleting the extra checks is reasonable?

Also not handled: dynamically increasing the buffer size if the function returns that the buffer is too small. `GETPW_R_SIZE_MAX` is `1024` on Ubuntu 19.10 / 5.3 / amd64.