### PR TITLE
sys: termios: Define VMIN and VTIME as VEOF and VEOL on sparc64

### DIFF
--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -583,6 +583,11 @@ libc_enum! {
     }
 }
 
+#[cfg(not(all(target_os = "linux", target_arch = "sparc64")))]
+pub const VMIN: SpecialCharacterIndices = SpecialCharacterIndices::VEOF;
+#[cfg(not(all(target_os = "linux", target_arch = "sparc64")))]
+pub const VTIME: SpecialCharacterIndices = SpecialCharacterIndices::VEOL;
+
 pub use libc::NCCS;
 #[cfg(any(target_os = "dragonfly",
           target_os = "freebsd",


### PR DESCRIPTION
On sparc64, glibc defines VMIN as VEOF and VTIME as VEOL for
termios, so we need to inherit these alias definitions for
nix-rust as well.

Fixes #1149