### PR TITLE
sys: termios: Fix inverted logic for [cfg()] conditional for sparc64

### DIFF
--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -584,9 +584,10 @@ libc_enum! {
 }
 
 #[cfg(all(target_os = "linux", target_arch = "sparc64"))]
-pub const VMIN: SpecialCharacterIndices = SpecialCharacterIndices::VEOF;
-#[cfg(all(target_os = "linux", target_arch = "sparc64"))]
-pub const VTIME: SpecialCharacterIndices = SpecialCharacterIndices::VEOL;
+impl SpecialCharacterIndices {
+    pub const VMIN: SpecialCharacterIndices = SpecialCharacterIndices::VEOF;
+    pub const VTIME: SpecialCharacterIndices = SpecialCharacterIndices::VEOL;
+}
 
 pub use libc::NCCS;
 #[cfg(any(target_os = "dragonfly",

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -583,9 +583,9 @@ libc_enum! {
     }
 }
 
-#[cfg(not(all(target_os = "linux", target_arch = "sparc64")))]
+#[cfg(all(target_os = "linux", target_arch = "sparc64"))]
 pub const VMIN: SpecialCharacterIndices = SpecialCharacterIndices::VEOF;
-#[cfg(not(all(target_os = "linux", target_arch = "sparc64")))]
+#[cfg(all(target_os = "linux", target_arch = "sparc64"))]
 pub const VTIME: SpecialCharacterIndices = SpecialCharacterIndices::VEOL;
 
 pub use libc::NCCS;


### PR DESCRIPTION
The fix for #1149 has the logic for the [cfg()] conditional inverted
so that the aliases for VMIN and VTIME are defined on targets that
are not linux-sparc64.