### PR TITLE
Remove the last use of mem::uninitialized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 #![deny(unstable_features)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
-// XXX Allow deprecated items until release 0.16.0.  See issue #1096.
-#![allow(deprecated)]
 
 // External crates
 #[macro_use]

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -250,7 +250,7 @@ impl Termios {
     #[doc(hidden)]
     pub unsafe fn default_uninit() -> Self {
         Termios {
-            inner: RefCell::new(mem::uninitialized()),
+            inner: RefCell::new(mem::zeroed()),
             input_flags: InputFlags::empty(),
             output_flags: OutputFlags::empty(),
             control_flags: ControlFlags::empty(),

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -323,7 +323,7 @@ mod freebsd_ioctls {
     #[test]
     fn test_ioctl_read() {
         let file = tempfile().unwrap();
-        let mut termios = unsafe { mem::uninitialized() };
+        let mut termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocgeta(file.as_raw_fd(), &mut termios) };
         assert_eq!(res, Err(Sys(ENOTTY)));
     }
@@ -332,7 +332,7 @@ mod freebsd_ioctls {
     #[test]
     fn test_ioctl_write_ptr() {
         let file = tempfile().unwrap();
-        let termios: termios = unsafe { mem::uninitialized() };
+        let termios: termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocseta(file.as_raw_fd(), &termios) };
         assert_eq!(res, Err(Sys(ENOTTY)));
     }

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,5 +1,3 @@
-// XXX Allow deprecated items until release 0.16.0.  See issue #1096.
-#![allow(deprecated)]
 extern crate bytes;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 extern crate caps;


### PR DESCRIPTION
Replace it with mem::zeroed.  It isn't perfect, but it's better than it
was.

Issue #1115