### PR TITLE
Add support for IP_RECVERR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ bitflags = "1.0"
 cfg-if = "0.1.2"
 void = "1.0.2"
 
+[patch.crates-io]
+libc = { git = "https://github.com/mcpherrinm/libc" }
+
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,10 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.60", features = [ "extra_traits" ] }
+libc = { version = "0.2.68", features = [ "extra_traits" ] }
 bitflags = "1.0"
 cfg-if = "0.1.2"
 void = "1.0.2"
-
-[patch.crates-io]
-libc = { git = "https://github.com/mcpherrinm/libc" }
 
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -558,7 +558,7 @@ impl ControlMessageOwned {
                 ControlMessageOwned::Ipv4RecvErr(err, addr)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
-            (libc::IPPROTO_IPV6, libc::IP_RECVERR) => {
+            (libc::IPPROTO_IPV6, libc::IPV6_RECVERR) => {
                 let ee = p as *const libc::sock_extended_err;
                 let err = ptr::read_unaligned(ee);
                 let addr = ptr::read_unaligned(libc::SO_EE_OFFENDER(ee) as *const sockaddr_in6);

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -305,6 +305,10 @@ sockopt_impl!(Both, Ipv4RecvIf, libc::IPPROTO_IP, libc::IP_RECVIF, bool);
     target_os = "openbsd",
 ))]
 sockopt_impl!(Both, Ipv4RecvDstAddr, libc::IPPROTO_IP, libc::IP_RECVDSTADDR, bool);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+sockopt_impl!(Both, Ipv4RecvErr, libc::IPPROTO_IP, libc::IP_RECVERR, bool);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+sockopt_impl!(Both, Ipv6RecvErr, libc::IPPROTO_IPV6, libc::IPV6_RECVERR, bool);
 
 
 #[cfg(any(target_os = "android", target_os = "linux"))]


### PR DESCRIPTION
This pull request adds support for setting the IP_RECVERR sockopt, and then decoding the resulting messages from recvmsg.  My intent is to use this to implement a traceroute program (And so need ICMP TTL exceeded messages), though IP_RECVERR is useful in general when writing UDP network programs.  It is, unfortunately, a linux-specific API.  

There's no tests here, but I've been trying it out with this bit of code:
https://github.com/mcpherrinm/traceroute/commit/8a92b6d66d7a44a60b261ff382f38f307b435ef5

SockExtendedErr is the struct type returned as a Cmsg from recvmsg.   It (like the C linux/errqueue.h which defines it) uses u8 and u32.  I think we'll want something more user-friendly here, so I'd say this PR is still a work-in-progress.

I am new to the `nix` codebase (and am not very experienced with Rust), so would appreciate early feedback.