### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Fixed
 ### Removed
+- Removed deprecated Error::description from error types
+  (#[1175](https://github.com/nix-rust/nix/pull/1175))
 
 ## [0.16.1] - 23 December 2019
 ### Added

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -111,11 +111,7 @@ impl ErrnoSentinel for libc::sighandler_t {
     fn sentinel() -> Self { libc::SIG_ERR }
 }
 
-impl error::Error for Errno {
-    fn description(&self) -> &str {
-        self.desc()
-    }
-}
+impl error::Error for Errno {}
 
 impl fmt::Display for Errno {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,16 +152,7 @@ impl From<std::string::FromUtf8Error> for Error {
     fn from(_: std::string::FromUtf8Error) -> Error { Error::InvalidUtf8 }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::InvalidPath => "Invalid path",
-            Error::InvalidUtf8 => "Invalid UTF-8 string",
-            Error::UnsupportedOperation => "Unsupported Operation",
-            Error::Sys(ref errno) => errno.desc(),
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementations of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919