### PR TITLE
Add CLK_TCK to SysconfVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Add `CLK_TCK` to `SysconfVar`
+  (#[1177](https://github.com/nix-rust/nix/pull/1177))
 ### Changed
 ### Fixed
 ### Removed

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1994,7 +1994,8 @@ pub enum SysconfVar {
     BC_STRING_MAX = libc::_SC_BC_STRING_MAX,
     /// Maximum number of simultaneous processes per real user ID.
     CHILD_MAX = libc::_SC_CHILD_MAX,
-    // _SC_CLK_TCK is obsolete
+    // The number of clock ticks per second.
+    CLK_TCK = libc::_SC_CLK_TCK,
     /// Maximum number of weights that can be assigned to an entry of the
     /// LC_COLLATE order keyword in the locale definition file
     COLL_WEIGHTS_MAX = libc::_SC_COLL_WEIGHTS_MAX,


### PR DESCRIPTION
http://man7.org/linux/man-pages/man3/sysconf.3.html says that the
corresponding variable is obsolete, but I think that just means the
constant defined in limits.h is obsolete. Checking the value using
sysconf is still valid.