### PR TITLE
Make FsType's raw type public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   where it's available, and clears the environment of all variables
   via `std::env::vars` and `std::env::remove_var` on others.
   (#[1185](https://github.com/nix-rust/nix/pull/1185))
+- `FsType` inner value made public.
+  (#[1187](https://github.com/nix-rust/nix/pull/1187))
 ### Changed
 ### Fixed
 ### Removed

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -20,19 +20,19 @@ pub struct Statfs(libc::statfs);
 
 #[cfg(target_os = "freebsd")]
 #[derive(Eq, Copy, Clone, PartialEq, Debug)]
-pub struct FsType(u32);
+pub struct FsType(pub u32);
 #[cfg(target_os = "android")]
 #[derive(Eq, Copy, Clone, PartialEq, Debug)]
-pub struct FsType(libc::c_ulong);
+pub struct FsType(pub libc::c_ulong);
 #[cfg(all(target_os = "linux", target_arch = "s390x"))]
 #[derive(Eq, Copy, Clone, PartialEq, Debug)]
-pub struct FsType(u32);
+pub struct FsType(pub u32);
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 #[derive(Eq, Copy, Clone, PartialEq, Debug)]
-pub struct FsType(libc::c_ulong);
+pub struct FsType(pub libc::c_ulong);
 #[cfg(all(target_os = "linux", not(any(target_arch = "s390x", target_env = "musl"))))]
 #[derive(Eq, Copy, Clone, PartialEq, Debug)]
-pub struct FsType(libc::c_long);
+pub struct FsType(pub libc::c_long);
 
 #[cfg(all(target_os = "linux", not(target_env = "musl"), not(target_arch = "s390x")))]
 pub const ADFS_SUPER_MAGIC: FsType = FsType(libc::ADFS_SUPER_MAGIC);


### PR DESCRIPTION
# Motivation
Currently, `FsType` API is limited. In fact, only operation is supports is comparison with one of well-known IDs.
But:
* This list is incomplete. For example, it misses cgroupfs and cgroup2fs.
* This approach doesn't work with custom FSs.