### PR TITLE
Add getrlimit(2) and setrlimit(2)

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -53,6 +53,8 @@ pub mod quota;
 #[cfg(any(target_os = "linux"))]
 pub mod reboot;
 
+pub mod resource;
+
 pub mod select;
 
 #[cfg(any(target_os = "android",

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -18,11 +18,11 @@ libc_enum!{
         RLIMIT_STACK,
 
         // BSDs and Linux
-        #[cfg(all(unix, not(target_os = "solaris")))]
+        #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_MEMLOCK,
-        #[cfg(all(unix, not(target_os = "solaris")))]
+        #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_NPROC,
-        #[cfg(all(unix, not(target_os = "solaris")))]
+        #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_RSS,
 
         // Android and Linux only

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -60,6 +60,18 @@ libc_enum!{
 ///
 /// * `resource`: The [`Resource`] that we want to get the limits of.
 ///
+/// # Examples
+///
+/// ```
+/// use nix::sys::resource::{getrlimit, Resource};
+///
+/// fn main() {
+///     let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+///     println!("current soft_limit: {:?}", soft_limit);
+///     println!("current hard_limit: {:?}", hard_limit);
+/// }
+/// ```
+///
 /// # References
 ///
 /// [getrlimit(2)](https://linux.die.net/man/2/getrlimit)
@@ -84,6 +96,18 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 /// * `soft_limit`: The value that the kenrel enforces for the corresponding resource.
 /// * `hard_limit`: The ceiling for the soft limit. Must be lower or equal to the current hard limit
 ///   for non-root users.
+///
+/// # Examples
+///
+/// ```no_run
+/// use nix::sys::resource::{setrlimit, Resource};
+///
+/// fn main() {
+///     let soft_limit = Some(1024);
+///     let hard_limit = None;
+///     setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
+/// }
+/// ```
 ///
 /// # References
 ///

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -54,7 +54,7 @@ libc_enum!{
 
 /// Get the current processes resource limits
 ///
-/// A value of `None` corresponds to `RLIM_INFINITY`, which means there's no limit.
+/// A value of None indicates that there's no limit.
 ///
 /// # Parameters
 ///
@@ -64,11 +64,10 @@ libc_enum!{
 ///
 /// ```
 /// # use nix::sys::resource::{getrlimit, Resource};
-/// # fn main() {
+///
 /// let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
 /// println!("current soft_limit: {:?}", soft_limit);
 /// println!("current hard_limit: {:?}", hard_limit);
-/// # }
 /// ```
 ///
 /// # References
@@ -79,6 +78,7 @@ libc_enum!{
 pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)> {
     let mut rlim: rlimit = unsafe { mem::uninitialized() };
     let res = unsafe { libc::getrlimit(resource as c_int, &mut rlim as *mut _) };
+    // TODO: use Option::filter after it has been stabilized
     Errno::result(res).map(|_| {
         (if rlim.rlim_cur != RLIM_INFINITY { Some(rlim.rlim_cur) } else { None },
          if rlim.rlim_max != RLIM_INFINITY { Some(rlim.rlim_max) } else { None })
@@ -87,7 +87,7 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 
 /// Set the current processes resource limits
 ///
-/// A value of `None` corresponds to `RLIM_INFINITY`, which means there's no limit.
+/// A value of None indicates that there's no limit.
 ///
 /// # Parameters
 ///
@@ -100,11 +100,10 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 ///
 /// ```no_run
 /// # use nix::sys::resource::{setrlimit, Resource};
-/// # fn main() {
+///
 /// let soft_limit = Some(1024);
 /// let hard_limit = None;
 /// setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
-/// # }
 /// ```
 ///
 /// # References
@@ -118,5 +117,5 @@ pub fn setrlimit(resource: Resource, soft_limit: Option<rlim_t>, hard_limit: Opt
     rlim.rlim_max = hard_limit.unwrap_or(RLIM_INFINITY);
 
     let res = unsafe { libc::setrlimit(resource as c_int, &rlim as *const _) };
-    Errno::result(res).map(drop)
+    Errno::result(res).map(|_| ())
 }

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -7,46 +7,67 @@ pub use libc::rlim_t;
 use {Errno, Result};
 
 libc_enum!{
+    /// A resource that limits apply to
     #[repr(i32)]
     pub enum Resource {
         // POSIX
+        /// This is the maximum size of the process's virtual memory (address space). The limit is specified in bytes, and is rounded down to the system page size.
         RLIMIT_AS,
+        /// This is the maximum size of a core file (see core(5)) in bytes that the process may dump.
         RLIMIT_CORE,
+        /// This is a limit, in seconds, on the amount of CPU time that the process can consume.
         RLIMIT_CPU,
+        /// This is the maximum size of the process's data segment (initialized data, uninitialized data, and heap). The limit is specified in bytes, and is rounded down to the system page size.
         RLIMIT_DATA,
+        /// This is the maximum size in bytes of files that the process may create. Attempts to extend a file beyond this limit result in delivery of a SIGXFSZ signal.
         RLIMIT_FSIZE,
+        /// This specifies a value one greater than the maximum file descriptor number that can be opened by this process.
         RLIMIT_NOFILE,
+        /// This is the maximum size of the process stack, in bytes. Upon reaching this limit, a SIGSEGV signal is generated.
         RLIMIT_STACK,
 
         // BSDs and Linux
+        /// This is the maximum number of bytes of memory that may be locked into RAM. This limit is in effect rounded down to the nearest multiple of the system page size.
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_MEMLOCK,
+        /// This is a limit on the number of extant process (or, more precisely on Linux, threads) for the real user ID of the calling process.
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_NPROC,
+        /// This is a limit (in bytes) on the process's resident set (the number of virtual pages resident in RAM).
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
         RLIMIT_RSS,
 
         // Android and Linux only
+        /// This is a limit on the combined number of flock(2) locks and fcntl(2) leases that this process may establish.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_LOCKS,
+        /// This is a limit on the number of bytes that can be allocated for POSIX message queues for the real user ID of the calling process.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_MSGQUEUE,
+        /// This specifies a ceiling to which the process's nice value can be raised using setpriority(2) or nice(2). The actual ceiling for the nice value is calculated as 20 - rlim_cur.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_NICE,
+        /// This specifies a ceiling on the real-time priority that may be set for this process using sched_setscheduler(2) and sched_setparam(2).
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_RTPRIO,
+        /// This is a limit (in microseconds) on the amount of CPU time that a process scheduled under a real-time scheduling policy may consume without making a blocking system call.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_RTTIME,
+        /// This is a limit on the number of signals that may be queued for the real user ID of the calling process. Both standard and real-time signals are counted for the purpose of checking this limit.
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_SIGPENDING,
 
         // Available on some BSD
+        /// The maximum number of kqueues this user id is allowed to create.
         #[cfg(target_os = "freebsd")]
         RLIMIT_KQUEUES,
+        /// The maximum number of pseudo-terminals this user id is allowed to create.
         #[cfg(target_os = "freebsd")]
         RLIMIT_NPTS,
+        /// The maximum size (in bytes) of socket buffer usage for this user.
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
         RLIMIT_SBSIZE,
+        /// The maximum size (in bytes) of the swap space that may be reserved or used by all of this user id's processes.
         #[cfg(target_os = "freebsd")]
         RLIMIT_SWAP,
     }

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -5,39 +5,40 @@ pub use libc::rlim_t;
 
 use {Errno, Result};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[repr(i32)]
-pub enum Resource {
-    // POSIX
-    RLIMIT_AS = libc::RLIMIT_AS,
-    RLIMIT_CORE = libc::RLIMIT_CORE,
-    RLIMIT_CPU = libc::RLIMIT_CPU,
-    RLIMIT_DATA = libc::RLIMIT_DATA,
-    RLIMIT_FSIZE = libc::RLIMIT_FSIZE,
-    RLIMIT_NOFILE = libc::RLIMIT_NOFILE,
-    RLIMIT_STACK = libc::RLIMIT_STACK,
+libc_enum!{
+    #[repr(i32)]
+    pub enum Resource {
+        // POSIX
+        RLIMIT_AS,
+        RLIMIT_CORE,
+        RLIMIT_CPU,
+        RLIMIT_DATA,
+        RLIMIT_FSIZE,
+        RLIMIT_NOFILE,
+        RLIMIT_STACK,
 
-    // BSDs and Linux
-    #[cfg(all(unix, not(target_os = "solaris")))]
-    RLIMIT_MEMLOCK = libc::RLIMIT_MEMLOCK,
-    #[cfg(all(unix, not(target_os = "solaris")))]
-    RLIMIT_NPROC = libc::RLIMIT_NPROC,
-    #[cfg(all(unix, not(target_os = "solaris")))]
-    RLIMIT_RSS = libc::RLIMIT_RSS,
+        // BSDs and Linux
+        #[cfg(all(unix, not(target_os = "solaris")))]
+        RLIMIT_MEMLOCK,
+        #[cfg(all(unix, not(target_os = "solaris")))]
+        RLIMIT_NPROC,
+        #[cfg(all(unix, not(target_os = "solaris")))]
+        RLIMIT_RSS,
 
-    // Android and Linux only
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_LOCKS = libc::RLIMIT_LOCKS,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_MSGQUEUE = libc::RLIMIT_MSGQUEUE,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_NICE = libc::RLIMIT_NICE,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_RTPRIO = libc::RLIMIT_RTPRIO,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_RTTIME = libc::RLIMIT_RTTIME,
-    #[cfg(any(target_os = "android", target_os = "linux"))]
-    RLIMIT_SIGPENDING = libc::RLIMIT_SIGPENDING,
+        // Android and Linux only
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_LOCKS,
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_MSGQUEUE,
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_NICE,
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_RTPRIO,
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_RTTIME,
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        RLIMIT_SIGPENDING,
+    }
 }
 
 pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)> {

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -134,6 +134,7 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 /// [`Resource`]: enum.Resource.html
 pub fn setrlimit(resource: Resource, soft_limit: Option<rlim_t>, hard_limit: Option<rlim_t>) -> Result<()> {
     let mut rlim: rlimit = unsafe { mem::uninitialized() };
+    // TODO: How do we handle the case where soft_limit isn't Some()?
     rlim.rlim_cur = soft_limit.unwrap_or(RLIM_INFINITY);
     rlim.rlim_max = hard_limit.unwrap_or(RLIM_INFINITY);
 

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -63,13 +63,12 @@ libc_enum!{
 /// # Examples
 ///
 /// ```
-/// use nix::sys::resource::{getrlimit, Resource};
-///
-/// fn main() {
-///     let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
-///     println!("current soft_limit: {:?}", soft_limit);
-///     println!("current hard_limit: {:?}", hard_limit);
-/// }
+/// # use nix::sys::resource::{getrlimit, Resource};
+/// # fn main() {
+/// let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+/// println!("current soft_limit: {:?}", soft_limit);
+/// println!("current hard_limit: {:?}", hard_limit);
+/// # }
 /// ```
 ///
 /// # References
@@ -93,20 +92,19 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 /// # Parameters
 ///
 /// * `resource`: The [`Resource`] that we want to set the limits of.
-/// * `soft_limit`: The value that the kenrel enforces for the corresponding resource.
+/// * `soft_limit`: The value that the kernel enforces for the corresponding resource.
 /// * `hard_limit`: The ceiling for the soft limit. Must be lower or equal to the current hard limit
 ///   for non-root users.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use nix::sys::resource::{setrlimit, Resource};
-///
-/// fn main() {
-///     let soft_limit = Some(1024);
-///     let hard_limit = None;
-///     setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
-/// }
+/// # use nix::sys::resource::{setrlimit, Resource};
+/// # fn main() {
+/// let soft_limit = Some(1024);
+/// let hard_limit = None;
+/// setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
+/// # }
 /// ```
 ///
 /// # References

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -38,6 +38,16 @@ libc_enum!{
         RLIMIT_RTTIME,
         #[cfg(any(target_os = "android", target_os = "linux"))]
         RLIMIT_SIGPENDING,
+
+        // Non-Linux
+        #[cfg(target_os = "freebsd")]
+        RLIMIT_KQUEUES,
+        #[cfg(target_os = "freebsd")]
+        RLIMIT_NPTS,
+        #[cfg(target_os = "freebsd")]
+        RLIMIT_SBSIZE,
+        #[cfg(target_os = "freebsd")]
+        RLIMIT_SWAP,
     }
 }
 

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -134,10 +134,9 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 /// [`Resource`]: enum.Resource.html
 pub fn setrlimit(resource: Resource, soft_limit: Option<rlim_t>, hard_limit: Option<rlim_t>) -> Result<()> {
     let mut rlim: rlimit = unsafe { mem::uninitialized() };
-    // TODO: How do we handle the case where soft_limit isn't Some()?
     rlim.rlim_cur = soft_limit.unwrap_or(RLIM_INFINITY);
     rlim.rlim_max = hard_limit.unwrap_or(RLIM_INFINITY);
-
+    
     let res = unsafe { libc::setrlimit(resource as c_int, &rlim as *const _) };
     Errno::result(res).map(|_| ())
 }

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -1,13 +1,7 @@
 use std::mem;
 
-use libc::{self, c_int};
-pub use libc::{rlimit, rlim_t, RLIM_INFINITY};
-
-#[cfg(any(target_os = "linux",
-          target_os = "openbsd",
-          target_os = "netbsd",
-          target_os = "bitrig"))]
-pub use libc::{RLIM_SAVED_CUR, RLIM_SAVED_MAX};
+use libc::{self, c_int, rlimit, RLIM_INFINITY};
+pub use libc::rlim_t;
 
 use {Errno, Result};
 
@@ -15,13 +9,14 @@ use {Errno, Result};
 #[repr(i32)]
 pub enum Resource {
     // POSIX
+    RLIMIT_AS = libc::RLIMIT_AS,
     RLIMIT_CORE = libc::RLIMIT_CORE,
     RLIMIT_CPU = libc::RLIMIT_CPU,
     RLIMIT_DATA = libc::RLIMIT_DATA,
     RLIMIT_FSIZE = libc::RLIMIT_FSIZE,
     RLIMIT_NOFILE = libc::RLIMIT_NOFILE,
     RLIMIT_STACK = libc::RLIMIT_STACK,
-    RLIMIT_AS = libc::RLIMIT_AS,
+
     // BSDs and Linux
     #[cfg(all(unix, not(target_os = "solaris")))]
     RLIMIT_MEMLOCK = libc::RLIMIT_MEMLOCK,
@@ -29,40 +24,35 @@ pub enum Resource {
     RLIMIT_NPROC = libc::RLIMIT_NPROC,
     #[cfg(all(unix, not(target_os = "solaris")))]
     RLIMIT_RSS = libc::RLIMIT_RSS,
-    // Linux-only
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_LOCKS = libc::RLIMIT_LOCKS,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_MSGQUEUE = libc::RLIMIT_MSGQUEUE,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_NICE = libc::RLIMIT_NICE,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_RTPRIO = libc::RLIMIT_RTPRIO,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_RTTIME = libc::RLIMIT_RTTIME,
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    RLIMIT_SIGPENDING = libc::RLIMIT_SIGPENDING,
-}
 
-#[inline]
-fn rlim_to_option(rlim: rlim_t) -> Option<rlim_t> {
-    match rlim {
-        RLIM_INFINITY => None,
-        rlim => Some(rlim),
-    }
+    // Android and Linux only
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_LOCKS = libc::RLIMIT_LOCKS,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_MSGQUEUE = libc::RLIMIT_MSGQUEUE,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_NICE = libc::RLIMIT_NICE,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_RTPRIO = libc::RLIMIT_RTPRIO,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_RTTIME = libc::RLIMIT_RTTIME,
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    RLIMIT_SIGPENDING = libc::RLIMIT_SIGPENDING,
 }
 
 pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)> {
     let mut rlim: rlimit = unsafe { mem::uninitialized() };
     let res = unsafe { libc::getrlimit(resource as c_int, &mut rlim as *mut _) };
-    Errno::result(res)?;
-    Ok((rlim_to_option(rlim.rlim_cur), rlim_to_option(rlim.rlim_max)))
+    Errno::result(res).map(|_| {
+        (if rlim.rlim_cur != RLIM_INFINITY { Some(rlim.rlim_cur) } else { None },
+         if rlim.rlim_max != RLIM_INFINITY { Some(rlim.rlim_max) } else { None })
+    })
 }
 
-pub fn setrlimit(resource: Resource, limit: (Option<rlim_t>, Option<rlim_t>)) -> Result<()> {
+pub fn setrlimit(resource: Resource, soft_limit: Option<rlim_t>, hard_limit: Option<rlim_t>) -> Result<()> {
     let mut rlim: rlimit = unsafe { mem::uninitialized() };
-    rlim.rlim_cur = limit.0.unwrap_or(RLIM_INFINITY);
-    rlim.rlim_max = limit.1.unwrap_or(RLIM_INFINITY);
+    rlim.rlim_cur = soft_limit.unwrap_or(RLIM_INFINITY);
+    rlim.rlim_max = hard_limit.unwrap_or(RLIM_INFINITY);
 
     let res = unsafe { libc::setrlimit(resource as c_int, &rlim as *const _) };
     Errno::result(res).map(drop)

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -1,0 +1,69 @@
+use std::mem;
+
+use libc::{self, c_int};
+pub use libc::{rlimit, rlim_t, RLIM_INFINITY};
+
+#[cfg(any(target_os = "linux",
+          target_os = "openbsd",
+          target_os = "netbsd",
+          target_os = "bitrig"))]
+pub use libc::{RLIM_SAVED_CUR, RLIM_SAVED_MAX};
+
+use {Errno, Result};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum Resource {
+    // POSIX
+    RLIMIT_CORE = libc::RLIMIT_CORE,
+    RLIMIT_CPU = libc::RLIMIT_CPU,
+    RLIMIT_DATA = libc::RLIMIT_DATA,
+    RLIMIT_FSIZE = libc::RLIMIT_FSIZE,
+    RLIMIT_NOFILE = libc::RLIMIT_NOFILE,
+    RLIMIT_STACK = libc::RLIMIT_STACK,
+    RLIMIT_AS = libc::RLIMIT_AS,
+    // BSDs and Linux
+    #[cfg(all(unix, not(target_os = "solaris")))]
+    RLIMIT_MEMLOCK = libc::RLIMIT_MEMLOCK,
+    #[cfg(all(unix, not(target_os = "solaris")))]
+    RLIMIT_NPROC = libc::RLIMIT_NPROC,
+    #[cfg(all(unix, not(target_os = "solaris")))]
+    RLIMIT_RSS = libc::RLIMIT_RSS,
+    // Linux-only
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_LOCKS = libc::RLIMIT_LOCKS,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_MSGQUEUE = libc::RLIMIT_MSGQUEUE,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_NICE = libc::RLIMIT_NICE,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_RTPRIO = libc::RLIMIT_RTPRIO,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_RTTIME = libc::RLIMIT_RTTIME,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    RLIMIT_SIGPENDING = libc::RLIMIT_SIGPENDING,
+}
+
+#[inline]
+fn rlim_to_option(rlim: rlim_t) -> Option<rlim_t> {
+    match rlim {
+        RLIM_INFINITY => None,
+        rlim => Some(rlim),
+    }
+}
+
+pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)> {
+    let mut rlim: rlimit = unsafe { mem::uninitialized() };
+    let res = unsafe { libc::getrlimit(resource as c_int, &mut rlim as *mut _) };
+    Errno::result(res)?;
+    Ok((rlim_to_option(rlim.rlim_cur), rlim_to_option(rlim.rlim_max)))
+}
+
+pub fn setrlimit(resource: Resource, limit: (Option<rlim_t>, Option<rlim_t>)) -> Result<()> {
+    let mut rlim: rlimit = unsafe { mem::uninitialized() };
+    rlim.rlim_cur = limit.0.unwrap_or(RLIM_INFINITY);
+    rlim.rlim_max = limit.1.unwrap_or(RLIM_INFINITY);
+
+    let res = unsafe { libc::setrlimit(resource as c_int, &rlim as *const _) };
+    Errno::result(res).map(drop)
+}

--- a/test/test.rs
+++ b/test/test.rs
@@ -114,6 +114,7 @@ mod test_kmod;
 mod test_mq;
 mod test_net;
 mod test_nix_path;
+mod test_resource;
 mod test_poll;
 mod test_pty;
 #[cfg(any(target_os = "android",

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -1,5 +1,13 @@
 use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
+/// Tests the RLIMIT_NOFILE functionality of getrlimit(), where the resource RLIMIT_NOFILE refers
+/// to the maximum file descriptor number that can be opened by the process (aka the maximum number
+/// of file descriptors that the process can open, since Linux 4.5).
+///
+/// We first fetch the existing file descriptor maximum values using getrlimit(), then edit the
+/// soft limit to make sure it has a new and distinct value to the hard limit. We then setrlimit()
+/// to put the new soft limit in effect, and then getrlimit() once more to ensure the limits have
+/// been updated.
 #[test]
 pub fn test_resource_limits_nofile() {
     let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
@@ -15,6 +23,12 @@ pub fn test_resource_limits_nofile() {
     assert_eq!(new_soft_limit, soft_limit);
 }
 
+/// Tests the RLIMIT_STACK functionality of getrlimit(), where the resource RLIMIT_STACK refers to
+/// the maximum stack size that can be spawned by the current process before SIGSEGV is generated. 
+///
+/// We first save the current stack limits, then newly set the soft limit to the same size as the
+/// hard limit. We check to make sure these limits have been updated properly. We then set the
+/// stack limits back to the original values, and make sure they have been updated properly.
 #[test]
 pub fn test_resource_limits_stack() {
     let (mut soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_STACK).unwrap();

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -1,7 +1,22 @@
 use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
 #[test]
-pub fn test_resource_limits() {
+pub fn test_resource_limits_nofile() {
+    let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+
+    // make sure the soft limit and hard limit are not equal
+    let soft_limit = match soft_limit {
+        Some(nofile) => Some(nofile -1),
+        None => Some(1024),
+    };
+    setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
+
+    let (new_soft_limit, new_hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+    assert!(new_soft_limit != new_hard_limit);
+}
+
+#[test]
+pub fn test_resource_limits_stack() {
     let (mut soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_STACK).unwrap();
     let orig_limit = (soft_limit, hard_limit);
 

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -1,0 +1,22 @@
+use nix::sys::resource::{Resource, getrlimit, setrlimit};
+
+#[test]
+pub fn test_resource_limits() {
+    let mut limit = getrlimit(Resource::RLIMIT_STACK).unwrap();
+    assert!(limit.0 != limit.1);
+
+    let orig_limit = limit;
+
+    limit.0 = limit.1;
+    setrlimit(Resource::RLIMIT_STACK, limit).unwrap();
+
+    let limit2 = getrlimit(Resource::RLIMIT_STACK).unwrap();
+    assert_eq!(limit.0, limit2.0);
+    assert_eq!(limit.1, limit2.1);
+
+    setrlimit(Resource::RLIMIT_STACK, orig_limit).unwrap();
+
+    let final_limit = getrlimit(Resource::RLIMIT_STACK).unwrap();
+    assert_eq!(orig_limit.0, final_limit.0);
+    assert_eq!(orig_limit.1, final_limit.1);
+}

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -2,19 +2,17 @@ use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
 #[test]
 pub fn test_resource_limits() {
-    let mut limit = getrlimit(Resource::RLIMIT_STACK).unwrap();
-    assert!(limit.0 != limit.1);
+    let (mut soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_STACK).unwrap();
+    let orig_limit = (soft_limit, hard_limit);
 
-    let orig_limit = limit;
-
-    limit.0 = limit.1;
-    setrlimit(Resource::RLIMIT_STACK, limit).unwrap();
+    soft_limit = hard_limit;
+    setrlimit(Resource::RLIMIT_STACK, soft_limit, hard_limit).unwrap();
 
     let limit2 = getrlimit(Resource::RLIMIT_STACK).unwrap();
-    assert_eq!(limit.0, limit2.0);
-    assert_eq!(limit.1, limit2.1);
+    assert_eq!(soft_limit, limit2.0);
+    assert_eq!(hard_limit, limit2.1);
 
-    setrlimit(Resource::RLIMIT_STACK, orig_limit).unwrap();
+    setrlimit(Resource::RLIMIT_STACK, orig_limit.0, orig_limit.1).unwrap();
 
     let final_limit = getrlimit(Resource::RLIMIT_STACK).unwrap();
     assert_eq!(orig_limit.0, final_limit.0);

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -6,12 +6,12 @@ pub fn test_resource_limits_nofile() {
 
     // make sure the soft limit and hard limit are not equal
     let soft_limit = match soft_limit {
-        Some(nofile) => Some(nofile -1),
+        Some(nofile) => Some(nofile - 1),
         None => Some(1024),
     };
     setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
 
-    let (new_soft_limit, new_hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
+    let (new_soft_limit, _new_hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
     assert_eq!(new_soft_limit, soft_limit);
 }
 

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -12,7 +12,7 @@ pub fn test_resource_limits_nofile() {
     setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
 
     let (new_soft_limit, new_hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
-    assert!(new_soft_limit != new_hard_limit);
+    assert_eq!(new_soft_limit, soft_limit);
 }
 
 #[test]


### PR DESCRIPTION
This is a continuation of #879. I've added comments and removed usage of the now-deprecated std::mem::uninitialized() function. 