### PR TITLE
Implement open file descriptor locks in fcntl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added support for `F_OFD_*` `fcntl` commands on Linux and Android.
+  (#[1195](https://github.com/nix-rust/nix/pull/1195))
 - Added `env::clearenv()`: calls `libc::clearenv` on platforms
   where it's available, and clears the environment of all variables
   via `std::env::vars` and `std::env::remove_var` on others.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.60", features = [ "extra_traits" ] }
+libc = { version = "0.2.68", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
 void = "1.0.2"

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -286,6 +286,12 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
             F_SETLKW(flock) => libc::fcntl(fd, libc::F_SETLKW, flock),
             F_GETLK(flock) => libc::fcntl(fd, libc::F_GETLK, flock),
             #[cfg(any(target_os = "android", target_os = "linux"))]
+            F_OFD_SETLK(flock) => libc::fcntl(fd, libc::F_OFD_SETLK, flock),
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            F_OFD_SETLKW(flock) => libc::fcntl(fd, libc::F_OFD_SETLKW, flock),
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            F_OFD_GETLK(flock) => libc::fcntl(fd, libc::F_OFD_GETLK, flock),
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             F_ADD_SEALS(flag) => libc::fcntl(fd, libc::F_ADD_SEALS, flag.bits()),
             #[cfg(any(target_os = "android", target_os = "linux"))]
             F_GET_SEALS => libc::fcntl(fd, libc::F_GET_SEALS),
@@ -295,8 +301,6 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
             F_GETPIPE_SZ => libc::fcntl(fd, libc::F_GETPIPE_SZ),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             F_SETPIPE_SZ(size) => libc::fcntl(fd, libc::F_SETPIPE_SZ, size),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            _ => unimplemented!()
         }
     };
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -211,7 +211,14 @@ mod linux_android {
     }
 
     #[test]
-    #[cfg(not(target_arch = "mips"))]
+    #[cfg(not(any(target_arch = "aarch64",
+                  target_arch = "arm",
+                  target_arch = "armv7",
+                  target_arch = "i686",
+                  target_arch = "mips",
+                  target_arch = "mips64",
+                  target_arch = "mips64el",
+                  target_arch = "powerpc64")))]
     fn test_ofd_locks() {
         let tmp = NamedTempFile::new().unwrap();
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -207,7 +207,7 @@ mod linux_android {
     #[cfg(not(any(target_arch = "aarch64",
                   target_arch = "arm",
                   target_arch = "armv7",
-                  target_arch = "i686",
+                  target_arch = "x86",
                   target_arch = "mips",
                   target_arch = "mips64",
                   target_arch = "mips64el",

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -205,7 +205,7 @@ mod linux_android {
         let tmp = NamedTempFile::new().unwrap();
 
         let fd = tmp.as_raw_fd();
-        let inode = fstat(fd).unwrap().st_ino;
+        let inode = fstat(fd).unwrap().st_ino as usize;
 
         let mut flock = libc::flock {
             l_type: libc::F_WRLCK as libc::c_short,
@@ -230,7 +230,7 @@ mod linux_android {
         assert_eq!(None, lock_info(inode));
     }
 
-    fn lock_info(inode: u64) -> Option<(String, String)> {
+    fn lock_info(inode: usize) -> Option<(String, String)> {
         let file = File::open("/proc/locks").unwrap();
         let buf = BufReader::new(file);
 
@@ -240,7 +240,7 @@ mod linux_android {
             let lock_type = parts[1];
             let lock_access = parts[3];
             let ino_parts: Vec<_> = parts[5].split(':').collect();
-            let ino: u64 = ino_parts[2].parse().unwrap();
+            let ino: usize = ino_parts[2].parse().unwrap();
             if ino == inode {
                 return Some((lock_type.to_string(), lock_access.to_string()))
             }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -216,7 +216,7 @@ mod linux_android {
             #[cfg(target_arch="mips")]
             l_sysid: 0,
             #[cfg(target_arch="mips")]
-            pad: 0,
+            pad: [0; 4],
         };
         fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).unwrap();
         assert_eq!(Some(("OFDLCK".to_string(), "WRITE".to_string())), lock_info(inode));

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -213,6 +213,10 @@ mod linux_android {
             l_start: 0,
             l_len: 0,
             l_pid: 0,
+            #[cfg(target_arch="mips")]
+            l_sysid: 0,
+            #[cfg(target_arch="mips")]
+            pad: 0,
         };
         fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).unwrap();
         assert_eq!(Some(("OFDLCK".to_string(), "WRITE".to_string())), lock_info(inode));

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -218,7 +218,8 @@ mod linux_android {
                   target_arch = "mips",
                   target_arch = "mips64",
                   target_arch = "mips64el",
-                  target_arch = "powerpc64")))]
+                  target_arch = "powerpc64",
+                  target_arch = "powerpc64le")))]
     fn test_ofd_locks() {
         let tmp = NamedTempFile::new().unwrap();
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -200,6 +200,9 @@ mod linux_android {
         assert_eq!(100, read(fd, &mut buf).unwrap());
     }
 
+    // This test is disabled for the target architectures below
+    // due to OFD locks not being available in the kernel/libc
+    // versions used in the CI environment.
     #[test]
     #[cfg(not(any(target_arch = "aarch64",
                   target_arch = "arm",


### PR DESCRIPTION
Hello

This PR updates libc to 0.2.68, which adds the `F_OFD_*` fcntl commands, and uses them in `nix::fcntl::fcntl`.