### PR TITLE
Add an iterator over all events pollable with waitpid(-1, WNOHANG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   identity for filesystem checks per-thread.
   (#[1163](https://github.com/nix-rust/nix/pull/1163))
 - Derived `Ord`, `PartialOrd` for `unistd::Pid` (#[1189](https://github.com/nix-rust/nix/pull/1189))
+- Added `sys::wait::child_event_iter` to conveniently handle all child events after a SIGCHLD signal. (#[1196](https://github.com/nix-rust/nix/pull/1196))
 
 ### Changed
 ### Fixed

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -245,7 +245,9 @@ pub fn wait() -> Result<WaitStatus> {
 /// Returns an iterator over all currently available events of child processes.
 /// 
 /// This iterator is best used with a signal handler on the signal SIGCHLD
-/// ```
+/// (Note that this example uses the signal_hook crate. This is just for clarity, it would of course work with any other mechanism to
+/// receive signals)
+/// ```ignore
 /// for signal in signals.forever() {
 ///     match signal as libc::c_int {
 ///         signal_hook::SIGCHLD => {
@@ -253,7 +255,7 @@ pub fn wait() -> Result<WaitStatus> {
 ///             child_event_iter
 ///                 .take_while(Result::is_ok) // you probably want to do some error handling, instead of just stopping the iterator
 ///                 .for_each(|val| {
-///                     println("A child did something! {:?}", val);
+///                     println!("A child did something! {:?}", val);
 ///                 });
 ///         }
 ///         _ => unreachable!("We only handle SIGCHLD"),

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -210,7 +210,7 @@ impl WaitStatus {
     }
 }
 
-/// Wait for an event of a child process, either for a specific PID, or all children by passing None as pid 
+/// Wait for an event of a child process, either for a specific PID, or all children by passing None as pid
 pub fn waitpid<P: Into<Option<Pid>>>(pid: P, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
     use self::WaitStatus::*;
 
@@ -235,31 +235,25 @@ pub fn waitpid<P: Into<Option<Pid>>>(pid: P, options: Option<WaitPidFlag>) -> Re
     }
 }
 
-
-/// The same as calling waitpid(None, None)
+/// The same as calling [waitpid](fn.waitpid.html)(None, None)
 pub fn wait() -> Result<WaitStatus> {
     waitpid(None, None)
 }
 
-
 /// Returns an iterator over all currently available events of child processes.
+///
+/// This iterator is best used with a signal handler on the signal `SIGCHLD` to handle all pending events.
 /// 
-/// This iterator is best used with a signal handler on the signal SIGCHLD
-/// (Note that this example uses the signal_hook crate. This is just for clarity, it would of course work with any other mechanism to
-/// receive signals)
-/// ```ignore
-/// for signal in signals.forever() {
-///     match signal as libc::c_int {
-///         signal_hook::SIGCHLD => {
-///             // one or more child events exist. We need to handle all now, because the signal is not sent for each.
-///             child_event_iter
-///                 .take_while(Result::is_ok) // you probably want to do some error handling, instead of just stopping the iterator
-///                 .for_each(|val| {
-///                     println!("A child did something! {:?}", val);
-///                 });
-///         }
-///         _ => unreachable!("We only handle SIGCHLD"),
-///     }
+/// Note that you should not call this directly in a signal handler, since those have some restrictions on what may
+/// happen in them. Use a conditional variable to notify some other routine or use a crate like [signal_hook](https://crates.io/crates/signal-hook)
+/// ```
+/// fn handle_sigchld() {
+///     // one or more child events exist. We need to handle all now, because the signal is not sent for each.
+///     nix::sys::wait::child_event_iter()
+///         .take_while(Result::is_ok) // you probably want to do some error handling, instead of just stopping the iterator
+///         .for_each(|val| {
+///             println!("A child did something! {:?}", val);
+///         });
 /// }
 /// ```
 pub fn child_event_iter() -> ChildEventIter {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -105,7 +105,9 @@ impl WaitStatus {
     pub fn pid(&self) -> Option<Pid> {
         use self::WaitStatus::*;
         match *self {
-            Exited(p, _) | Signaled(p, _, _) | Stopped(p, _) | Continued(p) => Some(p),
+            Exited(p, _) | Signaled(p, _, _) | Stopped(p, _) | Continued(p) => {
+                Some(p)
+            }
             StillAlive => None,
             #[cfg(any(target_os = "android", target_os = "linux"))]
             PtraceEvent(p, _, _) | PtraceSyscall(p) => Some(p),
@@ -211,7 +213,10 @@ impl WaitStatus {
 }
 
 /// Wait for an event of a child process, either for a specific PID, or all children by passing None as pid
-pub fn waitpid<P: Into<Option<Pid>>>(pid: P, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
+pub fn waitpid<P: Into<Option<Pid>>>(
+    pid: P,
+    options: Option<WaitPidFlag>,
+) -> Result<WaitStatus> {
     use self::WaitStatus::*;
 
     let mut status: i32 = 0;
@@ -240,19 +245,27 @@ pub fn wait() -> Result<WaitStatus> {
     waitpid(None, None)
 }
 
-/// Returns an iterator over all currently available events of child processes, as would be available via waitpid with the 
+/// Returns an iterator over all currently available events of child
+/// processes, as would be available via waitpid with the
 /// [`WNOHANG`](struct.WaitPidFlag.html#associatedconstant.WNOHANG) flag.
 ///
-/// This iterator is best used with a signal handler on the signal `SIGCHLD` to handle all pending events. The iterator ends either
-/// if all remaining children are still running normally or no more children are running.
-/// 
-/// Note that you should not call this directly in a signal handler, since those have some restrictions on what may
-/// happen in them. Use a conditional variable to notify some other routine or use a crate like [signal_hook](https://crates.io/crates/signal-hook)
+/// This iterator is best used with a signal handler on the signal `SIGCHLD`
+/// to handle all pending events. The iterator ends either
+/// if all remaining children are still running normally or no more children
+/// are running.
+///
+/// Note that you should not call this directly in a signal handler, since
+/// those have some restrictions on what may
+/// happen in them. Use a conditional variable to notify some other routine
+/// or use a crate like [signal_hook](https://crates.io/crates/signal-hook)
 /// ```
 /// fn handle_sigchld() {
-///     // one or more child events exist. We need to handle all now, because the signal is not sent for each.
+///     // one or more child events exist. We need to handle all now, because
+///     // the signal is not sent for each.
 ///     nix::sys::wait::child_event_iter()
-///         .take_while(Result::is_ok) // you probably want to do some error handling, instead of just stopping the iterator
+///         // you probably want to do some error handling, instead of just
+///         //stopping the iterator
+///         .take_while(Result::is_ok)
 ///         .for_each(|val| {
 ///             println!("A child did something! {:?}", val);
 ///         });
@@ -261,18 +274,20 @@ pub fn wait() -> Result<WaitStatus> {
 pub fn child_event_iter() -> ChildEventIter {
     std::iter::from_fn(get_next_child_event)
 }
-type ChildEventIter = std::iter::FromFn<fn() -> std::option::Option<Result<WaitStatus>>>;
+type ChildEventIter =
+    std::iter::FromFn<fn() -> std::option::Option<Result<WaitStatus>>>;
 
-/// use waitpid with WNOHANG to poll the next event or return None if no more events exist
+/// use waitpid with WNOHANG to poll the next event or return None if no more
+/// events exist
 fn get_next_child_event() -> Option<Result<WaitStatus>> {
     match waitpid(None, Some(WaitPidFlag::WNOHANG)) {
         Ok(status) => {
             if status == WaitStatus::StillAlive {
                 None
-            }else{
+            } else {
                 Some(Ok(status))
             }
-        },
+        }
         Err(e) => {
             if let crate::Error::Sys(crate::errno::Errno::ECHILD) = e {
                 // No more events to be waited on
@@ -281,11 +296,15 @@ fn get_next_child_event() -> Option<Result<WaitStatus>> {
                 // Some other error, which we cannot handle here
                 //
                 // This might be unecessary, since the other errors are either
-                // 1. EINTR which only occurs if WNOHANG is not used, but it is used here
-                // 2. EINVAL which should be impossible since only valid WaitPidFlags can be created
+                // 1. EINTR which only occurs if WNOHANG is not used, but it
+                //    is used here
+                // 2. EINVAL which should be impossible since only valid
+                //    WaitPidFlags can be created
                 //
-                // Not having this error handling would make the API nicer, but it could introduce breakage on some
-                // systems that do not conform to the POSIX definition of waitpid?
+                // Not having this error handling would make the API nicer,
+                // but it could introduce breakage on some
+                // systems that do not conform to the POSIX definition of
+                // waitpid, so lets leave it.
                 Some(Err(e))
             }
         }


### PR DESCRIPTION
PR for the issue #1153. It basically provides an iterator over all currently available child events. This makes handling of the SIGCHLD signal easier, since it may be sent for multiple events and not just one.