### PR TITLE
Add cargo features 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,54 @@ exclude     = [
 libc = { version = "0.2.60", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
-void = "1.0.2"
+void = { version = "1.0.2", optional = true }
+
+[features]
+default = [
+  "inotify", "epoll", "socket", "ifaddrs", "ptrace", "pthread", "memfd",
+  "quota", "select", "reboot", "signal", "signalfd", "sendfile", "aio", "wait",
+  "mount", "ucontext", "utsname", "uio", "fcntl", "unistd", "pty", "features",
+  "dir", "env", "kmod", "mqueue", "net", "sched", "event", "eventfd", "ioctl",
+  "mman", "stat", "statfs", "statvfs", "termios", "time"
+]
+inotify = []
+epoll = []
+socket = ["ifaddrs", "uio", "time"]
+ifaddrs = ["net"]
+ptrace = []
+pthread = []
+memfd = []
+quota = []
+select = []
+reboot = ["void"]
+signal = []
+signalfd = ["signal"]
+sendfile = []
+aio = ["signal"]
+wait = ["signal"]
+mount = []
+ucontext = []
+utsname = []
+uio = ["unistd"]
+fcntl = ["uio", "stat"]
+unistd = ["void", "fcntl"]
+pty = ["fcntl", "unistd"]
+features = ["utsname"]
+dir = []
+env = []
+kmod = []
+mqueue = []
+net = []
+sched = []
+event = []
+eventfd = []
+ioctl = []
+mman = []
+stat = ["time"]
+statfs = []
+statvfs = []
+termios = []
+time = []
 
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default = [
   "quota", "select", "reboot", "signal", "signalfd", "sendfile", "aio", "wait",
   "mount", "ucontext", "utsname", "uio", "fcntl", "unistd", "pty", "features",
   "dir", "env", "kmod", "mqueue", "net", "sched", "event", "eventfd", "ioctl",
-  "mman", "stat", "statfs", "statvfs", "termios", "time"
+  "mman", "stat", "statfs", "statvfs", "termios", "time", "poll"
 ]
 inotify = []
 epoll = []
@@ -67,6 +67,7 @@ statfs = []
 statvfs = []
 termios = []
 time = []
+poll = []
 
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(test, deny(warnings))]
 #![recursion_limit = "500"]
 #![deny(unused)]
+#![allow(unused_macros)]
 #![deny(unstable_features)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
@@ -20,6 +21,7 @@
 extern crate bitflags;
 #[macro_use]
 extern crate cfg_if;
+#[cfg(any(feature = "unistd", feature = "reboot"))]
 extern crate void;
 
 // Re-exported external crates
@@ -29,47 +31,60 @@ pub extern crate libc;
 #[macro_use] mod macros;
 
 // Public crates
+#[cfg(feature = "dir")]
 pub mod dir;
+#[cfg(feature = "env")]
 pub mod env;
 pub mod errno;
 #[deny(missing_docs)]
+#[cfg(feature = "features")]
 pub mod features;
+#[cfg(feature = "fcntl")]
 pub mod fcntl;
 #[deny(missing_docs)]
-#[cfg(any(target_os = "android",
+#[cfg(all(feature = "ifaddrs",
+	any(target_os = "android",
           target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",
           target_os = "macos",
           target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "openbsd")))]
 pub mod ifaddrs;
-#[cfg(any(target_os = "android",
-          target_os = "linux"))]
+#[cfg(all(feature = "kmod",
+	any(target_os = "android",
+        target_os = "linux")))]
 pub mod kmod;
-#[cfg(any(target_os = "android",
-          target_os = "linux"))]
+#[cfg(all(feature = "mount",
+	any(target_os = "android",
+        target_os = "linux")))]
 pub mod mount;
-#[cfg(any(target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "fushsia",
-          target_os = "linux",
-          target_os = "netbsd"))]
+#[cfg(all(feature = "mqueue",
+	any(target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fushsia",
+        target_os = "linux",
+        target_os = "netbsd")))]
 pub mod mqueue;
 #[deny(missing_docs)]
+#[cfg(feature = "net")]
 pub mod net;
 #[deny(missing_docs)]
+#[cfg(feature = "poll")]
 pub mod poll;
 #[deny(missing_docs)]
+#[cfg(feature = "pty")]
 pub mod pty;
+#[cfg(feature = "sched")]
 pub mod sched;
 pub mod sys;
 // This can be implemented for other platforms as soon as libc
 // provides bindings for them.
-#[cfg(all(target_os = "linux",
+#[cfg(all(target_os = "linux", feature = "ucontext",
           any(target_arch = "x86", target_arch = "x86_64")))]
 pub mod ucontext;
+#[cfg(feature = "unistd")]
 pub mod unistd;
 
 /*

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,100 +1,117 @@
-#[cfg(any(target_os = "dragonfly",
+#[cfg(all(feature = "aio",
+    any(target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",
           target_os = "macos",
-          target_os = "netbsd"))]
+          target_os = "netbsd")))]
 pub mod aio;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(all(feature = "epoll", any(target_os = "android", target_os = "linux")))]
 pub mod epoll;
 
-#[cfg(any(target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "ios",
-          target_os = "macos",
-          target_os = "netbsd",
-          target_os = "openbsd"))]
+#[cfg(all(feature = "event",
+    any(target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd")))]
 pub mod event;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "eventfd", target_os = "linux"))]
 pub mod eventfd;
 
-#[cfg(any(target_os = "android",
-          target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "ios",
-          target_os = "linux",
-          target_os = "macos",
-          target_os = "netbsd",
-          target_os = "openbsd"))]
+#[cfg(all(feature = "ioctl",
+    any(target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd")))]
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "memfd", target_os = "linux"))]
 pub mod memfd;
 
+#[cfg(feature = "mman")]
 pub mod mman;
 
+#[cfg(feature = "pthread")]
 pub mod pthread;
 
-#[cfg(any(target_os = "android",
+#[cfg(all(feature = "ptrace",
+    any(target_os = "android",
           target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "linux",
           target_os = "macos",
           target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "openbsd")))]
 pub mod ptrace;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "quota", target_os = "linux"))]
 pub mod quota;
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(all(feature = "reboot", target_os = "linux"))]
 pub mod reboot;
 
+#[cfg(feature = "select")]
 pub mod select;
 
-#[cfg(any(target_os = "android",
+#[cfg(all(feature = "sendfile",
+    any(target_os = "android",
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",
-          target_os = "macos"))]
+          target_os = "macos")))]
 pub mod sendfile;
 
+#[cfg(feature = "signal")]
 pub mod signal;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(all(feature = "signalfd", any(target_os = "android", target_os = "linux")))]
 pub mod signalfd;
 
+#[cfg(feature = "socket")]
 pub mod socket;
 
+#[cfg(feature = "stat")]
 pub mod stat;
 
-#[cfg(any(target_os = "android",
-          target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "ios",
-          target_os = "linux",
-          target_os = "macos",
-          target_os = "openbsd"
-))]
+#[cfg(all(feature = "statfs",
+    any(target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "openbsd")))]
 pub mod statfs;
 
+#[cfg(feature = "statvfs")]
 pub mod statvfs;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod sysinfo;
 
+#[cfg(feature = "termios")]
 pub mod termios;
 
+#[cfg(feature = "time")]
 pub mod time;
 
+#[cfg(feature = "uio")]
 pub mod uio;
 
+#[cfg(feature = "utsname")]
 pub mod utsname;
 
+#[cfg(feature = "wait")]
 pub mod wait;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(all(feature = "inotify", any(target_os = "android", target_os = "linux")))]
 pub mod inotify;


### PR DESCRIPTION
Hello ! 

I have been using nix for a while now across my projects and I consistently use only small subsets of it. I therefore modified nix in order to use features so I can only "pay" for what I use.

The main advantage is shorter compilation times, it also allows for reducing transitive dependencies (`void` for example is only used by reboot and unistd).