### PR TITLE
Fix unaligned casting of cmsg data to af_alg_iv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a bug in nix::unistd that would result in an infinite loop
   when a group or user lookup required a buffer larger than
   16KB. (#[1198](https://github.com/nix-rust/nix/pull/1198))
+- Fixed unaligned casting of `cmsg_data` to `af_alg_iv` (#[1206](https://github.com/nix-rust/nix/pull/1206))
 
 ### Removed
 


### PR DESCRIPTION
Casting a pointer to `cmsg_data` to `af_alg_iv` is incorrect since it's not properly aligned. As of the [`cmsg` man page](http://man7.org/linux/man-pages/man3/cmsg.3.html) "Applications should not cast it to a pointer type matching the payload, but should instead use memcpy(3) to copy data to or from a suitably declared object." 