### PR TITLE
Add select::FdSet::fds() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))
 - Enabled `sys::ptrace::setregs` and `sys::ptrace::getregs` on x86_64-unknown-linux-musl target
   (#[1198](https://github.com/nix-rust/nix/pull/1198))
-- `select::FdSet::contains` and `select::FdSet::highest` now operate on `&FdSet`
-  instead of `&mut FdSet`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   identity for filesystem checks per-thread.
   (#[1163](https://github.com/nix-rust/nix/pull/1163))
 - Derived `Ord`, `PartialOrd` for `unistd::Pid` (#[1189](https://github.com/nix-rust/nix/pull/1189))
+- Added `select::FdSet::fds` method to iterate over file descriptors in a set.
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))
 - Enabled `sys::ptrace::setregs` and `sys::ptrace::getregs` on x86_64-unknown-linux-musl target
   (#[1198](https://github.com/nix-rust/nix/pull/1198))
+- `select::FdSet::contains` and `select::FdSet::highest` now operate on `&FdSet`
+  instead of `&mut FdSet`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1163](https://github.com/nix-rust/nix/pull/1163))
 - Derived `Ord`, `PartialOrd` for `unistd::Pid` (#[1189](https://github.com/nix-rust/nix/pull/1189))
 - Added `select::FdSet::fds` method to iterate over file descriptors in a set.
+  (#[#1207](https://github.com/nix-rust/nix/pull/1207))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1163](https://github.com/nix-rust/nix/pull/1163))
 - Derived `Ord`, `PartialOrd` for `unistd::Pid` (#[1189](https://github.com/nix-rust/nix/pull/1189))
 - Added `select::FdSet::fds` method to iterate over file descriptors in a set.
-  (#[#1207](https://github.com/nix-rust/nix/pull/1207))
+  ([#1207](https://github.com/nix-rust/nix/pull/1207))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -64,9 +64,11 @@ impl FdSet {
         self.fds(None).next_back()
     }
 
-    /// Returns an iterator over the file descriptors in the set. For
-    /// performance, it takes an optional higher bound: the iterator will not
-    /// return any elements of the set greater than the given file descriptor.
+    /// Returns an iterator over the file descriptors in the set.
+    /// 
+    /// For performance, it takes an optional higher bound: the iterator will
+    /// not return any elements of the set greater than the given file
+    /// descriptor.
     ///
     /// # Examples
     ///

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -341,6 +341,20 @@ mod tests {
     }
 
     #[test]
+    fn fdset_fds() {
+        let mut set = FdSet::new();
+        assert_eq!(set.fds(None).collect::<Vec<_>>(), vec![]);
+        set.insert(0);
+        assert_eq!(set.fds(None).collect::<Vec<_>>(), vec![0]);
+        set.insert(90);
+        assert_eq!(set.fds(None).collect::<Vec<_>>(), vec![0, 90]);
+
+        // highest limit
+        assert_eq!(set.fds(Some(89)).collect::<Vec<_>>(), vec![0]);
+        assert_eq!(set.fds(Some(90)).collect::<Vec<_>>(), vec![0, 90]);
+    }
+
+    #[test]
     fn test_select() {
         let (r1, w1) = pipe().unwrap();
         write(w1, b"hi!").unwrap();

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -73,13 +73,11 @@ impl FdSet {
     /// # extern crate nix;
     /// # use nix::sys::select::FdSet;
     /// # use std::os::unix::io::RawFd;
-    /// # fn main() {
     /// let mut set = FdSet::new();
     /// set.insert(4);
     /// set.insert(9);
     /// let fds: Vec<RawFd> = set.fds().collect();
     /// assert_eq!(fds, vec![4, 9]);
-    /// # }
     /// ```
     #[inline]
     pub fn fds(&self) -> Fds {


### PR DESCRIPTION
To be more consistent with most Rust APIs and enable cloning of the iterator, I made `FdSet::contains` operate on an immutable borrow instead of a mutable one by copying the set. If this is not desirable, I can roll that back from this PR and focus purely on the `fds()` method.