### PR TITLE
Support sendmmsg/recvmmsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   ([#1207](https://github.com/nix-rust/nix/pull/1207))
 - Added support for UDP generic segmentation offload (GSO) and generic 
   receive offload (GRO) ([#1209](https://github.com/nix-rust/nix/pull/1209))
+- Added support for `sendmmsg` and `recvmmsg` calls
+  (#[1208](https://github.com/nix-rust/nix/pull/1208))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -67,6 +67,12 @@ impl AsRef<timespec> for TimeSpec {
     }
 }
 
+impl AsMut<timespec> for TimeSpec {
+    fn as_mut(&mut self) -> &mut timespec {
+        &mut self.0
+    }
+}
+
 impl Ord for TimeSpec {
     // The implementation of cmp is simplified by assuming that the struct is
     // normalized.  That is, tv_nsec must always be within [0, 1_000_000_000)
@@ -256,6 +262,12 @@ const TV_MIN_SECONDS: i64 = -TV_MAX_SECONDS;
 impl AsRef<timeval> for TimeVal {
     fn as_ref(&self) -> &timeval {
         &self.0
+    }
+}
+
+impl AsMut<timeval> for TimeVal {
+    fn as_mut(&mut self) -> &mut timeval {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
This pull request adds `sendmmsg` and `recvmmsg` functions. They are used to send and receive multiple messages per one call. Additionally, `AsMut` implemented for both `TimeSpec` and `TimeVal`. 

This is still WIP, because we need to find the best way on how to pass multiple values to *mmsg functions. Current approach with iterators doesn't seem ergonomic.