### PR TITLE
Support UDP GSO and GRO on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Derived `Ord`, `PartialOrd` for `unistd::Pid` (#[1189](https://github.com/nix-rust/nix/pull/1189))
 - Added `select::FdSet::fds` method to iterate over file descriptors in a set.
   ([#1207](https://github.com/nix-rust/nix/pull/1207))
+- Added support for UDP generic segmentation offload (GSO) and generic 
+  receive offload (GRO) ([#1209](https://github.com/nix-rust/nix/pull/1209))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc/", features = [ "extra_traits" ] }
+libc = { version = "0.2.69", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
 void = "1.0.2"
@@ -29,6 +29,7 @@ bytes = "0.4.8"
 lazy_static = "1.2"
 rand = "0.6"
 tempfile = "3.0.5"
+semver = "0.9.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.3.1"

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -308,7 +308,10 @@ sockopt_impl!(Both, Ipv4RecvIf, libc::IPPROTO_IP, libc::IP_RECVIF, bool);
     target_os = "openbsd",
 ))]
 sockopt_impl!(Both, Ipv4RecvDstAddr, libc::IPPROTO_IP, libc::IP_RECVDSTADDR, bool);
-
+#[cfg(target_os = "linux")]
+sockopt_impl!(Both, UdpGsoSegment, libc::SOL_UDP, libc::UDP_SEGMENT, libc::c_int);
+#[cfg(target_os = "linux")]
+sockopt_impl!(Both, UdpGroSegment, libc::IPPROTO_UDP, libc::UDP_GRO, bool);
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This PR implements support for UDP GSO and GRO on Linux. It provides the way to send/receive UDP payloads bigger than interface MTU. The goal is to improve UDP performance. 

GSO was introduced in Linux 4.18, GRO in 5.3
