### PR TITLE
Fix UB in getsockopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed `getsockopt`.  The old code produced UB which triggers a panic with
+  Rust 1.44.0.
+  (#[1214](https://github.com/nix-rust/nix/pull/1214))
+
 - Fixed a bug in nix::unistd that would result in an infinite loop
   when a group or user lookup required a buffer larger than
   16KB. (#[1198](https://github.com/nix-rust/nix/pull/1198))


### PR DESCRIPTION
The old code tried to zero-initialize an enum for which 0 is not a valid
value.  That worked for older compilers, but triggers a panic with Rust
1.44.0.  The correct technique is to use mem::MaybeUninit.

Fixes #1212