### PR TITLE
Remove sys::socket::addr::from_libc_sockaddr from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+- Removed `sys::socket::addr::from_libc_sockaddr` from the public API.
+  (#[1215](https://github.com/nix-rust/nix/pull/1215))
+
 ## [0.17.0] - 3 February 2020
 ### Added
 - Add `CLK_TCK` to `SysconfVar`

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -714,7 +714,12 @@ impl SockAddr {
     ///
     /// Supports only the following address families: Unix, Inet (v4 & v6), Netlink and System.
     /// Returns None for unsupported families.
-    pub unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
+    ///
+    /// # Safety
+    ///
+    /// unsafe because it takes a raw pointer as argument.  The caller must
+    /// ensure that the pointer is valid.
+    pub(crate) unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
         if addr.is_null() {
             None
         } else {


### PR DESCRIPTION
This function never should've been public, since it's basically
impossible to use directly.  It's only public due to an oversight from
PR #667 .