### PR TITLE
Add UnixCredentials support on FreeBSD/DragonFly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   receive offload (GRO) ([#1209](https://github.com/nix-rust/nix/pull/1209))
 - Added support for `sendmmsg` and `recvmmsg` calls
   (#[1208](https://github.com/nix-rust/nix/pull/1208))
+- Added support for `SCM_CREDS` messages (`UnixCredentials`) on FreeBSD/DragonFly
+  (#[1216](https://github.com/nix-rust/nix/pull/1216))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.69", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc/", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
 void = "1.0.2"


### PR DESCRIPTION
This allows working with `SCM_CREDS` messages, which are like `SCM_CREDENTIALS` on Linux, but slightly different (always overwritten by the kernel, contain a bit more info — euid and groups).

With this PR, it is possible to write portable code that would use the appropriate message for the platform, but one remaining quirk is that `PassCred` thing still has to be present and `cfg`'d to Linux.

Adding the `SCM_CREDS` constant to libc: https://github.com/rust-lang/libc/pull/1740