### PR TITLE
Test on Rust stable again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,12 +85,8 @@ matrix:
       rust: 1.36.0
 
     # Make sure stable is always working too
-    # FIXME: Travis's "stable" images are stuck on 1.35.0.  Until that's fixed,
-    # explicitly request 1.37.0, which is as of this writing the latest stable
-    # release.
-    # https://travis-ci.community/t/stable-rust-channel-outdated/4213
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.37.0
+      rust: stable
 
     # Test that we can build with the lowest version of all dependencies.
     # "cargo test" doesn't work because some of our dev-dependencies, like


### PR DESCRIPTION
This commit reverts eba3b516f7f76465e2fbe1c16724786144f01e8e, which
worked around a Travis CI bug that has since been fixed.  The effect is
to resume testing on the latest Rust stable.