### PR TITLE
Add SO_BINDTODEVICE sockopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1208](https://github.com/nix-rust/nix/pull/1208))
 - Added support for `SCM_CREDS` messages (`UnixCredentials`) on FreeBSD/DragonFly
   (#[1216](https://github.com/nix-rust/nix/pull/1216))
+- Added `BindToDevice` socket option (sockopt) on Linux
+  (#[1233](https://github.com/nix-rust/nix/pull/1233))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -260,6 +260,8 @@ sockopt_impl!(SetOnly, SndBufForce, libc::SOL_SOCKET, libc::SO_SNDBUFFORCE, usiz
 sockopt_impl!(GetOnly, SockType, libc::SOL_SOCKET, libc::SO_TYPE, super::SockType);
 sockopt_impl!(GetOnly, AcceptConn, libc::SOL_SOCKET, libc::SO_ACCEPTCONN, bool);
 #[cfg(any(target_os = "android", target_os = "linux"))]
+sockopt_impl!(Both, BindToDevice, libc::SOL_SOCKET, libc::SO_BINDTODEVICE, OsString<[u8; libc::IFNAMSIZ]>);
+#[cfg(any(target_os = "android", target_os = "linux"))]
 sockopt_impl!(GetOnly, OriginalDst, libc::SOL_IP, libc::SO_ORIGINAL_DST, libc::sockaddr_in);
 sockopt_impl!(Both, ReceiveTimestamp, libc::SOL_SOCKET, libc::SO_TIMESTAMP, bool);
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -51,3 +51,19 @@ fn test_tcp_congestion() {
         val
     );
 }
+
+#[test]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+fn test_bindtodevice() {
+    skip_if_not_root!("test_bindtodevice");
+
+    let fd = socket(AddressFamily::Inet, SockType::Stream, SockFlag::empty(), None).unwrap();
+
+    let val = getsockopt(fd, sockopt::BindToDevice).unwrap();
+    setsockopt(fd, sockopt::BindToDevice, &val).unwrap();
+
+    assert_eq!(
+        getsockopt(fd, sockopt::BindToDevice).unwrap(),
+        val
+    );
+}


### PR DESCRIPTION
This is available only on Linux as far I know, [socket(7)](https://linux.die.net/man/7/socket) has some information
about the `SO_BINDTODEVICE` sockopt. In simple words it binds a socket
to an specific network device (specified as an string like "wlo1",
"eth0", etc.), to only process packets from that device.

Note: this is untested (for now, i'll test it today), but should work out of the box.