### PR TITLE
Replace void crate with Rust standard lib Infallible type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1198](https://github.com/nix-rust/nix/pull/1198))
 - On Linux, `ptrace::write` is now an `unsafe` function.  Caveat programmer.
   (#[1245](https://github.com/nix-rust/nix/pull/1245))
+- `execv`, `execve`, `execvp` and `execveat` in `::nix::unistd` and `reboot` in
+  `::nix::sys::reboot` now return `Result<Infallible>` instead of `Result<Void>` (#[1239](https://github.com/nix-rust/nix/pull/1239))
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude     = [
 libc = { git = "https://github.com/rust-lang/libc/", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
-void = "1.0.2"
 
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 extern crate bitflags;
 #[macro_use]
 extern crate cfg_if;
-extern crate void;
 
 // Re-exported external crates
 pub extern crate libc;

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -3,7 +3,7 @@
 use {Error, Result};
 use errno::Errno;
 use libc;
-use void::Void;
+use std::convert::Infallible;
 use std::mem::drop;
 
 libc_enum! {
@@ -22,7 +22,7 @@ libc_enum! {
     }
 }
 
-pub fn reboot(how: RebootMode) -> Result<Void> {
+pub fn reboot(how: RebootMode) -> Result<Infallible> {
     unsafe {
         libc::reboot(how as libc::c_int)
     };

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -7,11 +7,11 @@ use fcntl::FcntlArg::F_SETFD;
 use libc::{self, c_char, c_void, c_int, c_long, c_uint, size_t, pid_t, off_t,
            uid_t, gid_t, mode_t, PATH_MAX};
 use std::{fmt, mem, ptr};
+use std::convert::Infallible;
 use std::ffi::{CString, CStr, OsString, OsStr};
 use std::os::unix::ffi::{OsStringExt, OsStrExt};
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
-use void::Void;
 use sys::stat::Mode;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -707,7 +707,7 @@ fn to_exec_array(args: &[&CStr]) -> Vec<*const c_char> {
 /// performs the same action but does not allow for customization of the
 /// environment for the new process.
 #[inline]
-pub fn execv(path: &CStr, argv: &[&CStr]) -> Result<Void> {
+pub fn execv(path: &CStr, argv: &[&CStr]) -> Result<Infallible> {
     let args_p = to_exec_array(argv);
 
     unsafe {
@@ -731,7 +731,7 @@ pub fn execv(path: &CStr, argv: &[&CStr]) -> Result<Void> {
 /// in the `args` list is an argument to the new process. Each element in the
 /// `env` list should be a string in the form "key=value".
 #[inline]
-pub fn execve(path: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
+pub fn execve(path: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Infallible> {
     let args_p = to_exec_array(args);
     let env_p = to_exec_array(env);
 
@@ -752,7 +752,7 @@ pub fn execve(path: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
 /// would not work if "bash" was specified for the path argument, but `execvp`
 /// would assuming that a bash executable was on the system `PATH`.
 #[inline]
-pub fn execvp(filename: &CStr, args: &[&CStr]) -> Result<Void> {
+pub fn execvp(filename: &CStr, args: &[&CStr]) -> Result<Infallible> {
     let args_p = to_exec_array(args);
 
     unsafe {
@@ -772,7 +772,7 @@ pub fn execvp(filename: &CStr, args: &[&CStr]) -> Result<Void> {
 #[cfg(any(target_os = "haiku",
           target_os = "linux",
           target_os = "openbsd"))]
-pub fn execvpe(filename: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
+pub fn execvpe(filename: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Infallible> {
     let args_p = to_exec_array(args);
     let env_p = to_exec_array(env);
 
@@ -800,7 +800,7 @@ pub fn execvpe(filename: &CStr, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
           target_os = "linux",
           target_os = "freebsd"))]
 #[inline]
-pub fn fexecve(fd: RawFd, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
+pub fn fexecve(fd: RawFd, args: &[&CStr], env: &[&CStr]) -> Result<Infallible> {
     let args_p = to_exec_array(args);
     let env_p = to_exec_array(env);
 
@@ -824,7 +824,7 @@ pub fn fexecve(fd: RawFd, args: &[&CStr], env: &[&CStr]) -> Result<Void> {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub fn execveat(dirfd: RawFd, pathname: &CStr, args: &[&CStr],
-                env: &[&CStr], flags: super::fcntl::AtFlags) -> Result<Void> {
+                env: &[&CStr], flags: super::fcntl::AtFlags) -> Result<Infallible> {
     let args_p = to_exec_array(args);
     let env_p = to_exec_array(env);
 


### PR DESCRIPTION
[`std::convert::Infallible`](https://doc.rust-lang.org/stable/std/convert/enum.Infallible.html) has been available since Rust 1.34 and nix currently targets Rust 1.36 or later so this should not cause problems.

Fixes #1238