### PR TITLE
Apply `repr(transparent)` to several FFI types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   16KB. (#[1198](https://github.com/nix-rust/nix/pull/1198))
 - Fixed unaligned casting of `cmsg_data` to `af_alg_iv` (#[1206](https://github.com/nix-rust/nix/pull/1206))
 - Fixed `readlink`/`readlinkat` when reading symlinks longer than `PATH_MAX` (#[1231](https://github.com/nix-rust/nix/pull/1231))
+- `PollFd`, `EpollEvent`, `IpMembershipRequest`, `Ipv6MembershipRequest`,
+  `TimeVal`, and `IoVec` are now `repr(transparent)`.  This is required for
+  correctness's sake across all architectures and compilers, though now bugs
+  have been reported so far.
+  (#[1243](https://github.com/nix-rust/nix/pull/1243))
 
 ### Removed
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -17,7 +17,7 @@ use errno::Errno;
 ///
 /// After a call to `poll` or `ppoll`, the events that occured can be
 /// retrieved by calling [`revents()`](#method.revents) on the `PollFd`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct PollFd {
     pollfd: libc::pollfd,

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -43,7 +43,7 @@ libc_bitflags!{
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[repr(C)]
+#[repr(transparent)]
 pub struct EpollEvent {
     event: libc::epoll_event,
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -278,7 +278,7 @@ cfg_if! {
 /// Request for multicast socket operations
 ///
 /// This is a wrapper type around `ip_mreq`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IpMembershipRequest(libc::ip_mreq);
 
@@ -297,7 +297,7 @@ impl IpMembershipRequest {
 /// Request for ipv6 multicast socket operations
 ///
 /// This is a wrapper type around `ipv6_mreq`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Ipv6MembershipRequest(libc::ipv6_mreq);
 

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -245,7 +245,7 @@ impl fmt::Display for TimeSpec {
 
 
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TimeVal(timeval);
 

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -158,7 +158,7 @@ pub fn process_vm_readv(pid: ::unistd::Pid, local_iov: &[IoVec<&mut [u8]>], remo
     Errno::result(res).map(|r| r as usize)
 }
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct IoVec<T>(libc::iovec, PhantomData<T>);
 


### PR DESCRIPTION
repr(transparent) is required in order to safely cast between an FFI
type and its NewType.  This commit applies that attribute to PollFd,
EpollEvent, IpMembershipRequest, Ipv6MembershipRequest, TimeVal, and
IoVec.

Fixes #1241