### PR TITLE
Make ptrace::write unsafe on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))
 - Enabled `sys::ptrace::setregs` and `sys::ptrace::getregs` on x86_64-unknown-linux-musl target
   (#[1198](https://github.com/nix-rust/nix/pull/1198))
+- On Linux, `ptrace::write` is now an `unsafe` function.  Caveat programmer.
+  (#[1245](https://github.com/nix-rust/nix/pull/1245))
 
 ### Fixed
 

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -425,8 +425,15 @@ pub fn read(pid: Pid, addr: AddressType) -> Result<c_long> {
 }
 
 /// Writes a word into the processes memory at the given address
-pub fn write(pid: Pid, addr: AddressType, data: *mut c_void) -> Result<()> {
-    unsafe {
-        ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(drop)
-    }
+///
+/// # Safety
+///
+/// The `data` argument is passed directly to `ptrace(2)`.  Read that man page
+/// for guidance.
+pub unsafe fn write(
+    pid: Pid,
+    addr: AddressType,
+    data: *mut c_void) -> Result<()>
+{
+    ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(drop)
 }


### PR DESCRIPTION
It always should've been unsafe, because it dereferences a user-provided
pointer.