### PR TITLE
Add EV_DISPATCH, EV_RECEIPT items for EventFlags, and fix build on OpenBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1216](https://github.com/nix-rust/nix/pull/1216))
 - Added `BindToDevice` socket option (sockopt) on Linux
   (#[1233](https://github.com/nix-rust/nix/pull/1233))
+- Added `EventFilter` bitflags for `EV_DISPATCH` and `EV_RECEIPT` on OpenBSD.
+  (#[1252](https://github.com/nix-rust/nix/pull/1252))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -28,7 +28,7 @@ type type_of_data = intptr_t;
 #[cfg(any(target_os = "netbsd"))]
 type type_of_udata = intptr_t;
 #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-type type_of_data = libc::int64_t;
+type type_of_data = i64;
 
 #[cfg(target_os = "netbsd")]
 type type_of_event_filter = u32;

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -90,14 +90,9 @@ libc_bitflags!{
         EV_CLEAR;
         EV_DELETE;
         EV_DISABLE;
-        // No released version of OpenBSD supports EV_DISPATCH or EV_RECEIPT.
-        // These have been commited to the -current branch though and are
-        // expected to be part of the OpenBSD 6.2 release in Nov 2017.
-        // See: https://marc.info/?l=openbsd-tech&m=149621427511219&w=2
-        // https://github.com/rust-lang/libc/pull/613
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
                   target_os = "ios", target_os = "macos",
-                  target_os = "netbsd"))]
+                  target_os = "netbsd", target_os = "openbsd"))]
         EV_DISPATCH;
         #[cfg(target_os = "freebsd")]
         EV_DROP;
@@ -116,7 +111,7 @@ libc_bitflags!{
         EV_POLL;
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
                   target_os = "ios", target_os = "macos",
-                  target_os = "netbsd"))]
+                  target_os = "netbsd", target_os = "openbsd"))]
         EV_RECEIPT;
         EV_SYSFLAGS;
     }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -920,7 +920,6 @@ pub fn sendmsg(fd: RawFd, iov: &[IoVec<&[u8]>], cmsgs: &[ControlMessage],
     target_os = "linux",
     target_os = "android",
     target_os = "freebsd",
-    target_os = "openbsd",
     target_os = "netbsd",
 ))]
 #[derive(Debug)]
@@ -956,7 +955,6 @@ pub struct SendMmsgData<'a, I, C>
     target_os = "linux",
     target_os = "android",
     target_os = "freebsd",
-    target_os = "openbsd",
     target_os = "netbsd",
 ))]
 pub fn sendmmsg<'a, I, C>(

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -309,7 +309,6 @@ mod recvfrom {
         target_os = "linux",
         target_os = "android",
         target_os = "freebsd",
-        target_os = "openbsd",
         target_os = "netbsd",
     ))]
     #[test]


### PR DESCRIPTION
This pull request:

- Adds `EV_DISPATCH` and `EV_RECEIPT` to `EventFlags`. OpenBSD supports these now. 
c379d1a
- Fixes a regression that caused `nix` to be unable to build on OpenBSD since #1208. 
dd0a990
- Makes a change to avoid a deprecation warning from `libc` crate, which breaks tests. 
0f9fcbd

Since I know y'all don't have OpenBSD in CI right now, I've attached the results of a `cargo test` run on OpenBSD 6.7.

Thanks for your time!

[testresults.txt](https://github.com/nix-rust/nix/files/4684597/testresults.txt)

Fixes #1251 