### PR TITLE
Remove several deprecated constants and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   optional arguments.
   (#[1242](https://github.com/nix-rust/nix/pull/1242))
 
-- Removed `unistd::daemon`, `unistd::pipe2`,
-  `sys::event::FilterFlag::NOTE_EXIT_REPARENTED`, and
-  `sys::event::FilterFlag::NOTE_REAP` on OSX and ios.  Removed
-  `sys::ptrace::ptrace` on Android and Linux.
+- Removed `unistd::daemon` and `unistd::pipe2` on OSX and ios
+  (#[1255](https://github.com/nix-rust/nix/pull/1255))
+
+- Removed `sys::event::FilterFlag::NOTE_EXIT_REPARENTED` and
+  `sys::event::FilterFlag::NOTE_REAP` on OSX and ios.
+  (#[1255](https://github.com/nix-rust/nix/pull/1255))
+
+- Removed `sys::ptrace::ptrace` on Android and Linux.
   (#[1255](https://github.com/nix-rust/nix/pull/1255))
 
 ## [0.17.0] - 3 February 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   optional arguments.
   (#[1242](https://github.com/nix-rust/nix/pull/1242))
 
+- Removed `unistd::daemon`, `unistd::pipe2`,
+  `sys::event::FilterFlag::NOTE_EXIT_REPARENTED`, and
+  `sys::event::FilterFlag::NOTE_REAP` on OSX and ios.  Removed
+  `sys::ptrace::ptrace` on Android and Linux.
+  (#[1255](https://github.com/nix-rust/nix/pull/1255))
+
 ## [0.17.0] - 3 February 2020
 ### Added
 - Add `CLK_TCK` to `SysconfVar`

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -128,10 +128,6 @@ libc_bitflags!(
         NOTE_EXEC;
         NOTE_EXIT;
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        #[deprecated( since="0.14.0", note="Deprecated since OSX 10.9")]
-        #[allow(deprecated)]
-        NOTE_EXIT_REPARENTED;
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
         NOTE_EXITSTATUS;
         NOTE_EXTEND;
         #[cfg(any(target_os = "macos",
@@ -177,11 +173,6 @@ libc_bitflags!(
         NOTE_OOB;
         NOTE_PCTRLMASK;
         NOTE_PDATAMASK;
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
-        #[deprecated( since="0.14.0", note="Deprecated since OSX 10.9")]
-        #[allow(deprecated)]
-        NOTE_REAP;
         NOTE_RENAME;
         NOTE_REVOKE;
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -168,22 +168,6 @@ libc_bitflags! {
     }
 }
 
-/// Performs a ptrace request. If the request in question is provided by a specialised function
-/// this function will return an unsupported operation error.
-#[deprecated(
-    since="0.10.0",
-    note="usages of `ptrace()` should be replaced with the specialized helper functions instead"
-)]
-pub unsafe fn ptrace(request: Request, pid: Pid, addr: AddressType, data: *mut c_void) -> Result<c_long> {
-    use self::Request::*;
-    match request {
-        PTRACE_PEEKTEXT | PTRACE_PEEKDATA | PTRACE_GETSIGINFO | 
-            PTRACE_GETEVENTMSG | PTRACE_SETSIGINFO | PTRACE_SETOPTIONS | 
-            PTRACE_POKETEXT | PTRACE_POKEDATA | PTRACE_KILL => Err(Error::UnsupportedOperation),
-        _ => ptrace_other(request, pid, addr, data)
-    }
-}
-
 fn ptrace_peek(request: Request, pid: Pid, addr: AddressType, data: *mut c_void) -> Result<c_long> {
     let ret = unsafe {
         Errno::clear();

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -867,12 +867,12 @@ pub fn execveat(dirfd: RawFd, pathname: &CStr, args: &[&CStr],
 ///   descriptors will remain identical after daemonizing.
 /// * `noclose = false`: The process' stdin, stdout, and stderr will point to
 ///   `/dev/null` after daemonizing.
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), deprecated(
-    since="0.14.0",
-    note="Deprecated in MacOSX 10.5"
-))]
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), allow(deprecated))]
-#[cfg(not(target_os = "redox"))]
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
+          target_os = "freebsd",
+          target_os = "linux",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
 pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
     let res = unsafe { libc::daemon(nochdir as c_int, noclose as c_int) };
     Errno::result(res).map(drop)
@@ -1081,60 +1081,6 @@ pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
     Errno::result(res)?;
 
     unsafe { Ok((fds.assume_init()[0], fds.assume_init()[1])) }
-}
-
-/// Like `pipe`, but allows setting certain file descriptor flags.
-///
-/// The following flags are supported, and will be set after the pipe is
-/// created:
-///
-/// `O_CLOEXEC`:    Set the close-on-exec flag for the new file descriptors.
-/// `O_NONBLOCK`:   Set the non-blocking flag for the ends of the pipe.
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-#[deprecated(
-    since="0.10.0",
-    note="pipe2(2) is not actually atomic on these platforms.  Use pipe(2) and fcntl(2) instead"
-)]
-pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
-    let mut fds = mem::MaybeUninit::<[c_int; 2]>::uninit();
-
-    let res = unsafe { libc::pipe(fds.as_mut_ptr() as *mut c_int) };
-
-    Errno::result(res)?;
-
-    unsafe {
-        pipe2_setflags(fds.assume_init()[0], fds.assume_init()[1], flags)?;
-
-        Ok((fds.assume_init()[0], fds.assume_init()[1]))
-    }
-}
-
-#[cfg(any(target_os = "ios", target_os = "macos"))]
-fn pipe2_setflags(fd1: RawFd, fd2: RawFd, flags: OFlag) -> Result<()> {
-    use crate::fcntl::FcntlArg::F_SETFL;
-
-    let mut res = Ok(0);
-
-    if flags.contains(OFlag::O_CLOEXEC) {
-        res = res
-            .and_then(|_| fcntl(fd1, F_SETFD(FdFlag::FD_CLOEXEC)))
-            .and_then(|_| fcntl(fd2, F_SETFD(FdFlag::FD_CLOEXEC)));
-    }
-
-    if flags.contains(OFlag::O_NONBLOCK) {
-        res = res
-            .and_then(|_| fcntl(fd1, F_SETFL(OFlag::O_NONBLOCK)))
-            .and_then(|_| fcntl(fd2, F_SETFL(OFlag::O_NONBLOCK)));
-    }
-
-    match res {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let _ = close(fd1);
-            let _ = close(fd2);
-            Err(e)
-        }
-    }
 }
 
 /// Truncate a file to a specified length

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -561,6 +561,14 @@ fn test_pipe() {
 
 // pipe2(2) is the same as pipe(2), except it allows setting some flags.  Check
 // that we can set a flag.
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
+          target_os = "emscripten",
+          target_os = "freebsd",
+          target_os = "linux",
+          target_os = "redox",
+          target_os = "netbsd",
+          target_os = "openbsd"))]
 #[test]
 fn test_pipe2() {
     let (fd0, fd1) = pipe2(OFlag::O_CLOEXEC).unwrap();

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -566,9 +566,9 @@ fn test_pipe() {
           target_os = "emscripten",
           target_os = "freebsd",
           target_os = "linux",
-          target_os = "redox",
           target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "openbsd",
+          target_os = "redox"))]
 #[test]
 fn test_pipe2() {
     let (fd0, fd1) = pipe2(OFlag::O_CLOEXEC).unwrap();


### PR DESCRIPTION
* `unistd::daemon` on Apple
* `unistd::pipe2` on Apple
* `sys::event::FilterFlag::NOTE_EXIT_REPARENTED` on Apple
* `sys::event::FilterFlag::NOTE_REAP` on Apple
* `sys::ptrace::ptrace` on Android and Linux

All have been deprecated for more than two releases and one year.