### PR TITLE
Expose IP_PKTINFO Control Message on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1244](https://github.com/nix-rust/nix/pull/1244))
 - Added `unistd::ttyname`
   (#[1259](https://github.com/nix-rust/nix/pull/1259))
+- Added support for `Ipv4PacketInfo` and `Ipv6PacketInfo` to `ControlMessage` for iOS and Android.
+  (#[1265](https://github.com/nix-rust/nix/pull/1265))
 
 ### Changed
 - Changed `fallocate` return type from `c_int` to `()` (#[1201](https://github.com/nix-rust/nix/pull/1201))

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -730,7 +730,9 @@ pub enum ControlMessage<'a> {
     /// [`ip(7)`](http://man7.org/linux/man-pages/man7/ip.7.html) man page.
     #[cfg(any(target_os = "linux",
               target_os = "macos",
-              target_os = "netbsd"))]
+              target_os = "netbsd",
+              target_os = "android",
+              target_os = "ios",))]
     Ipv4PacketInfo(&'a libc::in_pktinfo),
 
     /// Configure the sending addressing and interface for v6
@@ -740,7 +742,9 @@ pub enum ControlMessage<'a> {
     #[cfg(any(target_os = "linux",
               target_os = "macos",
               target_os = "netbsd",
-              target_os = "freebsd"))]
+              target_os = "freebsd",
+              target_os = "android",
+              target_os = "ios",))]
     Ipv6PacketInfo(&'a libc::in6_pktinfo),
 }
 
@@ -824,10 +828,12 @@ impl<'a> ControlMessage<'a> {
                 gso_size as *const _ as *const u8
             },
             #[cfg(any(target_os = "linux", target_os = "macos",
-                      target_os = "netbsd"))]
+                      target_os = "netbsd", target_os = "android",
+                      target_os = "ios",))]
             ControlMessage::Ipv4PacketInfo(info) => info as *const _ as *const u8,
             #[cfg(any(target_os = "linux", target_os = "macos",
-                      target_os = "netbsd", target_os = "freebsd"))]
+                      target_os = "netbsd", target_os = "freebsd",
+                      target_os = "android", target_os = "ios",))]
             ControlMessage::Ipv6PacketInfo(info) => info as *const _ as *const u8,
         };
         unsafe {
@@ -870,10 +876,12 @@ impl<'a> ControlMessage<'a> {
                 mem::size_of_val(gso_size)
             },
             #[cfg(any(target_os = "linux", target_os = "macos",
-              target_os = "netbsd"))]
+              target_os = "netbsd", target_os = "android",
+              target_os = "ios",))]
             ControlMessage::Ipv4PacketInfo(info) => mem::size_of_val(info),
             #[cfg(any(target_os = "linux", target_os = "macos",
-              target_os = "netbsd", target_os = "freebsd"))]
+              target_os = "netbsd", target_os = "freebsd",
+              target_os = "android", target_os = "ios",))]
             ControlMessage::Ipv6PacketInfo(info) => mem::size_of_val(info),
         }
     }
@@ -892,10 +900,12 @@ impl<'a> ControlMessage<'a> {
             #[cfg(target_os = "linux")]
             ControlMessage::UdpGsoSegments(_) => libc::SOL_UDP,
             #[cfg(any(target_os = "linux", target_os = "macos",
-                      target_os = "netbsd"))]
+                      target_os = "netbsd", target_os = "android",
+                      target_os = "ios",))]
             ControlMessage::Ipv4PacketInfo(_) => libc::IPPROTO_IP,
             #[cfg(any(target_os = "linux", target_os = "macos",
-              target_os = "netbsd", target_os = "freebsd"))]
+              target_os = "netbsd", target_os = "freebsd",
+              target_os = "android", target_os = "ios",))]
             ControlMessage::Ipv6PacketInfo(_) => libc::IPPROTO_IPV6,
         }
     }
@@ -925,10 +935,12 @@ impl<'a> ControlMessage<'a> {
                 libc::UDP_SEGMENT
             },
             #[cfg(any(target_os = "linux", target_os = "macos",
-                      target_os = "netbsd"))]
+                      target_os = "netbsd", target_os = "android",
+                      target_os = "ios",))]
             ControlMessage::Ipv4PacketInfo(_) => libc::IP_PKTINFO,
             #[cfg(any(target_os = "linux", target_os = "macos",
-                      target_os = "netbsd", target_os = "freebsd"))]
+                      target_os = "netbsd", target_os = "freebsd",
+                      target_os = "android", target_os = "ios",))]
             ControlMessage::Ipv6PacketInfo(_) => libc::IPV6_PKTINFO,
         }
     }


### PR DESCRIPTION
The commit https://github.com/nix-rust/nix/pull/1222 added the very
useful Ipv4PktInfo to allow `sendmsg` to define the origin of the ip.

Unfortunattely, it didn't add the struct to Android target devices as
well. This commit adds the `target_os = "android"` and `target_os =" ios"` checks on the same
place to allow the compilation to work for the following archs tested:

- `cross build --target aarch64-linux-android`
- `cross build --target x86_64-linux-android`
- `cross build --target armv7-linux-androideabi`
- `cross build --target aarch64-apple-ios`
- `cross build --target x86_64-apple-ios`