### PR TITLE
Drop support for powerpc64-unknown-linux-gnu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,6 @@ matrix:
       rust: 1.36.0
     - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
       rust: 1.36.0
-    - env: TARGET=powerpc64-unknown-linux-gnu
-      rust: 1.36.0
     - env: TARGET=powerpc64le-unknown-linux-gnu
       rust: 1.36.0
     - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `sys::ptrace::ptrace` on Android and Linux.
   (#[1255](https://github.com/nix-rust/nix/pull/1255))
 
+- Dropped support for powerpc64-unknown-linux-gnu
+  (#[1266](https://github.com/nix-rust/nix/pull/1268))
+
 ## [0.17.0] - 3 February 2020
 ### Added
 - Add `CLK_TCK` to `SysconfVar`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Tier 1:
   * mips64-unknown-linux-gnuabi64
   * mips64el-unknown-linux-gnuabi64
   * mipsel-unknown-linux-gnu
-  * powerpc64-unknown-linux-gnu
   * powerpc64le-unknown-linux-gnu
   * x86_64-apple-darwin
   * x86_64-unknown-freebsd


### PR DESCRIPTION
The build is failing due to no fault of Nix.  Even rust-embedded/cross
has given up on fixing it, so there's no hope for us.

Fixes #1267

See also https://github.com/rust-embedded/cross/pull/440