### PR TITLE
Add fuchsia support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,7 +116,7 @@ task:
         TARGET: x86_64-unknown-linux-musl
         TOOLCHAIN: 1.40.0
   container:
-    image: rust:1.36
+    image: rust:1.40
   setup_script:
     - rustup toolchain install $TOOLCHAIN
     - rustup target add --toolchain $TOOLCHAIN $TARGET
@@ -161,7 +161,7 @@ task:
       env:
         TARGET: x86_64-unknown-netbsd
   container:
-    image: rust:1.36
+    image: rust:1.40
   setup_script:
     - rustup target add $TARGET
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -160,6 +160,10 @@ task:
     - name: NetBSD x86_64
       env:
         TARGET: x86_64-unknown-netbsd
+    - name: Fuchsia x86_64
+      env:
+        TARGET: x86_64-fuchsia
+        CHECK_TESTS: true
   container:
     image: rust:1.40
   setup_script:
@@ -167,6 +171,7 @@ task:
   script:
     - cargo +$TOOLCHAIN check --target $TARGET
     - cargo +$TOOLCHAIN check --target $TARGET --release
+    - 'if [ "$CHECK_TESTS" == true ]; then cargo +$TOOLCHAIN check --all-targets --target $TARGET; fi'
     # TODO: check the tests, too.  The old Travis CI setup didn't do that, so
     # they don't build on all platforms.
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `mremap` (#[1306](https://github.com/nix-rust/nix/pull/1306))
 
 - Added `personality` (#[1331](https://github.com/nix-rust/nix/pull/1331))
+
+- Added limited Fuchsia support (#[1285](https://github.com/nix-rust/nix/pull/1285))
+
 ### Fixed
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ targets = [
   "x86_64-unknown-openbsd",
   "x86_64-unknown-netbsd",
   "x86_64-unknown-dragonfly",
+  "x86_64-fuchsia",
   "x86_64-unknown-redox"
 ]
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Tier 2:
   * x86_64-unknown-netbsd
 
 Tier 3:
+  * x86_64-fuchsia
   * x86_64-unknown-redox
 
 ## Usage

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -20,7 +20,8 @@ cfg_if! {
         }
     } else if #[cfg(any(target_os = "linux",
                         target_os = "redox",
-                        target_os = "dragonfly"))] {
+                        target_os = "dragonfly",
+                        target_os = "fuchsia"))] {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno_location()
         }
@@ -188,192 +189,254 @@ fn desc(errno: Errno) -> &'static str {
         EHOSTDOWN       => "Host is down",
         EHOSTUNREACH    => "No route to host",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ECHRNG          => "Channel number out of range",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EL2NSYNC        => "Level 2 not synchronized",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EL3HLT          => "Level 3 halted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EL3RST          => "Level 3 reset",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELNRNG          => "Link number out of range",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EUNATCH         => "Protocol driver not attached",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOCSI          => "No CSI structure available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EL2HLT          => "Level 2 halted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADE           => "Invalid exchange",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADR           => "Invalid request descriptor",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EXFULL          => "Exchange full",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOANO          => "No anode",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADRQC         => "Invalid request code",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADSLT         => "Invalid slot",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBFONT          => "Bad font file format",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOSTR          => "Device not a stream",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENODATA         => "No data available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ETIME           => "Timer expired",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOSR           => "Out of streams resources",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENONET          => "Machine is not on the network",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOPKG          => "Package not installed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EREMOTE         => "Object is remote",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOLINK         => "Link has been severed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EADV            => "Advertise error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ESRMNT          => "Srmount error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ECOMM           => "Communication error on send",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EPROTO          => "Protocol error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EMULTIHOP       => "Multihop attempted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EDOTDOT         => "RFS specific error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADMSG         => "Not a data message",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EOVERFLOW       => "Value too large for defined data type",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOTUNIQ        => "Name not unique on network",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EBADFD          => "File descriptor in bad state",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EREMCHG         => "Remote address changed",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELIBACC         => "Can not access a needed shared library",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELIBBAD         => "Accessing a corrupted shared library",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELIBSCN         => ".lib section in a.out corrupted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELIBMAX         => "Attempting to link in too many shared libraries",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ELIBEXEC        => "Cannot exec a shared library directly",
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia", target_os = "openbsd"))]
         EILSEQ          => "Illegal byte sequence",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ERESTART        => "Interrupted system call should be restarted",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ESTRPIPE        => "Streams pipe error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EUSERS          => "Too many users",
 
         #[cfg(any(target_os = "linux", target_os = "android",
-                  target_os = "netbsd", target_os = "redox"))]
+                  target_os = "fuchsia", target_os = "netbsd",
+                  target_os = "redox"))]
         EOPNOTSUPP      => "Operation not supported on transport endpoint",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ESTALE          => "Stale file handle",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EUCLEAN         => "Structure needs cleaning",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOTNAM         => "Not a XENIX named type file",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENAVAIL         => "No XENIX semaphores available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EISNAM          => "Is a named type file",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EREMOTEIO       => "Remote I/O error",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EDQUOT          => "Quota exceeded",
 
         #[cfg(any(target_os = "linux", target_os = "android",
-                  target_os = "openbsd", target_os = "dragonfly"))]
+                  target_os = "fuchsia", target_os = "openbsd",
+                  target_os = "dragonfly"))]
         ENOMEDIUM       => "No medium found",
 
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia", target_os = "openbsd"))]
         EMEDIUMTYPE     => "Wrong medium type",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ECANCELED       => "Operation canceled",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOKEY          => "Required key not available",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EKEYEXPIRED     => "Key has expired",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EKEYREVOKED     => "Key has been revoked",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EKEYREJECTED    => "Key was rejected by service",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         EOWNERDEAD      => "Owner died",
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android",
+                  target_os = "fuchsia"))]
         ENOTRECOVERABLE => "State not recoverable",
 
-        #[cfg(all(target_os = "linux", not(target_arch="mips")))]
+        #[cfg(any(all(target_os = "linux", not(target_arch="mips")),
+                  target_os = "fuchsia"))]
         ERFKILL         => "Operation not possible due to RF-kill",
 
-        #[cfg(all(target_os = "linux", not(target_arch="mips")))]
+        #[cfg(any(all(target_os = "linux", not(target_arch="mips")),
+                  target_os = "fuchsia"))]
         EHWPOISON       => "Memory page has hardware error",
 
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
@@ -567,7 +630,8 @@ fn desc(errno: Errno) -> &'static str {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android",
+          target_os = "fuchsia"))]
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]

--- a/src/features.rs
+++ b/src/features.rs
@@ -97,7 +97,7 @@ mod os {
 #[cfg(any(target_os = "macos", target_os = "freebsd",
           target_os = "dragonfly", target_os = "ios",
           target_os = "openbsd", target_os = "netbsd",
-          target_os = "redox"))]
+          target_os = "redox", target_os = "fuchsia"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets
     pub fn socket_atomic_cloexec() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub mod net;
 #[deny(missing_docs)]
 pub mod poll;
 #[deny(missing_docs)]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 pub mod pty;
 pub mod sched;
 pub mod sys;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -39,8 +39,10 @@ libc_enum!{
         SIGPIPE,
         SIGALRM,
         SIGTERM,
-        #[cfg(all(any(target_os = "android", target_os = "emscripten", target_os = "linux"),
-                  not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))))]
+        #[cfg(all(any(target_os = "android", target_os = "emscripten",
+                      target_os = "fuchsia", target_os = "linux"),
+                  not(any(target_arch = "mips", target_arch = "mips64",
+                          target_arch = "sparc64"))))]
         SIGSTKFLT,
         SIGCHLD,
         SIGCONT,
@@ -55,14 +57,17 @@ libc_enum!{
         SIGPROF,
         SIGWINCH,
         SIGIO,
-        #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "emscripten",
+                  target_os = "fuchsia", target_os = "linux"))]
         SIGPWR,
         SIGSYS,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                      target_os = "linux", target_os = "redox")))]
+                      target_os = "fuchsia", target_os = "linux",
+                      target_os = "redox")))]
         SIGEMT,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                      target_os = "linux", target_os = "redox")))]
+                      target_os = "fuchsia", target_os = "linux",
+                      target_os = "redox")))]
         SIGINFO,
     }
 }
@@ -86,8 +91,10 @@ impl FromStr for Signal {
             "SIGPIPE" => Signal::SIGPIPE,
             "SIGALRM" => Signal::SIGALRM,
             "SIGTERM" => Signal::SIGTERM,
-            #[cfg(all(any(target_os = "android", target_os = "emscripten", target_os = "linux"),
-                      not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))))]
+            #[cfg(all(any(target_os = "android", target_os = "emscripten",
+                          target_os = "fuchsia", target_os = "linux"),
+                      not(any(target_arch = "mips", target_arch = "mips64",
+                              target_arch = "sparc64"))))]
             "SIGSTKFLT" => Signal::SIGSTKFLT,
             "SIGCHLD" => Signal::SIGCHLD,
             "SIGCONT" => Signal::SIGCONT,
@@ -102,14 +109,17 @@ impl FromStr for Signal {
             "SIGPROF" => Signal::SIGPROF,
             "SIGWINCH" => Signal::SIGWINCH,
             "SIGIO" => Signal::SIGIO,
-            #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
+            #[cfg(any(target_os = "android", target_os = "emscripten",
+                      target_os = "fuchsia", target_os = "linux"))]
             "SIGPWR" => Signal::SIGPWR,
             "SIGSYS" => Signal::SIGSYS,
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                          target_os = "linux", target_os = "redox")))]
+                          target_os = "fuchsia", target_os = "linux",
+                          target_os = "redox")))]
             "SIGEMT" => Signal::SIGEMT,
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                          target_os = "linux", target_os = "redox")))]
+                          target_os = "fuchsia", target_os = "linux",
+                          target_os = "redox")))]
             "SIGINFO" => Signal::SIGINFO,
             _ => return Err(Error::invalid_argument()),
         })
@@ -139,7 +149,8 @@ impl Signal {
             Signal::SIGPIPE => "SIGPIPE",
             Signal::SIGALRM => "SIGALRM",
             Signal::SIGTERM => "SIGTERM",
-            #[cfg(all(any(target_os = "android", target_os = "emscripten", target_os = "linux"),
+            #[cfg(all(any(target_os = "android", target_os = "emscripten",
+                          target_os = "fuchsia", target_os = "linux"),
                       not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))))]
             Signal::SIGSTKFLT => "SIGSTKFLT",
             Signal::SIGCHLD => "SIGCHLD",
@@ -155,14 +166,17 @@ impl Signal {
             Signal::SIGPROF => "SIGPROF",
             Signal::SIGWINCH => "SIGWINCH",
             Signal::SIGIO => "SIGIO",
-            #[cfg(any(target_os = "android", target_os = "emscripten", target_os = "linux"))]
+            #[cfg(any(target_os = "android", target_os = "emscripten",
+                      target_os = "fuchsia", target_os = "linux"))]
             Signal::SIGPWR => "SIGPWR",
             Signal::SIGSYS => "SIGSYS",
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                          target_os = "linux", target_os = "redox")))]
+                          target_os = "fuchsia", target_os = "linux",
+                          target_os = "redox")))]
             Signal::SIGEMT => "SIGEMT",
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                          target_os = "linux", target_os = "redox")))]
+                          target_os = "fuchsia", target_os = "linux",
+                          target_os = "redox")))]
             Signal::SIGINFO => "SIGINFO",
         }
     }
@@ -213,7 +227,10 @@ const SIGNALS: [Signal; 29] = [
     SIGWINCH,
     SIGIO,
     SIGSYS];
-#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))))]
+#[cfg(all(any(target_os = "linux", target_os = "android",
+              target_os = "emscripten", target_os = "fuchsia"),
+          not(any(target_arch = "mips", target_arch = "mips64",
+                  target_arch = "sparc64"))))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -246,7 +263,10 @@ const SIGNALS: [Signal; 31] = [
     SIGIO,
     SIGPWR,
     SIGSYS];
-#[cfg(all(any(target_os = "linux", target_os = "android", target_os = "emscripten"), any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64")))]
+#[cfg(all(any(target_os = "linux", target_os = "android",
+              target_os = "emscripten", target_os = "fuchsia"),
+          any(target_arch = "mips", target_arch = "mips64",
+              target_arch = "sparc64")))]
 const SIGNALS: [Signal; 30] = [
     SIGHUP,
     SIGINT,
@@ -279,7 +299,8 @@ const SIGNALS: [Signal; 30] = [
     SIGPWR,
     SIGSYS];
 #[cfg(not(any(target_os = "linux", target_os = "android",
-              target_os = "emscripten", target_os = "redox")))]
+              target_os = "fuchsia", target_os = "emscripten",
+              target_os = "redox")))]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
     SIGINT,
@@ -749,6 +770,7 @@ pub fn kill<T: Into<Option<Signal>>>(pid: Pid, signal: T) -> Result<()> {
 /// If `pgrp` less then or equal 1, the behavior is platform-specific.
 /// If `signal` is `None`, `killpg` will only preform error checking and won't
 /// send any signal.
+#[cfg(not(target_os = "fuchsia"))]
 pub fn killpg<T: Into<Option<Signal>>>(pgrp: Pid, signal: T) -> Result<()> {
     let res = unsafe { libc::killpg(pgrp.into(),
                                   match signal.into() {
@@ -829,7 +851,10 @@ mod sigevent {
         /// `SIGEV_SIGNAL`.  That field is part of a union that shares space with the
         /// more genuinely useful `sigev_notify_thread_id`
         pub fn new(sigev_notify: SigevNotify) -> SigEvent {
-            let mut sev = unsafe { mem::zeroed::<libc::sigevent>()};
+            // NB: This uses MaybeUninit rather than mem::zeroed because libc::sigevent contains a
+            // function pointer on Fuchsia as of https://github.com/rust-lang/libc/commit/2f59370,
+            // and function pointers must not be null.
+            let mut sev = unsafe { mem::MaybeUninit::<libc::sigevent>::zeroed().assume_init() };
             sev.sigev_notify = match sigev_notify {
                 SigevNotify::SigevNone => libc::SIGEV_NONE,
                 SigevNotify::SigevSignal{..} => libc::SIGEV_SIGNAL,

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -21,7 +21,8 @@ use crate::sys::socket::addr::sys_control::SysControlAddr;
           target_os = "linux",
           target_os = "macos",
           target_os = "netbsd",
-          target_os = "openbsd"))]
+          target_os = "openbsd",
+          target_os = "fuchsia"))]
 pub use self::datalink::LinkAddr;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::vsock::VsockAddr;
@@ -41,7 +42,7 @@ pub enum AddressFamily {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     Netlink = libc::AF_NETLINK,
     /// Low level packet interface (see [`packet(7)`](http://man7.org/linux/man-pages/man7/packet.7.html))
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
     Packet = libc::AF_PACKET,
     /// KEXT Controls and Notifications
     #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -718,6 +719,7 @@ impl SockAddr {
     ///
     /// unsafe because it takes a raw pointer as argument.  The caller must
     /// ensure that the pointer is valid.
+    #[cfg(not(target_os = "fuchsia"))]
     pub(crate) unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
         if addr.is_null() {
             None
@@ -1045,7 +1047,7 @@ pub mod sys_control {
 }
 
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
 mod datalink {
     use super::{fmt, AddressFamily};
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -426,6 +426,7 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 /// This function may fail in a number of different scenarios.  See the man
 /// pages for additional details on possible failure cases.
 #[inline]
+#[cfg(not(target_os = "fuchsia"))]
 pub fn fchdir(dirfd: RawFd) -> Result<()> {
     let res = unsafe { libc::fchdir(dirfd) };
 
@@ -1095,7 +1096,7 @@ pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
 ///
 /// See also
 /// [truncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html)
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
@@ -1232,6 +1233,7 @@ pub fn unlinkat<P: ?Sized + NixPath>(
 
 
 #[inline]
+#[cfg(not(target_os = "fuchsia"))]
 pub fn chroot<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe { libc::chroot(cstr.as_ptr()) }
@@ -2546,13 +2548,16 @@ pub struct User {
     /// Path to shell
     pub shell: PathBuf,
     /// Login class
-    #[cfg(not(any(target_os = "android", target_os = "linux")))]
+    #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                  target_os = "linux")))]
     pub class: CString,
     /// Last password change
-    #[cfg(not(any(target_os = "android", target_os = "linux")))]
+    #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                  target_os = "linux")))]
     pub change: libc::time_t,
     /// Expiration time of account
-    #[cfg(not(any(target_os = "android", target_os = "linux")))]
+    #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                  target_os = "linux")))]
     pub expire: libc::time_t
 }
 
@@ -2569,11 +2574,14 @@ impl From<&libc::passwd> for User {
                 shell: PathBuf::from(OsStr::from_bytes(CStr::from_ptr((*pw).pw_shell).to_bytes())),
                 uid: Uid::from_raw((*pw).pw_uid),
                 gid: Gid::from_raw((*pw).pw_gid),
-                #[cfg(not(any(target_os = "android", target_os = "linux")))]
+                #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                              target_os = "linux")))]
                 class: CString::new(CStr::from_ptr((*pw).pw_class).to_bytes()).unwrap(),
-                #[cfg(not(any(target_os = "android", target_os = "linux")))]
+                #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                              target_os = "linux")))]
                 change: (*pw).pw_change,
-                #[cfg(not(any(target_os = "android", target_os = "linux")))]
+                #[cfg(not(any(target_os = "android", target_os = "fuchsia",
+                              target_os = "linux")))]
                 expire: (*pw).pw_expire
             }
         }
@@ -2781,6 +2789,7 @@ impl Group {
 
 /// Get the name of the terminal device that is open on file descriptor fd
 /// (see [`ttyname(3)`](http://man7.org/linux/man-pages/man3/ttyname.3.html)).
+#[cfg(not(target_os = "fuchsia"))]
 pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
     const PATH_MAX: usize = libc::PATH_MAX as usize;
     let mut buf = vec![0_u8; PATH_MAX];

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -53,7 +53,7 @@ cfg_if! {
     }
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 #[macro_export] macro_rules! skip_if_not_root {
     ($name:expr) => {
         use nix::unistd::Uid;

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -21,9 +21,9 @@ mod test_sockopt;
 mod test_select;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_sysinfo;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 mod test_termios;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 mod test_ioctl;
 mod test_wait;
 mod test_uio;

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -12,6 +12,7 @@ fn test_kill_none() {
 }
 
 #[test]
+#[cfg(not(target_os = "fuchsia"))]
 fn test_killpg_none() {
     killpg(getpgrp(), None)
         .expect("Should be able to send signal to my process group.");

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1,4 +1,3 @@
-use nix::ifaddrs::InterfaceAddress;
 use nix::sys::socket::{AddressFamily, InetAddr, UnixAddr, getsockname};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -1161,7 +1160,7 @@ pub fn test_syscontrol() {
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
-fn loopback_address(family: AddressFamily) -> Option<InterfaceAddress> {
+fn loopback_address(family: AddressFamily) -> Option<nix::ifaddrs::InterfaceAddress> {
     use std::io;
     use std::io::Write;
     use nix::ifaddrs::getifaddrs;

--- a/test/test.rs
+++ b/test/test.rs
@@ -23,7 +23,7 @@ mod test_mq;
 mod test_net;
 mod test_nix_path;
 mod test_poll;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 mod test_pty;
 #[cfg(any(target_os = "android",
           target_os = "linux"))]

--- a/test/test_ptymaster_drop.rs
+++ b/test/test_ptymaster_drop.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 mod t {
     use nix::fcntl::OFlag;
     use nix::pty::*;

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -7,7 +7,7 @@ use nix::unistd::ForkResult::*;
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::wait::*;
 use nix::sys::stat::{self, Mode, SFlag};
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 use nix::pty::{posix_openpt, grantpt, unlockpt, ptsname};
 use nix::errno::Errno;
 #[cfg(not(target_os = "redox"))]
@@ -201,7 +201,7 @@ mod linux_android {
 
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "fuchsia")))]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
     skip_if_not_root!("test_setgroups");
@@ -224,7 +224,7 @@ fn test_setgroups() {
 
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "fuchsia")))]
 fn test_initgroups() {
     // Skip this test when not run as root as `initgroups()` and `setgroups()`
     // require root.
@@ -406,6 +406,7 @@ cfg_if!{
 }
 
 #[test]
+#[cfg(not(target_os = "fuchsia"))]
 fn test_fchdir() {
     // fchdir changes the process's cwd
     let _dr = crate::DirRestore::new();
@@ -552,7 +553,7 @@ cfg_if!{
                 skip_if_jailed!("test_acct");
             }
         }
-    } else if #[cfg(not(target_os = "redox"))] {
+    } else if #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))] {
         macro_rules! require_acct{
             () => {
                 skip_if_not_root!("test_acct");
@@ -562,7 +563,7 @@ cfg_if!{
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_acct() {
     use tempfile::NamedTempFile;
     use std::process::Command;
@@ -649,7 +650,7 @@ fn test_pipe2() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_truncate() {
     let tempdir = tempdir().unwrap();
     let path = tempdir.path().join("file");
@@ -1033,7 +1034,7 @@ fn test_setfsuid() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_ttyname() {
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
     assert!(fd.as_raw_fd() > 0);
@@ -1056,7 +1057,7 @@ fn test_ttyname() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_ttyname_not_pty() {
     let fd = File::open("/dev/zero").unwrap();
     assert!(fd.as_raw_fd() > 0);
@@ -1064,7 +1065,7 @@ fn test_ttyname_not_pty() {
 }
 
 #[test]
-#[cfg(all(not(target_os = "redox")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_ttyname_invalid_fd() {
     assert_eq!(ttyname(-1), Err(Error::Sys(Errno::EBADF)));
 }


### PR DESCRIPTION
This change adds support for the Fuchsia operating system to the nix
crate. Fuchsia developers have a use case for nix, particularly its safe
interfaces to the recvmsg(2) and sendmsg(2). Adding support requires:
* incrementing the libc dependency to 0.2.74
* conditionally not compiling nix functionality which depends on libc functionality
  that does not exist for Fuchsia