### PR TITLE
Support `TCP_MAXSEG` TCP Maximum Segment Size socket options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1335](https://github.com/nix-rust/nix/pull/1335))
 - Exposed `SockAddr::from_raw_sockaddr`
   (#[1447](https://github.com/nix-rust/nix/pull/1447))
+- Added support for `TCP_MAXSEG` TCP Maximum Segment Size socket options
+  (#[1292](https://github.com/nix-rust/nix/pull/1292))
 
 ### Changed
 

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -265,6 +265,13 @@ sockopt_impl!(Both, TcpKeepAlive, libc::IPPROTO_TCP, libc::TCP_KEEPALIVE, u32);
           target_os = "linux",
           target_os = "nacl"))]
 sockopt_impl!(Both, TcpKeepIdle, libc::IPPROTO_TCP, libc::TCP_KEEPIDLE, u32);
+cfg_if! {
+    if #[cfg(any(target_os = "android", target_os = "linux"))] {
+        sockopt_impl!(Both, TcpMaxSeg, libc::IPPROTO_TCP, libc::TCP_MAXSEG, u32);
+    } else {
+        sockopt_impl!(GetOnly, TcpMaxSeg, libc::IPPROTO_TCP, libc::TCP_MAXSEG, u32);
+    }
+}
 #[cfg(not(target_os = "openbsd"))]
 sockopt_impl!(Both, TcpKeepCount, libc::IPPROTO_TCP, libc::TCP_KEEPCNT, u32);
 #[cfg(not(target_os = "openbsd"))]


### PR DESCRIPTION
Found myself in a situation where I needed to advertise a specific MSS. Thought this crate is the appropriate place for this feature (especially since the `TCP_MAXSEG` const was exposed through it before), so here goes.

Actual change is of course tiny but it comes with a test. Happy to make changes, especially since I need to do more research on which platforms this works.