### PR TITLE
DragonFlyBSD: use __errno_location now provided by the libc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.73", features = [ "extra_traits" ] }
+libc = { version = "0.2.77", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
 

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-#[cfg(target_os = "dragonfly")]
-fn main() {
-    cc::Build::new()
-        .file("src/errno_dragonfly.c")
-        .compile("liberrno_dragonfly.a");
-}
-
-#[cfg(not(target_os = "dragonfly"))]
-fn main() {}

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-#[cfg(not(target_os = "dragonfly"))]
 use libc::{c_int, c_void};
 use std::{fmt, io, error};
 use crate::{Error, Result};
@@ -13,32 +12,15 @@ cfg_if! {
         unsafe fn errno_location() -> *mut c_int {
             libc::__error()
         }
-    } else if #[cfg(target_os = "dragonfly")] {
-        // DragonFly uses a thread-local errno variable, but #[thread_local] is
-        // feature-gated and not available in stable Rust as of this writing
-        // (Rust 1.21.0). We have to use a C extension to access it
-        // (src/errno_dragonfly.c).
-        //
-        // Tracking issue for `thread_local` stabilization:
-        //
-        //     https://github.com/rust-lang/rust/issues/29594
-        //
-        // Once this becomes stable, we can remove build.rs,
-        // src/errno_dragonfly.c, and use:
-        //
-        //     extern { #[thread_local] static errno: c_int; }
-        //
-        #[link(name="errno_dragonfly", kind="static")]
-        extern {
-            pub fn errno_location() -> *mut c_int;
-        }
     } else if #[cfg(any(target_os = "android",
                         target_os = "netbsd",
                         target_os = "openbsd"))] {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno()
         }
-    } else if #[cfg(any(target_os = "linux", target_os = "redox"))] {
+    } else if #[cfg(any(target_os = "linux",
+                        target_os = "redox",
+                        target_os = "dragonfly"))] {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno_location()
         }

--- a/src/errno_dragonfly.c
+++ b/src/errno_dragonfly.c
@@ -1,3 +1,0 @@
-#include <errno.h>
-
-int *errno_location() { return &errno; }


### PR DESCRIPTION
Dragonfly recently (in Dfly 5.8) added an `__errno_location()` function to make it easy to access the thread-local `errno` variable. This has been exposed in rust-libc as of 0.2.77. This PR uses that functionality instead of the locally compiled C language shim, which the PR removes. One issue is backwards compatibilty. It requires 0.2.77 libc and DragonFly 5.8. Not sure how to gracefully handle older DragonFly versions, although I'm also not sure doing so is worth it.