### PR TITLE
Add PTRACE_SYSEMU and PTRACE_SYSEMU_SINGLESTEP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `clock_gettime`, `clock_settime`, `clock_getres`,
   `clock_getcpuclockid` functions and `ClockId` struct.
   (#[1281](https://github.com/nix-rust/nix/pull/1281))
+- Added wrapper functions for `PTRACE_SYSEMU` and `PTRACE_SYSEMU_SINGLESTEP`.
+  (#[1300](https://github.com/nix-rust/nix/pull/1300))
 ### Changed
 - Expose `SeekData` and `SeekHole` on all Linux targets
 (#[1284](https://github.com/nix-rust/nix/pull/1284))


### PR DESCRIPTION
Closes #1249.  
I think @jabedude was working on this, but as there was no progress since May I went ahead and implemented it myself.
I'm not completely sure about the cfg gates. Could we enable the functions for more targets?
I'm also open for suggestions of better names for the new functions.