### PR TITLE
Support vsock on Android as well as Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 - Added Netlink protocol families to the `SockProtocol` enum
-(#[1289](https://github.com/nix-rust/nix/pull/1289))
+  (#[1289](https://github.com/nix-rust/nix/pull/1289))
 - Added `clock_gettime`, `clock_settime`, `clock_getres`,
   `clock_getcpuclockid` functions and `ClockId` struct.
   (#[1281](https://github.com/nix-rust/nix/pull/1281))
 - Added wrapper functions for `PTRACE_SYSEMU` and `PTRACE_SYSEMU_SINGLESTEP`.
   (#[1300](https://github.com/nix-rust/nix/pull/1300))
+- Add support for Vsock on Android rather than just Linux.
+  (#[1301](https://github.com/nix-rust/nix/pull/1301))
+
 ### Changed
 - Expose `SeekData` and `SeekHole` on all Linux targets
 (#[1284](https://github.com/nix-rust/nix/pull/1284))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude     = [
 ]
 
 [dependencies]
-libc = { version = "0.2.77", features = [ "extra_traits" ] }
+libc = { version = "0.2.78", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "0.1.10"
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -23,7 +23,7 @@ use crate::sys::socket::addr::sys_control::SysControlAddr;
           target_os = "netbsd",
           target_os = "openbsd"))]
 pub use self::datalink::LinkAddr;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::vsock::VsockAddr;
 
 /// These constants specify the protocol family to be used
@@ -115,7 +115,7 @@ pub enum AddressFamily {
     Alg = libc::AF_ALG,
     #[cfg(target_os = "linux")]
     Nfc = libc::AF_NFC,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     Vsock = libc::AF_VSOCK,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -242,7 +242,7 @@ impl AddressFamily {
                       target_os = "netbsd",
                       target_os = "openbsd"))]
             libc::AF_LINK => Some(AddressFamily::Link),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             libc::AF_VSOCK => Some(AddressFamily::Vsock),
             _ => None
         }
@@ -647,7 +647,7 @@ pub enum SockAddr {
               target_os = "netbsd",
               target_os = "openbsd"))]
     Link(LinkAddr),
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     Vsock(VsockAddr),
 }
 
@@ -675,7 +675,7 @@ impl SockAddr {
         SysControlAddr::from_name(sockfd, name, unit).map(|a| SockAddr::SysControl(a))
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     pub fn new_vsock(cid: u32, port: u32) -> SockAddr {
         SockAddr::Vsock(VsockAddr::new(cid, port))
     }
@@ -700,7 +700,7 @@ impl SockAddr {
                       target_os = "netbsd",
                       target_os = "openbsd"))]
             SockAddr::Link(..) => AddressFamily::Link,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             SockAddr::Vsock(..) => AddressFamily::Vsock,
         }
     }
@@ -751,7 +751,7 @@ impl SockAddr {
                         Some(SockAddr::Link(ether_addr))
                     }
                 },
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "android", target_os = "linux"))]
                 Some(AddressFamily::Vsock) => Some(SockAddr::Vsock(
                     VsockAddr(*(addr as *const libc::sockaddr_vm)))),
                 // Other address families are currently not supported and simply yield a None
@@ -837,7 +837,7 @@ impl SockAddr {
                 },
                 mem::size_of_val(addr) as libc::socklen_t
             ),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             SockAddr::Vsock(VsockAddr(ref sa)) => (
                 // This cast is always allowed in C
                 unsafe {
@@ -869,7 +869,7 @@ impl fmt::Display for SockAddr {
                       target_os = "netbsd",
                       target_os = "openbsd"))]
             SockAddr::Link(ref ether_addr) => ether_addr.fmt(f),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             SockAddr::Vsock(ref svm) => svm.fmt(f),
         }
     }
@@ -1204,7 +1204,7 @@ mod datalink {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod vsock {
     use crate::sys::socket::addr::AddressFamily;
     use libc::{sa_family_t, sockaddr_vm};

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -33,7 +33,7 @@ pub use self::addr::{
 pub use crate::sys::socket::addr::netlink::NetlinkAddr;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use crate::sys::socket::addr::alg::AlgAddr;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use crate::sys::socket::addr::vsock::VsockAddr;
 
 pub use libc::{
@@ -1737,7 +1737,7 @@ pub fn sockaddr_storage_to_addr(
             };
             Ok(SockAddr::Alg(AlgAddr(salg)))
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         libc::AF_VSOCK => {
             use libc::sockaddr_vm;
             let svm = unsafe {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1411,7 +1411,7 @@ pub fn test_recv_ipv6pktinfo() {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[test]
 pub fn test_vsock() {
     use libc;
@@ -1428,13 +1428,13 @@ pub fn test_vsock() {
                     SockFlag::empty(), None)
              .expect("socket failed");
 
-    // VMADDR_CID_HYPERVISOR and VMADDR_CID_RESERVED are reserved, so we expect
+    // VMADDR_CID_HYPERVISOR and VMADDR_CID_LOCAL are reserved, so we expect
     // an EADDRNOTAVAIL error.
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_HYPERVISOR, port);
     assert_eq!(bind(s1, &sockaddr).err(),
                Some(Error::Sys(Errno::EADDRNOTAVAIL)));
 
-    let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_RESERVED, port);
+    let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_LOCAL, port);
     assert_eq!(bind(s1, &sockaddr).err(),
                Some(Error::Sys(Errno::EADDRNOTAVAIL)));
 


### PR DESCRIPTION
This change depends on rust-lang/libc#1905 so can't be merged until that is merged and released.