### PR TITLE
Release v0.19.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [0.19.0] - 6 October 2020
+### Added
 - Added Netlink protocol families to the `SockProtocol` enum
   (#[1289](https://github.com/nix-rust/nix/pull/1289))
 - Added `clock_gettime`, `clock_settime`, `clock_getres`,
@@ -17,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Expose `SeekData` and `SeekHole` on all Linux targets
-(#[1284](https://github.com/nix-rust/nix/pull/1284))
+  (#[1284](https://github.com/nix-rust/nix/pull/1284))
 - Changed unistd::{execv,execve,execvp,execvpe,fexecve,execveat} to take both `&[&CStr]` and `&[CString]` as its list argument(s).
   (#[1278](https://github.com/nix-rust/nix/pull/1278))
 - Made `unistd::fork` an unsafe funtion, bringing it in line with [libstd's decision](https://github.com/rust-lang/rust/pull/58059).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
 edition     = "2018"
-version     = "0.18.0"
+version     = "0.19.0"
 authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To use `nix`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nix = "0.18.0"
+nix = "0.19.0"
 ```
 
 ## Contributing


### PR DESCRIPTION
I'd like to get a new version of the crate released including #1301 so that I can get the vsock crate building on Android, and get both imported into the Android tree.