### PR TITLE
add Cirrus CI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rust bindings to *nix APIs
 
-[![Build Status](https://travis-ci.org/nix-rust/nix.svg?branch=master)](https://travis-ci.org/nix-rust/nix)
+[![Travis Build Status](https://travis-ci.org/nix-rust/nix.svg?branch=master)](https://travis-ci.org/nix-rust/nix)
+[![Cirrus Build Status](https://api.cirrus-ci.com/github/nix-rust/nix.svg)](https://cirrus-ci.com/github/nix-rust/nix)
 [![crates.io](http://meritbadge.herokuapp.com/nix)](https://crates.io/crates/nix)
 
 [Documentation (Releases)](https://docs.rs/nix/)


### PR DESCRIPTION
I couldn't find the build status of this repo for any BDSs very easily - I had to look through some issues. I thought this badge would be a nice addition.