### PR TITLE
update require_kernel_version string to handle "_" in version string

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -95,7 +95,11 @@ cfg_if! {
 
                 let uname = nix::sys::utsname::uname();
 
-                let mut version = Version::parse(uname.release()).unwrap();
+                // Linux may report version as 4.18.el8_2.x86_64 or 5.18.200-fc33.x86_64
+                // semver sematics does not support underscore. Replace this with hypen.
+                let mut version = Version::parse(
+                    &uname.release().to_string().replace("_", "-")
+                ).unwrap();
 
                 //Keep only numeric parts
                 version.pre.clear();


### PR DESCRIPTION
 test code breaks on fc333

```
$ cargo test
failures:

---- sys::test_socket::recvfrom::udp_offload::gro stdout ----
thread 'sys::test_socket::recvfrom::udp_offload::gro' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError("Extra junk after valid version: _64")', test/sys/test_socket.rs:292:13
```

this is due underscore in release string( arch/x86_64), which is not supported by semver.
```
$ uname -r
5.8.14-300.fc33.x86_64

```