### PR TITLE
KEEPCNT/KEEPINTVL aren't available on OpenBSD.

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -252,7 +252,9 @@ sockopt_impl!(Both, TcpKeepAlive, libc::IPPROTO_TCP, libc::TCP_KEEPALIVE, u32);
           target_os = "linux",
           target_os = "nacl"))]
 sockopt_impl!(Both, TcpKeepIdle, libc::IPPROTO_TCP, libc::TCP_KEEPIDLE, u32);
+#[cfg(not(target_os = "openbsd"))]
 sockopt_impl!(Both, TcpKeepCount, libc::IPPROTO_TCP, libc::TCP_KEEPCNT, u32);
+#[cfg(not(target_os = "openbsd"))]
 sockopt_impl!(Both, TcpKeepInterval, libc::IPPROTO_TCP, libc::TCP_KEEPINTVL, u32);
 sockopt_impl!(Both, RcvBuf, libc::SOL_SOCKET, libc::SO_RCVBUF, usize);
 sockopt_impl!(Both, SndBuf, libc::SOL_SOCKET, libc::SO_SNDBUF, usize);


### PR DESCRIPTION
Without this commit, nix doesn't currently compile on OpenBSD. Some keepalive settings can be set globally, but not per-socket (see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=970550 for some digging into this). Since it seems that NetBSD and DragonflyBSD have these settings, it makes more sense to only exclude them on OpenBSD rather than include them on (pretty much every) other operating systems.