### PR TITLE
Add IPV6_MULTICAST_IF sockopt

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -235,6 +235,7 @@ cfg_if! {
 }
 sockopt_impl!(Both, IpMulticastTtl, libc::IPPROTO_IP, libc::IP_MULTICAST_TTL, u8);
 sockopt_impl!(Both, IpMulticastLoop, libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP, bool);
+sockopt_impl!(Both, Ipv6MulticastIf, libc::IPPROTO_IPV6, libc::IPV6_MULTICAST_IF, libc::c_uint);
 sockopt_impl!(Both, ReceiveTimeout, libc::SOL_SOCKET, libc::SO_RCVTIMEO, TimeVal);
 sockopt_impl!(Both, SendTimeout, libc::SOL_SOCKET, libc::SO_SNDTIMEO, TimeVal);
 sockopt_impl!(Both, Broadcast, libc::SOL_SOCKET, libc::SO_BROADCAST, bool);


### PR DESCRIPTION
The value type is a `libc::c_uint` since that's what's returned by `nix::net::if_::if_nametoindex`.

I haven't gated the sockopt for any particular target_os since it seems to be widely supported by the libc package:

```
src/vxworks/mod.rs
734:pub const IPV6_MULTICAST_IF: ::c_int = 9;

src/fuchsia/mod.rs
1774:pub const IPV6_MULTICAST_IF: ::c_int = 17;

src/unix/newlib/mod.rs
512:pub const IPV6_MULTICAST_IF: ::c_int = 9;

src/unix/haiku/mod.rs
843:pub const IPV6_MULTICAST_IF: ::c_int = 24;

src/unix/uclibc/mod.rs
906:pub const IPV6_MULTICAST_IF: ::c_int = 17;

src/unix/solarish/mod.rs
939:pub const IPV6_MULTICAST_IF: ::c_int = 0x6;

src/unix/redox/mod.rs
448:pub const IPV6_MULTICAST_IF: ::c_int = 17;

src/unix/linux_like/mod.rs
895:pub const IPV6_MULTICAST_IF: ::c_int = 17;

src/unix/bsd/mod.rs
299:pub const IPV6_MULTICAST_IF: ::c_int = 9;
```

I don't know if there's a better way to check for system availability than grep'ing the libc package, it's the first time I try to do this, any feedback welcome!