### PR TITLE
Add `PTRACE_EVENT_STOP` enum variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1422](https://github.com/nix-rust/nix/pull/1422))
 - Added `IP6T_SO_ORIGINAL_DST` sockopt.
   (#[1490](https://github.com/nix-rust/nix/pull/1490))
+- Added the `PTRACE_EVENT_STOP` variant to the `sys::ptrace::Event` enum
+  (#[1335](https://github.com/nix-rust/nix/pull/1335))
 
 ### Changed
 

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -137,9 +137,11 @@ libc_enum!{
         /// Event for a stop before an exit. Unlike the waitpid Exit status program.
         /// registers can still be examined
         PTRACE_EVENT_EXIT,
-        /// STop triggered by a seccomp rule on a tracee.
+        /// Stop triggered by a seccomp rule on a tracee.
         PTRACE_EVENT_SECCOMP,
-        // PTRACE_EVENT_STOP not provided by libc because it's defined in glibc 2.26
+        /// Stop triggered by the `INTERRUPT` syscall, or a group stop,
+        /// or when a new child is attached.
+        PTRACE_EVENT_STOP,
     }
 }
 
@@ -401,7 +403,7 @@ pub fn kill(pid: Pid) -> Result<()> {
     }
 }
 
-/// Move the stopped tracee process forward by a single step as with 
+/// Move the stopped tracee process forward by a single step as with
 /// `ptrace(PTRACE_SINGLESTEP, ...)`
 ///
 /// Advances the execution of the process with PID `pid` by a single step optionally delivering a
@@ -411,11 +413,11 @@ pub fn kill(pid: Pid) -> Result<()> {
 /// ```rust
 /// use nix::sys::ptrace::step;
 /// use nix::unistd::Pid;
-/// use nix::sys::signal::Signal; 
+/// use nix::sys::signal::Signal;
 /// use nix::sys::wait::*;
 /// fn main() {
-///     // If a process changes state to the stopped state because of a SIGUSR1 
-///     // signal, this will step the process forward and forward the user 
+///     // If a process changes state to the stopped state because of a SIGUSR1
+///     // signal, this will step the process forward and forward the user
 ///     // signal to the stopped process
 ///     match waitpid(Pid::from_raw(-1), None) {
 ///         Ok(WaitStatus::Stopped(pid, Signal::SIGUSR1)) => {


### PR DESCRIPTION
Adds the `PTRACE_EVENT_STOP` variant to the `ptrace::Event` enum.

Smaller part of #1279

Closes #1334 