### PR TITLE
Allow Android to use timerfd

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -103,5 +103,5 @@ pub mod wait;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod inotify;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod timerfd;


### PR DESCRIPTION
Hey there! I'm from the Android Bluetooth team, and we're using timerfd for our timers (even in our old C/C++ code) since they can wake the device. Here's a small patch that opens up timerfd to the Android config too.