### PR TITLE
Add docs.rs target list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,19 @@ exclude     = [
   "/bors.toml"
 ]
 
+[package.metadata.docs.rs]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-linux-android",
+  "x86_64-apple-darwin",
+  "aarch64-apple-ios",
+  "x86_64-unknown-freebsd",
+  "x86_64-unknown-openbsd",
+  "x86_64-unknown-netbsd",
+  "x86_64-unknown-dragonfly",
+  "x86_64-unknown-redox"
+]
+
 [dependencies]
 libc = { version = "0.2.78", features = [ "extra_traits" ] }
 bitflags = "1.1"


### PR DESCRIPTION
ref: https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html

Makes sense to build docs for all supported OSes (BSD, Redox) rather than completely empty docs for Windows :)