### PR TITLE
Add a passwd field to Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
+- Added a `passwd` field to `Group` (#[1338](https://github.com/nix-rust/nix/pull/1338))
 - Added `mremap` (#[1306](https://github.com/nix-rust/nix/pull/1306))
 - Added `personality` (#[1331](https://github.com/nix-rust/nix/pull/1331))
 - Added limited Fuchsia support (#[1285](https://github.com/nix-rust/nix/pull/1285))

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2671,6 +2671,8 @@ impl User {
 pub struct Group {
     /// Group name
     pub name: String,
+    /// Group password
+    pub passwd: CString,
     /// Group ID
     pub gid: Gid,
     /// List of Group members
@@ -2683,6 +2685,7 @@ impl From<&libc::group> for Group {
         unsafe {
             Group {
                 name: CStr::from_ptr((*gr).gr_name).to_string_lossy().into_owned(),
+                passwd: CString::new(CStr::from_ptr((*gr).gr_passwd).to_bytes()).unwrap(),
                 gid: Gid::from_raw((*gr).gr_gid),
                 mem: Group::members((*gr).gr_mem)
             }


### PR DESCRIPTION
Adds a `passwd` field to unistd::Group. The `gr_passwd` field exists on `libc::group` and wasn't exposed.

I didn't see tests for `from(libc:group)` for either `User` or `Password`. Let me know if there are other tests I should add!