### PR TITLE
Disable test-aio-drop in GNU environments

### DIFF
--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -9,6 +9,7 @@
               target_os = "macos",
               target_os = "freebsd",
               target_os = "netbsd")))]
+#[cfg_attr(target_env = "gnu", ignore = "Occasionally fails in Travis; glibc bug suspected")]
 fn test_drop() {
     use nix::sys::aio::*;
     use nix::sys::signal::*;


### PR DESCRIPTION
This test occasionally fails in Travis on x86_64-unknown-linux-gnu.  The
failure takes the form of the test executable receiving a random signal.
Sometimes SIGHUP, sometimes SIGKILL, etc.  I think this must be a bug in
glibc, even though I can't reproduce it in my development environment.
But it interferes with CI too much to leave enabled.