### PR TITLE
Add public API for PTRACE_GETFPREGS and PTRACE_SETFPREGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 - Added `mremap` (#[1306](https://github.com/nix-rust/nix/pull/1306))
+- Added public API for the `PTRACE_GETFPREGS` and `PTRACE_SETFPREGS` requests.
+  (#[1356](https://github.com/nix-rust/nix/pull/1356))
 
 ### Fixed
 ### Changed


### PR DESCRIPTION
Currently there is no public API for the `PTRACE_GETFPREGS` and `PTRACE_SETFPREGS` requests [(the generic `ptrace` call has been deprecated since 0.10.0](https://docs.rs/nix/0.17.0/nix/sys/ptrace/fn.ptrace.html)). The added functions mimick the ones already in place for `PTRACE_GETREGS` and `PTRACE_SETREGS`.