### PR TITLE
Support sys::statfs::*_MAGIC constants on s390x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `mremap` (#[1306](https://github.com/nix-rust/nix/pull/1306))
 
 ### Fixed
+- Fixed `MAGIC` constants in `nix::sys::statfs` on s390x (#[1357](https://github.com/nix-rust/nix/pull/1357))
+
 ### Changed
 
 - i686-apple-darwin has been demoted to Tier 2 support, because it's deprecated

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -90,6 +90,65 @@ pub const CGROUP_SUPER_MAGIC: FsType = FsType(libc::CGROUP_SUPER_MAGIC);
 #[cfg(all(target_os = "linux", not(target_env = "musl"), not(target_arch = "s390x")))]
 pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC);
 
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const ADFS_SUPER_MAGIC: FsType = FsType(libc::ADFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const AFFS_SUPER_MAGIC: FsType = FsType(libc::AFFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const CODA_SUPER_MAGIC: FsType = FsType(libc::CODA_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const CRAMFS_MAGIC: FsType = FsType(libc::CRAMFS_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const EFS_SUPER_MAGIC: FsType = FsType(libc::EFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const EXT2_SUPER_MAGIC: FsType = FsType(libc::EXT2_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const EXT3_SUPER_MAGIC: FsType = FsType(libc::EXT3_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const EXT4_SUPER_MAGIC: FsType = FsType(libc::EXT4_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const HPFS_SUPER_MAGIC: FsType = FsType(libc::HPFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const HUGETLBFS_MAGIC: FsType = FsType(libc::HUGETLBFS_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const ISOFS_SUPER_MAGIC: FsType = FsType(libc::ISOFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const JFFS2_SUPER_MAGIC: FsType = FsType(libc::JFFS2_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const MINIX_SUPER_MAGIC: FsType = FsType(libc::MINIX_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const MINIX_SUPER_MAGIC2: FsType = FsType(libc::MINIX_SUPER_MAGIC2 as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const MINIX2_SUPER_MAGIC: FsType = FsType(libc::MINIX2_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const MINIX2_SUPER_MAGIC2: FsType = FsType(libc::MINIX2_SUPER_MAGIC2 as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const MSDOS_SUPER_MAGIC: FsType = FsType(libc::MSDOS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const NCP_SUPER_MAGIC: FsType = FsType(libc::NCP_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const NFS_SUPER_MAGIC: FsType = FsType(libc::NFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const OPENPROM_SUPER_MAGIC: FsType = FsType(libc::OPENPROM_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const OVERLAYFS_SUPER_MAGIC: FsType = FsType(libc::OVERLAYFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const PROC_SUPER_MAGIC: FsType = FsType(libc::PROC_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const QNX4_SUPER_MAGIC: FsType = FsType(libc::QNX4_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const REISERFS_SUPER_MAGIC: FsType = FsType(libc::REISERFS_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const SMB_SUPER_MAGIC: FsType = FsType(libc::SMB_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const TMPFS_MAGIC: FsType = FsType(libc::TMPFS_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const USBDEVICE_SUPER_MAGIC: FsType = FsType(libc::USBDEVICE_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const CGROUP_SUPER_MAGIC: FsType = FsType(libc::CGROUP_SUPER_MAGIC as u32);
+#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as u32);
+
 impl Statfs {
     /// Magic code defining system type
     #[cfg(not(any(


### PR DESCRIPTION
Hi, I work in container development on Linux on Z at IBM.
Currently, `cargo test` fails on s390x (IBM Z mainframe) with

```
error[E0425]: cannot find value `OVERLAYFS_SUPER_MAGIC` in module `nix::sys::statfs`
   --> test/test_fcntl.rs:242:58
    |
242 |         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
    |                                                          ^^^^^^^^^^^^^^^^^^^^^ not found in `nix::sys::statfs`
    |
help: consider importing one of these items
    |
84  |     use crate::sys::test_signal::libc::OVERLAYFS_SUPER_MAGIC;
    |
84  |     use libc::OVERLAYFS_SUPER_MAGIC;
    |

error[E0425]: cannot find value `OVERLAYFS_SUPER_MAGIC` in module `nix::sys::statfs`
   --> test/test_fcntl.rs:284:58
    |
284 |         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
    |                                                          ^^^^^^^^^^^^^^^^^^^^^ not found in `nix::sys::statfs`
    |
help: consider importing one of these items
    |
84  |     use crate::sys::test_signal::libc::OVERLAYFS_SUPER_MAGIC;
    |
84  |     use libc::OVERLAYFS_SUPER_MAGIC;
    |
```

Similar issues occur when other `*_MAGIC` constants from `nix::sys::statfs` are to be used ([this](https://github.com/kata-containers/cgroups-rs/blob/master/src/hierarchies.rs#L231) is where I ran into it).
These constants are currently disabled for s390x because an `FsType` should be `u32` on s390x rather than the `libc::c_long` of GNU non-s390x (this is, in principle, already implemented), but the `*_MAGIC` constants from `libc` are `i64`.
However, it is safe to store them as 32bit integers, since according to [`statfs(2)`](https://man7.org/linux/man-pages/man2/statfs.2.html), all the constants aren't any wider than 32bit.
Thus, I suggest the attached change to declare these constants as `u32` on s390x.
This leads to a successful run of `cargo test` on s390x.
Please let me know if you think this could be done more elegantly.