### PR TITLE
add IP_MULTICAST_IF for sockopt

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -385,8 +385,9 @@ cfg_if! {
                          target_arch = "powerpc64"))))] {
         /// Request for multicast socket's outgoing interface
         ///
-        /// The value must be a `libc::in_addr` structure, which is the most common.
-        /// `ip_mreqn` or `ip_mreq` structure are not supported. One reason is that
+        /// The value is a `libc::in_addr` structure, which is the most common.
+        /// `ip_mreqn` or `ip_mreq` structure are not supported at this point, one
+        /// reason is that if we use enum to represent all possible structures,
         /// `#[repr(transparent)]` does not support enum.
         #[repr(transparent)]
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -375,18 +375,28 @@ impl Ipv6MembershipRequest {
     }
 }
 
-/// Request for multicast socket's outgoing interface
-///
-/// The value must be a `libc::in_addr` structure, which is the most common.
-/// `ip_mreqn` or `ip_mreq` structure are not supported. One reason is that
-/// `#[repr(transparent)]` does not support enum.
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IpMulticastIfInAddr(libc::in_addr);
+cfg_if! {
+    if #[cfg(not(all(target_os = "linux",
+                     target_env = "gnu",
+                     any(target_arch = "mips",
+                         target_arch = "mips64",
+                         target_arch = "aarch64",
+                         target_arch = "arm",
+                         target_arch = "powerpc64"))))] {
+        /// Request for multicast socket's outgoing interface
+        ///
+        /// The value must be a `libc::in_addr` structure, which is the most common.
+        /// `ip_mreqn` or `ip_mreq` structure are not supported. One reason is that
+        /// `#[repr(transparent)]` does not support enum.
+        #[repr(transparent)]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        pub struct IpMulticastIfInAddr(libc::in_addr);
 
-impl IpMulticastIfInAddr {
-    pub fn new(interface: Ipv4Addr) -> Self {
-        IpMulticastIfInAddr(interface.0)
+        impl IpMulticastIfInAddr {
+            pub fn new(interface: Ipv4Addr) -> Self {
+                IpMulticastIfInAddr(interface.0)
+            }
+        }
     }
 }
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -375,6 +375,24 @@ impl Ipv6MembershipRequest {
     }
 }
 
+/// Request for multicast socket's outgoing interface
+///
+/// Normally the value is an `in_addr` structure, but
+/// Linux also supports an ip_mreqn or (since Linux 3.5) ip_mreq
+/// structure, hence define an enum to support future expansions.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IpMulticastIfRequest {
+    IN_ADDR(libc::in_addr),
+}
+
+impl IpMulticastIfRequest {
+    /// Instantiate a new `IpMulticastIfRequest::IN_ADDR`
+    pub fn new_in_addr(interface: Ipv4Addr) -> Self {
+        IpMulticastIfRequest::IN_ADDR(interface.0)
+    }
+}
+
 /// Create a buffer large enough for storing some control messages as returned
 /// by [`recvmsg`](fn.recvmsg.html).
 ///

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -377,18 +377,16 @@ impl Ipv6MembershipRequest {
 
 /// Request for multicast socket's outgoing interface
 ///
-/// Normally the value is an `in_addr` structure, but
-/// Linux also supports an ip_mreqn or (since Linux 3.5) ip_mreq
-/// structure, hence define an enum to support future expansions.
+/// The value must be a `libc::in_addr` structure, which is the most common.
+/// `ip_mreqn` or `ip_mreq` structure are not supported. One reason is that
+/// `#[repr(transparent)]` does not support enum.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum IpMulticastIfRequest {
-    IN_ADDR(libc::in_addr),
-}
+pub struct IpMulticastIfInAddr(libc::in_addr);
 
-impl IpMulticastIfRequest {
-    /// Instantiate a new `IpMulticastIfRequest::IN_ADDR`
-    pub fn new_in_addr(interface: Ipv4Addr) -> Self {
-        IpMulticastIfRequest::IN_ADDR(interface.0)
+impl IpMulticastIfInAddr {
+    pub fn new(interface: Ipv4Addr) -> Self {
+        IpMulticastIfInAddr(interface.0)
     }
 }
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -380,7 +380,6 @@ impl Ipv6MembershipRequest {
 /// Normally the value is an `in_addr` structure, but
 /// Linux also supports an ip_mreqn or (since Linux 3.5) ip_mreq
 /// structure, hence define an enum to support future expansions.
-#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IpMulticastIfRequest {
     IN_ADDR(libc::in_addr),

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -233,6 +233,7 @@ cfg_if! {
         sockopt_impl!(SetOnly, Ipv6DropMembership, libc::IPPROTO_IPV6, libc::IPV6_LEAVE_GROUP, super::Ipv6MembershipRequest);
     }
 }
+sockopt_impl!(Both, IpMulticastIf, libc::IPPROTO_IP, libc::IP_MULTICAST_IF, super::IpMulticastIfRequest);
 sockopt_impl!(Both, IpMulticastTtl, libc::IPPROTO_IP, libc::IP_MULTICAST_TTL, u8);
 sockopt_impl!(Both, IpMulticastLoop, libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP, bool);
 sockopt_impl!(Both, ReceiveTimeout, libc::SOL_SOCKET, libc::SO_RCVTIMEO, TimeVal);

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -233,7 +233,17 @@ cfg_if! {
         sockopt_impl!(SetOnly, Ipv6DropMembership, libc::IPPROTO_IPV6, libc::IPV6_LEAVE_GROUP, super::Ipv6MembershipRequest);
     }
 }
-sockopt_impl!(Both, IpMulticastIf, libc::IPPROTO_IP, libc::IP_MULTICAST_IF, super::IpMulticastIfInAddr);
+cfg_if! {
+    if #[cfg(not(all(target_os = "linux",
+                     target_env = "gnu",
+                     any(target_arch = "mips",
+                         target_arch = "mips64",
+                         target_arch = "aarch64",
+                         target_arch = "arm",
+                         target_arch = "powerpc64"))))] {
+        sockopt_impl!(Both, IpMulticastIf, libc::IPPROTO_IP, libc::IP_MULTICAST_IF, super::IpMulticastIfInAddr);
+    }
+}
 sockopt_impl!(Both, IpMulticastTtl, libc::IPPROTO_IP, libc::IP_MULTICAST_TTL, u8);
 sockopt_impl!(Both, IpMulticastLoop, libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP, bool);
 sockopt_impl!(Both, ReceiveTimeout, libc::SOL_SOCKET, libc::SO_RCVTIMEO, TimeVal);

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -233,7 +233,7 @@ cfg_if! {
         sockopt_impl!(SetOnly, Ipv6DropMembership, libc::IPPROTO_IPV6, libc::IPV6_LEAVE_GROUP, super::Ipv6MembershipRequest);
     }
 }
-sockopt_impl!(Both, IpMulticastIf, libc::IPPROTO_IP, libc::IP_MULTICAST_IF, super::IpMulticastIfRequest);
+sockopt_impl!(Both, IpMulticastIf, libc::IPPROTO_IP, libc::IP_MULTICAST_IF, super::IpMulticastIfInAddr);
 sockopt_impl!(Both, IpMulticastTtl, libc::IPPROTO_IP, libc::IP_MULTICAST_TTL, u8);
 sockopt_impl!(Both, IpMulticastLoop, libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP, bool);
 sockopt_impl!(Both, ReceiveTimeout, libc::SOL_SOCKET, libc::SO_RCVTIMEO, TimeVal);

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -97,6 +97,13 @@ fn test_so_tcp_keepalive() {
 }
 
 #[test]
+#[cfg(not(all(target_os = "linux",
+                     target_env = "gnu",
+                     any(target_arch = "mips",
+                         target_arch = "mips64",
+                         target_arch = "aarch64",
+                         target_arch = "arm",
+                         target_arch = "powerpc64"))))]
 fn test_so_multicast_if() {
     let fd = socket(AddressFamily::Inet, SockType::Datagram, SockFlag::empty(), None).unwrap();
     let addrs = getifaddrs().unwrap();

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1,6 +1,14 @@
 use rand::{thread_rng, Rng};
-use nix::ifaddrs::getifaddrs;
-use nix::sys::socket::{AddressFamily, IpAddr, IpMulticastIfInAddr, SockAddr, SockFlag, SockProtocol, SockType, getsockopt, setsockopt, socket, sockopt};
+use nix::sys::socket::{socket, sockopt, getsockopt, setsockopt, AddressFamily, SockType, SockFlag, SockProtocol};
+#[cfg(not(all(target_os = "linux",
+                     target_env = "gnu",
+                     any(target_arch = "mips",
+                         target_arch = "mips64",
+                         target_arch = "aarch64",
+                         target_arch = "arm",
+                         target_arch = "powerpc64"))))]
+use nix::{ifaddrs::getifaddrs, sys::socket::{IpAddr, IpMulticastIfInAddr, SockAddr}};
+
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::*;
 

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1,6 +1,6 @@
 use rand::{thread_rng, Rng};
 use nix::ifaddrs::getifaddrs;
-use nix::sys::socket::{AddressFamily, IpAddr, IpMulticastIfRequest, SockAddr, SockFlag, SockProtocol, SockType, getsockopt, setsockopt, socket, sockopt};
+use nix::sys::socket::{AddressFamily, IpAddr, IpMulticastIfInAddr, SockAddr, SockFlag, SockProtocol, SockType, getsockopt, setsockopt, socket, sockopt};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::*;
 
@@ -104,7 +104,7 @@ fn test_so_multicast_if() {
     for if_addr in addrs {
         if let Some(SockAddr::Inet(inet_addr)) = if_addr.address {
             if let IpAddr::V4(ipv4_addr) = inet_addr.ip() {
-                let request = IpMulticastIfRequest::new_in_addr(ipv4_addr);
+                let request = IpMulticastIfInAddr::new(ipv4_addr);
                 setsockopt(fd, sockopt::IpMulticastIf, &request).unwrap();
                 assert_eq!(getsockopt(fd, sockopt::IpMulticastIf).unwrap(), request);
             }


### PR DESCRIPTION
IP_MULTICAST_IF is not supported by `sockopt` in `nix`. See issue #1360 .

According to Linux [man page](https://man7.org/linux/man-pages/man7/ip.7.html), IP_MULTICAST_IF is used in this way: 

quote:
```
IP_MULTICAST_IF (since Linux 1.2)
              Set the local device for a multicast socket.  The argument for
              setsockopt(2) is an ip_mreqn or (since Linux 3.5) ip_mreq
              structure similar to IP_ADD_MEMBERSHIP, or an in_addr struc‐
              ture.  (The kernel determines which structure is being passed
              based on the size passed in optlen.)  For getsockopt(2), the
              argument is an in_addr structure.
```

Please review this patch.  Also I have a question:  how do we add automated testing for such `sockopt` in `nix`? I've added a test case in my own code that uses `nix` and it works, but don't know about the practice of testing inside `nix`. Thanks.

Update: 12/24/2020

The original approach of defining an Enum did not work well because `#[repr(transparent)]` does not support Enum. Moreover, my use cases only care about `in_addr` value, which is the most common AFAIK. So I refactored the patch to address the major cases I actually understand, and added a test case.

Also, based on the Github Actions results, I excluded the patch from the (OS, env, arch) that failed with error `ENOPROTOOPT`.
