### PR TITLE
Add Conversion: Signal into c_int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Implemented trait `Into<c_int>` for `Signal` (#[1367](https://github.com/nix-rust/nix/pull/1367))
 - Added `mremap` (#[1306](https://github.com/nix-rust/nix/pull/1306))
 - Added `personality` (#[1331](https://github.com/nix-rust/nix/pull/1331))
 - Added limited Fuchsia support (#[1285](https://github.com/nix-rust/nix/pull/1285))


### PR DESCRIPTION
**Background**
Some APIs (such as `nix::sched::clone`) requires a signal field with type `c_int` but not `nix::sys::signal::Signal`.
But I didn't find any functions can convert a `Signal` enum into its id in `int`.

**Description**
impl the `Into<c_int>` trait for `nix::sys::signal::Signal`.

**Other infomation**
The tests has passed on my computer(`Ubuntu 20.10`, `rustc 1.50.0-nightly`)