### PR TITLE
Fix fcntl for FreeBSD platform

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -20,7 +20,7 @@ use crate::sys::uio::IoVec; // For vmsplice
     target_os = "fuchsia",
     any(target_os = "wasi", target_env = "wasi"),
     target_env = "uclibc",
-    target_env = "freebsd"
+    target_os = "freebsd"
 ))]
 pub use self::posix_fadvise::*;
 
@@ -587,7 +587,7 @@ pub fn fallocate(
     target_os = "fuchsia",
     any(target_os = "wasi", target_env = "wasi"),
     target_env = "uclibc",
-    target_env = "freebsd"
+    target_os = "freebsd"
 ))]
 mod posix_fadvise {
     use crate::errno::Errno;

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -332,7 +332,7 @@ mod linux_android {
           target_os = "fuchsia",
           any(target_os = "wasi", target_env = "wasi"),
           target_env = "uclibc",
-          target_env = "freebsd"))]
+          target_os = "freebsd"))]
 mod test_posix_fadvise {
 
     use tempfile::NamedTempFile;


### PR DESCRIPTION
When compiling the following code with nix `0.19.1` under FreeBSD 12.2:

```
use std::os::unix::io::AsRawFd;

fn main() {
    let f = std::fs::File::create("/tmp/testfile").unwrap();

    nix::fcntl::posix_fadvise(
        f.as_raw_fd(),
        0,
        0,
        nix::fcntl::PosixFadviseAdvice::POSIX_FADV_NOREUSE,
    ).unwrap();
}
```

I get the following error:

```
error[E0433]: failed to resolve: could not find `PosixFadviseAdvice` in `fcntl`
  --> src/main.rs:10:21
   |
10 |         nix::fcntl::PosixFadviseAdvice::POSIX_FADV_NOREUSE,
   |                     ^^^^^^^^^^^^^^^^^^ could not find `PosixFadviseAdvice` in `fcntl`

error[E0425]: cannot find function `posix_fadvise` in module `nix::fcntl`
 --> src/main.rs:6:17
  |
6 |     nix::fcntl::posix_fadvise(
  |                 ^^^^^^^^^^^^^ not found in `nix::fcntl`

error: aborting due to 2 previous errors
```

Checking the documentation I noticed the documentation for the FreeBSD platform was missing:

https://docs.rs/nix/0.19.1/x86_64-unknown-freebsd/nix/?search=PosixFadviseAdvice

Checking the code I noticed that `target_env` was used instead of `target_os`:
* https://doc.rust-lang.org/reference/conditional-compilation.html#target_env
* https://doc.rust-lang.org/reference/conditional-compilation.html#target_os

Switching to `target_os` fixed the compilation errors. I also ran the tests with the fix and they seemed to be fine:

```
test result: ok. 68 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out
```

I hope this makes sense to fix.
