### PR TITLE
pty: Make forkpty() unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
 ### Changed
+- Made `forkpty` unsafe, like `fork`
+  (#[1390](https://github.com/nix-rust/nix/pull/1390))
+
 ### Fixed
 ### Removed
 

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -255,7 +255,9 @@ fn test_forkpty() {
 
     let string = "naninani\n";
     let echoed_string = "naninani\r\n";
-    let pty = forkpty(None, None).unwrap();
+    let pty = unsafe {
+        forkpty(None, None).unwrap()
+    };
     match pty.fork_result {
         Child => {
             write(STDOUT_FILENO, string.as_bytes()).unwrap();


### PR DESCRIPTION
After the child returns from a fork() of a multi-threaded process, it is
undefined behaviour to call non-async-signal-safe functions according to
POSIX.  Since forkpty() is implemented in terms of fork(), those
restrictions should apply to it too.

Fixes #1388