### PR TITLE
Allow sockaddr_ll size mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (#[1390](https://github.com/nix-rust/nix/pull/1390))
 
 ### Fixed
+- Allow `sockaddr_ll` size, as reported by the Linux kernel, to be smaller then it's definition
+  (#[1395](https://github.com/nix-rust/nix/pull/1395))
+
 ### Removed
 
 - Removed `sys::socket::accept4` from Android arm because libc removed it in

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1711,7 +1711,10 @@ pub fn sockaddr_storage_to_addr(
         #[cfg(any(target_os = "android", target_os = "linux"))]
         libc::AF_PACKET => {
             use libc::sockaddr_ll;
-            assert_eq!(len as usize, mem::size_of::<sockaddr_ll>());
+            // Apparently the Linux kernel can return smaller sizes when
+            // the value in the last element of sockaddr_ll (`sll_addr`) is
+            // smaller than the declared size of that field
+            assert!(len as usize <= mem::size_of::<sockaddr_ll>());
             let sll = unsafe {
                 *(addr as *const _ as *const sockaddr_ll)
             };


### PR DESCRIPTION
Apparently the Linux kernel can return smaller sizes when the value in
the last element of sockaddr_ll (`sll_addr`) is smaller than the
declared size of that field.