### PR TITLE
Add aarch64-apple-darwin with tier 3 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ task:
   name: macOS aarch64
   env:
     TARGET: aarch64-apple-darwin
-    TOOLCHAIN: stable
+    TOOLCHAIN: 1.50.0
     DISABLE_TESTS: 1
   osx_instance:
     image: big-sur-xcode
@@ -70,7 +70,6 @@ task:
     - . $HOME/.cargo/env
     - bash ci/script.sh
   before_cache_script: rm -rf $CARGO_HOME/registry/index
-  allow_failures: true
 
 # Use cross for QEMU-based testing
 # cross needs to execute Docker, so we must use Cirrus's Docker Builder task.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,6 @@ task:
   before_cache_script: rm -rf $CARGO_HOME/registry/index
   allow_failures: true
 
-task:
 # Use cross for QEMU-based testing
 # cross needs to execute Docker, so we must use Cirrus's Docker Builder task.
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,29 @@ task:
     - bash ci/script.sh
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
+
+# macOS aarch64 requires a more recent toolchain than the other macOS targets.
+task:
+  name: macOS aarch64
+  env:
+    TARGET: aarch64-apple-darwin
+    TOOLCHAIN: stable
+    DISABLE_TESTS: 1
+  osx_instance:
+    image: big-sur-xcode
+  setup_script:
+    - curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
+    - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
+    - . $HOME/.cargo/env
+    - rustup target add $TARGET
+    - bash ci/install.sh
+  script:
+    - . $HOME/.cargo/env
+    - bash ci/script.sh
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
+  allow_failures: true
+
+task:
 # Use cross for QEMU-based testing
 # cross needs to execute Docker, so we must use Cirrus's Docker Builder task.
 task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Made `forkpty` unsafe, like `fork`
   (#[1390](https://github.com/nix-rust/nix/pull/1390))
+- Added `aarch64-apple-darwin` with Tier 3 support.
 
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added `aarch64-apple-darwin` with Tier 3 support.
+  (#[1396](https://github.com/nix-rust/nix/pull/1396))
 
 ### Changed
 - Made `forkpty` unsafe, like `fork`
   (#[1390](https://github.com/nix-rust/nix/pull/1390))
-- Added `aarch64-apple-darwin` with Tier 3 support.
 
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Tier 2:
   * x86_64-unknown-netbsd
 
 Tier 3:
+  * aarch64-apple-darwin
   * x86_64-fuchsia
   * x86_64-unknown-redox
   * x86_64-unknown-linux-gnux32

--- a/bors.toml
+++ b/bors.toml
@@ -27,6 +27,7 @@ status = [
   "Redox x86_64",
   "Rust Stable",
   "iOS",
+  "macOS aarch64",
 ]
 
 # Set bors's timeout to 1 hour


### PR DESCRIPTION
README.md says tier 3 targets are allowed to fail CI builds, but I couldn't see how the other tier 3 targets are configured in such a way. `allow_failures: true` seems to be the way on Cirrus.