### PR TITLE
Remove accept4 on Android arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+- Removed `sys::socket::accept4` from Android arm because libc removed it in
+  version 0.2.87.
+  ([#1399](https://github.com/nix-rust/nix/pull/1399))
+
 ## [0.20.0] - 20 February 2021
 ### Added
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1481,7 +1481,14 @@ pub fn accept(sockfd: RawFd) -> Result<RawFd> {
 /// Accept a connection on a socket
 ///
 /// [Further reading](http://man7.org/linux/man-pages/man2/accept.2.html)
-#[cfg(any(target_os = "android",
+#[cfg(any(all(
+            target_os = "android",
+            any(
+                target_arch = "aarch64",
+                target_arch = "x86",
+                target_arch = "x86_64"
+            )
+          ),
           target_os = "freebsd",
           target_os = "linux",
           target_os = "openbsd"))]


### PR DESCRIPTION
libc removed it in version 0.2.87.

https://github.com/rust-lang/libc/pull/2079