### PR TITLE
Temporarily disable test_vsock on QEMU arches

### DIFF
--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1491,6 +1491,7 @@ pub fn test_recv_ipv6pktinfo() {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(not(target_arch = "x86_64"), ignore)]
 #[test]
 pub fn test_vsock() {
     use libc;


### PR DESCRIPTION
Issue #1403