### PR TITLE
Fix test_vsock failure on VMADDR_CID_LOCAL testing and re-enable it

### DIFF
--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1508,16 +1508,10 @@ pub fn test_vsock() {
                     SockFlag::empty(), None)
              .expect("socket failed");
 
-    // VMADDR_CID_HYPERVISOR and VMADDR_CID_LOCAL are reserved, so we expect
-    // an EADDRNOTAVAIL error.
+    // VMADDR_CID_HYPERVISOR is reserved, so we expect an EADDRNOTAVAIL error.
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_HYPERVISOR, port);
     assert_eq!(bind(s1, &sockaddr).err(),
                Some(Error::Sys(Errno::EADDRNOTAVAIL)));
-
-    let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_LOCAL, port);
-    assert_eq!(bind(s1, &sockaddr).err(),
-               Some(Error::Sys(Errno::EADDRNOTAVAIL)));
-
 
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_ANY, port);
     assert_eq!(bind(s1, &sockaddr), Ok(()));

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1491,7 +1491,6 @@ pub fn test_recv_ipv6pktinfo() {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(not(target_arch = "x86_64"), ignore)]
 #[test]
 pub fn test_vsock() {
     use libc;


### PR DESCRIPTION
Starting from Linux 5.6, `VMADDR_CID_LOCAL` is supported to do local communication (loopback device).

Before Linux 5.6 it was called `VMADDR_CID_RESERVED` and was not supported, so we could expect an `EADDRNOTAVAIL`, but now this address is supported and handled by the 'vsock_loopback' kernel module loaded automatically if no other vsock transports are loaded.

Issue #1310
Issue #1403

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>