### PR TITLE
unistd: Increase maximum passwd/group buffer to 1MB

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2641,10 +2641,10 @@ impl User {
               libc::size_t,
               *mut *mut libc::passwd) -> libc::c_int
     {
-        let buflimit = 16384;
+        let buflimit = 1048576;
         let bufsize = match sysconf(SysconfVar::GETPW_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
-            Ok(None) | Err(_) => buflimit as usize,
+            Ok(None) | Err(_) => 16384,
         };
 
         let mut cbuf = Vec::with_capacity(bufsize);
@@ -2762,10 +2762,10 @@ impl Group {
               libc::size_t,
               *mut *mut libc::group) -> libc::c_int
     {
-        let buflimit = 16384;
+        let buflimit = 1048576;
         let bufsize = match sysconf(SysconfVar::GETGR_R_SIZE_MAX) {
             Ok(Some(n)) => n as usize,
-            Ok(None) | Err(_) => buflimit as usize,
+            Ok(None) | Err(_) => 16384,
         };
 
         let mut cbuf = Vec::with_capacity(bufsize);


### PR DESCRIPTION
We have one UNIX group that contains most of our users whose size is
about 20 kB, so `Group::from_name` is failing with ERANGE.

The discussion on PR #864 suggests that 1 MB is a reasonable maximum -
it follows what FreeBSD's libc does. (glibc appears to have no maximum
on the _r function and will just double the buffer until malloc fails,
but that's not particularly Rusty.)