### PR TITLE
Use memoffset::offset_of instead of homegrown macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ libc = { version = "0.2.82", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 
+[target.'cfg(not(target_os = "redox"))'.dependencies]
+memoffset = "0.6.3"
+
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -203,16 +203,3 @@ macro_rules! libc_enum {
         }
     };
 }
-
-/// A Rust version of the familiar C `offset_of` macro.  It returns the byte
-/// offset of `field` within struct `ty`
-#[cfg(not(target_os = "redox"))]
-macro_rules! offset_of {
-    ($ty:ty, $field:ident) => {{
-        // Safe because we don't actually read from the dereferenced pointer
-        #[allow(unused_unsafe)] // for when the macro is used in an unsafe block
-        unsafe {
-            &(*(ptr::null() as *const $ty)).$field as *const _ as usize
-        }
-    }}
-}

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1,6 +1,7 @@
 use super::sa_family_t;
 use crate::{Error, Result, NixPath};
 use crate::errno::Errno;
+use memoffset::offset_of;
 use std::{fmt, mem, net, ptr, slice};
 use std::ffi::OsStr;
 use std::hash::{Hash, Hasher};

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -5,6 +5,7 @@ use cfg_if::cfg_if;
 use crate::{Error, Result, errno::Errno};
 use libc::{self, c_void, c_int, iovec, socklen_t, size_t,
         CMSG_FIRSTHDR, CMSG_NXTHDR, CMSG_DATA, CMSG_LEN};
+use memoffset::offset_of;
 use std::{mem, ptr, slice};
 use std::os::unix::io::RawFd;
 use crate::sys::time::TimeVal;


### PR DESCRIPTION
The homegrown macro was fine in 2016, but at some point it technically
became UB.  The memoffset crate does the same thing, but avoids UB when
using rustc 1.51.0 or later.

Fixes #1415