### PR TITLE
Add PTRACE_INTERRUPT call as `ptrace::interrupt(pid)` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added `sendfile64` (#[1439](https://github.com/nix-rust/nix/pull/1439))
 - Added `MS_LAZYTIME` to `MsFlags`
   (#[1437](https://github.com/nix-rust/nix/pull/1437))
+- Added `ptrace::interrupt` method for platforms that support `PTRACE_INTERRUPT`
+  (#[1422](https://github.com/nix-rust/nix/pull/1422))
 
 ### Changed
 - Made `forkpty` unsafe, like `fork`

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -98,11 +98,9 @@ libc_enum!{
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
                                                target_arch = "mips64"))))]
         PTRACE_SETREGSET,
-        #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+        #[cfg(target_os = "linux")]
         PTRACE_SEIZE,
-        #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+        #[cfg(target_os = "linux")]
         PTRACE_INTERRUPT,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
                                                target_arch = "mips64"))))]
@@ -339,7 +337,7 @@ pub fn attach(pid: Pid) -> Result<()> {
 /// Attach to a running process, as with `ptrace(PTRACE_SEIZE, ...)`
 ///
 /// Attaches to the process specified in pid, making it a tracee of the calling process.
-#[cfg(all(target_os = "linux", not(any(target_arch = "mips", target_arch = "mips64"))))]
+#[cfg(target_os = "linux")]
 pub fn seize(pid: Pid, options: Options) -> Result<()> {
     unsafe {
         ptrace_other(
@@ -381,6 +379,16 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
     };
     unsafe {
         ptrace_other(Request::PTRACE_CONT, pid, ptr::null_mut(), data).map(drop) // ignore the useless return value
+    }
+}
+
+/// Stop a tracee, as with `ptrace(PTRACE_INTERRUPT, ...)`
+///
+/// This request is equivalent to `ptrace(PTRACE_INTERRUPT, ...)`
+#[cfg(target_os = "linux")]
+pub fn interrupt(pid: Pid) -> Result<()> {
+    unsafe {
+        ptrace_other(Request::PTRACE_INTERRUPT, pid, ptr::null_mut(), ptr::null_mut()).map(drop)
     }
 }
 


### PR DESCRIPTION
I've based the test on `fn test_ptrace_cont`. Removed some parts, but not 100% sure what's the proper way of testing in nix context.

From ptrace-man page:

```
       PTRACE_INTERRUPT (since Linux 3.4)
              Stop a tracee.  If the tracee is running or sleeping in
              kernel space and PTRACE_SYSCALL is in effect, the system
              call is interrupted and syscall-exit-stop is reported.
              (The interrupted system call is restarted when the tracee
              is restarted.)  If the tracee was already stopped by a
              signal and PTRACE_LISTEN was sent to it, the tracee stops
              with PTRACE_EVENT_STOP and WSTOPSIG(status) returns the
              stop signal.  If any other ptrace-stop is generated at the
              same time (for example, if a signal is sent to the
              tracee), this ptrace-stop happens.  If none of the above
              applies (for example, if the tracee is running in user
              space), it stops with PTRACE_EVENT_STOP with
              WSTOPSIG(status) == SIGTRAP.  PTRACE_INTERRUPT only works
              on tracees attached by PTRACE_SEIZE.
```

