### PR TITLE
Fix timestamp doc

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -510,6 +510,7 @@ pub enum ControlMessageOwned {
     ///
     /// # Examples
     ///
+    /// ```
     /// # #[macro_use] extern crate nix;
     /// # use nix::sys::socket::*;
     /// # use nix::sys::uio::IoVec;


### PR DESCRIPTION
This fixed doc test issue here: https://docs.rs/nix/0.20.0/nix/sys/socket/enum.ControlMessageOwned.html#variant.ScmTimestamp