### PR TITLE
Rewrite links to use https:// instead of http://

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
+This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust bindings to *nix APIs
 
 [![Cirrus Build Status](https://api.cirrus-ci.com/github/nix-rust/nix.svg)](https://cirrus-ci.com/github/nix-rust/nix)
-[![crates.io](http://meritbadge.herokuapp.com/nix)](https://crates.io/crates/nix)
+[![crates.io](https://meritbadge.herokuapp.com/nix)](https://crates.io/crates/nix)
 
 [Documentation (Releases)](https://docs.rs/nix/)
 
@@ -17,7 +17,7 @@ usage.
 
 As an example of what Nix provides, examine the differences between what is
 exposed by libc and nix for the
-[gethostname](http://man7.org/linux/man-pages/man2/gethostname.2.html) system
+[gethostname](https://man7.org/linux/man-pages/man2/gethostname.2.html) system
 call:
 
 ```rust,ignore

--- a/src/kmod.rs
+++ b/src/kmod.rs
@@ -42,7 +42,7 @@ use crate::Result;
 /// init_module(&mut contents, &CString::new("who=Rust when=Now,12").unwrap()).unwrap();
 /// ```
 ///
-/// See [`man init_module(2)`](http://man7.org/linux/man-pages/man2/init_module.2.html) for more information.
+/// See [`man init_module(2)`](https://man7.org/linux/man-pages/man2/init_module.2.html) for more information.
 pub fn init_module(module_image: &[u8], param_values: &CStr) -> Result<()> {
     let res = unsafe {
         libc::syscall(
@@ -79,7 +79,7 @@ libc_bitflags!(
 /// finit_module(&f, &CString::new("").unwrap(), ModuleInitFlags::empty()).unwrap();
 /// ```
 ///
-/// See [`man init_module(2)`](http://man7.org/linux/man-pages/man2/init_module.2.html) for more information.
+/// See [`man init_module(2)`](https://man7.org/linux/man-pages/man2/init_module.2.html) for more information.
 pub fn finit_module<T: AsRawFd>(fd: &T, param_values: &CStr, flags: ModuleInitFlags) -> Result<()> {
     let res = unsafe {
         libc::syscall(
@@ -96,7 +96,7 @@ pub fn finit_module<T: AsRawFd>(fd: &T, param_values: &CStr, flags: ModuleInitFl
 libc_bitflags!(
     /// Flags used by `delete_module`.
     ///
-    /// See [`man delete_module(2)`](http://man7.org/linux/man-pages/man2/delete_module.2.html)
+    /// See [`man delete_module(2)`](https://man7.org/linux/man-pages/man2/delete_module.2.html)
     /// for a detailed description how these flags work.
     pub struct DeleteModuleFlags: libc::c_int {
         O_NONBLOCK;
@@ -115,7 +115,7 @@ libc_bitflags!(
 /// delete_module(&CString::new("mymod").unwrap(), DeleteModuleFlags::O_NONBLOCK).unwrap();
 /// ```
 ///
-/// See [`man delete_module(2)`](http://man7.org/linux/man-pages/man2/delete_module.2.html) for more information.
+/// See [`man delete_module(2)`](https://man7.org/linux/man-pages/man2/delete_module.2.html) for more information.
 pub fn delete_module(name: &CStr, flags: DeleteModuleFlags) -> Result<()> {
     let res = unsafe { libc::syscall(libc::SYS_delete_module, name.as_ptr(), flags.bits()) };
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -1,6 +1,6 @@
 //! Posix Message Queue functions
 //!
-//! [Further reading and details on the C API](http://man7.org/linux/man-pages/man7/mq_overview.7.html)
+//! [Further reading and details on the C API](https://man7.org/linux/man-pages/man7/mq_overview.7.html)
 
 use crate::Result;
 use crate::errno::Errno;
@@ -67,7 +67,7 @@ impl MqAttr {
 
 /// Open a message queue
 ///
-/// See also [`mq_open(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_open.html)
+/// See also [`mq_open(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_open.html)
 // The mode.bits cast is only lossless on some OSes
 #[allow(clippy::cast_lossless)]
 pub fn mq_open(name: &CString,
@@ -89,7 +89,7 @@ pub fn mq_open(name: &CString,
 
 /// Remove a message queue
 ///
-/// See also [`mq_unlink(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_unlink.html)
+/// See also [`mq_unlink(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_unlink.html)
 pub fn mq_unlink(name: &CString) -> Result<()> {
     let res = unsafe { libc::mq_unlink(name.as_ptr()) };
     Errno::result(res).map(drop)
@@ -97,7 +97,7 @@ pub fn mq_unlink(name: &CString) -> Result<()> {
 
 /// Close a message queue
 ///
-/// See also [`mq_close(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_close.html)
+/// See also [`mq_close(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_close.html)
 pub fn mq_close(mqdes: mqd_t) -> Result<()> {
     let res = unsafe { libc::mq_close(mqdes) };
     Errno::result(res).map(drop)
@@ -105,7 +105,7 @@ pub fn mq_close(mqdes: mqd_t) -> Result<()> {
 
 /// Receive a message from a message queue
 ///
-/// See also [`mq_receive(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_receive.html)
+/// See also [`mq_receive(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_receive.html)
 pub fn mq_receive(mqdes: mqd_t, message: &mut [u8], msg_prio: &mut u32) -> Result<usize> {
     let len = message.len() as size_t;
     let res = unsafe {
@@ -119,7 +119,7 @@ pub fn mq_receive(mqdes: mqd_t, message: &mut [u8], msg_prio: &mut u32) -> Resul
 
 /// Send a message to a message queue
 ///
-/// See also [`mq_send(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_send.html)
+/// See also [`mq_send(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_send.html)
 pub fn mq_send(mqdes: mqd_t, message: &[u8], msq_prio: u32) -> Result<()> {
     let res = unsafe {
         libc::mq_send(mqdes,
@@ -132,7 +132,7 @@ pub fn mq_send(mqdes: mqd_t, message: &[u8], msq_prio: u32) -> Result<()> {
 
 /// Get message queue attributes
 ///
-/// See also [`mq_getattr(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_getattr.html)
+/// See also [`mq_getattr(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_getattr.html)
 pub fn mq_getattr(mqd: mqd_t) -> Result<MqAttr> {
     let mut attr = mem::MaybeUninit::<libc::mq_attr>::uninit();
     let res = unsafe { libc::mq_getattr(mqd, attr.as_mut_ptr()) };
@@ -143,7 +143,7 @@ pub fn mq_getattr(mqd: mqd_t) -> Result<MqAttr> {
 /// Returns the old attributes
 /// It is recommend to use the `mq_set_nonblock()` and `mq_remove_nonblock()` convenience functions as they are easier to use
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_setattr.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_setattr.html)
 pub fn mq_setattr(mqd: mqd_t, newattr: &MqAttr) -> Result<MqAttr> {
     let mut attr = mem::MaybeUninit::<libc::mq_attr>::uninit();
     let res = unsafe {

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -21,22 +21,22 @@ libc_bitflags!(
     /// Standard interface flags, used by `getifaddrs`
     pub struct InterfaceFlags: libc::c_int {
         /// Interface is running. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_UP;
         /// Valid broadcast address set. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_BROADCAST;
         /// Internal debugging flag. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_DEBUG;
         /// Interface is a loopback interface. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_LOOPBACK;
         /// Interface is a point-to-point link. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_POINTOPOINT;
         /// Avoid use of trailers. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android",
                   target_os = "fuchsia",
                   target_os = "ios",
@@ -50,7 +50,7 @@ libc_bitflags!(
         #[cfg(any(target_os = "dragonfly"))]
         IFF_SMART;
         /// Resources allocated. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android",
                   target_os = "dragonfly",
                   target_os = "freebsd",
@@ -64,16 +64,16 @@ libc_bitflags!(
                   target_os = "solaris"))]
         IFF_RUNNING;
         /// No arp protocol, L2 destination address not set. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_NOARP;
         /// Interface is in promiscuous mode. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_PROMISC;
         /// Receive all multicast packets. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_ALLMULTI;
         /// Master of a load balancing bundle. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_MASTER;
         /// transmission in progress, tx hardware queue is full
@@ -87,7 +87,7 @@ libc_bitflags!(
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
         IFF_INTELLIGENT;
         /// Slave of a load balancing bundle. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_SLAVE;
         /// Can't hear own transmissions.
@@ -99,7 +99,7 @@ libc_bitflags!(
                   target_os = "osx"))]
         IFF_SIMPLEX;
         /// Supports multicast. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_MULTICAST;
         /// Per link layer defined bit.
         #[cfg(any(target_os = "dragonfly",
@@ -113,7 +113,7 @@ libc_bitflags!(
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
         IFF_MULTI_BCAST;
         /// Is able to select media type via ifmap. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_PORTSEL;
         /// Per link layer defined bit.
@@ -128,7 +128,7 @@ libc_bitflags!(
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
         IFF_UNNUMBERED;
         /// Auto media selection active. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_AUTOMEDIA;
         /// Per link layer defined bit.
@@ -149,7 +149,7 @@ libc_bitflags!(
         #[cfg(any(target_os = "solaris", target_os = "illumos"))]
         IFF_DHCPRUNNING;
         /// The addresses are lost when the interface goes down. (see
-        /// [`netdevice(7)`](http://man7.org/linux/man-pages/man7/netdevice.7.html))
+        /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_DYNAMIC;
         /// Do not advertise.
@@ -218,7 +218,7 @@ libc_bitflags!(
         /// Do not provide packet information
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_NO_PI as libc::c_int;
-        /// TUN device (no Ethernet headers) 
+        /// TUN device (no Ethernet headers)
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         IFF_TUN as libc::c_int;
         /// TAP device

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -51,12 +51,12 @@ libc_bitflags! {
         /// Possibilities include:
         ///
         /// *  There is out-of-band data on a TCP socket (see
-        ///    [tcp(7)](http://man7.org/linux/man-pages/man7/tcp.7.html)).
+        ///    [tcp(7)](https://man7.org/linux/man-pages/man7/tcp.7.html)).
         /// *  A pseudoterminal master in packet mode has seen a state
         ///    change on the slave (see
-        ///    [ioctl_tty(2)](http://man7.org/linux/man-pages/man2/ioctl_tty.2.html)).
+        ///    [ioctl_tty(2)](https://man7.org/linux/man-pages/man2/ioctl_tty.2.html)).
         /// *  A cgroup.events file has been modified (see
-        ///    [cgroups(7)](http://man7.org/linux/man-pages/man7/cgroups.7.html)).
+        ///    [cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html)).
         POLLPRI;
         /// Writing is now possible, though a write larger that the
         /// available space in a socket or pipe will still block (unless
@@ -96,7 +96,7 @@ libc_bitflags! {
 }
 
 /// `poll` waits for one of a set of file descriptors to become ready to perform I/O.
-/// ([`poll(2)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html))
+/// ([`poll(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html))
 ///
 /// `fds` contains all [`PollFd`](struct.PollFd.html) to poll.
 /// The function will return as soon as any event occur for any of these `PollFd`s.
@@ -127,7 +127,7 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
 
 /// `ppoll()` allows an application to safely wait until either a file
 /// descriptor becomes ready or until a signal is caught.
-/// ([`poll(2)`](http://man7.org/linux/man-pages/man2/poll.2.html))
+/// ([`poll(2)`](https://man7.org/linux/man-pages/man2/poll.2.html))
 ///
 /// `ppoll` behaves like `poll`, but let you specify what signals may interrupt it
 /// with the `sigmask` argument. If you want `ppoll` to block indefinitely,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -92,7 +92,7 @@ impl io::Write for PtyMaster {
 }
 
 /// Grant access to a slave pseudoterminal (see
-/// [`grantpt(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/grantpt.html))
+/// [`grantpt(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/grantpt.html))
 ///
 /// `grantpt()` changes the mode and owner of the slave pseudoterminal device corresponding to the
 /// master pseudoterminal referred to by `fd`. This is a necessary step towards opening the slave.
@@ -106,7 +106,7 @@ pub fn grantpt(fd: &PtyMaster) -> Result<()> {
 }
 
 /// Open a pseudoterminal device (see
-/// [`posix_openpt(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_openpt.html))
+/// [`posix_openpt(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_openpt.html))
 ///
 /// `posix_openpt()` returns a file descriptor to an existing unused pseuterminal master device.
 ///
@@ -152,7 +152,7 @@ pub fn posix_openpt(flags: fcntl::OFlag) -> Result<PtyMaster> {
 }
 
 /// Get the name of the slave pseudoterminal (see
-/// [`ptsname(3)`](http://man7.org/linux/man-pages/man3/ptsname.3.html))
+/// [`ptsname(3)`](https://man7.org/linux/man-pages/man3/ptsname.3.html))
 ///
 /// `ptsname()` returns the name of the slave pseudoterminal device corresponding to the master
 /// referred to by `fd`.
@@ -179,7 +179,7 @@ pub unsafe fn ptsname(fd: &PtyMaster) -> Result<String> {
 }
 
 /// Get the name of the slave pseudoterminal (see
-/// [`ptsname(3)`](http://man7.org/linux/man-pages/man3/ptsname.3.html))
+/// [`ptsname(3)`](https://man7.org/linux/man-pages/man3/ptsname.3.html))
 ///
 /// `ptsname_r()` returns the name of the slave pseudoterminal device corresponding to the master
 /// referred to by `fd`. This is the threadsafe version of `ptsname()`, but it is not part of the
@@ -206,7 +206,7 @@ pub fn ptsname_r(fd: &PtyMaster) -> Result<String> {
 }
 
 /// Unlock a pseudoterminal master/slave pseudoterminal pair (see
-/// [`unlockpt(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlockpt.html))
+/// [`unlockpt(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlockpt.html))
 ///
 /// `unlockpt()` unlocks the slave pseudoterminal device corresponding to the master pseudoterminal
 /// referred to by `fd`. This must be called before trying to open the slave side of a
@@ -223,7 +223,7 @@ pub fn unlockpt(fd: &PtyMaster) -> Result<()> {
 
 /// Create a new pseudoterminal, returning the slave and master file descriptors
 /// in `OpenptyResult`
-/// (see [`openpty`](http://man7.org/linux/man-pages/man3/openpty.3.html)).
+/// (see [`openpty`](https://man7.org/linux/man-pages/man3/openpty.3.html)).
 ///
 /// If `winsize` is not `None`, the window size of the slave will be set to
 /// the values in `winsize`. If `termios` is not `None`, the pseudoterminal's
@@ -297,7 +297,7 @@ pub fn openpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b Termios>
 
 /// Create a new pseudoterminal, returning the master file descriptor and forked pid.
 /// in `ForkptyResult`
-/// (see [`forkpty`](http://man7.org/linux/man-pages/man3/forkpty.3.html)).
+/// (see [`forkpty`](https://man7.org/linux/man-pages/man3/forkpty.3.html)).
 ///
 /// If `winsize` is not `None`, the window size of the slave will be set to
 /// the values in `winsize`. If `termios` is not `None`, the pseudoterminal's
@@ -313,7 +313,7 @@ pub fn openpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b Termios>
 /// Those functions are only a small subset of your operating system's API, so
 /// special care must be taken to only invoke code you can control and audit.
 ///
-/// [async-signal-safe]: http://man7.org/linux/man-pages/man7/signal-safety.7.html
+/// [async-signal-safe]: https://man7.org/linux/man-pages/man7/signal-safety.7.html
 pub unsafe fn forkpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b Termios>>>(
     winsize: T,
     termios: U,

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -109,7 +109,7 @@ mod sched_linux_like {
     }
 
     /// `sched_setaffinity` set a thread's CPU affinity mask
-    /// ([`sched_setaffinity(2)`](http://man7.org/linux/man-pages/man2/sched_setaffinity.2.html))
+    /// ([`sched_setaffinity(2)`](https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html))
     ///
     /// `pid` is the thread ID to update.
     /// If pid is zero, then the calling thread is updated.
@@ -142,7 +142,7 @@ mod sched_linux_like {
     }
 
     /// `sched_getaffinity` get a thread's CPU affinity mask
-    /// ([`sched_getaffinity(2)`](http://man7.org/linux/man-pages/man2/sched_getaffinity.2.html))
+    /// ([`sched_getaffinity(2)`](https://man7.org/linux/man-pages/man2/sched_getaffinity.2.html))
     ///
     /// `pid` is the thread ID to check.
     /// If pid is zero, then the calling thread is checked.
@@ -219,7 +219,7 @@ mod sched_linux_like {
 
 /// Explicitly yield the processor to other threads.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html)
 pub fn sched_yield() -> Result<()> {
     let res = unsafe { libc::sched_yield() };
 

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -740,7 +740,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_cancel](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_cancel.html)
+    /// [aio_cancel](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_cancel.html)
     pub fn cancel(&mut self) -> Result<AioCancelStat> {
         match unsafe { libc::aio_cancel(self.aiocb.aio_fildes, &mut self.aiocb) } {
             libc::AIO_CANCELED => Ok(AioCancelStat::AioCanceled),
@@ -788,7 +788,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_error](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_error.html)
+    /// [aio_error](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_error.html)
     pub fn error(&mut self) -> Result<()> {
         match unsafe { libc::aio_error(&mut self.aiocb as *mut libc::aiocb) } {
             0 => Ok(()),
@@ -802,7 +802,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_fsync](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_fsync.html)
+    /// [aio_fsync](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_fsync.html)
     pub fn fsync(&mut self, mode: AioFsyncMode) -> Result<()> {
         let p: *mut libc::aiocb = &mut self.aiocb;
         Errno::result(unsafe {
@@ -848,7 +848,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_read](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_read.html)
+    /// [aio_read](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_read.html)
     pub fn read(&mut self) -> Result<()> {
         assert!(self.mutable, "Can't read into an immutable buffer");
         let p: *mut libc::aiocb = &mut self.aiocb;
@@ -872,7 +872,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_return](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_return.html)
+    /// [aio_return](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_return.html)
     // Note: this should be just `return`, but that's a reserved word
     pub fn aio_return(&mut self) -> Result<isize> {
         let p: *mut libc::aiocb = &mut self.aiocb;
@@ -884,7 +884,7 @@ impl<'a> AioCb<'a> {
     ///
     /// # References
     ///
-    /// [aio_write](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_write.html)
+    /// [aio_write](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_write.html)
     pub fn write(&mut self) -> Result<()> {
         let p: *mut libc::aiocb = &mut self.aiocb;
         Errno::result(unsafe {
@@ -935,7 +935,7 @@ impl<'a> AioCb<'a> {
 ///
 /// # References
 ///
-/// [`aio_cancel`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_cancel.html)
+/// [`aio_cancel`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_cancel.html)
 pub fn aio_cancel_all(fd: RawFd) -> Result<AioCancelStat> {
     match unsafe { libc::aio_cancel(fd, null_mut()) } {
         libc::AIO_CANCELED => Ok(AioCancelStat::AioCanceled),
@@ -976,7 +976,7 @@ pub fn aio_cancel_all(fd: RawFd) -> Result<AioCancelStat> {
 /// ```
 /// # References
 ///
-/// [`aio_suspend`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_suspend.html)
+/// [`aio_suspend`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_suspend.html)
 pub fn aio_suspend(list: &[&AioCb], timeout: Option<TimeSpec>) -> Result<()> {
     let plist = list as *const [&AioCb] as *const [*const libc::aiocb];
     let p = plist as *const *const libc::aiocb;
@@ -1084,7 +1084,7 @@ impl<'a> LioCb<'a> {
     ///
     /// # References
     ///
-    /// [`lio_listio`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html)
+    /// [`lio_listio`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html)
     ///
     /// [`aio_suspend`]: fn.aio_suspend.html
     /// [`AioCb::error`]: struct.AioCb.html#method.error
@@ -1146,9 +1146,9 @@ impl<'a> LioCb<'a> {
     ///
     /// # References
     ///
-    /// [`lio_listio`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html)
+    /// [`lio_listio`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html)
     ///
-    /// [`lio_listio`]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
+    /// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
     /// [`LioCb::aio_return`]: struct.LioCb.html#method.aio_return
     // Note: the addresses of any EINPROGRESS or EOK aiocbs _must_ not be
     // changed by this method, because the kernel relies on their addresses

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -2,8 +2,8 @@
 //!
 //! Inotify is a Linux-only API to monitor filesystems events.
 //!
-//! For more documentation, please read [inotify(7)](http://man7.org/linux/man-pages/man7/inotify.7.html).
-//! 
+//! For more documentation, please read [inotify(7)](https://man7.org/linux/man-pages/man7/inotify.7.html).
+//!
 //! # Examples
 //!
 //! Monitor all events happening in directory "test":
@@ -86,7 +86,7 @@ pub struct Inotify {
 
 /// This object is returned when you create a new watch on an inotify instance.
 /// It is then returned as part of an event once triggered. It allows you to
-/// know which watch triggered which event. 
+/// know which watch triggered which event.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct WatchDescriptor {
     wd: i32
@@ -94,18 +94,18 @@ pub struct WatchDescriptor {
 
 /// A single inotify event.
 ///
-/// For more documentation see, [inotify(7)](http://man7.org/linux/man-pages/man7/inotify.7.html).
+/// For more documentation see, [inotify(7)](https://man7.org/linux/man-pages/man7/inotify.7.html).
 #[derive(Debug)]
 pub struct InotifyEvent {
     /// Watch descriptor. This field corresponds to the watch descriptor you
     /// were issued when calling add_watch. It allows you to know which watch
-    /// this event comes from. 
+    /// this event comes from.
     pub wd: WatchDescriptor,
     /// Event mask. This field is a bitfield describing the exact event that
     /// occured.
     pub mask: AddWatchFlags,
     /// This cookie is a number that allows you to connect related events. For
-    /// now only IN_MOVED_FROM and IN_MOVED_TO can be connected. 
+    /// now only IN_MOVED_FROM and IN_MOVED_TO can be connected.
     pub cookie: u32,
     /// Filename. This field exists only if the event was triggered for a file
     /// inside the watched directory.
@@ -117,7 +117,7 @@ impl Inotify {
     ///
     /// Returns a Result containing an inotify instance.
     ///
-    /// For more information see, [inotify_init(2)](http://man7.org/linux/man-pages/man2/inotify_init.2.html).
+    /// For more information see, [inotify_init(2)](https://man7.org/linux/man-pages/man2/inotify_init.2.html).
     pub fn init(flags: InitFlags) -> Result<Inotify> {
         let res = Errno::result(unsafe {
             libc::inotify_init1(flags.bits())
@@ -126,14 +126,14 @@ impl Inotify {
         res.map(|fd| Inotify { fd })
     }
 
-    /// Adds a new watch on the target file or directory. 
+    /// Adds a new watch on the target file or directory.
     ///
-    /// Returns a watch descriptor. This is not a File Descriptor! 
+    /// Returns a watch descriptor. This is not a File Descriptor!
     ///
-    /// For more information see, [inotify_add_watch(2)](http://man7.org/linux/man-pages/man2/inotify_add_watch.2.html).
+    /// For more information see, [inotify_add_watch(2)](https://man7.org/linux/man-pages/man2/inotify_add_watch.2.html).
     pub fn add_watch<P: ?Sized + NixPath>(self,
                                           path: &P,
-                                          mask: AddWatchFlags) 
+                                          mask: AddWatchFlags)
                                             -> Result<WatchDescriptor>
     {
         let res = path.with_nix_path(|cstr| {
@@ -150,7 +150,7 @@ impl Inotify {
     ///
     /// Returns an EINVAL error if the watch descriptor is invalid.
     ///
-    /// For more information see, [inotify_rm_watch(2)](http://man7.org/linux/man-pages/man2/inotify_rm_watch.2.html).
+    /// For more information see, [inotify_rm_watch(2)](https://man7.org/linux/man-pages/man2/inotify_rm_watch.2.html).
     #[cfg(target_os = "linux")]
     pub fn rm_watch(self, wd: WatchDescriptor) -> Result<()> {
         let res = unsafe { libc::inotify_rm_watch(self.fd, wd.wd) };
@@ -167,8 +167,8 @@ impl Inotify {
 
     /// Reads a collection of events from the inotify file descriptor. This call
     /// can either be blocking or non blocking depending on whether IN_NONBLOCK
-    /// was set at initialization. 
-    /// 
+    /// was set at initialization.
+    ///
     /// Returns as many events as available. If the call was non blocking and no
     /// events could be read then the EAGAIN error is returned.
     pub fn read_events(self) -> Result<Vec<InotifyEvent>> {
@@ -194,14 +194,14 @@ impl Inotify {
             let name = match event.len {
                 0 => None,
                 _ => {
-                    let ptr = unsafe { 
+                    let ptr = unsafe {
                         buffer
                             .as_ptr()
                             .add(offset + header_size)
                             as *const c_char
                     };
                     let cstr = unsafe { CStr::from_ptr(ptr) };
-                
+
                     Some(OsStr::from_bytes(cstr.to_bytes()).to_owned())
                 }
             };

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -104,7 +104,7 @@
 //! respectively. To determine the specific `write_` variant to use you'll need to find
 //! what the argument type is supposed to be. If it's an `int`, then `write_int` should be used,
 //! otherwise it should be a pointer and `write_ptr` should be used. On Linux the
-//! [`ioctl_list` man page](http://man7.org/linux/man-pages/man2/ioctl_list.2.html) describes a
+//! [`ioctl_list` man page](https://man7.org/linux/man-pages/man2/ioctl_list.2.html) describes a
 //! large number of `ioctl`s and describes their argument data type.
 //!
 //! Using "bad" `ioctl`s

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -372,7 +372,7 @@ pub unsafe fn madvise(addr: *mut c_void, length: size_t, advise: MmapAdvise) -> 
 
 /// Set protection of memory mapping.
 ///
-/// See [`mprotect(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mprotect.html) for
+/// See [`mprotect(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mprotect.html) for
 /// details.
 ///
 /// # Safety

--- a/src/sys/pthread.rs
+++ b/src/sys/pthread.rs
@@ -3,7 +3,7 @@ use libc::{self, pthread_t};
 pub type Pthread = pthread_t;
 
 /// Obtain ID of the calling thread (see
-/// [`pthread_self(3)`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_self.html)
+/// [`pthread_self(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_self.html)
 ///
 /// The thread ID returned by `pthread_self()` is not the same thing as
 /// the kernel thread ID returned by a call to `gettid(2)`.

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -64,7 +64,7 @@ impl FdSet {
     }
 
     /// Returns an iterator over the file descriptors in the set.
-    /// 
+    ///
     /// For performance, it takes an optional higher bound: the iterator will
     /// not return any elements of the set greater than the given file
     /// descriptor.
@@ -155,7 +155,7 @@ impl<'a> FusedIterator for Fds<'a> {}
 ///
 /// # References
 ///
-/// [select(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html)
+/// [select(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html)
 ///
 /// [`FdSet::highest`]: struct.FdSet.html#method.highest
 pub fn select<'a, N, R, W, E, T>(nfds: N,
@@ -221,7 +221,7 @@ where
 ///
 /// # References
 ///
-/// [pselect(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pselect.html)
+/// [pselect(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pselect.html)
 ///
 /// [The new pselect() system call](https://lwn.net/Articles/176911/)
 ///

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -18,7 +18,7 @@ use crate::errno::Errno;
 ///
 /// `in_fd` must support `mmap`-like operations and therefore cannot be a socket.
 ///
-/// For more information, see [the sendfile(2) man page.](http://man7.org/linux/man-pages/man2/sendfile.2.html)
+/// For more information, see [the sendfile(2) man page.](https://man7.org/linux/man-pages/man2/sendfile.2.html)
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub fn sendfile(
     out_fd: RawFd,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -1,5 +1,5 @@
 // Portions of this file are Copyright 2014 The Rust Project Developers.
-// See http://rust-lang.org/COPYRIGHT.
+// See https://www.rust-lang.org/policies/licenses.
 
 ///! Operating system signals.
 
@@ -619,7 +619,7 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
     Errno::result(res).map(|_| SigAction { sigaction: oldact.assume_init() })
 }
 
-/// Signal management (see [signal(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))
+/// Signal management (see [signal(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))
 ///
 /// Installs `handler` for the given `signal`, returning the previous signal
 /// handler. `signal` should only be used following another call to `signal` or
@@ -724,8 +724,8 @@ fn do_pthread_sigmask(how: SigmaskHow,
 ///
 /// If both `set` and `oldset` is None, this function is a no-op.
 ///
-/// For more information, visit the [`pthread_sigmask`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_sigmask.html),
-/// or [`sigprocmask`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html) man pages.
+/// For more information, visit the [`pthread_sigmask`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_sigmask.html),
+/// or [`sigprocmask`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html) man pages.
 pub fn pthread_sigmask(how: SigmaskHow,
                        set: Option<&SigSet>,
                        oldset: Option<&mut SigSet>) -> Result<()>
@@ -736,7 +736,7 @@ pub fn pthread_sigmask(how: SigmaskHow,
 /// Examine and change blocked signals.
 ///
 /// For more informations see the [`sigprocmask` man
-/// pages](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html).
+/// pages](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html).
 pub fn sigprocmask(how: SigmaskHow, set: Option<&SigSet>, oldset: Option<&mut SigSet>) -> Result<()> {
     if set.is_none() && oldset.is_none() {
         return Ok(())
@@ -765,7 +765,7 @@ pub fn kill<T: Into<Option<Signal>>>(pid: Pid, signal: T) -> Result<()> {
 }
 
 /// Send a signal to a process group [(see
-/// killpg(3))](http://pubs.opengroup.org/onlinepubs/9699919799/functions/killpg.html).
+/// killpg(3))](https://pubs.opengroup.org/onlinepubs/9699919799/functions/killpg.html).
 ///
 /// If `pgrp` less then or equal 1, the behavior is platform-specific.
 /// If `signal` is `None`, `killpg` will only preform error checking and won't

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -46,7 +46,7 @@ pub const SIGNALFD_SIGINFO_SIZE: usize = 128;
 /// A signal must be blocked on every thread in a process, otherwise it won't be visible from
 /// signalfd (the default handler will be invoked instead).
 ///
-/// See [the signalfd man page for more information](http://man7.org/linux/man-pages/man2/signalfd.2.html)
+/// See [the signalfd man page for more information](https://man7.org/linux/man-pages/man2/signalfd.2.html)
 pub fn signalfd(fd: RawFd, mask: &SigSet, flags: SfdFlags) -> Result<RawFd> {
     unsafe {
         Errno::result(libc::signalfd(fd as libc::c_int, mask.as_ref(), flags.bits()))

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -34,16 +34,16 @@ pub use self::vsock::VsockAddr;
 #[repr(i32)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AddressFamily {
-    /// Local communication (see [`unix(7)`](http://man7.org/linux/man-pages/man7/unix.7.html))
+    /// Local communication (see [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html))
     Unix = libc::AF_UNIX,
-    /// IPv4 Internet protocols (see [`ip(7)`](http://man7.org/linux/man-pages/man7/ip.7.html))
+    /// IPv4 Internet protocols (see [`ip(7)`](https://man7.org/linux/man-pages/man7/ip.7.html))
     Inet = libc::AF_INET,
-    /// IPv6 Internet protocols (see [`ipv6(7)`](http://man7.org/linux/man-pages/man7/ipv6.7.html))
+    /// IPv6 Internet protocols (see [`ipv6(7)`](https://man7.org/linux/man-pages/man7/ipv6.7.html))
     Inet6 = libc::AF_INET6,
-    /// Kernel user interface device (see [`netlink(7)`](http://man7.org/linux/man-pages/man7/netlink.7.html))
+    /// Kernel user interface device (see [`netlink(7)`](https://man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
     Netlink = libc::AF_NETLINK,
-    /// Low level packet interface (see [`packet(7)`](http://man7.org/linux/man-pages/man7/packet.7.html))
+    /// Low level packet interface (see [`packet(7)`](https://man7.org/linux/man-pages/man7/packet.7.html))
     #[cfg(any(target_os = "android",
               target_os = "linux",
               target_os = "illumos",
@@ -67,7 +67,7 @@ pub enum AddressFamily {
     /// Access to raw ATM PVCs
     #[cfg(any(target_os = "android", target_os = "linux"))]
     AtmPvc = libc::AF_ATMPVC,
-    /// ITU-T X.25 / ISO-8208 protocol (see [`x25(7)`](http://man7.org/linux/man-pages/man7/x25.7.html))
+    /// ITU-T X.25 / ISO-8208 protocol (see [`x25(7)`](https://man7.org/linux/man-pages/man7/x25.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
     X25 = libc::AF_X25,
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -225,7 +225,7 @@ pub enum AddressFamily {
               target_os = "netbsd",
               target_os = "openbsd"))]
     Natm = libc::AF_NATM,
-    /// Unspecified address family, (see [`getaddrinfo(3)`](http://man7.org/linux/man-pages/man3/getaddrinfo.3.html))
+    /// Unspecified address family, (see [`getaddrinfo(3)`](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
     Unspec = libc::AF_UNSPEC,
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1,6 +1,6 @@
 //! Socket interface functions
 //!
-//! [Further reading](http://man7.org/linux/man-pages/man7/socket.7.html)
+//! [Further reading](https://man7.org/linux/man-pages/man7/socket.7.html)
 use cfg_if::cfg_if;
 use crate::{Error, Result, errno::Errno};
 use libc::{self, c_void, c_int, iovec, socklen_t, size_t,
@@ -95,9 +95,9 @@ pub enum SockType {
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SockProtocol {
-    /// TCP protocol ([ip(7)](http://man7.org/linux/man-pages/man7/ip.7.html))
+    /// TCP protocol ([ip(7)](https://man7.org/linux/man-pages/man7/ip.7.html))
     Tcp = libc::IPPROTO_TCP,
-    /// UDP protocol ([ip(7)](http://man7.org/linux/man-pages/man7/ip.7.html))
+    /// UDP protocol ([ip(7)](https://man7.org/linux/man-pages/man7/ip.7.html))
     Udp = libc::IPPROTO_UDP,
     /// Allows applications and other KEXTs to be notified when certain kernel events occur
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
@@ -219,7 +219,7 @@ libc_bitflags!{
         /// (via the [`fcntl`](../../fcntl/fn.fcntl.html)
         /// `F_SETFL` operation), but differs in that `MSG_DONTWAIT` is a per-
         /// call option, whereas `O_NONBLOCK` is a setting on the open file
-        /// description (see [open(2)](http://man7.org/linux/man-pages/man2/open.2.html)),
+        /// description (see [open(2)](https://man7.org/linux/man-pages/man2/open.2.html)),
         /// which will affect all threads in
         /// the calling process and as well as other processes that hold
         /// file descriptors referring to the same open file description.
@@ -247,7 +247,7 @@ libc_bitflags!{
         /// file descriptor using the `SCM_RIGHTS` operation (described in
         /// [unix(7)](https://linux.die.net/man/7/unix)).
         /// This flag is useful for the same reasons as the `O_CLOEXEC` flag of
-        /// [open(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html).
+        /// [open(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html).
         ///
         /// Only used in [`recvmsg`](fn.recvmsg.html) function.
         #[cfg(any(target_os = "android",
@@ -482,7 +482,7 @@ impl<'a> Iterator for CmsgIterator<'a> {
 /// A type-safe wrapper around a single control message, as used with
 /// [`recvmsg`](#fn.recvmsg).
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man3/cmsg.3.html)
+/// [Further reading](https://man7.org/linux/man-pages/man3/cmsg.3.html)
 //  Nix version 0.13.0 and earlier used ControlMessage for both recvmsg and
 //  sendmsg.  However, on some platforms the messages returned by recvmsg may be
 //  unaligned.  ControlMessageOwned takes those messages by copy, obviating any
@@ -721,14 +721,14 @@ impl ControlMessageOwned {
 /// [`sendmsg`](#fn.sendmsg).  More types may be added to this enum; do not
 /// exhaustively pattern-match it.
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man3/cmsg.3.html)
+/// [Further reading](https://man7.org/linux/man-pages/man3/cmsg.3.html)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ControlMessage<'a> {
     /// A message of type `SCM_RIGHTS`, containing an array of file
     /// descriptors passed between processes.
     ///
     /// See the description in the "Ancillary messages" section of the
-    /// [unix(7) man page](http://man7.org/linux/man-pages/man7/unix.7.html).
+    /// [unix(7) man page](https://man7.org/linux/man-pages/man7/unix.7.html).
     ///
     /// Using multiple `ScmRights` messages for a single `sendmsg` call isn't
     /// recommended since it causes platform-dependent behaviour: It might
@@ -745,7 +745,7 @@ pub enum ControlMessage<'a> {
     /// processes are verified by the kernel.
     ///
     /// For further information, please refer to the
-    /// [`unix(7)`](http://man7.org/linux/man-pages/man7/unix.7.html) man page.
+    /// [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html) man page.
     #[cfg(any(target_os = "android", target_os = "linux"))]
     ScmCredentials(&'a UnixCredentials),
     /// A message of type `SCM_CREDS`, containing the pid, uid, euid, gid and groups of
@@ -807,7 +807,7 @@ pub enum ControlMessage<'a> {
     /// Configure the sending addressing and interface for v4
     ///
     /// For further information, please refer to the
-    /// [`ip(7)`](http://man7.org/linux/man-pages/man7/ip.7.html) man page.
+    /// [`ip(7)`](https://man7.org/linux/man-pages/man7/ip.7.html) man page.
     #[cfg(any(target_os = "linux",
               target_os = "macos",
               target_os = "netbsd",
@@ -818,7 +818,7 @@ pub enum ControlMessage<'a> {
     /// Configure the sending addressing and interface for v6
     ///
     /// For further information, please refer to the
-    /// [`ipv6(7)`](http://man7.org/linux/man-pages/man7/ipv6.7.html) man page.
+    /// [`ipv6(7)`](https://man7.org/linux/man-pages/man7/ipv6.7.html) man page.
     #[cfg(any(target_os = "linux",
               target_os = "macos",
               target_os = "netbsd",
@@ -1403,7 +1403,7 @@ fn pack_mhdr_to_send<'a, I, C>(
 /// * `flags`:          Optional flags passed directly to the operating system.
 ///
 /// # References
-/// [recvmsg(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html)
+/// [recvmsg(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html)
 pub fn recvmsg<'a>(fd: RawFd, iov: &[IoVec<&mut [u8]>],
                    mut cmsg_buffer: Option<&'a mut Vec<u8>>,
                    flags: MsgFlags) -> Result<RecvMsg<'a>>
@@ -1431,7 +1431,7 @@ pub fn recvmsg<'a>(fd: RawFd, iov: &[IoVec<&mut [u8]>],
 /// protocols may exist, in which case a particular protocol must be
 /// specified in this manner.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html)
 pub fn socket<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: SockType, flags: SockFlag, protocol: T) -> Result<RawFd> {
     let protocol = match protocol.into() {
         None => 0,
@@ -1451,7 +1451,7 @@ pub fn socket<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: SockType
 
 /// Create a pair of connected sockets
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/socketpair.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/socketpair.html)
 pub fn socketpair<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: SockType, protocol: T,
                   flags: SockFlag) -> Result<(RawFd, RawFd)> {
     let protocol = match protocol.into() {
@@ -1475,7 +1475,7 @@ pub fn socketpair<T: Into<Option<SockProtocol>>>(domain: AddressFamily, ty: Sock
 
 /// Listen for connections on a socket
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html)
 pub fn listen(sockfd: RawFd, backlog: usize) -> Result<()> {
     let res = unsafe { libc::listen(sockfd, backlog as c_int) };
 
@@ -1484,7 +1484,7 @@ pub fn listen(sockfd: RawFd, backlog: usize) -> Result<()> {
 
 /// Bind a name to a socket
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html)
 pub fn bind(fd: RawFd, addr: &SockAddr) -> Result<()> {
     let res = unsafe {
         let (ptr, len) = addr.as_ffi_pair();
@@ -1496,7 +1496,7 @@ pub fn bind(fd: RawFd, addr: &SockAddr) -> Result<()> {
 
 /// Accept a connection on a socket
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html)
 pub fn accept(sockfd: RawFd) -> Result<RawFd> {
     let res = unsafe { libc::accept(sockfd, ptr::null_mut(), ptr::null_mut()) };
 
@@ -1505,7 +1505,7 @@ pub fn accept(sockfd: RawFd) -> Result<RawFd> {
 
 /// Accept a connection on a socket
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man2/accept.2.html)
+/// [Further reading](https://man7.org/linux/man-pages/man2/accept.2.html)
 #[cfg(any(all(
             target_os = "android",
             any(
@@ -1525,7 +1525,7 @@ pub fn accept4(sockfd: RawFd, flags: SockFlag) -> Result<RawFd> {
 
 /// Initiate a connection on a socket
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html)
 pub fn connect(fd: RawFd, addr: &SockAddr) -> Result<()> {
     let res = unsafe {
         let (ptr, len) = addr.as_ffi_pair();
@@ -1538,7 +1538,7 @@ pub fn connect(fd: RawFd, addr: &SockAddr) -> Result<()> {
 /// Receive data from a connection-oriented socket. Returns the number of
 /// bytes read
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html)
 pub fn recv(sockfd: RawFd, buf: &mut [u8], flags: MsgFlags) -> Result<usize> {
     unsafe {
         let ret = libc::recv(
@@ -1555,7 +1555,7 @@ pub fn recv(sockfd: RawFd, buf: &mut [u8], flags: MsgFlags) -> Result<usize> {
 /// the number of bytes read and, for connectionless sockets,  the socket
 /// address of the sender.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html)
 pub fn recvfrom(sockfd: RawFd, buf: &mut [u8])
     -> Result<(usize, Option<SockAddr>)>
 {
@@ -1581,7 +1581,7 @@ pub fn recvfrom(sockfd: RawFd, buf: &mut [u8])
 
 /// Send a message to a socket
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html)
 pub fn sendto(fd: RawFd, buf: &[u8], addr: &SockAddr, flags: MsgFlags) -> Result<usize> {
     let ret = unsafe {
         let (ptr, len) = addr.as_ffi_pair();
@@ -1593,7 +1593,7 @@ pub fn sendto(fd: RawFd, buf: &[u8], addr: &SockAddr, flags: MsgFlags) -> Result
 
 /// Send data to a connection-oriented socket. Returns the number of bytes read
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html)
 pub fn send(fd: RawFd, buf: &[u8], flags: MsgFlags) -> Result<usize> {
     let ret = unsafe {
         libc::send(fd, buf.as_ptr() as *const c_void, buf.len() as size_t, flags.bits())
@@ -1628,14 +1628,14 @@ pub trait SetSockOpt : Clone {
 
 /// Get the current value for the requested socket option
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html)
 pub fn getsockopt<O: GetSockOpt>(fd: RawFd, opt: O) -> Result<O::Val> {
     opt.get(fd)
 }
 
 /// Sets the value for the requested socket option
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html)
 ///
 /// # Examples
 ///
@@ -1656,7 +1656,7 @@ pub fn setsockopt<O: SetSockOpt>(fd: RawFd, opt: O, val: &O::Val) -> Result<()> 
 
 /// Get the address of the peer connected to the socket `fd`.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html)
 pub fn getpeername(fd: RawFd) -> Result<SockAddr> {
     unsafe {
         let mut addr = mem::MaybeUninit::uninit();
@@ -1676,7 +1676,7 @@ pub fn getpeername(fd: RawFd) -> Result<SockAddr> {
 
 /// Get the current address to which the socket `fd` is bound.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html)
 pub fn getsockname(fd: RawFd) -> Result<SockAddr> {
     unsafe {
         let mut addr = mem::MaybeUninit::uninit();
@@ -1786,7 +1786,7 @@ pub enum Shutdown {
 
 /// Shut down part of a full-duplex connection.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html)
 pub fn shutdown(df: RawFd, how: Shutdown) -> Result<()> {
     unsafe {
         use libc::shutdown;

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -127,7 +127,7 @@ pub fn fstatat<P: ?Sized + NixPath>(dirfd: RawFd, pathname: &P, f: AtFlags) -> R
 ///
 /// # References
 ///
-/// [fchmod(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmod.html).
+/// [fchmod(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmod.html).
 pub fn fchmod(fd: RawFd, mode: Mode) -> Result<()> {
     let res = unsafe { libc::fchmod(fd, mode.bits() as mode_t) };
 
@@ -156,7 +156,7 @@ pub enum FchmodatFlags {
 ///
 /// # References
 ///
-/// [fchmodat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
+/// [fchmodat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
 #[cfg(not(target_os = "redox"))]
 pub fn fchmodat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
@@ -190,7 +190,7 @@ pub fn fchmodat<P: ?Sized + NixPath>(
 ///
 /// # References
 ///
-/// [utimes(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/utimes.html).
+/// [utimes(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimes.html).
 pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -> Result<()> {
     let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = path.with_nix_path(|cstr| unsafe {
@@ -209,7 +209,7 @@ pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -
 ///
 /// # References
 ///
-/// [lutimes(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lutimes.html).
+/// [lutimes(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/lutimes.html).
 #[cfg(any(target_os = "linux",
           target_os = "haiku",
           target_os = "ios",
@@ -229,7 +229,7 @@ pub fn lutimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) 
 ///
 /// # References
 ///
-/// [futimens(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html).
+/// [futimens(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html).
 #[inline]
 pub fn futimens(fd: RawFd, atime: &TimeSpec, mtime: &TimeSpec) -> Result<()> {
     let times: [libc::timespec; 2] = [*atime.as_ref(), *mtime.as_ref()];
@@ -260,7 +260,7 @@ pub enum UtimensatFlags {
 ///
 /// # References
 ///
-/// [utimensat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
+/// [utimensat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
 #[cfg(not(target_os = "redox"))]
 pub fn utimensat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -1,6 +1,6 @@
 //! Get filesystem statistics
 //!
-//! See [the man pages](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatvfs.html)
+//! See [the man pages](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatvfs.html)
 //! for more details.
 use std::mem;
 use std::os::unix::io::AsRawFd;
@@ -54,7 +54,7 @@ libc_bitflags!(
 
 /// Wrapper around the POSIX `statvfs` struct
 ///
-/// For more information see the [`statvfs(3)` man pages](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html).
+/// For more information see the [`statvfs(3)` man pages](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html).
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Statvfs(libc::statvfs);

--- a/src/sys/sysinfo.rs
+++ b/src/sys/sysinfo.rs
@@ -71,7 +71,7 @@ impl SysInfo {
 
 /// Returns system information.
 ///
-/// [See `sysinfo(2)`](http://man7.org/linux/man-pages/man2/sysinfo.2.html).
+/// [See `sysinfo(2)`](https://man7.org/linux/man-pages/man2/sysinfo.2.html).
 pub fn sysinfo() -> Result<SysInfo> {
     let mut info = mem::MaybeUninit::uninit();
     let res = unsafe { libc::sysinfo(info.as_mut_ptr()) };

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -5,7 +5,7 @@
 //! types here or exported directly.
 //!
 //! If you are unfamiliar with the `termios` API, you should first read the
-//! [API documentation](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/termios.h.html) and
+//! [API documentation](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/termios.h.html) and
 //! then come back to understand how `nix` safely wraps it.
 //!
 //! It should be noted that this API incurs some runtime overhead above the base `libc` definitions.
@@ -906,7 +906,7 @@ cfg_if!{
                  target_os = "netbsd",
                  target_os = "openbsd"))] {
         /// Get input baud rate (see
-        /// [cfgetispeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
+        /// [cfgetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
         ///
         /// `cfgetispeed()` extracts the input baud rate from the given `Termios` structure.
         pub fn cfgetispeed(termios: &Termios) -> u32 {
@@ -915,7 +915,7 @@ cfg_if!{
         }
 
         /// Get output baud rate (see
-        /// [cfgetospeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetospeed.html)).
+        /// [cfgetospeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetospeed.html)).
         ///
         /// `cfgetospeed()` extracts the output baud rate from the given `Termios` structure.
         pub fn cfgetospeed(termios: &Termios) -> u32 {
@@ -924,7 +924,7 @@ cfg_if!{
         }
 
         /// Set input baud rate (see
-        /// [cfsetispeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetispeed.html)).
+        /// [cfsetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetispeed.html)).
         ///
         /// `cfsetispeed()` sets the intput baud rate in the given `Termios` structure.
         pub fn cfsetispeed<T: Into<u32>>(termios: &mut Termios, baud: T) -> Result<()> {
@@ -935,7 +935,7 @@ cfg_if!{
         }
 
         /// Set output baud rate (see
-        /// [cfsetospeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetospeed.html)).
+        /// [cfsetospeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetospeed.html)).
         ///
         /// `cfsetospeed()` sets the output baud rate in the given termios structure.
         pub fn cfsetospeed<T: Into<u32>>(termios: &mut Termios, baud: T) -> Result<()> {
@@ -960,7 +960,7 @@ cfg_if!{
         use std::convert::TryInto;
 
         /// Get input baud rate (see
-        /// [cfgetispeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
+        /// [cfgetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
         ///
         /// `cfgetispeed()` extracts the input baud rate from the given `Termios` structure.
         pub fn cfgetispeed(termios: &Termios) -> BaudRate {
@@ -969,7 +969,7 @@ cfg_if!{
         }
 
         /// Get output baud rate (see
-        /// [cfgetospeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetospeed.html)).
+        /// [cfgetospeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetospeed.html)).
         ///
         /// `cfgetospeed()` extracts the output baud rate from the given `Termios` structure.
         pub fn cfgetospeed(termios: &Termios) -> BaudRate {
@@ -978,7 +978,7 @@ cfg_if!{
         }
 
         /// Set input baud rate (see
-        /// [cfsetispeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetispeed.html)).
+        /// [cfsetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetispeed.html)).
         ///
         /// `cfsetispeed()` sets the intput baud rate in the given `Termios` structure.
         pub fn cfsetispeed(termios: &mut Termios, baud: BaudRate) -> Result<()> {
@@ -989,7 +989,7 @@ cfg_if!{
         }
 
         /// Set output baud rate (see
-        /// [cfsetospeed(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetospeed.html)).
+        /// [cfsetospeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfsetospeed.html)).
         ///
         /// `cfsetospeed()` sets the output baud rate in the given `Termios` structure.
         pub fn cfsetospeed(termios: &mut Termios, baud: BaudRate) -> Result<()> {
@@ -1014,7 +1014,7 @@ cfg_if!{
 }
 
 /// Configures the port to something like the "raw" mode of the old Version 7 terminal driver (see
-/// [termios(3)](http://man7.org/linux/man-pages/man3/termios.3.html)).
+/// [termios(3)](https://man7.org/linux/man-pages/man3/termios.3.html)).
 ///
 /// `cfmakeraw()` configures the termios structure such that input is available character-by-
 /// character, echoing is disabled, and all special input and output processing is disabled. Note
@@ -1041,7 +1041,7 @@ pub fn cfmakesane(termios: &mut Termios) {
 }
 
 /// Return the configuration of a port
-/// [tcgetattr(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetattr.html)).
+/// [tcgetattr(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetattr.html)).
 ///
 /// `tcgetattr()` returns a `Termios` structure with the current configuration for a port. Modifying
 /// this structure *will not* reconfigure the port, instead the modifications should be done to
@@ -1057,7 +1057,7 @@ pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
 }
 
 /// Set the configuration for a terminal (see
-/// [tcsetattr(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetattr.html)).
+/// [tcsetattr(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetattr.html)).
 ///
 /// `tcsetattr()` reconfigures the given port based on a given `Termios` structure. This change
 /// takes affect at a time specified by `actions`. Note that this function may return success if
@@ -1068,13 +1068,13 @@ pub fn tcsetattr(fd: RawFd, actions: SetArg, termios: &Termios) -> Result<()> {
 }
 
 /// Block until all output data is written (see
-/// [tcdrain(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcdrain.html)).
+/// [tcdrain(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcdrain.html)).
 pub fn tcdrain(fd: RawFd) -> Result<()> {
     Errno::result(unsafe { libc::tcdrain(fd) }).map(drop)
 }
 
 /// Suspend or resume the transmission or reception of data (see
-/// [tcflow(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcflow.html)).
+/// [tcflow(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcflow.html)).
 ///
 /// `tcflow()` suspends of resumes the transmission or reception of data for the given port
 /// depending on the value of `action`.
@@ -1083,7 +1083,7 @@ pub fn tcflow(fd: RawFd, action: FlowArg) -> Result<()> {
 }
 
 /// Discard data in the output or input queue (see
-/// [tcflush(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcflush.html)).
+/// [tcflush(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcflush.html)).
 ///
 /// `tcflush()` will discard data for a terminal port in the input queue, output queue, or both
 /// depending on the value of `action`.
@@ -1092,7 +1092,7 @@ pub fn tcflush(fd: RawFd, action: FlushArg) -> Result<()> {
 }
 
 /// Send a break for a specific duration (see
-/// [tcsendbreak(3p)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsendbreak.html)).
+/// [tcsendbreak(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsendbreak.html)).
 ///
 /// When using asynchronous data transmission `tcsendbreak()` will transmit a continuous stream
 /// of zero-valued bits for an implementation-defined duration.
@@ -1101,7 +1101,7 @@ pub fn tcsendbreak(fd: RawFd, duration: c_int) -> Result<()> {
 }
 
 /// Get the session controlled by the given terminal (see
-/// [tcgetsid(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetsid.html)).
+/// [tcgetsid(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetsid.html)).
 pub fn tcgetsid(fd: RawFd) -> Result<Pid> {
     let res = unsafe { libc::tcgetsid(fd) };
 

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -3,7 +3,7 @@
 //! Timer FD is a Linux-only API to create timers and get expiration
 //! notifications through file descriptors.
 //!
-//! For more documentation, please read [timerfd_create(2)](http://man7.org/linux/man-pages/man2/timerfd_create.2.html).
+//! For more documentation, please read [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html).
 //!
 //! # Examples
 //!
@@ -56,7 +56,7 @@ impl FromRawFd for TimerFd {
 
 libc_enum! {
     /// The type of the clock used to mark the progress of the timer. For more
-    /// details on each kind of clock, please refer to [timerfd_create(2)](http://man7.org/linux/man-pages/man2/timerfd_create.2.html).
+    /// details on each kind of clock, please refer to [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html).
     #[repr(i32)]
     pub enum ClockId {
         CLOCK_REALTIME,

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -112,7 +112,7 @@ pub struct RemoteIoVec {
 ///
 /// This function is only available on Linux.
 ///
-/// [`process_vm_writev`(2)]: http://man7.org/linux/man-pages/man2/process_vm_writev.2.html
+/// [`process_vm_writev`(2)]: https://man7.org/linux/man-pages/man2/process_vm_writev.2.html
 /// [ptrace]: ../ptrace/index.html
 /// [`IoVec`]: struct.IoVec.html
 /// [`RemoteIoVec`]: struct.RemoteIoVec.html
@@ -147,7 +147,7 @@ pub fn process_vm_writev(
 ///
 /// This function is only available on Linux.
 ///
-/// [`process_vm_readv`(2)]: http://man7.org/linux/man-pages/man2/process_vm_readv.2.html
+/// [`process_vm_readv`(2)]: https://man7.org/linux/man-pages/man2/process_vm_readv.2.html
 /// [`ptrace`]: ../ptrace/index.html
 /// [`IoVec`]: struct.IoVec.html
 /// [`RemoteIoVec`]: struct.RemoteIoVec.html

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -81,14 +81,14 @@ pub enum WaitStatus {
     /// field is the `PTRACE_EVENT_*` value of the event.
     ///
     /// [`nix::sys::ptrace`]: ../ptrace/index.html
-    /// [`ptrace`(2)]: http://man7.org/linux/man-pages/man2/ptrace.2.html
+    /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
     PtraceEvent(Pid, Signal, c_int),
     /// The traced process was stopped by execution of a system call,
     /// and `PTRACE_O_TRACESYSGOOD` is in effect. See [`ptrace`(2)] for
     /// more information.
     ///
-    /// [`ptrace`(2)]: http://man7.org/linux/man-pages/man2/ptrace.2.html
+    /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
     PtraceSyscall(Pid),
     /// The process was previously stopped but has resumed execution

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -191,7 +191,7 @@ impl ForkResult {
 }
 
 /// Create a new child process duplicating the parent process ([see
-/// fork(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html)).
+/// fork(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html)).
 ///
 /// After calling the fork system call (successfully) two processes will
 /// be created that are identical with the exception of their pid and the
@@ -228,7 +228,7 @@ impl ForkResult {
 /// Those functions are only a small subset of your operating system's API, so
 /// special care must be taken to only invoke code you can control and audit.
 ///
-/// [async-signal-safe]: http://man7.org/linux/man-pages/man7/signal-safety.7.html
+/// [async-signal-safe]: https://man7.org/linux/man-pages/man7/signal-safety.7.html
 #[inline]
 pub unsafe fn fork() -> Result<ForkResult> {
     use self::ForkResult::*;
@@ -241,7 +241,7 @@ pub unsafe fn fork() -> Result<ForkResult> {
 }
 
 /// Get the pid of this process (see
-/// [getpid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpid.html)).
+/// [getpid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpid.html)).
 ///
 /// Since you are running code, there is always a pid to return, so there
 /// is no error case that needs to be handled.
@@ -251,7 +251,7 @@ pub fn getpid() -> Pid {
 }
 
 /// Get the pid of this processes' parent (see
-/// [getpid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getppid.html)).
+/// [getpid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getppid.html)).
 ///
 /// There is always a parent pid to return, so there is no error case that needs
 /// to be handled.
@@ -261,7 +261,7 @@ pub fn getppid() -> Pid {
 }
 
 /// Set a process group ID (see
-/// [setpgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html)).
+/// [setpgid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html)).
 ///
 /// Set the process group id (PGID) of a particular process.  If a pid of zero
 /// is specified, then the pid of the calling process is used.  Process groups
@@ -281,14 +281,14 @@ pub fn getpgid(pid: Option<Pid>) -> Result<Pid> {
 }
 
 /// Create new session and set process group id (see
-/// [setsid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html)).
+/// [setsid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html)).
 #[inline]
 pub fn setsid() -> Result<Pid> {
     Errno::result(unsafe { libc::setsid() }).map(Pid)
 }
 
 /// Get the process group ID of a session leader
-/// [getsid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getsid.html).
+/// [getsid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsid.html).
 ///
 /// Obtain the process group ID of the process that is the session leader of the process specified
 /// by pid. If pid is zero, it specifies the calling process.
@@ -301,7 +301,7 @@ pub fn getsid(pid: Option<Pid>) -> Result<Pid> {
 
 
 /// Get the terminal foreground process group (see
-/// [tcgetpgrp(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetpgrp.html)).
+/// [tcgetpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetpgrp.html)).
 ///
 /// Get the group process id (GPID) of the foreground process group on the
 /// terminal associated to file descriptor (FD).
@@ -311,7 +311,7 @@ pub fn tcgetpgrp(fd: c_int) -> Result<Pid> {
     Errno::result(res).map(Pid)
 }
 /// Set the terminal foreground process group (see
-/// [tcgetpgrp(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html)).
+/// [tcgetpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html)).
 ///
 /// Get the group process id (PGID) to the foreground process group on the
 /// terminal associated to file descriptor (FD).
@@ -323,7 +323,7 @@ pub fn tcsetpgrp(fd: c_int, pgrp: Pid) -> Result<()> {
 
 
 /// Get the group id of the calling process (see
-///[getpgrp(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgrp.html)).
+///[getpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgrp.html)).
 ///
 /// Get the process group id (PGID) of the calling process.
 /// According to the man page it is always successful.
@@ -333,7 +333,7 @@ pub fn getpgrp() -> Pid {
 }
 
 /// Get the caller's thread ID (see
-/// [gettid(2)](http://man7.org/linux/man-pages/man2/gettid.2.html).
+/// [gettid(2)](https://man7.org/linux/man-pages/man2/gettid.2.html).
 ///
 /// This function is only available on Linux based systems.  In a single
 /// threaded process, the main thread will have the same ID as the process.  In
@@ -349,7 +349,7 @@ pub fn gettid() -> Pid {
 }
 
 /// Create a copy of the specified file descriptor (see
-/// [dup(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html)).
+/// [dup(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html)).
 ///
 /// The new file descriptor will be have a new index but refer to the same
 /// resource as the old file descriptor and the old and new file descriptors may
@@ -366,7 +366,7 @@ pub fn dup(oldfd: RawFd) -> Result<RawFd> {
 }
 
 /// Create a copy of the specified file descriptor using the specified fd (see
-/// [dup(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html)).
+/// [dup(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html)).
 ///
 /// This function behaves similar to `dup()` except that it will try to use the
 /// specified fd instead of allocating a new one.  See the man pages for more
@@ -379,7 +379,7 @@ pub fn dup2(oldfd: RawFd, newfd: RawFd) -> Result<RawFd> {
 }
 
 /// Create a new copy of the specified file descriptor using the specified fd
-/// and flags (see [dup(2)](http://man7.org/linux/man-pages/man2/dup.2.html)).
+/// and flags (see [dup(2)](https://man7.org/linux/man-pages/man2/dup.2.html)).
 ///
 /// This function behaves similar to `dup2()` but allows for flags to be
 /// specified.
@@ -406,7 +406,7 @@ fn dup3_polyfill(oldfd: RawFd, newfd: RawFd, flags: OFlag) -> Result<RawFd> {
 }
 
 /// Change the current working directory of the calling process (see
-/// [chdir(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/chdir.html)).
+/// [chdir(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/chdir.html)).
 ///
 /// This function may fail in a number of different scenarios.  See the man
 /// pages for additional details on possible failure cases.
@@ -421,7 +421,7 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 
 /// Change the current working directory of the process to the one
 /// given as an open file descriptor (see
-/// [fchdir(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchdir.html)).
+/// [fchdir(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchdir.html)).
 ///
 /// This function may fail in a number of different scenarios.  See the man
 /// pages for additional details on possible failure cases.
@@ -433,7 +433,7 @@ pub fn fchdir(dirfd: RawFd) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
-/// Creates new directory `path` with access rights `mode`.  (see [mkdir(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html))
+/// Creates new directory `path` with access rights `mode`.  (see [mkdir(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html))
 ///
 /// # Errors
 ///
@@ -481,7 +481,7 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 /// - the path name is too long (longer than `PATH_MAX`, usually 4096 on linux, 1024 on OS X)
 ///
 /// For a full list consult
-/// [posix specification](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifo.html)
+/// [posix specification](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifo.html)
 ///
 /// # Example
 ///
@@ -519,7 +519,7 @@ pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 ///
 /// # References
 ///
-/// [mkfifoat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifoat.html).
+/// [mkfifoat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifoat.html).
 // mkfifoat is not implemented in OSX or android
 #[inline]
 #[cfg(not(any(
@@ -541,7 +541,7 @@ pub fn mkfifoat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Mode)
 /// If `dirfd` is `None`, then `path2` is relative to the current working
 /// directory. This is identical to `libc::symlink(path1, path2)`.
 ///
-/// See also [symlinkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/symlinkat.html).
+/// See also [symlinkat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/symlinkat.html).
 #[cfg(not(target_os = "redox"))]
 pub fn symlinkat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
     path1: &P1,
@@ -637,7 +637,7 @@ fn chown_raw_ids(owner: Option<Uid>, group: Option<Gid>) -> (libc::uid_t, libc::
 
 /// Change the ownership of the file at `path` to be owned by the specified
 /// `owner` (user) and `group` (see
-/// [chown(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html)).
+/// [chown(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html)).
 ///
 /// The owner/group for the provided path name will not be modified if `None` is
 /// provided for that argument.  Ownership change will be attempted for the path
@@ -693,7 +693,7 @@ pub enum FchownatFlags {
 ///
 /// # References
 ///
-/// [fchownat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fchownat.html).
+/// [fchownat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchownat.html).
 #[cfg(not(target_os = "redox"))]
 pub fn fchownat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
@@ -722,7 +722,7 @@ fn to_exec_array<S: AsRef<CStr>>(args: &[S]) -> Vec<*const c_char> {
 }
 
 /// Replace the current process image with a new one (see
-/// [exec(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
+/// [exec(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
 ///
 /// See the `::nix::unistd::execve` system call for additional details.  `execv`
 /// performs the same action but does not allow for customization of the
@@ -740,7 +740,7 @@ pub fn execv<S: AsRef<CStr>>(path: &CStr, argv: &[S]) -> Result<Infallible> {
 
 
 /// Replace the current process image with a new one (see
-/// [execve(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
+/// [execve(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
 ///
 /// The execve system call allows for another process to be "called" which will
 /// replace the current process image.  That is, this process becomes the new
@@ -765,7 +765,7 @@ pub fn execve<SA: AsRef<CStr>, SE: AsRef<CStr>>(path: &CStr, args: &[SA], env: &
 
 /// Replace the current process image with a new one and replicate shell `PATH`
 /// searching behavior (see
-/// [exec(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
+/// [exec(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html)).
 ///
 /// See `::nix::unistd::execve` for additional details.  `execvp` behaves the
 /// same as execv except that it will examine the `PATH` environment variables
@@ -785,7 +785,7 @@ pub fn execvp<S: AsRef<CStr>>(filename: &CStr, args: &[S]) -> Result<Infallible>
 
 /// Replace the current process image with a new one and replicate shell `PATH`
 /// searching behavior (see
-/// [`execvpe(3)`](http://man7.org/linux/man-pages/man3/exec.3.html)).
+/// [`execvpe(3)`](https://man7.org/linux/man-pages/man3/exec.3.html)).
 ///
 /// This functions like a combination of `execvp(2)` and `execve(2)` to pass an
 /// environment and have a search path. See these two for additional
@@ -805,7 +805,7 @@ pub fn execvpe<SA: AsRef<CStr>, SE: AsRef<CStr>>(filename: &CStr, args: &[SA], e
 }
 
 /// Replace the current process image with a new one (see
-/// [fexecve(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fexecve.html)).
+/// [fexecve(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fexecve.html)).
 ///
 /// The `fexecve` function allows for another process to be "called" which will
 /// replace the current process image.  That is, this process becomes the new
@@ -833,7 +833,7 @@ pub fn fexecve<SA: AsRef<CStr> ,SE: AsRef<CStr>>(fd: RawFd, args: &[SA], env: &[
 }
 
 /// Execute program relative to a directory file descriptor (see
-/// [execveat(2)](http://man7.org/linux/man-pages/man2/execveat.2.html)).
+/// [execveat(2)](https://man7.org/linux/man-pages/man2/execveat.2.html)).
 ///
 /// The `execveat` function allows for another process to be "called" which will
 /// replace the current process image.  That is, this process becomes the new
@@ -858,7 +858,7 @@ pub fn execveat<SA: AsRef<CStr>,SE: AsRef<CStr>>(dirfd: RawFd, pathname: &CStr, 
 }
 
 /// Daemonize this process by detaching from the controlling terminal (see
-/// [daemon(3)](http://man7.org/linux/man-pages/man3/daemon.3.html)).
+/// [daemon(3)](https://man7.org/linux/man-pages/man3/daemon.3.html)).
 ///
 /// When a process is launched it is typically associated with a parent and it,
 /// in turn, by its controlling terminal/process.  In order for a process to run
@@ -896,7 +896,7 @@ pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
 }
 
 /// Set the system host name (see
-/// [sethostname(2)](http://man7.org/linux/man-pages/man2/gethostname.2.html)).
+/// [sethostname(2)](https://man7.org/linux/man-pages/man2/gethostname.2.html)).
 ///
 /// Given a name, attempt to update the system host name to the given string.
 /// On some systems, the host name is limited to as few as 64 bytes.  An error
@@ -926,7 +926,7 @@ pub fn sethostname<S: AsRef<OsStr>>(name: S) -> Result<()> {
 
 /// Get the host name and store it in the provided buffer, returning a pointer
 /// the `CStr` in that buffer on success (see
-/// [gethostname(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html)).
+/// [gethostname(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html)).
 ///
 /// This function call attempts to get the host name for the running system and
 /// store it in a provided buffer.  The buffer will be populated with bytes up
@@ -961,7 +961,7 @@ pub fn gethostname(buffer: &mut [u8]) -> Result<&CStr> {
 /// `std::fs::File`.  Explicitly closing them with this method too can result in
 /// a double-close condition, which can cause confusing `EBADF` errors in
 /// seemingly unrelated code.  Caveat programmer.  See also
-/// [close(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html).
+/// [close(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html).
 ///
 /// # Examples
 ///
@@ -991,7 +991,7 @@ pub fn close(fd: RawFd) -> Result<()> {
 
 /// Read from a raw file descriptor.
 ///
-/// See also [read(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html)
+/// See also [read(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html)
 pub fn read(fd: RawFd, buf: &mut [u8]) -> Result<usize> {
     let res = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut c_void, buf.len() as size_t) };
 
@@ -1000,7 +1000,7 @@ pub fn read(fd: RawFd, buf: &mut [u8]) -> Result<usize> {
 
 /// Write to a raw file descriptor.
 ///
-/// See also [write(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html)
+/// See also [write(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html)
 pub fn write(fd: RawFd, buf: &[u8]) -> Result<usize> {
     let res = unsafe { libc::write(fd, buf.as_ptr() as *const c_void, buf.len() as size_t) };
 
@@ -1044,7 +1044,7 @@ pub enum Whence {
 
 /// Move the read/write file offset.
 ///
-/// See also [lseek(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html)
+/// See also [lseek(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html)
 pub fn lseek(fd: RawFd, offset: off_t, whence: Whence) -> Result<off_t> {
     let res = unsafe { libc::lseek(fd, offset, whence as i32) };
 
@@ -1060,7 +1060,7 @@ pub fn lseek64(fd: RawFd, offset: libc::off64_t, whence: Whence) -> Result<libc:
 
 /// Create an interprocess channel.
 ///
-/// See also [pipe(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pipe.html)
+/// See also [pipe(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pipe.html)
 pub fn pipe() -> Result<(RawFd, RawFd)> {
     unsafe {
         let mut fds = mem::MaybeUninit::<[c_int; 2]>::uninit();
@@ -1078,12 +1078,12 @@ pub fn pipe() -> Result<(RawFd, RawFd)> {
 /// The following flags are supported, and will be set atomically as the pipe is
 /// created:
 ///
-/// `O_CLOEXEC`:    Set the close-on-exec flag for the new file descriptors.  
+/// `O_CLOEXEC`:    Set the close-on-exec flag for the new file descriptors.
 #[cfg_attr(target_os = "linux", doc = "`O_DIRECT`: Create a pipe that performs I/O in \"packet\" mode.  ")]
 #[cfg_attr(target_os = "netbsd", doc = "`O_NOSIGPIPE`: Return `EPIPE` instead of raising `SIGPIPE`.  ")]
 /// `O_NONBLOCK`:   Set the non-blocking flag for the ends of the pipe.
 ///
-/// See also [pipe(2)](http://man7.org/linux/man-pages/man2/pipe.2.html)
+/// See also [pipe(2)](https://man7.org/linux/man-pages/man2/pipe.2.html)
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",
           target_os = "emscripten",
@@ -1109,7 +1109,7 @@ pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
 /// Truncate a file to a specified length
 ///
 /// See also
-/// [truncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html)
+/// [truncate(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/truncate.html)
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
@@ -1124,7 +1124,7 @@ pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
 /// Truncate a file to a specified length
 ///
 /// See also
-/// [ftruncate(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html)
+/// [ftruncate(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html)
 pub fn ftruncate(fd: RawFd, len: off_t) -> Result<()> {
     Errno::result(unsafe { libc::ftruncate(fd, len) }).map(drop)
 }
@@ -1163,7 +1163,7 @@ pub enum LinkatFlags {
 /// process. If either `oldpath` or `newpath` is absolute, then `dirfd` is ignored.
 ///
 /// # References
-/// See also [linkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/linkat.html)
+/// See also [linkat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/linkat.html)
 #[cfg(not(target_os = "redox"))] // RedoxFS does not support symlinks yet
 pub fn linkat<P: ?Sized + NixPath>(
     olddirfd: Option<RawFd>,
@@ -1199,7 +1199,7 @@ pub fn linkat<P: ?Sized + NixPath>(
 
 /// Remove a directory entry
 ///
-/// See also [unlink(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html)
+/// See also [unlink(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html)
 pub fn unlink<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
@@ -1225,7 +1225,7 @@ pub enum UnlinkatFlags {
 /// is performed.
 ///
 /// # References
-/// See also [unlinkat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html)
+/// See also [unlinkat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlinkat.html)
 #[cfg(not(target_os = "redox"))]
 pub fn unlinkat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
@@ -1258,7 +1258,7 @@ pub fn chroot<P: ?Sized + NixPath>(path: &P) -> Result<()> {
 
 /// Commit filesystem caches to disk
 ///
-/// See also [sync(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sync.html)
+/// See also [sync(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sync.html)
 #[cfg(any(
     target_os = "dragonfly",
     target_os = "freebsd",
@@ -1272,7 +1272,7 @@ pub fn sync() {
 
 /// Synchronize changes to a file
 ///
-/// See also [fsync(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fsync.html)
+/// See also [fsync(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsync.html)
 #[inline]
 pub fn fsync(fd: RawFd) -> Result<()> {
     let res = unsafe { libc::fsync(fd) };
@@ -1283,7 +1283,7 @@ pub fn fsync(fd: RawFd) -> Result<()> {
 /// Synchronize the data of a file
 ///
 /// See also
-/// [fdatasync(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fdatasync.html)
+/// [fdatasync(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdatasync.html)
 // `fdatasync(2) is in POSIX, but in libc it is only defined in `libc::notbsd`.
 // TODO: exclude only Apple systems after https://github.com/rust-lang/libc/pull/211
 #[cfg(any(target_os = "linux",
@@ -1300,7 +1300,7 @@ pub fn fdatasync(fd: RawFd) -> Result<()> {
 
 /// Get a real user ID
 ///
-/// See also [getuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getuid.html)
+/// See also [getuid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getuid.html)
 // POSIX requires that getuid is always successful, so no need to check return
 // value or errno.
 #[inline]
@@ -1310,7 +1310,7 @@ pub fn getuid() -> Uid {
 
 /// Get the effective user ID
 ///
-/// See also [geteuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/geteuid.html)
+/// See also [geteuid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/geteuid.html)
 // POSIX requires that geteuid is always successful, so no need to check return
 // value or errno.
 #[inline]
@@ -1320,7 +1320,7 @@ pub fn geteuid() -> Uid {
 
 /// Get the real group ID
 ///
-/// See also [getgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getgid.html)
+/// See also [getgid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getgid.html)
 // POSIX requires that getgid is always successful, so no need to check return
 // value or errno.
 #[inline]
@@ -1330,7 +1330,7 @@ pub fn getgid() -> Gid {
 
 /// Get the effective group ID
 ///
-/// See also [getegid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getegid.html)
+/// See also [getegid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getegid.html)
 // POSIX requires that getegid is always successful, so no need to check return
 // value or errno.
 #[inline]
@@ -1340,7 +1340,7 @@ pub fn getegid() -> Gid {
 
 /// Set the effective user ID
 ///
-/// See also [seteuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/seteuid.html)
+/// See also [seteuid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/seteuid.html)
 #[inline]
 pub fn seteuid(euid: Uid) -> Result<()> {
     let res = unsafe { libc::seteuid(euid.into()) };
@@ -1350,7 +1350,7 @@ pub fn seteuid(euid: Uid) -> Result<()> {
 
 /// Set the effective group ID
 ///
-/// See also [setegid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setegid.html)
+/// See also [setegid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setegid.html)
 #[inline]
 pub fn setegid(egid: Gid) -> Result<()> {
     let res = unsafe { libc::setegid(egid.into()) };
@@ -1360,7 +1360,7 @@ pub fn setegid(egid: Gid) -> Result<()> {
 
 /// Set the user ID
 ///
-/// See also [setuid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setuid.html)
+/// See also [setuid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setuid.html)
 #[inline]
 pub fn setuid(uid: Uid) -> Result<()> {
     let res = unsafe { libc::setuid(uid.into()) };
@@ -1370,7 +1370,7 @@ pub fn setuid(uid: Uid) -> Result<()> {
 
 /// Set the group ID
 ///
-/// See also [setgid(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setgid.html)
+/// See also [setgid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setgid.html)
 #[inline]
 pub fn setgid(gid: Gid) -> Result<()> {
     let res = unsafe { libc::setgid(gid.into()) };
@@ -1382,7 +1382,7 @@ pub fn setgid(gid: Gid) -> Result<()> {
 /// On both success and failure, this call returns the previous filesystem user
 /// ID of the caller.
 ///
-/// See also [setfsuid(2)](http://man7.org/linux/man-pages/man2/setfsuid.2.html)
+/// See also [setfsuid(2)](https://man7.org/linux/man-pages/man2/setfsuid.2.html)
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn setfsuid(uid: Uid) -> Uid {
     let prev_fsuid = unsafe { libc::setfsuid(uid.into()) };
@@ -1393,7 +1393,7 @@ pub fn setfsuid(uid: Uid) -> Uid {
 /// On both success and failure, this call returns the previous filesystem group
 /// ID of the caller.
 ///
-/// See also [setfsgid(2)](http://man7.org/linux/man-pages/man2/setfsgid.2.html)
+/// See also [setfsgid(2)](https://man7.org/linux/man-pages/man2/setfsgid.2.html)
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn setfsgid(gid: Gid) -> Gid {
     let prev_fsgid = unsafe { libc::setfsgid(gid.into()) };
@@ -1402,7 +1402,7 @@ pub fn setfsgid(gid: Gid) -> Gid {
 
 /// Get the list of supplementary group IDs of the calling process.
 ///
-/// [Further reading](http://pubs.opengroup.org/onlinepubs/009695399/functions/getgroups.html)
+/// [Further reading](https://pubs.opengroup.org/onlinepubs/009695399/functions/getgroups.html)
 ///
 /// **Note:** This function is not available for Apple platforms. On those
 /// platforms, checking group membership should be achieved via communication
@@ -1450,7 +1450,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
 
 /// Set the list of supplementary group IDs for the calling process.
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man2/getgroups.2.html)
+/// [Further reading](https://man7.org/linux/man-pages/man2/getgroups.2.html)
 ///
 /// **Note:** This function is not available for Apple platforms. On those
 /// platforms, group membership management should be achieved via communication
@@ -1510,7 +1510,7 @@ pub fn setgroups(groups: &[Gid]) -> Result<()> {
 /// Gets the group IDs of all groups that `user` is a member of. The additional
 /// group `group` is also added to the list.
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man3/getgrouplist.3.html)
+/// [Further reading](https://man7.org/linux/man-pages/man3/getgrouplist.3.html)
 ///
 /// **Note:** This function is not available for Apple platforms. On those
 /// platforms, checking group membership should be achieved via communication
@@ -1574,7 +1574,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
 /// that `user` is a member of. The additional group `group` is also added to
 /// the list.
 ///
-/// [Further reading](http://man7.org/linux/man-pages/man3/initgroups.3.html)
+/// [Further reading](https://man7.org/linux/man-pages/man3/initgroups.3.html)
 ///
 /// **Note:** This function is not available for Apple platforms. On those
 /// platforms, group membership management should be achieved via communication
@@ -1623,7 +1623,7 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
 
 /// Suspend the thread until a signal is received.
 ///
-/// See also [pause(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pause.html).
+/// See also [pause(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pause.html).
 #[inline]
 #[cfg(not(target_os = "redox"))]
 pub fn pause() {
@@ -1689,7 +1689,7 @@ pub mod alarm {
     //!
     //! # References
     //!
-    //! See also [alarm(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/alarm.html).
+    //! See also [alarm(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/alarm.html).
 
     /// Schedule an alarm signal.
     ///
@@ -1719,7 +1719,7 @@ pub mod alarm {
 
 /// Suspend execution for an interval of time
 ///
-/// See also [sleep(2)](http://pubs.opengroup.org/onlinepubs/009695399/functions/sleep.html#tag_03_705_05)
+/// See also [sleep(2)](https://pubs.opengroup.org/onlinepubs/009695399/functions/sleep.html#tag_03_705_05)
 // Per POSIX, does not fail
 #[inline]
 pub fn sleep(seconds: c_uint) -> c_uint {
@@ -1759,7 +1759,7 @@ pub mod acct {
 /// Err is returned either if no temporary filename could be created or the template doesn't
 /// end with XXXXXX
 ///
-/// See also [mkstemp(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkstemp.html)
+/// See also [mkstemp(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkstemp.html)
 ///
 /// # Example
 ///
@@ -1790,7 +1790,7 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 /// Variable names for `pathconf`
 ///
 /// Nix uses the same naming convention for these variables as the
-/// [getconf(1)](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html) utility.
+/// [getconf(1)](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html) utility.
 /// That is, `PathconfVar` variables have the same name as the abstract
 /// variables  shown in the `pathconf(2)` man page.  Usually, it's the same as
 /// the C variable name without the leading `_PC_`.
@@ -1800,9 +1800,9 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 ///
 /// # References
 ///
-/// - [pathconf(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html)
-/// - [limits.h](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
-/// - [unistd.h](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
+/// - [pathconf(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html)
+/// - [limits.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
+/// - [unistd.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(i32)]
 pub enum PathconfVar {
@@ -1896,7 +1896,7 @@ pub enum PathconfVar {
 }
 
 /// Like `pathconf`, but works with file descriptors instead of paths (see
-/// [fpathconf(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html))
+/// [fpathconf(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html))
 ///
 /// # Parameters
 ///
@@ -1928,12 +1928,12 @@ pub fn fpathconf(fd: RawFd, var: PathconfVar) -> Result<Option<c_long>> {
 }
 
 /// Get path-dependent configurable system variables (see
-/// [pathconf(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html))
+/// [pathconf(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html))
 ///
 /// Returns the value of a path-dependent configurable system variable.  Most
 /// supported variables also have associated compile-time constants, but POSIX
 /// allows their values to change at runtime.  There are generally two types of
-/// `pathconf` variables: options and limits.  See [pathconf(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html) for more details.
+/// `pathconf` variables: options and limits.  See [pathconf(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html) for more details.
 ///
 /// # Parameters
 ///
@@ -1969,7 +1969,7 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 /// Variable names for `sysconf`
 ///
 /// Nix uses the same naming convention for these variables as the
-/// [getconf(1)](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html) utility.
+/// [getconf(1)](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html) utility.
 /// That is, `SysconfVar` variables have the same name as the abstract variables
 /// shown in the `sysconf(3)` man page.  Usually, it's the same as the C
 /// variable name without the leading `_SC_`.
@@ -1979,9 +1979,9 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 ///
 /// # References
 ///
-/// - [sysconf(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html)
-/// - [unistd.h](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
-/// - [limits.h](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
+/// - [sysconf(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html)
+/// - [unistd.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
+/// - [limits.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(i32)]
 pub enum SysconfVar {
@@ -2434,7 +2434,7 @@ pub enum SysconfVar {
 }
 
 /// Get configurable system variables (see
-/// [sysconf(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html))
+/// [sysconf(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html))
 ///
 /// Returns the value of a configurable system variable.  Most supported
 /// variables also have associated compile-time constants, but POSIX
@@ -2492,7 +2492,7 @@ mod setres {
     use super::{Uid, Gid};
 
     /// Sets the real, effective, and saved uid.
-    /// ([see setresuid(2)](http://man7.org/linux/man-pages/man2/setresuid.2.html))
+    /// ([see setresuid(2)](https://man7.org/linux/man-pages/man2/setresuid.2.html))
     ///
     /// * `ruid`: real user id
     /// * `euid`: effective user id
@@ -2508,7 +2508,7 @@ mod setres {
     }
 
     /// Sets the real, effective, and saved gid.
-    /// ([see setresuid(2)](http://man7.org/linux/man-pages/man2/setresuid.2.html))
+    /// ([see setresuid(2)](https://man7.org/linux/man-pages/man2/setresuid.2.html))
     ///
     /// * `rgid`: real group id
     /// * `egid`: effective group id
@@ -2539,7 +2539,7 @@ libc_bitflags!{
 }
 
 /// Checks the file named by `path` for accessibility according to the flags given by `amode`
-/// See [access(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html)
+/// See [access(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/access.html)
 pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
@@ -2672,7 +2672,7 @@ impl User {
     /// Get a user by UID.
     ///
     /// Internally, this function calls
-    /// [getpwuid_r(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
+    /// [getpwuid_r(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
     ///
     /// # Examples
     ///
@@ -2691,7 +2691,7 @@ impl User {
     /// Get a user by name.
     ///
     /// Internally, this function calls
-    /// [getpwnam_r(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
+    /// [getpwnam_r(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
     ///
     /// # Examples
     ///
@@ -2793,7 +2793,7 @@ impl Group {
     /// Get a group by GID.
     ///
     /// Internally, this function calls
-    /// [getgrgid_r(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
+    /// [getgrgid_r(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
     ///
     /// # Examples
     ///
@@ -2814,7 +2814,7 @@ impl Group {
     /// Get a group by name.
     ///
     /// Internally, this function calls
-    /// [getgrnam_r(3)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
+    /// [getgrnam_r(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpwuid_r.html)
     ///
     /// # Examples
     ///
@@ -2835,7 +2835,7 @@ impl Group {
 }
 
 /// Get the name of the terminal device that is open on file descriptor fd
-/// (see [`ttyname(3)`](http://man7.org/linux/man-pages/man3/ttyname.3.html)).
+/// (see [`ttyname(3)`](https://man7.org/linux/man-pages/man3/ttyname.3.html)).
 #[cfg(not(target_os = "fuchsia"))]
 pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
     const PATH_MAX: usize = libc::PATH_MAX as usize;


### PR DESCRIPTION
All of the `http://` links in the repository are also available as `https://, and have been updated.

The sole exception to this trivially rewrite is a dead-link to `http://rust-lang.org/COPYRIGHT`, which has been replaced with `https://www.rust-lang.org/policies/licenses`.