### PR TITLE
Add MS_LAZYTIME flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added TIMESTAMPNS support for linux
   (#[1402](https://github.com/nix-rust/nix/pull/1402))
 - Added `sendfile64` (#[1439](https://github.com/nix-rust/nix/pull/1439))
+- Added `MS_LAZYTIME` to `MsFlags`
+  (#[1437](https://github.com/nix-rust/nix/pull/1437))
 
 ### Changed
 - Made `forkpty` unsafe, like `fork`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.93", features = [ "extra_traits" ] }
+libc = { version = "0.2.95", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -38,6 +38,7 @@ libc_bitflags!(
         MS_KERNMOUNT;
         MS_I_VERSION;
         MS_STRICTATIME;
+        MS_LAZYTIME;
         MS_ACTIVE;
         MS_NOUSER;
         MS_RMT_MASK;


### PR DESCRIPTION
MS_LAZYTIME (since Linux 4.0) reduces on-disk updates of inode
timestamps (atime, mtime, ctime) by maintaining these changes only in memory.

MS_LAZYTIME is available from `libc` v0.2.95.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>