### PR TITLE
misc Clippy cleanup

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -94,7 +94,7 @@ impl ErrnoSentinel for i64 {
 }
 
 impl ErrnoSentinel for *mut c_void {
-    fn sentinel() -> Self { (-1 as isize) as *mut c_void }
+    fn sentinel() -> Self { -1isize as *mut c_void }
 }
 
 impl ErrnoSentinel for libc::sighandler_t {

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -166,7 +166,7 @@ libc_bitflags!(
 );
 
 // The conversion is not identical on all operating systems.
-#[allow(clippy::identity_conversion)]
+#[allow(clippy::useless_conversion)]
 pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<RawFd> {
     let fd = path.with_nix_path(|cstr| {
         unsafe { libc::open(cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint) }
@@ -176,7 +176,7 @@ pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<R
 }
 
 // The conversion is not identical on all operating systems.
-#[allow(clippy::identity_conversion)]
+#[allow(clippy::useless_conversion)]
 #[cfg(not(target_os = "redox"))]
 pub fn openat<P: ?Sized + NixPath>(
     dirfd: RawFd,
@@ -264,7 +264,7 @@ fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P) -> Result
         Some(dirfd) => super::sys::stat::fstatat(dirfd, path, AtFlags::AT_SYMLINK_NOFOLLOW),
         None => super::sys::stat::lstat(path)
     }
-        .and_then(|x| Ok(x.st_size))
+        .map(|x| x.st_size)
         .unwrap_or(0);
     let mut try_size = if reported_size > 0 {
         // Note: even if `lstat`'s apparently valid answer turns out to be

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -513,7 +513,7 @@ impl<'a> AioCb<'a> {
         }
     }
 
-    fn error_unpinned(self: &mut Self) -> Result<()> {
+    fn error_unpinned(&mut self) -> Result<()> {
         let r = unsafe {
             libc::aio_error(&mut self.aiocb.0 as *mut libc::aiocb)
         };
@@ -645,7 +645,7 @@ impl<'a> AioCb<'a> {
         SigEvent::from(&self.aiocb.0.aio_sigevent)
     }
 
-    fn aio_return_unpinned(self: &mut Self) -> Result<isize> {
+    fn aio_return_unpinned(&mut self) -> Result<isize> {
         unsafe {
             let p: *mut libc::aiocb = &mut self.aiocb.0;
             self.in_progress = false;
@@ -838,6 +838,10 @@ unsafe impl<'a> Sync for LioCb<'a> {}
 
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 impl<'a> LioCb<'a> {
+    pub fn is_empty(&self) -> bool {
+        self.aiocbs.is_empty()
+    }
+
     /// Return the number of individual [`AioCb`]s contained.
     pub fn len(&self) -> usize {
         self.aiocbs.len()

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -133,16 +133,14 @@ pub fn kill(pid: Pid) -> Result<()> {
 /// use nix::unistd::Pid;
 /// use nix::sys::signal::Signal;
 /// use nix::sys::wait::*;
-/// fn main() {
-///     // If a process changes state to the stopped state because of a SIGUSR1
-///     // signal, this will step the process forward and forward the user
-///     // signal to the stopped process
-///     match waitpid(Pid::from_raw(-1), None) {
-///         Ok(WaitStatus::Stopped(pid, Signal::SIGUSR1)) => {
-///             let _ = step(pid, Signal::SIGUSR1);
-///         }
-///         _ => {},
+/// // If a process changes state to the stopped state because of a SIGUSR1
+/// // signal, this will step the process forward and forward the user
+/// // signal to the stopped process
+/// match waitpid(Pid::from_raw(-1), None) {
+///     Ok(WaitStatus::Stopped(pid, Signal::SIGUSR1)) => {
+///         let _ = step(pid, Signal::SIGUSR1);
 ///     }
+///     _ => {},
 /// }
 /// ```
 #[cfg(

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -50,12 +50,10 @@ impl FdSet {
     ///
     /// ```
     /// # use nix::sys::select::FdSet;
-    /// # fn main() {
     /// let mut set = FdSet::new();
     /// set.insert(4);
     /// set.insert(9);
     /// assert_eq!(set.highest(), Some(9));
-    /// # }
     /// ```
     ///
     /// [`select`]: fn.select.html

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -710,7 +710,7 @@ impl ControlMessageOwned {
             },
             (_, _) => {
                 let sl = slice::from_raw_parts(p, len);
-                let ucmsg = UnknownCmsg(*header, Vec::<u8>::from(&sl[..]));
+                let ucmsg = UnknownCmsg(*header, Vec::<u8>::from(sl));
                 ControlMessageOwned::Unknown(ucmsg)
             }
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -185,9 +185,9 @@ impl ClockId {
     pub const CLOCK_VIRTUAL: ClockId = ClockId(libc::CLOCK_VIRTUAL);
 }
 
-impl Into<clockid_t> for ClockId {
-    fn into(self) -> clockid_t {
-        self.as_raw()
+impl From<ClockId> for clockid_t {
+    fn from(clock_id: ClockId) -> Self {
+        clock_id.as_raw()
     }
 }
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -450,15 +450,13 @@ pub fn fchdir(dirfd: RawFd) -> Result<()> {
 /// use nix::sys::stat;
 /// use tempfile::tempdir;
 ///
-/// fn main() {
-///     let tmp_dir1 = tempdir().unwrap();
-///     let tmp_dir2 = tmp_dir1.path().join("new_dir");
+/// let tmp_dir1 = tempdir().unwrap();
+/// let tmp_dir2 = tmp_dir1.path().join("new_dir");
 ///
-///     // create new directory and give read, write and execute rights to the owner
-///     match unistd::mkdir(&tmp_dir2, stat::Mode::S_IRWXU) {
-///        Ok(_) => println!("created {:?}", tmp_dir2),
-///        Err(err) => println!("Error creating directory: {}", err),
-///     }
+/// // create new directory and give read, write and execute rights to the owner
+/// match unistd::mkdir(&tmp_dir2, stat::Mode::S_IRWXU) {
+///    Ok(_) => println!("created {:?}", tmp_dir2),
+///    Err(err) => println!("Error creating directory: {}", err),
 /// }
 /// ```
 #[inline]
@@ -490,15 +488,13 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 /// use nix::sys::stat;
 /// use tempfile::tempdir;
 ///
-/// fn main() {
-///     let tmp_dir = tempdir().unwrap();
-///     let fifo_path = tmp_dir.path().join("foo.pipe");
+/// let tmp_dir = tempdir().unwrap();
+/// let fifo_path = tmp_dir.path().join("foo.pipe");
 ///
-///     // create new fifo and give read, write and execute rights to the owner
-///     match unistd::mkfifo(&fifo_path, stat::Mode::S_IRWXU) {
-///        Ok(_) => println!("created {:?}", fifo_path),
-///        Err(err) => println!("Error creating fifo: {}", err),
-///     }
+/// // create new fifo and give read, write and execute rights to the owner
+/// match unistd::mkfifo(&fifo_path, stat::Mode::S_IRWXU) {
+///    Ok(_) => println!("created {:?}", fifo_path),
+///    Err(err) => println!("Error creating fifo: {}", err),
 /// }
 /// ```
 #[inline]
@@ -587,11 +583,9 @@ fn reserve_double_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
 /// ```rust
 /// use nix::unistd;
 ///
-/// fn main() {
-///     // assume that we are allowed to get current directory
-///     let dir = unistd::getcwd().unwrap();
-///     println!("The current directory is {:?}", dir);
-/// }
+/// // assume that we are allowed to get current directory
+/// let dir = unistd::getcwd().unwrap();
+/// println!("The current directory is {:?}", dir);
 /// ```
 #[inline]
 pub fn getcwd() -> Result<PathBuf> {
@@ -624,6 +618,8 @@ pub fn getcwd() -> Result<PathBuf> {
 }
 
 /// Computes the raw UID and GID values to pass to a `*chown` call.
+// The cast is not unnecessary on all platforms.
+#[allow(clippy::unnecessary_cast)]
 fn chown_raw_ids(owner: Option<Uid>, group: Option<Gid>) -> (libc::uid_t, libc::gid_t) {
     // According to the POSIX specification, -1 is used to indicate that owner and group
     // are not to be changed.  Since uid_t and gid_t are unsigned types, we have to wrap
@@ -969,20 +965,16 @@ pub fn gethostname(buffer: &mut [u8]) -> Result<&CStr> {
 /// use std::os::unix::io::AsRawFd;
 /// use nix::unistd::close;
 ///
-/// fn main() {
-///     let f = tempfile::tempfile().unwrap();
-///     close(f.as_raw_fd()).unwrap();   // Bad!  f will also close on drop!
-/// }
+/// let f = tempfile::tempfile().unwrap();
+/// close(f.as_raw_fd()).unwrap();   // Bad!  f will also close on drop!
 /// ```
 ///
 /// ```rust
 /// use std::os::unix::io::IntoRawFd;
 /// use nix::unistd::close;
 ///
-/// fn main() {
-///     let f = tempfile::tempfile().unwrap();
-///     close(f.into_raw_fd()).unwrap(); // Good.  into_raw_fd consumes f
-/// }
+/// let f = tempfile::tempfile().unwrap();
+/// close(f.into_raw_fd()).unwrap(); // Good.  into_raw_fd consumes f
 /// ```
 pub fn close(fd: RawFd) -> Result<()> {
     let res = unsafe { libc::close(fd) };
@@ -1563,7 +1555,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
             // groups as possible, but Linux manpages do not mention this
             // behavior.
             reserve_double_buffer_size(&mut groups, ngroups_max as usize)
-                .or_else(|_| Err(Error::invalid_argument()))?;
+                .map_err(|_| Error::invalid_argument())?;
         }
     }
 }

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -56,10 +56,10 @@ mod linux {
     #[test]
     fn test_op_write_64() {
         if cfg!(any(target_arch = "mips64", target_arch="powerpc64")){
-            assert_eq!(request_code_write!(b'z', 10, (1 as u64) << 32) as u32,
+            assert_eq!(request_code_write!(b'z', 10, 1u64 << 32) as u32,
                        0x8000_7A0A);
         } else {
-            assert_eq!(request_code_write!(b'z', 10, (1 as u64) << 32) as u32,
+            assert_eq!(request_code_write!(b'z', 10, 1u64 << 32) as u32,
                        0x4000_7A0A);
         }
 
@@ -80,10 +80,10 @@ mod linux {
     #[test]
     fn test_op_read_64() {
         if cfg!(any(target_arch = "mips64", target_arch="powerpc64")){
-            assert_eq!(request_code_read!(b'z', 10, (1 as u64) << 32) as u32,
+            assert_eq!(request_code_read!(b'z', 10, 1u64 << 32) as u32,
                        0x4000_7A0A);
         } else {
-            assert_eq!(request_code_read!(b'z', 10, (1 as u64) << 32) as u32,
+            assert_eq!(request_code_read!(b'z', 10, 1u64 << 32) as u32,
                        0x8000_7A0A);
         }
     }
@@ -97,7 +97,7 @@ mod linux {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_read_write_64() {
-        assert_eq!(request_code_readwrite!(b'z', 10, (1 as u64) << 32) as u32,
+        assert_eq!(request_code_readwrite!(b'z', 10, 1u64 << 32) as u32,
                    0xC000_7A0A);
     }
 }
@@ -131,7 +131,7 @@ mod bsd {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_write_64() {
-        assert_eq!(request_code_write!(b'z', 10, (1 as u64) << 32), 0x8000_7A0A);
+        assert_eq!(request_code_write!(b'z', 10, 1u64 << 32), 0x8000_7A0A);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod bsd {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_read_64() {
-        assert_eq!(request_code_read!(b'z', 10, (1 as u64) << 32), 0x4000_7A0A);
+        assert_eq!(request_code_read!(b'z', 10, 1u64 << 32), 0x4000_7A0A);
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod bsd {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_read_write_64() {
-        assert_eq!(request_code_readwrite!(b'z', 10, (1 as u64) << 32), 0xC000_7A0A);
+        assert_eq!(request_code_readwrite!(b'z', 10, 1u64 << 32), 0xC000_7A0A);
     }
 }
 

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,4 +1,3 @@
-use libc;
 #[cfg(not(target_os = "redox"))]
 use nix::Error;
 use nix::sys::signal::*;
@@ -53,9 +52,9 @@ fn test_sigprocmask() {
 
     // Make sure the old set doesn't contain the signal, otherwise the following
     // test don't make sense.
-    assert_eq!(old_signal_set.contains(SIGNAL), false,
-               "the {:?} signal is already blocked, please change to a \
-                different one", SIGNAL);
+    assert!(!old_signal_set.contains(SIGNAL),
+            "the {:?} signal is already blocked, please change to a \
+             different one", SIGNAL);
 
     // Now block the signal.
     let mut signal_set = SigSet::empty();
@@ -67,8 +66,8 @@ fn test_sigprocmask() {
     old_signal_set.clear();
     sigprocmask(SigmaskHow::SIG_BLOCK, None, Some(&mut old_signal_set))
         .expect("expect to be able to retrieve old signals");
-    assert_eq!(old_signal_set.contains(SIGNAL), true,
-               "expected the {:?} to be blocked", SIGNAL);
+    assert!(old_signal_set.contains(SIGNAL),
+            "expected the {:?} to be blocked", SIGNAL);
 
     // Reset the signal.
     sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&signal_set), None)

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -74,7 +74,7 @@ fn test_bindtodevice() {
 fn test_so_tcp_keepalive() {
     let fd = socket(AddressFamily::Inet, SockType::Stream, SockFlag::empty(), SockProtocol::Tcp).unwrap();
     setsockopt(fd, sockopt::KeepAlive, &true).unwrap();
-    assert_eq!(getsockopt(fd, sockopt::KeepAlive).unwrap(), true);
+    assert!(getsockopt(fd, sockopt::KeepAlive).unwrap());
 
     #[cfg(any(target_os = "android",
               target_os = "dragonfly",

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -214,7 +214,7 @@ fn test_process_vm_readv() {
     use crate::*;
 
     require_capability!(CAP_SYS_PTRACE);
-    let _ = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
+    let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Pre-allocate memory in the child, since allocation isn't safe
     // post-fork (~= async-signal-safe)

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -8,7 +8,7 @@ use libc::_exit;
 #[test]
 #[cfg(not(target_os = "redox"))]
 fn test_wait_signal() {
-    let _ = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
+    let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Safe: The child only calls `pause` and/or `_exit`, which are async-signal-safe.
     match unsafe{fork()}.expect("Error: Fork Failed") {

--- a/test/test_net.rs
+++ b/test/test_net.rs
@@ -8,5 +8,5 @@ const LOOPBACK: &[u8] = b"lo0";
 
 #[test]
 fn test_if_nametoindex() {
-    assert!(if_nametoindex(&LOOPBACK[..]).is_ok());
+    assert!(if_nametoindex(LOOPBACK).is_ok());
 }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -44,18 +44,6 @@ use nix::unistd::chdir;
 
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 use nix::Result;
-use tempfile;
-
-#[allow(unused_comparisons)]
-// uid and gid are signed on Windows, but not on other platforms. This function
-// allows warning free compiles on all platforms, and can be removed when
-// expression-level #[allow] is available.
-#[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
-fn valid_uid_gid(stat: FileStat) -> bool {
-    // uid could be 0 for the `root` user. This quite possible when
-    // the tests are being run on a rooted Android device.
-    stat.st_uid >= 0 && stat.st_gid >= 0
-}
 
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 fn assert_stat_results(stat_result: Result<FileStat>) {
@@ -64,7 +52,6 @@ fn assert_stat_results(stat_result: Result<FileStat>) {
     assert!(stats.st_ino > 0);      // inode is positive integer, exact number machine dependent
     assert!(stats.st_mode > 0);     // must be positive integer
     assert_eq!(stats.st_nlink, 1);   // there links created, must be 1
-    assert!(valid_uid_gid(stats));  // must be positive integers
     assert_eq!(stats.st_size, 0);    // size is 0 because we did not write anything to the file
     assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
     assert!(stats.st_blocks <= 16);  // Up to 16 blocks can be allocated for a blank file
@@ -84,7 +71,6 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
     // On other platforms they are the same (either both are u16 or u32).
     assert_eq!((stats.st_mode as usize) & (S_IFMT as usize), S_IFLNK as usize); // should be a link
     assert_eq!(stats.st_nlink, 1);   // there links created, must be 1
-    assert!(valid_uid_gid(stats));  // must be positive integers
     assert!(stats.st_size > 0);    // size is > 0 because it points to another file
     assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -441,7 +441,7 @@ fn test_getcwd() {
     // kicks in.  Note: One path cannot be longer than 255 bytes
     // (NAME_MAX) whole path cannot be longer than PATH_MAX (usually
     // 4096 on linux, 1024 on macos)
-    let mut inner_tmp_dir = tmpdir_path.to_path_buf();
+    let mut inner_tmp_dir = tmpdir_path;
     for _ in 0..5 {
         let newdir = iter::repeat("a").take(100).collect::<String>();
         inner_tmp_dir.push(newdir);


### PR DESCRIPTION
* Fix race conditions in the tests.  Two tests were grabbing a mutex but
  immediately dropping it.  Thank you, Clippy.

* Remove vestigial Windows support.  Remove some code added to support
  Windows in 2015.  Nix is no longer intended to ever run on Windows.

* Various other minor Clippy lints.