### PR TITLE
Overhaul Nix's error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1440](https://github.com/nix-rust/nix/pull/1440))
 - Minimum supported Rust version is now 1.41.0.
   ([#1440](https://github.com/nix-rust/nix/pull/1440))
+- `ptsname_r` now returns a lossily-converted string in the event of bad UTF,
+  just like `ptsname`.
+  ([#1446](https://github.com/nix-rust/nix/pull/1446))
 - Errno aliases are now associated consts on `Errno`, instead of consts in the
   `errno` module.
   (#[1452](https://github.com/nix-rust/nix/pull/1452))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1457](https://github.com/nix-rust/nix/pull/1457))
 
 ### Changed
+- `ptsname_r` now returns a lossily-converted string in the event of bad UTF,
+  just like `ptsname`.
+  ([#1446](https://github.com/nix-rust/nix/pull/1446))
+- Nix's error type is now a simple wrapper around the platform's Errno.  This
+  means it is now `Into<std::io::Error>`.  It's also `Clone`, `Copy`, `Eq`, and
+  has a small fixed size.  It also requires less typing.  For example, the old
+  enum variant `nix::Error::Sys(nix::errno::Errno::EINVAL)` is now simply
+  `nix::Error::EINVAL`.
+  ([#1446](https://github.com/nix-rust/nix/pull/1446))
+
 ### Fixed
 ### Removed
 
@@ -46,9 +56,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1440](https://github.com/nix-rust/nix/pull/1440))
 - Minimum supported Rust version is now 1.41.0.
   ([#1440](https://github.com/nix-rust/nix/pull/1440))
-- `ptsname_r` now returns a lossily-converted string in the event of bad UTF,
-  just like `ptsname`.
-  ([#1446](https://github.com/nix-rust/nix/pull/1446))
 - Errno aliases are now associated consts on `Errno`, instead of consts in the
   `errno` module.
   (#[1452](https://github.com/nix-rust/nix/pull/1452))

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -84,7 +84,7 @@ impl AsRawFd for Dir {
 impl Drop for Dir {
     fn drop(&mut self) {
         let e = Errno::result(unsafe { libc::closedir(self.0.as_ptr()) });
-        if !std::thread::panicking() && e == Err(Error::Sys(Errno::EBADF)) {
+        if !std::thread::panicking() && e == Err(Error::from(Errno::EBADF)) {
             panic!("Closing an invalid file descriptor!");
         };
     }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -64,11 +64,21 @@ impl Errno {
         clear()
     }
 
+    pub(crate) fn result2<S: ErrnoSentinel + PartialEq<S>>(value: S)
+        -> std::result::Result<S, Self>
+    {
+        if value == S::sentinel() {
+            Err(Self::last())
+        } else {
+            Ok(value)
+        }
+    }
+
     /// Returns `Ok(value)` if it does not contain the sentinel value. This
     /// should not be used when `-1` is not the errno sentinel value.
     pub fn result<S: ErrnoSentinel + PartialEq<S>>(value: S) -> Result<S> {
         if value == S::sentinel() {
-            Err(Error::Sys(Self::last()))
+            Err(Error::from(Self::last()))
         } else {
             Ok(value)
         }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -288,7 +288,7 @@ fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P) -> Result
                 Some(next_size) => try_size = next_size,
                 // It's absurd that this would happen, but handle it sanely
                 // anyway.
-                None => break Err(super::Error::Sys(Errno::ENAMETOOLONG)),
+                None => break Err(super::Error::from(Errno::ENAMETOOLONG)),
             }
         }
     }
@@ -646,6 +646,6 @@ pub fn posix_fallocate(fd: RawFd, offset: libc::off_t, len: libc::off_t) -> Resu
     match Errno::result(res) {
         Err(err) => Err(err),
         Ok(0) => Ok(()),
-        Ok(errno) => Err(crate::Error::Sys(Errno::from_i32(errno))),
+        Ok(errno) => Err(crate::Error::from(Errno::from_i32(errno))),
     }
 }

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -1,4 +1,5 @@
 use crate::{
+    Error,
     Errno,
     NixPath,
     Result,
@@ -99,7 +100,7 @@ libc_bitflags!(
 /// by `nmount(2)`.
 #[derive(Debug)]
 pub struct NmountError {
-    errno: Errno,
+    errno: Error,
     errmsg: Option<String>
 }
 
@@ -109,14 +110,14 @@ impl NmountError {
         self.errmsg.as_deref()
     }
 
-    /// Returns the inner [`Errno`]
-    pub fn errno(&self) -> Errno {
+    /// Returns the inner [`Error`]
+    pub fn error(&self) -> Error {
         self.errno
     }
 
-    fn new(errno: Errno, errmsg: Option<&CStr>) -> Self {
+    fn new(error: Error, errmsg: Option<&CStr>) -> Self {
         Self {
-            errno,
+            errno: error,
             errmsg: errmsg.map(CStr::to_string_lossy).map(Cow::into_owned)
         }
     }

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -136,7 +136,7 @@ impl fmt::Display for NmountError {
 
 impl From<NmountError> for io::Error {
     fn from(err: NmountError) -> Self {
-        io::Error::from_raw_os_error(err.errno as i32)
+        err.errno.into()
     }
 }
 
@@ -381,7 +381,7 @@ impl<'a> Nmount<'a> {
                         Some(CStr::from_bytes_with_nul(sl).unwrap())
                     }
                 };
-                Err(NmountError::new(error.as_errno().unwrap(), errmsg))
+                Err(NmountError::new(error.into(), errmsg))
             }
         }
     }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -70,7 +70,7 @@ impl Drop for PtyMaster {
         // condition, which can cause confusing errors for future I/O
         // operations.
         let e = unistd::close(self.0);
-        if e == Err(Error(Errno::EBADF)) {
+        if e == Err(Errno::EBADF) {
             panic!("Closing an invalid file descriptor!");
         };
     }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -68,7 +68,7 @@ mod sched_linux_like {
         /// `field` is the CPU id to test
         pub fn is_set(&self, field: usize) -> Result<bool> {
             if field >= CpuSet::count() {
-                Err(Error::Sys(Errno::EINVAL))
+                Err(Error::from(Errno::EINVAL))
             } else {
                 Ok(unsafe { libc::CPU_ISSET(field, &self.cpu_set) })
             }
@@ -78,7 +78,7 @@ mod sched_linux_like {
         /// `field` is the CPU id to add
         pub fn set(&mut self, field: usize) -> Result<()> {
             if field >= CpuSet::count() {
-                Err(Error::Sys(Errno::EINVAL))
+                Err(Error::from(Errno::EINVAL))
             } else {
                 unsafe { libc::CPU_SET(field, &mut self.cpu_set); }
                 Ok(())
@@ -89,7 +89,7 @@ mod sched_linux_like {
         /// `field` is the CPU id to remove
         pub fn unset(&mut self, field: usize) -> Result<()> {
             if field >= CpuSet::count() {
-                Err(Error::Sys(Errno::EINVAL))
+                Err(Error::from(Errno::EINVAL))
             } else {
                 unsafe { libc::CPU_CLR(field, &mut self.cpu_set);}
                 Ok(())

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -983,13 +983,13 @@ impl<'a> LioCb<'a> {
                     // aiocb is complete; collect its status and don't resubmit
                     self.results[i] = Some(a.aio_return_unpinned());
                 },
-                Err(Error(Errno::EAGAIN)) => {
+                Err(Errno::EAGAIN) => {
                     self.list.push(a as *mut AioCb<'a> as *mut libc::aiocb);
                 },
-                Err(Error(Errno::EINPROGRESS)) => {
+                Err(Errno::EINPROGRESS) => {
                     // aiocb is was successfully queued; no need to do anything
                 },
-                Err(Error(Errno::EINVAL)) => panic!(
+                Err(Errno::EINVAL) => panic!(
                     "AioCb was never submitted, or already finalized"),
                 _ => unreachable!()
             }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,10 +1,9 @@
-use crate::Result;
+use crate::{Error, Result};
 use crate::errno::Errno;
 use libc::{self, c_int};
 use std::os::unix::io::RawFd;
 use std::ptr;
 use std::mem;
-use crate::Error;
 
 libc_bitflags!(
     pub struct EpollFlags: c_int {
@@ -86,7 +85,7 @@ pub fn epoll_ctl<'a, T>(epfd: RawFd, op: EpollOp, fd: RawFd, event: T) -> Result
 {
     let mut event: Option<&mut EpollEvent> = event.into();
     if event.is_none() && op != EpollOp::EpollCtlDel {
-        Err(Error::Sys(Errno::EINVAL))
+        Err(Error::from(Errno::EINVAL))
     } else {
         let res = unsafe {
             if let Some(ref mut event) = event {

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -320,7 +320,7 @@ pub unsafe fn mmap(addr: *mut c_void, length: size_t, prot: ProtFlags, flags: Ma
     let ret = libc::mmap(addr, length, prot.bits(), flags.bits(), fd, offset);
 
     if ret == libc::MAP_FAILED {
-        Err(Error::Sys(Errno::last()))
+        Err(Error::from(Errno::last()))
     } else {
         Ok(ret)
     }
@@ -344,7 +344,7 @@ pub unsafe fn mremap(
     let ret = libc::mremap(addr, old_size, new_size, flags.bits(), new_address.unwrap_or(std::ptr::null_mut()));
 
     if ret == libc::MAP_FAILED {
-        Err(Error::Sys(Errno::last()))
+        Err(Error::from(Errno::last()))
     } else {
         Ok(ret)
     }

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -2,7 +2,7 @@
 
 use cfg_if::cfg_if;
 use std::{mem, ptr};
-use crate::{Error, Result};
+use crate::Result;
 use crate::errno::Errno;
 use libc::{self, c_void, c_long, siginfo_t};
 use crate::unistd::Pid;
@@ -180,7 +180,7 @@ fn ptrace_peek(request: Request, pid: Pid, addr: AddressType, data: *mut c_void)
         libc::ptrace(request as RequestType, libc::pid_t::from(pid), addr, data)
     };
     match Errno::result(ret) {
-        Ok(..) | Err(Error(Errno::UnknownErrno)) => Ok(ret),
+        Ok(..) | Err(Errno::UnknownErrno) => Ok(ret),
         err @ Err(..) => err,
     }
 }

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -180,7 +180,7 @@ fn ptrace_peek(request: Request, pid: Pid, addr: AddressType, data: *mut c_void)
         libc::ptrace(request as RequestType, libc::pid_t::from(pid), addr, data)
     };
     match Errno::result(ret) {
-        Ok(..) | Err(Error::Sys(Errno::UnknownErrno)) => Ok(ret),
+        Ok(..) | Err(Error(Errno::UnknownErrno)) => Ok(ret),
         err @ Err(..) => err,
     }
 }

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -26,7 +26,7 @@ pub fn reboot(how: RebootMode) -> Result<Infallible> {
     unsafe {
         libc::reboot(how as libc::c_int)
     };
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Enable or disable the reboot keystroke (Ctrl-Alt-Delete).

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -108,7 +108,7 @@ impl SignalFd {
         match res {
             Ok(SIGNALFD_SIGINFO_SIZE) => Ok(Some(unsafe { mem::transmute(buffer.assume_init()) })),
             Ok(_) => unreachable!("partial read on signalfd"),
-            Err(Error::Sys(Errno::EAGAIN)) => Ok(None),
+            Err(Error(Errno::EAGAIN)) => Ok(None),
             Err(error) => Err(error)
         }
     }
@@ -117,7 +117,7 @@ impl SignalFd {
 impl Drop for SignalFd {
     fn drop(&mut self) {
         let e = unistd::close(self.0);
-        if !std::thread::panicking() && e == Err(Error::Sys(Errno::EBADF)) {
+        if !std::thread::panicking() && e == Err(Error::from(Errno::EBADF)) {
             panic!("Closing an invalid file descriptor!");
         };
     }

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -108,7 +108,7 @@ impl SignalFd {
         match res {
             Ok(SIGNALFD_SIGINFO_SIZE) => Ok(Some(unsafe { mem::transmute(buffer.assume_init()) })),
             Ok(_) => unreachable!("partial read on signalfd"),
-            Err(Error(Errno::EAGAIN)) => Ok(None),
+            Err(Errno::EAGAIN) => Ok(None),
             Err(error) => Err(error)
         }
     }

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -536,7 +536,7 @@ impl UnixAddr {
                 let bytes = cstr.to_bytes();
 
                 if bytes.len() > ret.sun_path.len() {
-                    return Err(Error::Sys(Errno::ENAMETOOLONG));
+                    return Err(Error::from(Errno::ENAMETOOLONG));
                 }
 
                 ptr::copy_nonoverlapping(bytes.as_ptr(),
@@ -563,7 +563,7 @@ impl UnixAddr {
             };
 
             if path.len() + 1 > ret.sun_path.len() {
-                return Err(Error::Sys(Errno::ENAMETOOLONG));
+                return Err(Error::from(Errno::ENAMETOOLONG));
             }
 
             // Abstract addresses are represented by sun_path[0] ==
@@ -1035,7 +1035,7 @@ pub mod sys_control {
 
         pub fn from_name(sockfd: RawFd, name: &str, unit: u32) -> Result<SysControlAddr> {
             if name.len() > MAX_KCTL_NAME {
-                return Err(Error::Sys(Errno::ENAMETOOLONG));
+                return Err(Error::from(Errno::ENAMETOOLONG));
             }
 
             let mut ctl_name = [0; MAX_KCTL_NAME];

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1572,7 +1572,7 @@ pub fn recvfrom(sockfd: RawFd, buf: &mut [u8])
             &mut len as *mut socklen_t))? as usize;
 
         match sockaddr_storage_to_addr(&addr, len as usize) {
-            Err(Error::Sys(Errno::ENOTCONN)) => Ok((ret, None)),
+            Err(Error(Errno::ENOTCONN)) => Ok((ret, None)),
             Ok(addr) => Ok((ret, Some(addr))),
             Err(e) => Err(e)
         }
@@ -1708,7 +1708,7 @@ pub fn sockaddr_storage_to_addr(
 
     assert!(len <= mem::size_of::<sockaddr_un>());
     if len < mem::size_of_val(&addr.ss_family) {
-        return Err(Error::Sys(Errno::ENOTCONN));
+        return Err(Error::from(Errno::ENOTCONN));
     }
 
     match c_int::from(addr.ss_family) {

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1572,7 +1572,7 @@ pub fn recvfrom(sockfd: RawFd, buf: &mut [u8])
             &mut len as *mut socklen_t))? as usize;
 
         match sockaddr_storage_to_addr(&addr, len as usize) {
-            Err(Error(Errno::ENOTCONN)) => Ok((ret, None)),
+            Err(Errno::ENOTCONN) => Ok((ret, None)),
             Ok(addr) => Ok((ret, Some(addr))),
             Err(e) => Err(e)
         }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -449,7 +449,7 @@ impl TryFrom<libc::speed_t> for BaudRate {
             B3500000 => Ok(BaudRate::B3500000),
             #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
             B4000000 => Ok(BaudRate::B4000000),
-            _ => Err(Error::invalid_argument())
+            _ => Err(Error::from(Errno::EINVAL))
         }
     }
 }

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -259,7 +259,7 @@ impl TimerFd {
         loop {
             if let Err(e) = read(self.fd, &mut [0u8; 8]) {
                 match e {
-                    Error::Sys(Errno::EINTR) => continue,
+                    Error(Errno::EINTR) => continue,
                     _ => return Err(e),
                 }
             } else {
@@ -277,7 +277,7 @@ impl Drop for TimerFd {
             let result = Errno::result(unsafe {
                 libc::close(self.fd)
             });
-            if let Err(Error::Sys(Errno::EBADF)) = result {
+            if let Err(Error(Errno::EBADF)) = result {
                 panic!("close of TimerFd encountered EBADF");
             }
         }

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -30,7 +30,7 @@
 //! ```
 use crate::sys::time::TimeSpec;
 use crate::unistd::read;
-use crate::{errno::Errno, Error, Result};
+use crate::{errno::Errno, Result};
 use bitflags::bitflags;
 use libc::c_int;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
@@ -259,7 +259,7 @@ impl TimerFd {
         loop {
             if let Err(e) = read(self.fd, &mut [0u8; 8]) {
                 match e {
-                    Error(Errno::EINTR) => continue,
+                    Errno::EINTR => continue,
                     _ => return Err(e),
                 }
             } else {
@@ -277,7 +277,7 @@ impl Drop for TimerFd {
             let result = Errno::result(unsafe {
                 libc::close(self.fd)
             });
-            if let Err(Error(Errno::EBADF)) = result {
+            if let Err(Errno::EBADF) = result {
                 panic!("close of TimerFd encountered EBADF");
             }
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -255,6 +255,6 @@ pub fn clock_getcpuclockid(pid: Pid) -> Result<ClockId> {
         let res = unsafe { clk_id.assume_init() };
         Ok(ClockId::from(res))
     } else {
-        Err(Error::Sys(Errno::from_i32(ret)))
+        Err(Error::from(Errno::from_i32(ret)))
     }
 }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1432,7 +1432,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
                 unsafe { groups.set_len(s as usize) };
                 return Ok(groups);
             },
-            Err(Error(Errno::EINVAL)) => {
+            Err(Errno::EINVAL) => {
                 // EINVAL indicates that the buffer size was too
                 // small, resize it up to ngroups_max as limit.
                 reserve_double_buffer_size(&mut groups, ngroups_max)

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -393,7 +393,7 @@ pub fn dup3(oldfd: RawFd, newfd: RawFd, flags: OFlag) -> Result<RawFd> {
 #[inline]
 fn dup3_polyfill(oldfd: RawFd, newfd: RawFd, flags: OFlag) -> Result<RawFd> {
     if oldfd == newfd {
-        return Err(Error::Sys(Errno::EINVAL));
+        return Err(Error::from(Errno::EINVAL));
     }
 
     let fd = dup2(oldfd, newfd)?;
@@ -567,7 +567,7 @@ fn reserve_double_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
     use std::cmp::min;
 
     if buf.capacity() >= limit {
-        return Err(Error::Sys(Errno::ERANGE))
+        return Err(Error::from(Errno::ERANGE))
     }
 
     let capacity = min(buf.capacity() * 2, limit);
@@ -610,7 +610,7 @@ pub fn getcwd() -> Result<PathBuf> {
                 let error = Errno::last();
                 // ERANGE means buffer was too small to store directory name
                 if error != Errno::ERANGE {
-                    return Err(Error::Sys(error));
+                    return Err(Error::from(error));
                 }
             }
 
@@ -734,7 +734,7 @@ pub fn execv<S: AsRef<CStr>>(path: &CStr, argv: &[S]) -> Result<Infallible> {
         libc::execv(path.as_ptr(), args_p.as_ptr())
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 
@@ -759,7 +759,7 @@ pub fn execve<SA: AsRef<CStr>, SE: AsRef<CStr>>(path: &CStr, args: &[SA], env: &
         libc::execve(path.as_ptr(), args_p.as_ptr(), env_p.as_ptr())
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Replace the current process image with a new one and replicate shell `PATH`
@@ -779,7 +779,7 @@ pub fn execvp<S: AsRef<CStr>>(filename: &CStr, args: &[S]) -> Result<Infallible>
         libc::execvp(filename.as_ptr(), args_p.as_ptr())
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Replace the current process image with a new one and replicate shell `PATH`
@@ -800,7 +800,7 @@ pub fn execvpe<SA: AsRef<CStr>, SE: AsRef<CStr>>(filename: &CStr, args: &[SA], e
         libc::execvpe(filename.as_ptr(), args_p.as_ptr(), env_p.as_ptr())
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Replace the current process image with a new one (see
@@ -828,7 +828,7 @@ pub fn fexecve<SA: AsRef<CStr> ,SE: AsRef<CStr>>(fd: RawFd, args: &[SA], env: &[
         libc::fexecve(fd, args_p.as_ptr(), env_p.as_ptr())
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Execute program relative to a directory file descriptor (see
@@ -853,7 +853,7 @@ pub fn execveat<SA: AsRef<CStr>,SE: AsRef<CStr>>(dirfd: RawFd, pathname: &CStr, 
                       args_p.as_ptr(), env_p.as_ptr(), flags);
     };
 
-    Err(Error::Sys(Errno::last()))
+    Err(Error::from(Errno::last()))
 }
 
 /// Daemonize this process by detaching from the controlling terminal (see
@@ -1056,13 +1056,13 @@ pub fn lseek64(fd: RawFd, offset: libc::off64_t, whence: Whence) -> Result<libc:
 /// Create an interprocess channel.
 ///
 /// See also [pipe(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pipe.html)
-pub fn pipe() -> Result<(RawFd, RawFd)> {
+pub fn pipe() -> std::result::Result<(RawFd, RawFd), Error> {
     unsafe {
         let mut fds = mem::MaybeUninit::<[c_int; 2]>::uninit();
 
         let res = libc::pipe(fds.as_mut_ptr() as *mut c_int);
 
-        Errno::result(res)?;
+        Error::result(res)?;
 
         Ok((fds.assume_init()[0], fds.assume_init()[1]))
     }
@@ -1133,7 +1133,7 @@ pub fn isatty(fd: RawFd) -> Result<bool> {
         } else {
             match Errno::last() {
                 Errno::ENOTTY => Ok(false),
-                err => Err(Error::Sys(err)),
+                err => Err(Error::from(err)),
             }
         }
     }
@@ -1432,11 +1432,11 @@ pub fn getgroups() -> Result<Vec<Gid>> {
                 unsafe { groups.set_len(s as usize) };
                 return Ok(groups);
             },
-            Err(Error::Sys(Errno::EINVAL)) => {
+            Err(Error(Errno::EINVAL)) => {
                 // EINVAL indicates that the buffer size was too
                 // small, resize it up to ngroups_max as limit.
                 reserve_double_buffer_size(&mut groups, ngroups_max)
-                    .or(Err(Error::Sys(Errno::EINVAL)))?;
+                    .or(Err(Error::from(Errno::EINVAL)))?;
             },
             Err(e) => return Err(e)
         }
@@ -1558,7 +1558,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
             // groups as possible, but Linux manpages do not mention this
             // behavior.
             reserve_double_buffer_size(&mut groups, ngroups_max as usize)
-                .map_err(|_| Error::invalid_argument())?;
+                .map_err(|_| Error::from(Errno::EINVAL))?;
         }
     }
 }
@@ -1916,7 +1916,7 @@ pub fn fpathconf(fd: RawFd, var: PathconfVar) -> Result<Option<c_long>> {
         if errno::errno() == 0 {
             Ok(None)
         } else {
-            Err(Error::Sys(Errno::last()))
+            Err(Error::from(Errno::last()))
         }
     } else {
         Ok(Some(raw))
@@ -1955,7 +1955,7 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
         if errno::errno() == 0 {
             Ok(None)
         } else {
-            Err(Error::Sys(Errno::last()))
+            Err(Error::from(Errno::last()))
         }
     } else {
         Ok(Some(raw))
@@ -2454,7 +2454,7 @@ pub fn sysconf(var: SysconfVar) -> Result<Option<c_long>> {
         if errno::errno() == 0 {
             Ok(None)
         } else {
-            Err(Error::Sys(Errno::last()))
+            Err(Error::from(Errno::last()))
         }
     } else {
         Ok(Some(raw))
@@ -2721,7 +2721,7 @@ impl User {
                 // Trigger the internal buffer resizing logic.
                 reserve_double_buffer_size(&mut cbuf, buflimit)?;
             } else {
-                return Err(Error::Sys(Errno::last()));
+                return Err(Error::from(Errno::last()));
             }
         }
     }
@@ -2842,7 +2842,7 @@ impl Group {
                 // Trigger the internal buffer resizing logic.
                 reserve_double_buffer_size(&mut cbuf, buflimit)?;
             } else {
-                return Err(Error::Sys(Errno::last()));
+                return Err(Error::from(Errno::last()));
             }
         }
     }
@@ -2901,7 +2901,7 @@ pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
 
     let ret = unsafe { libc::ttyname_r(fd, c_buf, buf.len()) };
     if ret != 0 {
-        return Err(Error::Sys(Errno::from_i32(ret)));
+        return Err(Error::from(Errno::from_i32(ret)));
     }
 
     let nul = buf.iter().position(|c| *c == b'\0').unwrap();

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -177,7 +177,7 @@ fn test_aio_suspend() {
             let cbbuf = [wcb.as_ref(), rcb.as_ref()];
             let r = aio_suspend(&cbbuf[..], Some(timeout));
             match r {
-                Err(Error::Sys(Errno::EINTR)) => continue,
+                Err(Error(Errno::EINTR)) => continue,
                 Err(e) => panic!("aio_suspend returned {:?}", e),
                 Ok(_) => ()
             };

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -177,7 +177,7 @@ fn test_aio_suspend() {
             let cbbuf = [wcb.as_ref(), rcb.as_ref()];
             let r = aio_suspend(&cbbuf[..], Some(timeout));
             match r {
-                Err(Error(Errno::EINTR)) => continue,
+                Err(Errno::EINTR) => continue,
                 Err(e) => panic!("aio_suspend returned {:?}", e),
                 Ok(_) => ()
             };

--- a/test/sys/test_epoll.rs
+++ b/test/sys/test_epoll.rs
@@ -8,11 +8,11 @@ pub fn test_epoll_errno() {
     let efd = epoll_create1(EpollCreateFlags::empty()).unwrap();
     let result = epoll_ctl(efd, EpollOp::EpollCtlDel, 1, None);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::Sys(Errno::ENOENT));
+    assert_eq!(result.unwrap_err(), Error::from(Errno::ENOENT));
 
     let result = epoll_ctl(efd, EpollOp::EpollCtlAdd, 1, None);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::Sys(Errno::EINVAL));
+    assert_eq!(result.unwrap_err(), Error::from(Errno::EINVAL));
 }
 
 #[test]

--- a/test/sys/test_inotify.rs
+++ b/test/sys/test_inotify.rs
@@ -14,7 +14,7 @@ pub fn test_inotify() {
     instance.add_watch(tempdir.path(), AddWatchFlags::IN_ALL_EVENTS).unwrap();
 
     let events = instance.read_events();
-    assert_eq!(events.unwrap_err(), Error::Sys(Errno::EAGAIN));
+    assert_eq!(events.unwrap_err(), Error::from(Errno::EAGAIN));
 
     File::create(tempdir.path().join("test")).unwrap();
 
@@ -31,7 +31,7 @@ pub fn test_inotify_multi_events() {
     instance.add_watch(tempdir.path(), AddWatchFlags::IN_ALL_EVENTS).unwrap();
 
     let events = instance.read_events();
-    assert_eq!(events.unwrap_err(), Error::Sys(Errno::EAGAIN));
+    assert_eq!(events.unwrap_err(), Error::from(Errno::EAGAIN));
 
     File::create(tempdir.path().join("test")).unwrap();
     rename(tempdir.path().join("test"), tempdir.path().join("test2")).unwrap();

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -167,7 +167,6 @@ mod linux_ioctls {
     use tempfile::tempfile;
     use libc::{TCGETS, TCSBRK, TCSETS, TIOCNXCL, termios};
 
-    use nix::Error;
     use nix::errno::Errno;
 
     ioctl_none_bad!(tiocnxcl, TIOCNXCL);
@@ -175,7 +174,7 @@ mod linux_ioctls {
     fn test_ioctl_none_bad() {
         let file = tempfile().unwrap();
         let res = unsafe { tiocnxcl(file.as_raw_fd()) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     ioctl_read_bad!(tcgets, TCGETS, termios);
@@ -184,7 +183,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut termios = unsafe { mem::zeroed() };
         let res = unsafe { tcgets(file.as_raw_fd(), &mut termios) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     ioctl_write_int_bad!(tcsbrk, TCSBRK);
@@ -192,7 +191,7 @@ mod linux_ioctls {
     fn test_ioctl_write_int_bad() {
         let file = tempfile().unwrap();
         let res = unsafe { tcsbrk(file.as_raw_fd(), 0) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     ioctl_write_ptr_bad!(tcsets, TCSETS, termios);
@@ -201,7 +200,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let termios: termios = unsafe { mem::zeroed() };
         let res = unsafe { tcsets(file.as_raw_fd(), &termios) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     // FIXME: Find a suitable example for `ioctl_readwrite_bad`
@@ -212,7 +211,7 @@ mod linux_ioctls {
     fn test_ioctl_none() {
         let file = tempfile().unwrap();
         let res = unsafe { log_status(file.as_raw_fd()) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     #[repr(C)]
@@ -231,7 +230,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { s_audio(file.as_raw_fd(), &data) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     // From linux/net/bluetooth/hci_sock.h
@@ -242,7 +241,7 @@ mod linux_ioctls {
     fn test_ioctl_write_int() {
         let file = tempfile().unwrap();
         let res = unsafe { hcidevup(file.as_raw_fd(), 0) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     // From linux/videodev2.h
@@ -252,7 +251,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { g_audio(file.as_raw_fd(), &mut data) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     // From linux/videodev2.h
@@ -262,7 +261,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { enum_audio(file.as_raw_fd(), &mut data) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     // FIXME: Find a suitable example for `ioctl_read_buf`.
@@ -288,7 +287,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let data: [spi_ioc_transfer; 4] = unsafe { mem::zeroed() };
         let res = unsafe { spi_ioc_message(file.as_raw_fd(), &data[..]) };
-        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
+        assert!(res == Err(Errno::ENOTTY) || res == Err(Errno::ENOSYS));
     }
 
     // FIXME: Find a suitable example for `ioctl_readwrite_buf`.
@@ -302,7 +301,6 @@ mod freebsd_ioctls {
     use tempfile::tempfile;
     use libc::termios;
 
-    use nix::Error;
     use nix::errno::Errno;
 
     // From sys/sys/ttycom.h
@@ -316,7 +314,7 @@ mod freebsd_ioctls {
     fn test_ioctl_none() {
         let file = tempfile().unwrap();
         let res = unsafe { tiocnxcl(file.as_raw_fd()) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     ioctl_read!(tiocgeta, TTY_IOC_MAGIC, TTY_IOC_TYPE_GETA, termios);
@@ -325,7 +323,7 @@ mod freebsd_ioctls {
         let file = tempfile().unwrap();
         let mut termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocgeta(file.as_raw_fd(), &mut termios) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 
     ioctl_write_ptr!(tiocseta, TTY_IOC_MAGIC, TTY_IOC_TYPE_SETA, termios);
@@ -334,6 +332,6 @@ mod freebsd_ioctls {
         let file = tempfile().unwrap();
         let termios: termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocseta(file.as_raw_fd(), &termios) };
-        assert_eq!(res, Err(Error(Errno::ENOTTY)));
+        assert_eq!(res, Err(Errno::ENOTTY));
     }
 }

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -167,15 +167,15 @@ mod linux_ioctls {
     use tempfile::tempfile;
     use libc::{TCGETS, TCSBRK, TCSETS, TIOCNXCL, termios};
 
-    use nix::Error::Sys;
-    use nix::errno::Errno::{ENOTTY, ENOSYS};
+    use nix::Error;
+    use nix::errno::Errno;
 
     ioctl_none_bad!(tiocnxcl, TIOCNXCL);
     #[test]
     fn test_ioctl_none_bad() {
         let file = tempfile().unwrap();
         let res = unsafe { tiocnxcl(file.as_raw_fd()) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     ioctl_read_bad!(tcgets, TCGETS, termios);
@@ -184,7 +184,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut termios = unsafe { mem::zeroed() };
         let res = unsafe { tcgets(file.as_raw_fd(), &mut termios) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     ioctl_write_int_bad!(tcsbrk, TCSBRK);
@@ -192,7 +192,7 @@ mod linux_ioctls {
     fn test_ioctl_write_int_bad() {
         let file = tempfile().unwrap();
         let res = unsafe { tcsbrk(file.as_raw_fd(), 0) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     ioctl_write_ptr_bad!(tcsets, TCSETS, termios);
@@ -201,7 +201,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let termios: termios = unsafe { mem::zeroed() };
         let res = unsafe { tcsets(file.as_raw_fd(), &termios) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     // FIXME: Find a suitable example for `ioctl_readwrite_bad`
@@ -212,7 +212,7 @@ mod linux_ioctls {
     fn test_ioctl_none() {
         let file = tempfile().unwrap();
         let res = unsafe { log_status(file.as_raw_fd()) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     #[repr(C)]
@@ -231,7 +231,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { s_audio(file.as_raw_fd(), &data) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     // From linux/net/bluetooth/hci_sock.h
@@ -242,7 +242,7 @@ mod linux_ioctls {
     fn test_ioctl_write_int() {
         let file = tempfile().unwrap();
         let res = unsafe { hcidevup(file.as_raw_fd(), 0) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     // From linux/videodev2.h
@@ -252,7 +252,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { g_audio(file.as_raw_fd(), &mut data) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     // From linux/videodev2.h
@@ -262,7 +262,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let mut data: v4l2_audio = unsafe { mem::zeroed() };
         let res = unsafe { enum_audio(file.as_raw_fd(), &mut data) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     // FIXME: Find a suitable example for `ioctl_read_buf`.
@@ -288,7 +288,7 @@ mod linux_ioctls {
         let file = tempfile().unwrap();
         let data: [spi_ioc_transfer; 4] = unsafe { mem::zeroed() };
         let res = unsafe { spi_ioc_message(file.as_raw_fd(), &data[..]) };
-        assert!(res == Err(Sys(ENOTTY)) || res == Err(Sys(ENOSYS)));
+        assert!(res == Err(Error(Errno::ENOTTY)) || res == Err(Error(Errno::ENOSYS)));
     }
 
     // FIXME: Find a suitable example for `ioctl_readwrite_buf`.
@@ -302,8 +302,8 @@ mod freebsd_ioctls {
     use tempfile::tempfile;
     use libc::termios;
 
-    use nix::Error::Sys;
-    use nix::errno::Errno::ENOTTY;
+    use nix::Error;
+    use nix::errno::Errno;
 
     // From sys/sys/ttycom.h
     const TTY_IOC_MAGIC: u8 = b't';
@@ -316,7 +316,7 @@ mod freebsd_ioctls {
     fn test_ioctl_none() {
         let file = tempfile().unwrap();
         let res = unsafe { tiocnxcl(file.as_raw_fd()) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     ioctl_read!(tiocgeta, TTY_IOC_MAGIC, TTY_IOC_TYPE_GETA, termios);
@@ -325,7 +325,7 @@ mod freebsd_ioctls {
         let file = tempfile().unwrap();
         let mut termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocgeta(file.as_raw_fd(), &mut termios) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 
     ioctl_write_ptr!(tiocseta, TTY_IOC_MAGIC, TTY_IOC_TYPE_SETA, termios);
@@ -334,6 +334,6 @@ mod freebsd_ioctls {
         let file = tempfile().unwrap();
         let termios: termios = unsafe { mem::zeroed() };
         let res = unsafe { tiocseta(file.as_raw_fd(), &termios) };
-        assert_eq!(res, Err(Sys(ENOTTY)));
+        assert_eq!(res, Err(Error(Errno::ENOTTY)));
     }
 }

--- a/test/sys/test_lio_listio_resubmit.rs
+++ b/test/sys/test_lio_listio_resubmit.rs
@@ -25,7 +25,7 @@ fn finish_liocb(liocb: &mut LioCb) {
             let e = liocb.error(j);
             match e {
                 Ok(()) => break,
-                Err(Error::Sys(Errno::EINPROGRESS)) =>
+                Err(Error(Errno::EINPROGRESS)) =>
                     thread::sleep(time::Duration::from_millis(10)),
                 Err(x) => panic!("aio_error({:?})", x)
             }
@@ -82,9 +82,9 @@ fn test_lio_listio_resubmit() {
         }
         let mut liocb = builder.finish();
         let mut err = liocb.listio(LioMode::LIO_NOWAIT, SigevNotify::SigevNone);
-        while err == Err(Error::Sys(Errno::EIO)) ||
-              err == Err(Error::Sys(Errno::EAGAIN)) ||
-              err == Err(Error::Sys(Errno::EINTR)) {
+        while err == Err(Error(Errno::EIO)) ||
+              err == Err(Error(Errno::EAGAIN)) ||
+              err == Err(Error(Errno::EINTR)) {
             // 
             thread::sleep(time::Duration::from_millis(10));
             resubmit_count += 1;

--- a/test/sys/test_lio_listio_resubmit.rs
+++ b/test/sys/test_lio_listio_resubmit.rs
@@ -4,7 +4,6 @@
 // we must disable the test here rather than in Cargo.toml
 #![cfg(target_os = "freebsd")]
 
-use nix::Error;
 use nix::errno::*;
 use nix::libc::off_t;
 use nix::sys::aio::*;
@@ -25,7 +24,7 @@ fn finish_liocb(liocb: &mut LioCb) {
             let e = liocb.error(j);
             match e {
                 Ok(()) => break,
-                Err(Error(Errno::EINPROGRESS)) =>
+                Err(Errno::EINPROGRESS) =>
                     thread::sleep(time::Duration::from_millis(10)),
                 Err(x) => panic!("aio_error({:?})", x)
             }
@@ -82,9 +81,9 @@ fn test_lio_listio_resubmit() {
         }
         let mut liocb = builder.finish();
         let mut err = liocb.listio(LioMode::LIO_NOWAIT, SigevNotify::SigevNone);
-        while err == Err(Error(Errno::EIO)) ||
-              err == Err(Error(Errno::EAGAIN)) ||
-              err == Err(Error(Errno::EINTR)) {
+        while err == Err(Errno::EIO) ||
+              err == Err(Errno::EAGAIN) ||
+              err == Err(Errno::EINTR) {
             // 
             thread::sleep(time::Duration::from_millis(10));
             resubmit_count += 1;

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -16,8 +16,8 @@ fn test_ptrace() {
     // FIXME: qemu-user doesn't implement ptrace on all arches, so permit ENOSYS
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::attach(getpid()).unwrap_err();
-    assert!(err == Error::Sys(Errno::EPERM) || err == Error::Sys(Errno::EINVAL) ||
-            err == Error::Sys(Errno::ENOSYS));
+    assert!(err == Error(Errno::EPERM) || err == Error(Errno::EINVAL) ||
+            err == Error(Errno::ENOSYS));
 }
 
 // Just make sure ptrace_setoptions can be called at all, for now.
@@ -26,7 +26,7 @@ fn test_ptrace() {
 fn test_ptrace_setoptions() {
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::setoptions(getpid(), Options::PTRACE_O_TRACESYSGOOD).unwrap_err();
-    assert!(err != Error::UnsupportedOperation);
+    assert!(err != Error(Errno::EOPNOTSUPP));
 }
 
 // Just make sure ptrace_getevent can be called at all, for now.
@@ -35,7 +35,7 @@ fn test_ptrace_setoptions() {
 fn test_ptrace_getevent() {
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::getevent(getpid()).unwrap_err();
-    assert!(err != Error::UnsupportedOperation);
+    assert!(err != Error(Errno::EOPNOTSUPP));
 }
 
 // Just make sure ptrace_getsiginfo can be called at all, for now.
@@ -43,8 +43,8 @@ fn test_ptrace_getevent() {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_getsiginfo() {
     require_capability!(CAP_SYS_PTRACE);
-    if let Err(Error::UnsupportedOperation) = ptrace::getsiginfo(getpid()) {
-        panic!("ptrace_getsiginfo returns Error::UnsupportedOperation!");
+    if let Err(Error(Errno::EOPNOTSUPP)) = ptrace::getsiginfo(getpid()) {
+        panic!("ptrace_getsiginfo returns Error(Errno::EOPNOTSUPP)!");
     }
 }
 
@@ -54,8 +54,8 @@ fn test_ptrace_getsiginfo() {
 fn test_ptrace_setsiginfo() {
     require_capability!(CAP_SYS_PTRACE);
     let siginfo = unsafe { mem::zeroed() };
-    if let Err(Error::UnsupportedOperation) = ptrace::setsiginfo(getpid(), &siginfo) {
-        panic!("ptrace_setsiginfo returns Error::UnsupportedOperation!");
+    if let Err(Error(Errno::EOPNOTSUPP)) = ptrace::setsiginfo(getpid(), &siginfo) {
+        panic!("ptrace_setsiginfo returns Error(Errno::EOPNOTSUPP)!");
     }
 }
 
@@ -79,7 +79,7 @@ fn test_ptrace_cont() {
     // On valid platforms the ptrace call should return Errno::EPERM, this
     // is already tested by `test_ptrace`.
     let err = ptrace::attach(getpid()).unwrap_err();
-    if err == Error::Sys(Errno::ENOSYS) {
+    if err == Error(Errno::ENOSYS) {
         return;
     }
 

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -1,4 +1,3 @@
-use nix::Error;
 use nix::errno::Errno;
 use nix::unistd::getpid;
 use nix::sys::ptrace;
@@ -16,8 +15,8 @@ fn test_ptrace() {
     // FIXME: qemu-user doesn't implement ptrace on all arches, so permit ENOSYS
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::attach(getpid()).unwrap_err();
-    assert!(err == Error(Errno::EPERM) || err == Error(Errno::EINVAL) ||
-            err == Error(Errno::ENOSYS));
+    assert!(err == Errno::EPERM || err == Errno::EINVAL ||
+            err == Errno::ENOSYS);
 }
 
 // Just make sure ptrace_setoptions can be called at all, for now.
@@ -26,7 +25,7 @@ fn test_ptrace() {
 fn test_ptrace_setoptions() {
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::setoptions(getpid(), Options::PTRACE_O_TRACESYSGOOD).unwrap_err();
-    assert!(err != Error(Errno::EOPNOTSUPP));
+    assert!(err != Errno::EOPNOTSUPP);
 }
 
 // Just make sure ptrace_getevent can be called at all, for now.
@@ -35,7 +34,7 @@ fn test_ptrace_setoptions() {
 fn test_ptrace_getevent() {
     require_capability!(CAP_SYS_PTRACE);
     let err = ptrace::getevent(getpid()).unwrap_err();
-    assert!(err != Error(Errno::EOPNOTSUPP));
+    assert!(err != Errno::EOPNOTSUPP);
 }
 
 // Just make sure ptrace_getsiginfo can be called at all, for now.
@@ -43,8 +42,8 @@ fn test_ptrace_getevent() {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_getsiginfo() {
     require_capability!(CAP_SYS_PTRACE);
-    if let Err(Error(Errno::EOPNOTSUPP)) = ptrace::getsiginfo(getpid()) {
-        panic!("ptrace_getsiginfo returns Error(Errno::EOPNOTSUPP)!");
+    if let Err(Errno::EOPNOTSUPP) = ptrace::getsiginfo(getpid()) {
+        panic!("ptrace_getsiginfo returns Errno::EOPNOTSUPP!");
     }
 }
 
@@ -54,8 +53,8 @@ fn test_ptrace_getsiginfo() {
 fn test_ptrace_setsiginfo() {
     require_capability!(CAP_SYS_PTRACE);
     let siginfo = unsafe { mem::zeroed() };
-    if let Err(Error(Errno::EOPNOTSUPP)) = ptrace::setsiginfo(getpid(), &siginfo) {
-        panic!("ptrace_setsiginfo returns Error(Errno::EOPNOTSUPP)!");
+    if let Err(Errno::EOPNOTSUPP) = ptrace::setsiginfo(getpid(), &siginfo) {
+        panic!("ptrace_setsiginfo returns Errno::EOPNOTSUPP!");
     }
 }
 
@@ -79,7 +78,7 @@ fn test_ptrace_cont() {
     // On valid platforms the ptrace call should return Errno::EPERM, this
     // is already tested by `test_ptrace`.
     let err = ptrace::attach(getpid()).unwrap_err();
-    if err == Error(Errno::ENOSYS) {
+    if err == Errno::ENOSYS {
         return;
     }
 

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_os = "redox"))]
-use nix::Error;
+use nix::{errno::Errno, Error};
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::convert::TryFrom;
@@ -92,7 +92,7 @@ fn test_signal_sigaction() {
     let _m = crate::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
 
     let action_handler = SigHandler::SigAction(test_sigaction_action);
-    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Error::UnsupportedOperation);
+    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Error(Errno::ENOTSUP));
 }
 
 #[test]

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,5 +1,5 @@
 #[cfg(not(target_os = "redox"))]
-use nix::{errno::Errno, Error};
+use nix::errno::Errno;
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::convert::TryFrom;
@@ -92,7 +92,7 @@ fn test_signal_sigaction() {
     let _m = crate::SIGNAL_MTX.lock().expect("Mutex got poisoned by another test");
 
     let action_handler = SigHandler::SigAction(test_sigaction_action);
-    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Error(Errno::ENOTSUP));
+    assert_eq!(unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(), Errno::ENOTSUP);
 }
 
 #[test]

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -519,7 +519,6 @@ mod recvfrom {
 // Test error handling of our recvmsg wrapper
 #[test]
 pub fn test_recvmsg_ebadf() {
-    use nix::Error;
     use nix::errno::Errno;
     use nix::sys::socket::{MsgFlags, recvmsg};
     use nix::sys::uio::IoVec;
@@ -528,7 +527,7 @@ pub fn test_recvmsg_ebadf() {
     let iov = [IoVec::from_mut_slice(&mut buf[..])];
     let fd = -1;    // Bad file descriptor
     let r = recvmsg(fd, &iov, None, MsgFlags::empty());
-    assert_eq!(r.err().unwrap(), Error(Errno::EBADF));
+    assert_eq!(r.err().unwrap(), Errno::EBADF);
 }
 
 // Disable the test on emulated platforms due to a bug in QEMU versions <
@@ -818,7 +817,6 @@ pub fn test_sendmsg_ipv4packetinfo() {
         target_os = "freebsd"))]
 #[test]
 pub fn test_sendmsg_ipv6packetinfo() {
-    use nix::Error;
     use nix::errno::Errno;
     use nix::sys::uio::IoVec;
     use nix::sys::socket::{socket, sendmsg, bind,
@@ -835,7 +833,7 @@ pub fn test_sendmsg_ipv6packetinfo() {
     let inet_addr = InetAddr::from_std(&std_sa);
     let sock_addr = SockAddr::new_inet(inet_addr);
 
-    if let Err(Error(Errno::EADDRNOTAVAIL)) = bind(sock, &sock_addr) {
+    if let Err(Errno::EADDRNOTAVAIL) = bind(sock, &sock_addr) {
         println!("IPv6 not available, skipping test.");
         return;
     }
@@ -1145,7 +1143,6 @@ pub fn test_unixdomain() {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[test]
 pub fn test_syscontrol() {
-    use nix::Error;
     use nix::errno::Errno;
     use nix::sys::socket::{socket, SockAddr, SockType, SockFlag, SockProtocol};
 
@@ -1153,7 +1150,7 @@ pub fn test_syscontrol() {
                     SockFlag::empty(), SockProtocol::KextControl)
              .expect("socket failed");
     let _sockaddr = SockAddr::new_sys_control(fd, "com.apple.net.utun_control", 0).expect("resolving sys_control name failed");
-    assert_eq!(SockAddr::new_sys_control(fd, "foo.bar.lol", 0).err(), Some(Error(Errno::ENOENT)));
+    assert_eq!(SockAddr::new_sys_control(fd, "foo.bar.lol", 0).err(), Some(Errno::ENOENT));
 
     // requires root privileges
     // connect(fd, &sockaddr).expect("connect failed");
@@ -1500,7 +1497,6 @@ pub fn test_recv_ipv6pktinfo() {
 #[test]
 pub fn test_vsock() {
     use libc;
-    use nix::Error;
     use nix::errno::Errno;
     use nix::sys::socket::{AddressFamily, socket, bind, connect, listen,
                            SockAddr, SockType, SockFlag};
@@ -1516,7 +1512,7 @@ pub fn test_vsock() {
     // VMADDR_CID_HYPERVISOR is reserved, so we expect an EADDRNOTAVAIL error.
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_HYPERVISOR, port);
     assert_eq!(bind(s1, &sockaddr).err(),
-               Some(Error(Errno::EADDRNOTAVAIL)));
+               Some(Errno::EADDRNOTAVAIL));
 
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_ANY, port);
     assert_eq!(bind(s1, &sockaddr), Ok(()));

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -528,7 +528,7 @@ pub fn test_recvmsg_ebadf() {
     let iov = [IoVec::from_mut_slice(&mut buf[..])];
     let fd = -1;    // Bad file descriptor
     let r = recvmsg(fd, &iov, None, MsgFlags::empty());
-    assert_eq!(r.err().unwrap(), Error::Sys(Errno::EBADF));
+    assert_eq!(r.err().unwrap(), Error(Errno::EBADF));
 }
 
 // Disable the test on emulated platforms due to a bug in QEMU versions <
@@ -835,7 +835,7 @@ pub fn test_sendmsg_ipv6packetinfo() {
     let inet_addr = InetAddr::from_std(&std_sa);
     let sock_addr = SockAddr::new_inet(inet_addr);
 
-    if let Err(Error::Sys(Errno::EADDRNOTAVAIL)) = bind(sock, &sock_addr) {
+    if let Err(Error(Errno::EADDRNOTAVAIL)) = bind(sock, &sock_addr) {
         println!("IPv6 not available, skipping test.");
         return;
     }
@@ -1153,7 +1153,7 @@ pub fn test_syscontrol() {
                     SockFlag::empty(), SockProtocol::KextControl)
              .expect("socket failed");
     let _sockaddr = SockAddr::new_sys_control(fd, "com.apple.net.utun_control", 0).expect("resolving sys_control name failed");
-    assert_eq!(SockAddr::new_sys_control(fd, "foo.bar.lol", 0).err(), Some(Error::Sys(Errno::ENOENT)));
+    assert_eq!(SockAddr::new_sys_control(fd, "foo.bar.lol", 0).err(), Some(Error(Errno::ENOENT)));
 
     // requires root privileges
     // connect(fd, &sockaddr).expect("connect failed");
@@ -1516,7 +1516,7 @@ pub fn test_vsock() {
     // VMADDR_CID_HYPERVISOR is reserved, so we expect an EADDRNOTAVAIL error.
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_HYPERVISOR, port);
     assert_eq!(bind(s1, &sockaddr).err(),
-               Some(Error::Sys(Errno::EADDRNOTAVAIL)));
+               Some(Error(Errno::EADDRNOTAVAIL)));
 
     let sockaddr = SockAddr::new_vsock(libc::VMADDR_CID_ANY, port);
     assert_eq!(bind(s1, &sockaddr), Ok(()));

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -32,14 +32,14 @@ fn test_tcgetattr_pty() {
 fn test_tcgetattr_enotty() {
     let file = tempfile().unwrap();
     assert_eq!(termios::tcgetattr(file.as_raw_fd()).err(),
-               Some(Error::Sys(Errno::ENOTTY)));
+               Some(Error(Errno::ENOTTY)));
 }
 
 // Test tcgetattr on an invalid file descriptor
 #[test]
 fn test_tcgetattr_ebadf() {
     assert_eq!(termios::tcgetattr(-1).err(),
-               Some(Error::Sys(Errno::EBADF)));
+               Some(Error(Errno::EBADF)));
 }
 
 // Test modifying output flags
@@ -126,5 +126,5 @@ fn test_local_flags() {
     let read = read(pty.master, &mut buf).unwrap_err();
     close(pty.master).unwrap();
     close(pty.slave).unwrap();
-    assert_eq!(read, Error::Sys(Errno::EAGAIN));
+    assert_eq!(read, Error(Errno::EAGAIN));
 }

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,7 +1,7 @@
 use std::os::unix::prelude::*;
 use tempfile::tempfile;
 
-use nix::{Error, fcntl};
+use nix::fcntl;
 use nix::errno::Errno;
 use nix::pty::openpty;
 use nix::sys::termios::{self, LocalFlags, OutputFlags, tcgetattr};
@@ -32,14 +32,14 @@ fn test_tcgetattr_pty() {
 fn test_tcgetattr_enotty() {
     let file = tempfile().unwrap();
     assert_eq!(termios::tcgetattr(file.as_raw_fd()).err(),
-               Some(Error(Errno::ENOTTY)));
+               Some(Errno::ENOTTY));
 }
 
 // Test tcgetattr on an invalid file descriptor
 #[test]
 fn test_tcgetattr_ebadf() {
     assert_eq!(termios::tcgetattr(-1).err(),
-               Some(Error(Errno::EBADF)));
+               Some(Errno::EBADF));
 }
 
 // Test modifying output flags
@@ -126,5 +126,5 @@ fn test_local_flags() {
     let read = read(pty.master, &mut buf).unwrap_err();
     close(pty.master).unwrap();
     close(pty.slave).unwrap();
-    assert_eq!(read, Error(Errno::EAGAIN));
+    assert_eq!(read, Errno::EAGAIN);
 }

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -1,5 +1,4 @@
 use nix::errno::Errno;
-use nix::Error;
 use nix::unistd::*;
 use nix::unistd::ForkResult::*;
 use nix::sys::signal::*;
@@ -42,7 +41,7 @@ fn test_waitstatus_from_raw() {
     let pid = Pid::from_raw(1);
     assert_eq!(WaitStatus::from_raw(pid, 0x0002), Ok(WaitStatus::Signaled(pid, Signal::SIGINT, false)));
     assert_eq!(WaitStatus::from_raw(pid, 0x0200), Ok(WaitStatus::Exited(pid, 2)));
-    assert_eq!(WaitStatus::from_raw(pid, 0x7f7f), Err(Error(Errno::EINVAL)));
+    assert_eq!(WaitStatus::from_raw(pid, 0x7f7f), Err(Errno::EINVAL));
 }
 
 #[test]

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -1,3 +1,4 @@
+use nix::errno::Errno;
 use nix::Error;
 use nix::unistd::*;
 use nix::unistd::ForkResult::*;
@@ -41,7 +42,7 @@ fn test_waitstatus_from_raw() {
     let pid = Pid::from_raw(1);
     assert_eq!(WaitStatus::from_raw(pid, 0x0002), Ok(WaitStatus::Signaled(pid, Signal::SIGINT, false)));
     assert_eq!(WaitStatus::from_raw(pid, 0x0200), Ok(WaitStatus::Exited(pid, 2)));
-    assert_eq!(WaitStatus::from_raw(pid, 0x7f7f), Err(Error::invalid_argument()));
+    assert_eq!(WaitStatus::from_raw(pid, 0x7f7f), Err(Error(Errno::EINVAL)));
 }
 
 #[test]

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -51,5 +51,5 @@ fn rewind() {
 
 #[test]
 fn ebadf() {
-    assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error::Sys(nix::errno::Errno::EBADF));
+    assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error(nix::errno::Errno::EBADF));
 }

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -51,5 +51,5 @@ fn rewind() {
 
 #[test]
 fn ebadf() {
-    assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error(nix::errno::Errno::EBADF));
+    assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error::EBADF);
 }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -55,7 +55,7 @@ fn test_renameat() {
     let new_dirfd = open(new_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
     renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap();
     assert_eq!(renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap_err(),
-               Error::Sys(Errno::ENOENT));
+               Error(Errno::ENOENT));
     close(old_dirfd).unwrap();
     close(new_dirfd).unwrap();
     assert!(new_dir.path().join("new").exists());
@@ -385,7 +385,7 @@ mod test_posix_fallocate {
                 assert_eq!(tmp.read(&mut data).expect("read failure"), LEN);
                 assert_eq!(&data[..], &[0u8; LEN][..]);
             }
-            Err(nix::Error::Sys(Errno::EINVAL)) => {
+            Err(nix::Error(Errno::EINVAL)) => {
                 // POSIX requires posix_fallocate to return EINVAL both for
                 // invalid arguments (i.e. len < 0) and if the operation is not
                 // supported by the file system.
@@ -401,12 +401,8 @@ mod test_posix_fallocate {
     fn errno() {
         let (rd, _wr) = pipe().unwrap();
         let err = posix_fallocate(rd as RawFd, 0, 100).unwrap_err();
-        use nix::Error::Sys;
-        match err {
-            Sys(Errno::EINVAL)
-                | Sys(Errno::ENODEV)
-                | Sys(Errno::ESPIPE)
-                | Sys(Errno::EBADF) => (),
+        match err.0 {
+            Errno::EINVAL | Errno::ENODEV | Errno::ESPIPE | Errno::EBADF => (),
             errno =>
                 panic!(
                     "unexpected errno {}",

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,6 +1,4 @@
 #[cfg(not(target_os = "redox"))]
-use nix::Error;
-#[cfg(not(target_os = "redox"))]
 use nix::errno::*;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl::{open, OFlag, readlink};
@@ -55,7 +53,7 @@ fn test_renameat() {
     let new_dirfd = open(new_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
     renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap();
     assert_eq!(renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap_err(),
-               Error(Errno::ENOENT));
+               Errno::ENOENT);
     close(old_dirfd).unwrap();
     close(new_dirfd).unwrap();
     assert!(new_dir.path().join("new").exists());
@@ -385,7 +383,7 @@ mod test_posix_fallocate {
                 assert_eq!(tmp.read(&mut data).expect("read failure"), LEN);
                 assert_eq!(&data[..], &[0u8; LEN][..]);
             }
-            Err(nix::Error(Errno::EINVAL)) => {
+            Err(Errno::EINVAL) => {
                 // POSIX requires posix_fallocate to return EINVAL both for
                 // invalid arguments (i.e. len < 0) and if the operation is not
                 // supported by the file system.
@@ -401,7 +399,7 @@ mod test_posix_fallocate {
     fn errno() {
         let (rd, _wr) = pipe().unwrap();
         let err = posix_fallocate(rd as RawFd, 0, 100).unwrap_err();
-        match err.0 {
+        match err {
             Errno::EINVAL | Errno::ENODEV | Errno::ESPIPE | Errno::EBADF => (),
             errno =>
                 panic!(

--- a/test/test_kmod/mod.rs
+++ b/test/test_kmod/mod.rs
@@ -130,7 +130,7 @@ fn test_finit_module_invalid() {
     let f = File::open(kmod_path).expect("unable to open kernel module");
     let result = finit_module(&f, &CString::new("").unwrap(), ModuleInitFlags::empty());
 
-    assert_eq!(result.unwrap_err(), Error::Sys(Errno::EINVAL));
+    assert_eq!(result.unwrap_err(), Error::from(Errno::EINVAL));
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn test_finit_module_twice_and_delete_module() {
 
     let result = finit_module(&f, &CString::new("").unwrap(), ModuleInitFlags::empty());
 
-    assert_eq!(result.unwrap_err(), Error::Sys(Errno::EEXIST));
+    assert_eq!(result.unwrap_err(), Error::from(Errno::EEXIST));
 
     delete_module(
         &CString::new(kmod_name).unwrap(),
@@ -163,5 +163,5 @@ fn test_delete_module_not_loaded() {
 
     let result = delete_module(&CString::new("hello").unwrap(), DeleteModuleFlags::empty());
 
-    assert_eq!(result.unwrap_err(), Error::Sys(Errno::ENOENT));
+    assert_eq!(result.unwrap_err(), Error::from(Errno::ENOENT));
 }

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -2,7 +2,6 @@ use std::ffi::CString;
 use std::str;
 
 use nix::errno::Errno;
-use nix::Error;
 use nix::mqueue::{mq_open, mq_close, mq_send, mq_receive, mq_attr_member_t};
 use nix::mqueue::{MqAttr, MQ_OFlag};
 use nix::sys::stat::Mode;
@@ -16,7 +15,7 @@ fn test_mq_send_and_receive() {
     let oflag0 = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r0 = mq_open(mq_name, oflag0, mode, Some(&attr));
-    if let Err(Error(Errno::ENOSYS)) = r0 {
+    if let Err(Errno::ENOSYS) = r0 {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -47,7 +46,7 @@ fn test_mq_getattr() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Error(Errno::ENOSYS)) = r {
+    if let Err(Errno::ENOSYS) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -70,7 +69,7 @@ fn test_mq_setattr() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Error(Errno::ENOSYS)) = r {
+    if let Err(Errno::ENOSYS) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -107,7 +106,7 @@ fn test_mq_set_nonblocking() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Error(Errno::ENOSYS)) = r {
+    if let Err(Errno::ENOSYS) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -132,7 +131,7 @@ fn test_mq_unlink() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name_opened, oflag, mode, Some(&initial_attr));
-    if let Err(Error(Errno::ENOSYS)) = r {
+    if let Err(Errno::ENOSYS) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -142,9 +141,9 @@ fn test_mq_unlink() {
     assert_eq!(res_unlink, Ok(()) );
 
     let res_unlink_not_opened = mq_unlink(mq_name_not_opened);
-    assert_eq!(res_unlink_not_opened, Err(Error(Errno::ENOENT)) );
+    assert_eq!(res_unlink_not_opened, Err(Errno::ENOENT) );
 
     mq_close(mqd).unwrap();
     let res_unlink_after_close = mq_unlink(mq_name_opened);
-    assert_eq!(res_unlink_after_close, Err(Error(Errno::ENOENT)) );
+    assert_eq!(res_unlink_after_close, Err(Errno::ENOENT) );
 }

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -1,8 +1,8 @@
 use std::ffi::CString;
 use std::str;
 
-use nix::errno::Errno::*;
-use nix::Error::Sys;
+use nix::errno::Errno;
+use nix::Error;
 use nix::mqueue::{mq_open, mq_close, mq_send, mq_receive, mq_attr_member_t};
 use nix::mqueue::{MqAttr, MQ_OFlag};
 use nix::sys::stat::Mode;
@@ -16,7 +16,7 @@ fn test_mq_send_and_receive() {
     let oflag0 = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r0 = mq_open(mq_name, oflag0, mode, Some(&attr));
-    if let Err(Sys(ENOSYS)) = r0 {
+    if let Err(Error(Errno::ENOSYS)) = r0 {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -47,7 +47,7 @@ fn test_mq_getattr() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Sys(ENOSYS)) = r {
+    if let Err(Error(Errno::ENOSYS)) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -70,7 +70,7 @@ fn test_mq_setattr() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Sys(ENOSYS)) = r {
+    if let Err(Error(Errno::ENOSYS)) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -107,7 +107,7 @@ fn test_mq_set_nonblocking() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name, oflag, mode, Some(&initial_attr));
-    if let Err(Sys(ENOSYS)) = r {
+    if let Err(Error(Errno::ENOSYS)) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -132,7 +132,7 @@ fn test_mq_unlink() {
     let oflag = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
     let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
     let r = mq_open(mq_name_opened, oflag, mode, Some(&initial_attr));
-    if let Err(Sys(ENOSYS)) = r {
+    if let Err(Error(Errno::ENOSYS)) = r {
         println!("message queues not supported or module not loaded?");
         return;
     };
@@ -142,9 +142,9 @@ fn test_mq_unlink() {
     assert_eq!(res_unlink, Ok(()) );
 
     let res_unlink_not_opened = mq_unlink(mq_name_not_opened);
-    assert_eq!(res_unlink_not_opened, Err(Sys(ENOENT)) );
+    assert_eq!(res_unlink_not_opened, Err(Error(Errno::ENOENT)) );
 
     mq_close(mqd).unwrap();
     let res_unlink_after_close = mq_unlink(mq_name_opened);
-    assert_eq!(res_unlink_after_close, Err(Sys(ENOENT)) );
+    assert_eq!(res_unlink_after_close, Err(Error(Errno::ENOENT)) );
 }

--- a/test/test_nmount.rs
+++ b/test/test_nmount.rs
@@ -46,6 +46,6 @@ fn bad_fstype() {
         .str_opt_owned("target", target.path().to_str().unwrap())
         .nmount(MntFlags::empty()).unwrap_err();
     
-    assert_eq!(e.errno(), Errno::EINVAL);
+    assert_eq!(e.error(), Errno::EINVAL);
     assert_eq!(e.errmsg(), Some("Invalid fstype"));
 }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -10,7 +10,7 @@ macro_rules! loop_while_eintr {
         loop {
             match $poll_expr {
                 Ok(nfds) => break nfds,
-                Err(Error::Sys(Errno::EINTR)) => (),
+                Err(Error(Errno::EINTR)) => (),
                 Err(e) => panic!("{}", e)
             }
         }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,5 +1,4 @@
 use nix::{
-    Error,
     errno::Errno,
     poll::{PollFlags, poll, PollFd},
     unistd::{write, pipe}
@@ -10,7 +9,7 @@ macro_rules! loop_while_eintr {
         loop {
             match $poll_expr {
                 Ok(nfds) => break nfds,
-                Err(Error(Errno::EINTR)) => (),
+                Err(Errno::EINTR) => (),
                 Err(e) => panic!("{}", e)
             }
         }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -15,7 +15,7 @@ use libc::{S_IFMT, S_IFLNK};
 use libc::mode_t;
 
 #[cfg(not(target_os = "redox"))]
-use nix::{fcntl, Error};
+use nix::fcntl;
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
 #[cfg(not(target_os = "redox"))]
@@ -304,5 +304,5 @@ fn test_mkdirat_fail() {
     let dirfd = fcntl::open(&tempdir.path().join(not_dir_filename), fcntl::OFlag::O_CREAT,
                             stat::Mode::empty()).unwrap();
     let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
-    assert_eq!(result, Error(Errno::ENOTDIR));
+    assert_eq!(result, Errno::ENOTDIR);
 }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -304,5 +304,5 @@ fn test_mkdirat_fail() {
     let dirfd = fcntl::open(&tempdir.path().join(not_dir_filename), fcntl::OFlag::O_CREAT,
                             stat::Mode::empty()).unwrap();
     let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
-    assert_eq!(result, Error::Sys(Errno::ENOTDIR));
+    assert_eq!(result, Error(Errno::ENOTDIR));
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -972,7 +972,7 @@ fn test_unlinkat_dir_noremovedir() {
 
     // Attempt unlink dir at relative path without proper flag
     let err_result = unlinkat(Some(dirfd), dirname, UnlinkatFlags::NoRemoveDir).unwrap_err();
-    assert!(err_result == Error::Sys(Errno::EISDIR) || err_result == Error::Sys(Errno::EPERM));
+    assert!(err_result == Error(Errno::EISDIR) || err_result == Error(Errno::EPERM));
  }
 
 #[test]
@@ -1015,8 +1015,8 @@ fn test_unlinkat_file() {
 fn test_access_not_existing() {
     let tempdir = tempdir().unwrap();
     let dir = tempdir.path().join("does_not_exist.txt");
-    assert_eq!(access(&dir, AccessFlags::F_OK).err().unwrap().as_errno().unwrap(),
-               Errno::ENOENT);
+    assert_eq!(access(&dir, AccessFlags::F_OK).err().unwrap(),
+               Error(Errno::ENOENT));
 }
 
 #[test]
@@ -1094,13 +1094,13 @@ fn test_ttyname() {
 fn test_ttyname_not_pty() {
     let fd = File::open("/dev/zero").unwrap();
     assert!(fd.as_raw_fd() > 0);
-    assert_eq!(ttyname(fd.as_raw_fd()), Err(Error::Sys(Errno::ENOTTY)));
+    assert_eq!(ttyname(fd.as_raw_fd()), Err(Error(Errno::ENOTTY)));
 }
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_ttyname_invalid_fd() {
-    assert_eq!(ttyname(-1), Err(Error::Sys(Errno::EBADF)));
+    assert_eq!(ttyname(-1), Err(Error(Errno::EBADF)));
 }
 
 #[test]

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -10,8 +10,6 @@ use nix::sys::stat::{self, Mode, SFlag};
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 use nix::pty::{posix_openpt, grantpt, unlockpt, ptsname};
 use nix::errno::Errno;
-#[cfg(not(target_os = "redox"))]
-use nix::Error;
 use std::{env, iter};
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
 use std::ffi::CString;
@@ -972,7 +970,7 @@ fn test_unlinkat_dir_noremovedir() {
 
     // Attempt unlink dir at relative path without proper flag
     let err_result = unlinkat(Some(dirfd), dirname, UnlinkatFlags::NoRemoveDir).unwrap_err();
-    assert!(err_result == Error(Errno::EISDIR) || err_result == Error(Errno::EPERM));
+    assert!(err_result == Errno::EISDIR || err_result == Errno::EPERM);
  }
 
 #[test]
@@ -1016,7 +1014,7 @@ fn test_access_not_existing() {
     let tempdir = tempdir().unwrap();
     let dir = tempdir.path().join("does_not_exist.txt");
     assert_eq!(access(&dir, AccessFlags::F_OK).err().unwrap(),
-               Error(Errno::ENOENT));
+               Errno::ENOENT);
 }
 
 #[test]
@@ -1094,13 +1092,13 @@ fn test_ttyname() {
 fn test_ttyname_not_pty() {
     let fd = File::open("/dev/zero").unwrap();
     assert!(fd.as_raw_fd() > 0);
-    assert_eq!(ttyname(fd.as_raw_fd()), Err(Error(Errno::ENOTTY)));
+    assert_eq!(ttyname(fd.as_raw_fd()), Err(Errno::ENOTTY));
 }
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 fn test_ttyname_invalid_fd() {
-    assert_eq!(ttyname(-1), Err(Error(Errno::EBADF)));
+    assert_eq!(ttyname(-1), Err(Errno::EBADF));
 }
 
 #[test]


### PR DESCRIPTION
For many of Nix's consumers it be convenient to easily convert a Nix
error into a std::io::Error.  That's currently not possible because of
the InvalidPath, InvalidUtf8, and UnsupportedOperation types that have
no equivalent in std::io::Error.

However, very few of Nix's public APIs actually return those unusual
errors.  So a more useful API would be for Nix's standard error type to
implement Into<std::io::Error>, and the few functions that must return
unusual errors like InvalidUtf8 should use bespoke error types.

This commit prototypes that approach by modifying just one function, for
now, to use the new error type.