### PR TITLE
Add documentation for sched::clone

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -180,11 +180,10 @@ mod sched_linux_like {
     /// ([`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html))
     ///
     /// `stack` is a reference to an array which will hold the stack of the new
-    /// process. Contrary to colling `clone(2)` from C, where the provided
-    /// stack address must be the highest address of the memory region, this is
-    /// not needed here. This requirement will be taken care of by `nix` and
-    /// the user only needs to provide a reference to a normally allocated
-    /// buffer.
+    /// process.  Unlike when calling `clone(2)` from C, the provided stack
+    /// address need not be the highest address of the region.  Nix will take
+    /// care of that requirement.  The user only needs to provide a reference to
+    /// a normally allocated buffer.
     pub fn clone(
         mut cb: CloneCb,
         stack: &mut [u8],

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -176,6 +176,15 @@ mod sched_linux_like {
         Errno::result(res).and(Ok(cpuset))
     }
 
+    /// `clone` create a child process
+    /// ([`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html))
+    ///
+    /// `stack` is a reference to an array which will hold the stack of the new
+    /// process. Contrary to colling `clone(2)` from C, where the provided
+    /// stack address must be the highest address of the memory region, this is
+    /// not needed here. This requirement will be taken care of by `nix` and
+    /// the user only needs to provide a reference to a normally allocated
+    /// buffer.
     pub fn clone(
         mut cb: CloneCb,
         stack: &mut [u8],


### PR DESCRIPTION
Add a note in the documentation for sched::clone to point out that the
stack pointer does not neet to be a reference to the highest address of
the stack.

Users who simply read the manpages for clone(2) might assume that they
will need to use unsafe pointer arithmetics in order to create a
reference to the highest address of their buffer, rather than providing
their buffer directly.