### PR TITLE
Fix several problems with Errno aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   longer be needed now that async/await are available.  `AioCb`s now work
   exclusively with borrowed buffers, not owned ones.
   (#[1440](https://github.com/nix-rust/nix/pull/1440))
+- Removed some Errno values from platforms where they aren't actually defined.
+  (#[1452](https://github.com/nix-rust/nix/pull/1452))
 
 ## [0.20.0] - 20 February 2021
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1395](https://github.com/nix-rust/nix/pull/1395))
 - Fix spurious errors using `sendmmsg` with multiple cmsgs
   (#[1414](https://github.com/nix-rust/nix/pull/1414))
+- Added `Errno::EOPNOTSUPP` to FreeBSD, where it was missing.
+  (#[1452](https://github.com/nix-rust/nix/pull/1452))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1440](https://github.com/nix-rust/nix/pull/1440))
 - Minimum supported Rust version is now 1.41.0.
   ([#1440](https://github.com/nix-rust/nix/pull/1440))
+- Errno aliases are now associated consts on `Errno`, instead of consts in the
+  `errno` module.`
+  (#[1452](https://github.com/nix-rust/nix/pull/1452))
 
 ### Fixed
 - Allow `sockaddr_ll` size, as reported by the Linux kernel, to be smaller then it's definition

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -843,9 +843,11 @@ mod consts {
         EHWPOISON       = libc::EHWPOISON,
     }
 
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-    pub const EDEADLOCK:   Errno = Errno::EDEADLK;
-    pub const ENOTSUP:     Errno = Errno::EOPNOTSUPP;
+    impl Errno {
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+        pub const ENOTSUP:     Errno = Errno::EOPNOTSUPP;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1103,9 +1105,11 @@ mod consts {
         EQFULL          = libc::EQFULL,
     }
 
-    pub const ELAST: Errno       = Errno::EQFULL;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-    pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::EQFULL;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1326,9 +1330,11 @@ mod consts {
         EOWNERDEAD      = libc::EOWNERDEAD,
     }
 
-    pub const ELAST: Errno       = Errno::EOWNERDEAD;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-    pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::EOWNERDEAD;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1538,10 +1544,12 @@ mod consts {
         EASYNC          = libc::EASYNC,
     }
 
-    pub const ELAST: Errno       = Errno::EASYNC;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-    pub const EDEADLOCK:   Errno = Errno::EDEADLK;
-    pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::EASYNC;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+        pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1750,8 +1758,10 @@ mod consts {
         EPROTO          = libc::EPROTO,
     }
 
-    pub const ELAST: Errno       = Errno::ENOTSUP;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::ENOTSUP;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1961,8 +1971,10 @@ mod consts {
         EPROTO          = libc::EPROTO,
     }
 
-    pub const ELAST: Errno       = Errno::ENOTSUP;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::ENOTSUP;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -2162,7 +2174,9 @@ mod consts {
         EPROTO = libc::EPROTO,
     }
 
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    impl Errno {
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -2387,8 +2401,10 @@ mod consts {
         ESTALE = libc::ESTALE,
     }
 
-    pub const ELAST: Errno       = Errno::ESTALE;
-    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    impl Errno {
+        pub const ELAST: Errno       = Errno::ESTALE;
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+    }
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1107,8 +1107,6 @@ mod consts {
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
 
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
-
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1332,8 +1330,6 @@ mod consts {
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
 
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
-
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1547,8 +1543,6 @@ mod consts {
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
     pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
 
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
-
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1758,8 +1752,6 @@ mod consts {
 
     pub const ELAST: Errno       = Errno::ENOTSUP;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
@@ -1972,8 +1964,6 @@ mod consts {
     pub const ELAST: Errno       = Errno::ENOTSUP;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
 
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
-
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2172,10 +2162,7 @@ mod consts {
         EPROTO = libc::EPROTO,
     }
 
-    pub const ELAST: Errno = Errno::UnknownErrno;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
-
-    pub const EL2NSYNC: Errno = Errno::UnknownErrno;
 
     pub fn from_i32(e: i32) -> Errno {
         use self::Errno::*;

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1334,6 +1334,7 @@ mod consts {
         pub const ELAST: Errno       = Errno::EOWNERDEAD;
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
         pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+        pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
     }
 
     pub fn from_i32(e: i32) -> Errno {


### PR DESCRIPTION
* Add Errno::EOPNOTSUPP to FreeBSD, where it is missing
* Errno aliases are now associated consts of the Errno type
* Remove Errno consts from platforms where they aren't defined