### PR TITLE
Support SO_RXQ_OVFL socket option (android/fuchsia/linux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1457](https://github.com/nix-rust/nix/pull/1457))
 - Added `renameat2` for Linux
   (#[1458](https://github.com/nix-rust/nix/pull/1458))
+- Added `RxqOvfl` support on Linux, Fuchsia and Android.
+  (#[1455](https://github.com/nix-rust/nix/pull/1455))
 
 ### Changed
 - `ptsname_r` now returns a lossily-converted string in the event of bad UTF,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -328,6 +328,8 @@ sockopt_impl!(Both, Ipv4RecvDstAddr, libc::IPPROTO_IP, libc::IP_RECVDSTADDR, boo
 sockopt_impl!(Both, UdpGsoSegment, libc::SOL_UDP, libc::UDP_SEGMENT, libc::c_int);
 #[cfg(target_os = "linux")]
 sockopt_impl!(Both, UdpGroSegment, libc::IPPROTO_UDP, libc::UDP_GRO, bool);
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+sockopt_impl!(Both, RxqOvfl, libc::SOL_SOCKET, libc::SO_RXQ_OVFL, libc::c_int);
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This PR implements support of RXQ_OVFL flag and parsing ControlMessage
to get the packet drop counter of UDP socket.