### PR TITLE
Added support for renameat2 on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1456](https://github.com/nix-rust/nix/pull/1456))
 - Added `TcpUserTimeout` socket option (sockopt) on Linux and Fuchsia.
   (#[1457](https://github.com/nix-rust/nix/pull/1457))
+- Added `renameat2` for Linux
+  (#[1458](https://github.com/nix-rust/nix/pull/1458))
 
 ### Changed
 - `ptsname_r` now returns a lossily-converted string in the event of bad UTF,


### PR DESCRIPTION
Hi, please find my PR for adding the linux-specific `renameat2` syscall.  It's largely similar to `renameat`, with an additional flags parameter:

The flags are:
* RENAME_REPLACE - performs an atomic swap.
* RENAME_NOREPLACE - returns EEXIST if the target already exists.
* RENAME_WHITEOUT - specific to overly/union filesystems, and I haven't added a test-case for this one.

PLEASE NOTE: It looks like my formatter has made numerous changes.  If you have a preferred formatting config then please let me know, and I can push up changes consistent with the accepted style.

I'm not all that experienced with rust, and this is my first time looking at the nix project, so I'm more than happy to receive guidance on improving my submission.

Cheers!