### PR TITLE
Bump libc to 0.2.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "72da7a6a464a5a2a17993b94d94d2ab99bb87db6", features = [ "extra_traits" ] }
+libc = { version = "0.2.98", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 


### PR DESCRIPTION
A new libc release with the MNT_ fixes was released.