### PR TITLE
Slim down the size of the built package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+syntax: glob
 Cargo.lock
 target/
-*.sw*
+*.diff
+*.rej
+*.orig
+.*.swn
+.*.swo
+.*.swp
 *.a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,7 @@ authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"
 categories  = ["os::unix-apis"]
-exclude     = [
-  "/.gitignore",
-  "/.cirrus.yml",
-  "/ci/*",
-  "/Cross.toml",
-  "/RELEASE_PROCEDURE.md",
-  "/bors.toml"
-]
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
* Switch Cargo from an exclude list to an include list.  The exclude list had gotten out-of-date.
* Add more file types to .gitignore