### PR TITLE
Use immutable receivers for FdSet::{highest, contains, fds}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
+
+- `FdSet::{contains, highest, fds}` no longer require a mutable reference.
+  (#[1464](https://github.com/nix-rust/nix/pull/1464))
+
 ### Fixed
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.98", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "9c1489fa8", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -32,8 +32,8 @@ impl FdSet {
         unsafe { libc::FD_CLR(fd, &mut self.0) };
     }
 
-    pub fn contains(&mut self, fd: RawFd) -> bool {
-        unsafe { libc::FD_ISSET(fd, &mut self.0) }
+    pub fn contains(&self, fd: RawFd) -> bool {
+        unsafe { libc::FD_ISSET(fd, &self.0) }
     }
 
     pub fn clear(&mut self) {
@@ -57,7 +57,7 @@ impl FdSet {
     /// ```
     ///
     /// [`select`]: fn.select.html
-    pub fn highest(&mut self) -> Option<RawFd> {
+    pub fn highest(&self) -> Option<RawFd> {
         self.fds(None).next_back()
     }
 
@@ -79,7 +79,7 @@ impl FdSet {
     /// assert_eq!(fds, vec![4, 9]);
     /// ```
     #[inline]
-    pub fn fds(&mut self, highest: Option<RawFd>) -> Fds {
+    pub fn fds(&self, highest: Option<RawFd>) -> Fds {
         Fds {
             set: self,
             range: 0..highest.map(|h| h as usize + 1).unwrap_or(FD_SETSIZE),
@@ -96,7 +96,7 @@ impl Default for FdSet {
 /// Iterator over `FdSet`.
 #[derive(Debug)]
 pub struct Fds<'a> {
-    set: &'a mut FdSet,
+    set: &'a FdSet,
     range: Range<usize>,
 }
 


### PR DESCRIPTION
There was never any good reason to use mutable receives in the first
place.  Nix originally did so because libc defined FD_ISSET as taking a
mutable receiver, which it did based on an inaccurate Linux man page.
But that's fixed now.

https://github.com/rust-lang/libc/pull/1725