### PR TITLE
Enable creating a const TimeSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added `TimeSpec::from_duration` and `TimeSpec::from_timespec`
+  (#[1465](https://github.com/nix-rust/nix/pull/1465))
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -77,11 +77,7 @@ impl From<timespec> for TimeSpec {
 
 impl From<Duration> for TimeSpec {
     fn from(duration: Duration) -> Self {
-        #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
-        TimeSpec(timespec {
-            tv_sec: duration.as_secs() as time_t,
-            tv_nsec: duration.subsec_nanos() as timespec_tv_nsec_t
-        })
+        Self::from_duration(duration)
     }
 }
 
@@ -197,6 +193,18 @@ impl TimeSpec {
 
     pub fn tv_nsec(&self) -> timespec_tv_nsec_t {
         self.0.tv_nsec
+    }
+
+    pub const fn from_duration(duration: Duration) -> Self {
+        #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+        TimeSpec(timespec {
+            tv_sec: duration.as_secs() as time_t,
+            tv_nsec: duration.subsec_nanos() as timespec_tv_nsec_t
+        })
+    }
+
+    pub const fn from_timespec(timespec: timespec) -> Self {
+        Self(timespec)
     }
 }
 


### PR DESCRIPTION
Previously, there was no way to create a `TimeSpec` in a `const` context because all creation was through traits. This adds two utility functions to create a `const TimeSpec` from a `libc::timespec` or an `std::time::Duration`.

An alternative approach would be to make the inner `timespec` field `pub`, which would not require any additional functions but would expose some (potentially unwanted) implementation details.