### PR TITLE
Add raw timerfd wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added raw `timerfd` wrappers (#[1468](https://github.com/nix-rust/nix/pull/1468))
+
 ### Changed
 ### Fixed
 ### Removed


### PR DESCRIPTION
Add raw wrappers for the timerfd functions (`timerfd_create`, `timerfd_settime`, and `timerfd_gettime`) and refactor `TimerFd` to use those wrappers safely. Additionally, add extra wrappers and conversion functions to convert between `Expiration` and `TimerSpec` (pulling out some of the logic explicitly).

It can be useful to handle timerfds in a "raw" way, and sometimes the `TimerFd` abstraction gets in the way. I encountered this while passing raw FDs around for epoll operations, and this interface is inspired by the `epoll` module: 1-to-1 wrappers over the libc function calls.

The `TimerFd` API remains identical, but it is implemented as a thin shim over the new functions.