### PR TITLE
Fix CONTRIBUTING.md formating

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ information you can provide, the better.
 
 We use labels to help manage issues. The structure is modeled after
 [Rust's issue labeling scheme][rust-labels]:
-- **A-**prefixed labels state which area of the project the issue
+- **A-** prefixed labels state which area of the project the issue
   relates to
-- **E-**prefixed labels explain the level of experience necessary to fix the
+- **E-** prefixed labels explain the level of experience necessary to fix the
   issue
-- **O-**prefixed labels specify the OS for issues that are OS-specific
-- **R-**prefixed labels specify the architecture for issues that are
+- **O-** prefixed labels specify the OS for issues that are OS-specific
+- **R-** prefixed labels specify the architecture for issues that are
   architecture-specific
 
 [rust-labels]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#issue-triage


### PR DESCRIPTION
Guess the label prefixes should be rendered bold and not with literal stars.