### PR TITLE
Add the IPV6_V6ONLY sockopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+
+- Added `IPV6_V6ONLY` sockopt.
+  (#[1470](https://github.com/nix-rust/nix/pull/1470))
+
 ### Changed
 
 - `FdSet::{contains, highest, fds}` no longer require a mutable reference.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -330,6 +330,7 @@ sockopt_impl!(Both, UdpGsoSegment, libc::SOL_UDP, libc::UDP_SEGMENT, libc::c_int
 sockopt_impl!(Both, UdpGroSegment, libc::IPPROTO_UDP, libc::UDP_GRO, bool);
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
 sockopt_impl!(Both, RxqOvfl, libc::SOL_SOCKET, libc::SO_RXQ_OVFL, libc::c_int);
+sockopt_impl!(Both, Ipv6V6Only, libc::IPPROTO_IPV6, libc::IPV6_V6ONLY, bool);
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
`IPV6_V6ONLY` allows the user to select between dual-stack and IPv6-only sockets.

Platform support seems to be good; all platforms with IPv6 support seem to have this sockopt.