### PR TITLE
unistd: Add conversion from User to libc::passwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `TimeSpec::from_duration` and `TimeSpec::from_timespec`
   (#[1465](https://github.com/nix-rust/nix/pull/1465))
-
 - Added `IPV6_V6ONLY` sockopt.
   (#[1470](https://github.com/nix-rust/nix/pull/1470))
+- Added `impl From<User> for libc::passwd` trait implementation to convert a `User`
+  into a `libc::passwd`. Consumes the `User` struct to give ownership over
+  the member pointers.
+  (#[1471](https://github.com/nix-rust/nix/pull/1471))
 - Added `pthread_kill`.
   (#[1472](https://github.com/nix-rust/nix/pull/1472))
 
@@ -18,6 +21,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - `FdSet::{contains, highest, fds}` no longer require a mutable reference.
   (#[1464](https://github.com/nix-rust/nix/pull/1464))
+- `User::gecos` and corresponding `libc::passwd::pw_gecos` are supported on
+  64-bit Android, change conditional compilation to include the field in
+  64-bit Android builds
+  (#[1471](https://github.com/nix-rust/nix/pull/1471))
 
 ### Fixed
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1025,6 +1025,14 @@ fn test_access_file_exists() {
     assert!(access(&path, AccessFlags::R_OK | AccessFlags::W_OK).is_ok());
 }
 
+#[test]
+fn test_user_into_passwd() {
+    // get the UID of the "nobody" user
+    let nobody = User::from_name("nobody").unwrap().unwrap();
+    let pwd: libc::passwd = nobody.into();
+    let _: User = (&pwd).into();
+}
+
 /// Tests setting the filesystem UID with `setfsuid`.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]


### PR DESCRIPTION
Add `From<User> for libc::passwd` trait implementation to convert a `User` into a `libc::passwd`

Implementation consumes the `User` struct, giving ownership over the internal members to the `libc::passwd` struct

Exposes the `User::gecos` field to 64-bit Android builds, since `libc::passwd::pw_gecos` is supported on those builds