### PR TITLE
Add pthread_kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `IPV6_V6ONLY` sockopt.
   (#[1470](https://github.com/nix-rust/nix/pull/1470))
+- Added `pthread_kill`.
+  (#[1472](https://github.com/nix-rust/nix/pull/1472))
 
 ### Changed
 

--- a/src/sys/pthread.rs
+++ b/src/sys/pthread.rs
@@ -1,3 +1,9 @@
+#[cfg(not(target_os = "redox"))]
+use crate::errno::Errno;
+#[cfg(not(target_os = "redox"))]
+use crate::Result;
+#[cfg(not(target_os = "redox"))]
+use crate::sys::signal::Signal;
 use libc::{self, pthread_t};
 
 pub type Pthread = pthread_t;
@@ -10,4 +16,20 @@ pub type Pthread = pthread_t;
 #[inline]
 pub fn pthread_self() -> Pthread {
     unsafe { libc::pthread_self() }
+}
+
+/// Send a signal to a thread (see [`pthread_kill(3)`]).
+///
+/// If `signal` is `None`, `pthread_kill` will only preform error checking and
+/// won't send any signal.
+///
+/// [`pthread_kill(3)`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_kill.html
+#[cfg(not(target_os = "redox"))]
+pub fn pthread_kill<T: Into<Option<Signal>>>(thread: Pthread, signal: T) -> Result<()> {
+    let sig = match signal.into() {
+        Some(s) => s as libc::c_int,
+        None => 0,
+    };
+    let res = unsafe { libc::pthread_kill(thread, sig) };
+    Errno::result(res).map(drop)
 }

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -13,3 +13,10 @@ fn test_pthread_self() {
     let tid = pthread_self();
     assert!(tid != 0);
 }
+
+#[test]
+#[cfg(not(target_os = "redox"))]
+fn test_pthread_kill_none() {
+    pthread_kill(pthread_self(), None)
+        .expect("Should be able to send signal to my thread.");
+}


### PR DESCRIPTION
This adds `pthread_kill`, following the design of `killpg`.

What do you think?