### PR TITLE
Mark most C-derived enums as non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `FdSet::{contains, highest, fds}` no longer require a mutable reference.
   (#[1464](https://github.com/nix-rust/nix/pull/1464))
 
+- Most enums that come from C, for example `Errno`, are now marked as
+  `#[non_exhaustive]`.
+  (#[1474](https://github.com/nix-rust/nix/pull/1474))
+
 ### Fixed
 
 - Added more errno definitions for better backwards compatibility with

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -768,6 +768,7 @@ fn desc(errno: Errno) -> &'static str {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -1073,6 +1074,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -1324,6 +1326,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -1562,6 +1565,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -1796,6 +1800,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -2019,6 +2024,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = libc::EPERM,
@@ -2244,6 +2250,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno = 0,
         EPERM = libc::EPERM,
@@ -2441,6 +2448,7 @@ mod consts {
 mod consts {
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Errno {
         UnknownErrno = 0,
         EPERM = libc::EPERM,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -374,6 +374,7 @@ libc_bitflags!(
 
 #[cfg(not(target_os = "redox"))]
 #[derive(Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum FcntlArg<'a> {
     F_DUPFD(RawFd),
     F_DUPFD_CLOEXEC(RawFd),
@@ -405,6 +406,7 @@ pub enum FcntlArg<'a> {
 
 #[cfg(target_os = "redox")]
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum FcntlArg {
     F_DUPFD(RawFd),
     F_DUPFD_CLOEXEC(RawFd),
@@ -454,6 +456,7 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum FlockArg {
     LockShared,
     LockExclusive,
@@ -649,6 +652,7 @@ mod posix_fadvise {
 
     libc_enum! {
         #[repr(i32)]
+        #[non_exhaustive]
         pub enum PosixFadviseAdvice {
             POSIX_FADV_NORMAL,
             POSIX_FADV_SEQUENTIAL,

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -39,6 +39,7 @@ libc_enum! {
     /// Mode for `AioCb::fsync`.  Controls whether only data or both data and
     /// metadata are synced.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum AioFsyncMode {
         /// do it like `fsync`
         O_SYNC,
@@ -57,6 +58,7 @@ libc_enum! {
     /// given `aiocb` should be used for a read operation, a write operation, or
     /// ignored.  Has no effect for any other aio functions.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum LioOpcode {
         LIO_NOP,
         LIO_WRITE,

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -29,6 +29,7 @@ libc_bitflags!(
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum EpollOp {
     EpollCtlAdd = libc::EPOLL_CTL_ADD,
     EpollCtlDel = libc::EPOLL_CTL_DEL,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -36,6 +36,7 @@ type type_of_event_filter = i16;
 libc_enum! {
     #[cfg_attr(target_os = "netbsd", repr(u32))]
     #[cfg_attr(not(target_os = "netbsd"), repr(i16))]
+    #[non_exhaustive]
     pub enum EventFilter {
         EVFILT_AIO,
         /// Returns whenever there is no remaining data in the write buffer

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -155,6 +155,7 @@ libc_enum!{
     ///
     /// Used by [`madvise`](./fn.madvise.html).
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum MmapAdvise {
         /// No further special treatment. This is the default.
         MADV_NORMAL,

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -24,6 +24,7 @@ cfg_if! {
 libc_enum! {
     #[repr(i32)]
     /// Ptrace Request enum defining the action to be taken.
+    #[non_exhaustive]
     pub enum Request {
         PT_TRACE_ME,
         PT_READ_I,

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -33,6 +33,7 @@ libc_enum!{
     #[cfg_attr(not(any(target_env = "musl", target_os = "android")), repr(u32))]
     #[cfg_attr(any(target_env = "musl", target_os = "android"), repr(i32))]
     /// Ptrace Request enum defining the action to be taken.
+    #[non_exhaustive]
     pub enum Request {
         PTRACE_TRACEME,
         PTRACE_PEEKTEXT,
@@ -123,6 +124,7 @@ libc_enum!{
     /// Using the ptrace options the tracer can configure the tracee to stop
     /// at certain events. This enum is used to define those events as defined
     /// in `man ptrace`.
+    #[non_exhaustive]
     pub enum Event {
         /// Event that stops before a return from fork or clone.
         PTRACE_EVENT_FORK,

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -42,6 +42,7 @@ libc_enum!{
 libc_enum!{
     /// The scope of the quota.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum QuotaType {
         /// Specify a user quota
         USRQUOTA,
@@ -53,6 +54,7 @@ libc_enum!{
 libc_enum!{
     /// The type of quota format to use.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum QuotaFmt {
         /// Use the original quota format.
         QFMT_VFS_OLD,

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -12,6 +12,7 @@ libc_enum! {
     /// See [`set_cad_enabled()`](fn.set_cad_enabled.html) for
     /// enabling/disabling Ctrl-Alt-Delete.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum RebootMode {
         RB_HALT_SYSTEM,
         RB_KEXEC,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -23,6 +23,7 @@ libc_enum!{
     // We would prefer to use the libc::c_int alias in the repr attribute. Unfortunately
     // this is not (yet) possible.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum Signal {
         SIGHUP,
         SIGINT,
@@ -396,6 +397,7 @@ libc_bitflags!{
 
 libc_enum! {
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum SigmaskHow {
         SIG_BLOCK,
         SIG_UNBLOCK,

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -32,6 +32,7 @@ pub use self::vsock::VsockAddr;
 /// These constants specify the protocol family to be used
 /// in [`socket`](fn.socket.html) and [`socketpair`](fn.socketpair.html)
 #[repr(i32)]
+#[non_exhaustive]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AddressFamily {
     /// Local communication (see [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html))
@@ -641,6 +642,7 @@ impl Hash for UnixAddr {
 
 /// Represents a socket address
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum SockAddr {
     Inet(InetAddr),
     Unix(UnixAddr),

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -70,6 +70,7 @@ pub use libc::{c_uint, CMSG_SPACE};
 /// when creating a socket with [`socket()`](fn.socket.html)
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum SockType {
     /// Provides sequenced, reliable, two-way, connection-
     /// based byte streams.  An out-of-band data transmission
@@ -94,6 +95,7 @@ pub enum SockType {
 /// to specify the protocol to use.
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum SockProtocol {
     /// TCP protocol ([ip(7)](https://man7.org/linux/man-pages/man7/ip.7.html))
     Tcp = libc::IPPROTO_TCP,
@@ -490,6 +492,7 @@ impl<'a> Iterator for CmsgIterator<'a> {
 //
 //  See https://github.com/nix-rust/nix/issues/999
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ControlMessageOwned {
     /// Received version of
     /// [`ControlMessage::ScmRights`][#enum.ControlMessage.html#variant.ScmRights]
@@ -739,6 +742,7 @@ impl ControlMessageOwned {
 ///
 /// [Further reading](https://man7.org/linux/man-pages/man3/cmsg.3.html)
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ControlMessage<'a> {
     /// A message of type `SCM_RIGHTS`, containing an array of file
     /// descriptors passed between processes.

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -256,6 +256,7 @@ libc_enum!{
     /// B0 is special and will disable the port.
     #[cfg_attr(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64"), repr(u64))]
     #[cfg_attr(not(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64")), repr(u32))]
+    #[non_exhaustive]
     pub enum BaudRate {
         B0,
         B50,
@@ -472,6 +473,7 @@ libc_enum! {
     ///
     /// Used as an argument to `tcsetattr()`
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum SetArg {
         /// The change will occur immediately
         TCSANOW,
@@ -487,6 +489,7 @@ libc_enum! {
     ///
     /// Used as an argument to `tcflush()`.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum FlushArg {
         /// Flush data that was received but not read
         TCIFLUSH,
@@ -502,6 +505,7 @@ libc_enum! {
     ///
     /// Used as an argument to `tcflow()`.
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum FlowArg {
         /// Suspend transmission
         TCOOFF,
@@ -518,6 +522,7 @@ libc_enum! {
 libc_enum! {
     /// Indices into the `termios.c_cc` array for special characters.
     #[repr(usize)]
+    #[non_exhaustive]
     pub enum SpecialCharacterIndices {
         VDISCARD,
         #[cfg(any(target_os = "dragonfly",

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -58,6 +58,7 @@ libc_enum! {
     /// The type of the clock used to mark the progress of the timer. For more
     /// details on each kind of clock, please refer to [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html).
     #[repr(i32)]
+    #[non_exhaustive]
     pub enum ClockId {
         CLOCK_REALTIME,
         CLOCK_MONOTONIC,

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1806,6 +1806,7 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 /// - [unistd.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum PathconfVar {
     #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "linux",
               target_os = "netbsd", target_os = "openbsd", target_os = "redox"))]
@@ -1985,6 +1986,7 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 /// - [limits.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum SysconfVar {
     /// Maximum number of I/O operations in a single list I/O call supported by
     /// the implementation.


### PR DESCRIPTION
Since libc may add new variants at any time, Nix's consumers should not
use exhaustive match patterns.

Fixes #1182