### PR TITLE
Improve the efficiency of cmsg_space!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "9c1489fa8", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "9c1489fa8", features = [ "const-extern-fn", "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -412,20 +412,19 @@ impl Ipv6MembershipRequest {
 /// let _ = cmsg_space!(RawFd, TimeVal);
 /// # }
 /// ```
-// Unfortunately, CMSG_SPACE isn't a const_fn, or else we could return a
-// stack-allocated array.
 #[macro_export]
 macro_rules! cmsg_space {
     ( $( $x:ty ),* ) => {
         {
-            let mut space = 0;
+            const SPACE: usize = 0
             $(
+                +
                 // CMSG_SPACE is always safe
-                space += unsafe {
+                unsafe {
                     $crate::sys::socket::CMSG_SPACE(::std::mem::size_of::<$x>() as $crate::sys::socket::c_uint)
-                } as usize;
-            )*
-            Vec::<u8>::with_capacity(space)
+                } as usize
+            )* ;
+            Vec::<u8>::with_capacity(SPACE)
         }
     }
 }


### PR DESCRIPTION
Compute the required space at compile time rather than at runtime.