### PR TITLE
Constify many functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `FdSet::{contains, highest, fds}` no longer require a mutable reference.
   (#[1464](https://github.com/nix-rust/nix/pull/1464))
 
+- Many more functions, mostly contructors, are now `const`.
+  (#[1476](https://github.com/nix-rust/nix/pull/1476))
+
 ### Fixed
 
 - Added more errno definitions for better backwards compatibility with

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -63,7 +63,7 @@ impl Errno {
         since = "0.22.0",
         note = "It's a no-op now; just delete it."
     )]
-    pub fn as_errno(self) -> Option<Self> {
+    pub const fn as_errno(self) -> Option<Self> {
         Some(self)
     }
 
@@ -81,7 +81,7 @@ impl Errno {
         since = "0.22.0",
         note = "Use Errno::EINVAL instead"
     )]
-    pub fn invalid_argument() -> Error {
+    pub const fn invalid_argument() -> Error {
         Errno::EINVAL
     }
 
@@ -122,7 +122,7 @@ impl Errno {
     )]
     #[allow(non_snake_case)]
     #[inline]
-    pub fn Sys(errno: Errno) -> Error {
+    pub const fn Sys(errno: Errno) -> Error {
         errno
     }
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -97,7 +97,7 @@ mod os {
 #[cfg(any(target_os = "illumos"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets
-    pub fn socket_atomic_cloexec() -> bool {
+    pub const fn socket_atomic_cloexec() -> bool {
         true
     }
 }
@@ -109,7 +109,7 @@ mod os {
           target_os = "solaris"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets
-    pub fn socket_atomic_cloexec() -> bool {
+    pub const fn socket_atomic_cloexec() -> bool {
         false
     }
 }

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -111,7 +111,7 @@ impl NmountError {
     }
 
     /// Returns the inner [`Error`]
-    pub fn error(&self) -> Error {
+    pub const fn error(&self) -> Error {
         self.errno
     }
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -59,7 +59,7 @@ impl MqAttr {
         }
     }
 
-    pub fn flags(&self) -> mq_attr_member_t {
+    pub const fn flags(&self) -> mq_attr_member_t {
         self.mq_attr.mq_flags
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -25,7 +25,7 @@ pub struct PollFd {
 impl PollFd {
     /// Creates a new `PollFd` specifying the events of interest
     /// for a given file descriptor.
-    pub fn new(fd: RawFd, events: PollFlags) -> PollFd {
+    pub const fn new(fd: RawFd, events: PollFlags) -> PollFd {
         PollFd {
             pollfd: libc::pollfd {
                 fd,

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -97,7 +97,7 @@ mod sched_linux_like {
         }
 
         /// Return the maximum number of CPU in CpuSet
-        pub fn count() -> usize {
+        pub const fn count() -> usize {
             8 * mem::size_of::<libc::cpu_set_t>()
         }
     }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -356,7 +356,7 @@ impl Iterator for SignalIterator {
 }
 
 impl Signal {
-    pub fn iterator() -> SignalIterator {
+    pub const fn iterator() -> SignalIterator {
         SignalIterator{next: 0}
     }
 }

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -372,7 +372,7 @@ impl IpAddr {
     /// Create a new IpAddr that contains an IPv4 address.
     ///
     /// The result will represent the IP address a.b.c.d
-    pub fn new_v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+    pub const fn new_v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(a, b, c, d))
     }
 
@@ -381,7 +381,7 @@ impl IpAddr {
     /// The result will represent the IP address a:b:c:d:e:f
     #[allow(clippy::many_single_char_names)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new_v6(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> IpAddr {
+    pub const fn new_v6(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> IpAddr {
         IpAddr::V6(Ipv6Addr::new(a, b, c, d, e, f, g, h))
     }
 
@@ -420,11 +420,11 @@ pub struct Ipv4Addr(pub libc::in_addr);
 
 impl Ipv4Addr {
     #[allow(clippy::identity_op)]   // More readable this way
-    pub fn new(a: u8, b: u8, c: u8, d: u8) -> Ipv4Addr {
-        let ip = ((u32::from(a) << 24) |
-                  (u32::from(b) << 16) |
-                  (u32::from(c) <<  8) |
-                  (u32::from(d) <<  0)).to_be();
+    pub const fn new(a: u8, b: u8, c: u8, d: u8) -> Ipv4Addr {
+        let ip = (((a as u32) << 24) |
+                  ((b as u32) << 16) |
+                  ((c as u32) <<  8) |
+                  ((d as u32) <<  0)).to_be();
 
         Ipv4Addr(libc::in_addr { s_addr: ip })
     }
@@ -436,16 +436,16 @@ impl Ipv4Addr {
         Ipv4Addr::new(bits[0], bits[1], bits[2], bits[3])
     }
 
-    pub fn any() -> Ipv4Addr {
+    pub const fn any() -> Ipv4Addr {
         Ipv4Addr(libc::in_addr { s_addr: libc::INADDR_ANY })
     }
 
-    pub fn octets(self) -> [u8; 4] {
+    pub const fn octets(self) -> [u8; 4] {
         let bits = u32::from_be(self.0.s_addr);
         [(bits >> 24) as u8, (bits >> 16) as u8, (bits >> 8) as u8, bits as u8]
     }
 
-    pub fn to_std(self) -> net::Ipv4Addr {
+    pub const fn to_std(self) -> net::Ipv4Addr {
         let bits = self.octets();
         net::Ipv4Addr::new(bits[0], bits[1], bits[2], bits[3])
     }
@@ -486,7 +486,7 @@ macro_rules! to_u16_array {
 impl Ipv6Addr {
     #[allow(clippy::many_single_char_names)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {
+    pub const fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {
         Ipv6Addr(libc::in6_addr{s6_addr: to_u8_array!(a,b,c,d,e,f,g,h)})
     }
 
@@ -496,11 +496,11 @@ impl Ipv6Addr {
     }
 
     /// Return the eight 16-bit segments that make up this address
-    pub fn segments(&self) -> [u16; 8] {
+    pub const fn segments(&self) -> [u16; 8] {
         to_u16_array!(self, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
     }
 
-    pub fn to_std(&self) -> net::Ipv6Addr {
+    pub const fn to_std(&self) -> net::Ipv6Addr {
         let s = self.segments();
         net::Ipv6Addr::new(s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7])
     }
@@ -913,11 +913,11 @@ pub mod netlink {
             NetlinkAddr(addr)
         }
 
-        pub fn pid(&self) -> u32 {
+        pub const fn pid(&self) -> u32 {
             self.0.nl_pid
         }
 
-        pub fn groups(&self) -> u32 {
+        pub const fn groups(&self) -> u32 {
             self.0.nl_groups
         }
     }
@@ -1020,7 +1020,7 @@ pub mod sys_control {
     pub struct SysControlAddr(pub libc::sockaddr_ctl);
 
     impl SysControlAddr {
-        pub fn new(id: u32, unit: u32) -> SysControlAddr {
+        pub const fn new(id: u32, unit: u32) -> SysControlAddr {
             let addr = libc::sockaddr_ctl {
                 sc_len: mem::size_of::<libc::sockaddr_ctl>() as c_uchar,
                 sc_family: AddressFamily::System as c_uchar,
@@ -1047,11 +1047,11 @@ pub mod sys_control {
             Ok(SysControlAddr::new(info.ctl_id, unit))
         }
 
-        pub fn id(&self) -> u32 {
+        pub const fn id(&self) -> u32 {
             self.0.sc_id
         }
 
-        pub fn unit(&self) -> u32 {
+        pub const fn unit(&self) -> u32 {
             self.0.sc_unit
         }
     }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -384,7 +384,7 @@ pub struct Ipv6MembershipRequest(libc::ipv6_mreq);
 
 impl Ipv6MembershipRequest {
     /// Instantiate a new `Ipv6MembershipRequest`
-    pub fn new(group: Ipv6Addr) -> Self {
+    pub const fn new(group: Ipv6Addr) -> Self {
         Ipv6MembershipRequest(libc::ipv6_mreq {
             ipv6mr_multiaddr: group.0,
             ipv6mr_interface: 0,

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -52,19 +52,19 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
 }
 
 #[cfg(target_os = "linux")]
-pub fn major(dev: dev_t) -> u64 {
+pub const fn major(dev: dev_t) -> u64 {
     ((dev >> 32) & 0xffff_f000) |
     ((dev >>  8) & 0x0000_0fff)
 }
 
 #[cfg(target_os = "linux")]
-pub fn minor(dev: dev_t) -> u64 {
+pub const fn minor(dev: dev_t) -> u64 {
     ((dev >> 12) & 0xffff_ff00) |
     ((dev      ) & 0x0000_00ff)
 }
 
 #[cfg(target_os = "linux")]
-pub fn makedev(major: u64, minor: u64) -> dev_t {
+pub const fn makedev(major: u64, minor: u64) -> dev_t {
     ((major & 0xffff_f000) << 32) |
     ((major & 0x0000_0fff) <<  8) |
     ((minor & 0xffff_ff00) << 12) |

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -187,11 +187,11 @@ impl TimeSpec {
     }
 
     #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
-    pub fn tv_sec(&self) -> time_t {
+    pub const fn tv_sec(&self) -> time_t {
         self.0.tv_sec
     }
 
-    pub fn tv_nsec(&self) -> timespec_tv_nsec_t {
+    pub const fn tv_nsec(&self) -> timespec_tv_nsec_t {
         self.0.tv_nsec
     }
 
@@ -404,11 +404,11 @@ impl TimeVal {
     }
 
     #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
-    pub fn tv_sec(&self) -> time_t {
+    pub const fn tv_sec(&self) -> time_t {
         self.0.tv_sec
     }
 
-    pub fn tv_usec(&self) -> suseconds_t {
+    pub const fn tv_usec(&self) -> suseconds_t {
         self.0.tv_usec
     }
 }

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -87,7 +87,7 @@ bitflags! {
 struct TimerSpec(libc::itimerspec);
 
 impl TimerSpec {
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self(libc::itimerspec {
             it_interval: libc::timespec {
                 tv_sec: 0,

--- a/src/time.rs
+++ b/src/time.rs
@@ -20,7 +20,7 @@ pub struct ClockId(clockid_t);
 
 impl ClockId {
     /// Creates `ClockId` from raw `clockid_t`
-    pub fn from_raw(clk_id: clockid_t) -> Self {
+    pub const fn from_raw(clk_id: clockid_t) -> Self {
         ClockId(clk_id)
     }
 
@@ -61,7 +61,7 @@ impl ClockId {
     }
 
     /// Gets the raw `clockid_t` wrapped by `self`
-    pub fn as_raw(self) -> clockid_t {
+    pub const fn as_raw(self) -> clockid_t {
         self.0
     }
 


### PR DESCRIPTION
Constify most functions that can be constified.  The exceptions are
mostly accessors for structs that have no const constructor.