### PR TITLE
Include `sys::eventfd` for target_os = "android"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   64-bit Android, change conditional compilation to include the field in
   64-bit Android builds
   (#[1471](https://github.com/nix-rust/nix/pull/1471))
+- `eventfd`s are supported on Android, change conditional compilation to
+  include `sys::eventfd::eventfd` and `sys::eventfd::EfdFlags`for Android
+  builds.
+  (#[1481](https://github.com/nix-rust/nix/pull/1481))
 
 ### Fixed
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -17,7 +17,7 @@ pub mod epoll;
           target_os = "openbsd"))]
 pub mod event;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub mod eventfd;
 
 #[cfg(any(target_os = "android",


### PR DESCRIPTION
Androids bionic [supports](https://android.googlesource.com/platform/bionic/+/d1ad4f6/libc/include/sys/eventfd.h) `eventfd`. The `libc` crate also exposes [`eventfd`](https://github.com/rust-lang/libc/blob/36a6a8e254db89cd31d178b4ba102055ceabf9a8/src/unix/linux_like/android/mod.rs#L2648) for target `android`. 

Extend the conditional compilation check to include the target_os "android".

Fixes #1480