### PR TITLE
Remove some actually unsupported termios iflags on redox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Removed a couple of termios constants on redox that were never actually
+  supported.
+  (#[1483](https://github.com/nix-rust/nix/pull/1483))
+
 ## [0.22.0] - 9 July 2021
 ### Added
 - Added `if_nameindex` (#[1445](https://github.com/nix-rust/nix/pull/1445))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "9c1489fa8", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "f5e31f208", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -604,7 +604,9 @@ libc_bitflags! {
         ICRNL;
         IXON;
         IXOFF;
+        #[cfg(not(target_os = "redox"))]
         IXANY;
+        #[cfg(not(target_os = "redox"))]
         IMAXBEL;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         IUTF8;


### PR DESCRIPTION
Related to rust-lang/libc#2327
