### PR TITLE
Don't use mem::transmute in SignalFd

### DIFF
--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -34,7 +34,7 @@ libc_bitflags!{
 }
 
 pub const SIGNALFD_NEW: RawFd = -1;
-pub const SIGNALFD_SIGINFO_SIZE: usize = 128;
+pub const SIGNALFD_SIGINFO_SIZE: usize = mem::size_of::<libc::signalfd_siginfo>();
 
 /// Creates a new file descriptor for reading signals.
 ///
@@ -144,14 +144,6 @@ impl Iterator for SignalFd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem;
-    use libc;
-
-
-    #[test]
-    fn check_siginfo_size() {
-        assert_eq!(mem::size_of::<libc::signalfd_siginfo>(), SIGNALFD_SIGINFO_SIZE);
-    }
 
     #[test]
     fn create_signalfd() {

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -34,7 +34,8 @@ libc_bitflags!{
 }
 
 pub const SIGNALFD_NEW: RawFd = -1;
-pub const SIGNALFD_SIGINFO_SIZE: usize = mem::size_of::<libc::signalfd_siginfo>();
+#[deprecated(since = "0.23.0", note = "use mem::size_of::<siginfo>() instead")]
+pub const SIGNALFD_SIGINFO_SIZE: usize = mem::size_of::<siginfo>();
 
 /// Creates a new file descriptor for reading signals.
 ///
@@ -98,15 +99,14 @@ impl SignalFd {
     }
 
     pub fn read_signal(&mut self) -> Result<Option<siginfo>> {
-        let mut buffer = mem::MaybeUninit::<[u8; SIGNALFD_SIGINFO_SIZE]>::uninit();
+        let mut buffer = mem::MaybeUninit::<siginfo>::uninit();
 
+        let size = mem::size_of_val(&buffer);
         let res = Errno::result(unsafe {
-            libc::read(self.0,
-                       buffer.as_mut_ptr() as *mut libc::c_void,
-                       SIGNALFD_SIGINFO_SIZE as libc::size_t)
+            libc::read(self.0, buffer.as_mut_ptr() as *mut libc::c_void, size)
         }).map(|r| r as usize);
         match res {
-            Ok(SIGNALFD_SIGINFO_SIZE) => Ok(Some(unsafe { mem::transmute(buffer.assume_init()) })),
+            Ok(x) if x == size => Ok(Some(unsafe { buffer.assume_init() })),
             Ok(_) => unreachable!("partial read on signalfd"),
             Err(Errno::EAGAIN) => Ok(None),
             Err(error) => Err(error)


### PR DESCRIPTION
    There was a better case for using it before mem::uninitialized was
    available, but not great.  Even before then, mem::zeroed could've been
    used instead.
    
    Issue #373
