### PR TITLE
Fix the build with bitflags-1.3.0 and newer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     image: freebsd-11-4-release-amd64
   setup_script:
     - fetch https://sh.rustup.rs -o rustup.sh
-    - sh rustup.sh -y --profile=minimal --default-toolchain 1.41.0
+    - sh rustup.sh -y --profile=minimal --default-toolchain 1.46.0
     - $HOME/.cargo/bin/rustup target add i686-unknown-freebsd
   amd64_test_script:
     - . $HOME/.cargo/env
@@ -46,7 +46,7 @@ task:
     image: catalina-xcode
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
-    - sh rustup.sh -y --profile=minimal --default-toolchain 1.41.0
+    - sh rustup.sh -y --profile=minimal --default-toolchain 1.46.0
     - . $HOME/.cargo/env
     - bash ci/install.sh
   script:
@@ -101,7 +101,7 @@ task:
   setup_script:
     - mkdir /tmp/home
     - curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
-    - sh rustup.sh -y --profile=minimal --default-toolchain 1.41.0
+    - sh rustup.sh -y --profile=minimal --default-toolchain 1.46.0
     - . $HOME/.cargo/env
     - bash ci/install.sh
   script:
@@ -119,13 +119,13 @@ task:
     - name: Linux x86_64
       env:
         TARGET: x86_64-unknown-linux-gnu
-        TOOLCHAIN: 1.41.0
+        TOOLCHAIN: 1.46.0
     - name: Linux x86_64 musl
       env:
         TARGET: x86_64-unknown-linux-musl
-        TOOLCHAIN: 1.41.0
+        TOOLCHAIN: 1.46.0
   container:
-    image: rust:1.41
+    image: rust:1.46
   setup_script:
     - rustup toolchain install $TOOLCHAIN
     - rustup target add --toolchain $TOOLCHAIN $TARGET
@@ -173,7 +173,7 @@ task:
       env:
         TARGET: x86_64-fuchsia
   container:
-    image: rust:1.41
+    image: rust:1.46
   setup_script:
     - rustup target add $TARGET
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,16 +31,13 @@ task:
     - name: OSX x86_64
       env:
         TARGET: x86_64-apple-darwin
-    - name: OSX i686
+    - name: iOS aarch64
       env:
-        TARGET: i686-apple-darwin
+        TARGET: aarch64-apple-ios
         DISABLE_TESTS: 1
-    - name: iOS
+    - name: iOS x86_64
       env:
-        # To save VM startup time, test all iOS targets in a single task.
-        # The startup and scheduling time was very significant for Travis, but
-        # not known for Cirrus.
-        TARGET: "aarch64-apple-ios;armv7-apple-ios;armv7s-apple-ios;i386-apple-ios;x86_64-apple-ios"
+        TARGET: x86_64-apple-ios
         DISABLE_TESTS: 1
   osx_instance:
     image: catalina-xcode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Many more functions, mostly contructors, are now `const`.
   (#[1476](https://github.com/nix-rust/nix/pull/1476))
+  (#[1492](https://github.com/nix-rust/nix/pull/1492))
 
 - `sys::event::KEvent::filter` now returns a `Result` instead of being
   infalliable.  The only cases where it will now return an error are cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   for all platforms.
   (#[1484](https://github.com/nix-rust/nix/pull/1484))
 
+- Removed support for 32-bit Apple targets, since they've been dropped by both
+  Rustc and Xcode.
+  (#[1492](https://github.com/nix-rust/nix/pull/1492))
+
 ## [0.22.0] - 9 July 2021
 ### Added
 - Added `if_nameindex` (#[1445](https://github.com/nix-rust/nix/pull/1445))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   where it previously would've had undefined behavior.
   (#[1484](https://github.com/nix-rust/nix/pull/1484))
 
+- Minimum supported Rust version is now 1.46.0.
+  ([#1492](https://github.com/nix-rust/nix/pull/1492))
+
 ### Fixed
 
 - Added more errno definitions for better backwards compatibility with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ targets = [
 
 [dependencies]
 libc = { git = "https://github.com/rust-lang/libc", rev = "f5e31f208", features = [ "extra_traits" ] }
-bitflags = "1.1"
+bitflags = "1.3.1"
 cfg-if = "1.0"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -68,11 +68,7 @@ Tier 2:
   * aarch64-linux-android
   * arm-linux-androideabi
   * arm-unknown-linux-musleabi
-  * armv7-apple-ios
   * armv7-linux-androideabi
-  * armv7s-apple-ios
-  * i386-apple-ios
-  * i686-apple-darwin
   * i686-linux-android
   * powerpc-unknown-linux-gnu
   * s390x-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Tier 3:
 
 ## Usage
 
-`nix` requires Rust 1.41.0 or newer.
+`nix` requires Rust 1.46.0 or newer.
 
 To use `nix`, add this to your `Cargo.toml`:
 

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -93,7 +93,7 @@ impl Errno {
         desc(self)
     }
 
-    pub fn from_i32(err: i32) -> Errno {
+    pub const fn from_i32(err: i32) -> Errno {
         from_i32(err)
     }
 
@@ -928,7 +928,7 @@ mod consts {
         pub const ENOTSUP:     Errno = Errno::EOPNOTSUPP;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -1207,7 +1207,7 @@ mod consts {
         pub const EDEADLOCK:   Errno = Errno::EDEADLK;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -1455,7 +1455,7 @@ mod consts {
         pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -1692,7 +1692,7 @@ mod consts {
         pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -1916,7 +1916,7 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -2141,7 +2141,7 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -2350,7 +2350,7 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {
@@ -2590,7 +2590,7 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    pub fn from_i32(e: i32) -> Errno {
+    pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
         match e {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -113,9 +113,9 @@ macro_rules! libc_enum {
         $v enum $BitFlags {
             $($entries)*
         }
-        #[allow(unused_doc_comment)]
         impl ::std::convert::TryFrom<$repr> for $BitFlags {
             type Error = $crate::Error;
+            #[allow(unused_doc_comments)]
             fn try_from(x: $repr) -> $crate::Result<Self> {
                 match x {
                     $($try_froms)*

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -133,7 +133,7 @@ impl Signal {
     /// This function is equivalent to `<Signal as AsRef<str>>::as_ref()`,
     /// with difference that returned string is `'static`
     /// and not bound to `self`'s lifetime.
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Signal::SIGHUP => "SIGHUP",
             Signal::SIGINT => "SIGINT",

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -237,7 +237,7 @@ impl AddressFamily {
     ///
     /// Currently only supports these address families: Unix, Inet (v4 & v6), Netlink, Link/Packet
     /// and System. Returns None for unsupported or unknown address families.
-    pub fn from_i32(family: i32) -> Option<AddressFamily> {
+    pub const fn from_i32(family: i32) -> Option<AddressFamily> {
         match family {
             libc::AF_UNIX => Some(AddressFamily::Unix),
             libc::AF_INET => Some(AddressFamily::Inet),
@@ -314,7 +314,7 @@ impl InetAddr {
         }
     }
     /// Gets the IP address associated with this socket address.
-    pub fn ip(&self) -> IpAddr {
+    pub const fn ip(&self) -> IpAddr {
         match *self {
             InetAddr::V4(ref sa) => IpAddr::V4(Ipv4Addr(sa.sin_addr)),
             InetAddr::V6(ref sa) => IpAddr::V6(Ipv6Addr(sa.sin6_addr)),
@@ -322,7 +322,7 @@ impl InetAddr {
     }
 
     /// Gets the port number associated with this socket address
-    pub fn port(&self) -> u16 {
+    pub const fn port(&self) -> u16 {
         match *self {
             InetAddr::V6(ref sa) => u16::from_be(sa.sin6_port),
             InetAddr::V4(ref sa) => u16::from_be(sa.sin_port),
@@ -393,7 +393,7 @@ impl IpAddr {
         }
     }
 
-    pub fn to_std(&self) -> net::IpAddr {
+    pub const fn to_std(&self) -> net::IpAddr {
         match *self {
             IpAddr::V4(ref ip) => net::IpAddr::V4(ip.to_std()),
             IpAddr::V6(ref ip) => net::IpAddr::V6(ip.to_std()),


### PR DESCRIPTION
Bitflags raised its MSRV in a minor version, forcing all consumers to follow suit.
    
Fixes #1491