### PR TITLE
Rework UnixAddr to fix soundness issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Minimum supported Rust version is now 1.46.0.
   ([#1492](https://github.com/nix-rust/nix/pull/1492))
 
+- Rework `UnixAddr` to encapsulate internals better in order to fix soundness
+  issues. No longer allows creating a `UnixAddr` from a raw `sockaddr_un`.
+  ([#1496](https://github.com/nix-rust/nix/pull/1496))
+
 ### Fixed
 
 - Added more errno definitions for better backwards compatibility with

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1802,10 +1802,10 @@ pub fn sockaddr_storage_to_addr(
         }
         libc::AF_UNIX => {
             let pathlen = len - offset_of!(sockaddr_un, sun_path);
-            let sun = unsafe {
-                *(addr as *const _ as *const sockaddr_un)
-            };
-            Ok(SockAddr::Unix(UnixAddr(sun, pathlen)))
+            unsafe {
+                let sun = *(addr as *const _ as *const sockaddr_un);
+                Ok(SockAddr::Unix(UnixAddr::from_raw_parts(sun, pathlen)))
+            }
         }
         #[cfg(any(target_os = "android", target_os = "linux"))]
         libc::AF_PACKET => {


### PR DESCRIPTION
Fixes #1494

I went with making `sun_path` always nul-terminated since that just seems to make things easier, since (at least according to linux man pages) `sockaddr_un`s returned by the kernel will always be nul-terminated.
