### PR TITLE
Conditionally enable functionality with feature flags

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,8 @@ build: &BUILD
     - $TOOL +$TOOLCHAIN $BUILD $ZFLAGS --target $TARGET --all-targets
     - $TOOL +$TOOLCHAIN doc $ZFLAGS --no-deps --target $TARGET
     - $TOOL +$TOOLCHAIN clippy $ZFLAGS --target $TARGET -- $CLIPPYFLAGS
+    - if [ -z "$NOHACK" ]; then $TOOL install cargo-hack; fi
+    - if [ -z "$NOHACK" ]; then $TOOL hack $ZFLAGS check --target $TARGET --each-feature; fi
 
 # Tests that do require executing the binaries
 test: &TEST
@@ -50,14 +52,16 @@ task:
     - cargo build --target i686-unknown-freebsd
     - cargo doc --no-deps --target i686-unknown-freebsd
     - cargo test --target i686-unknown-freebsd
+  i386_feature_script:
+    - . $HOME/.cargo/env
+    - cargo hack check --each-feature --target i686-unknown-freebsd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test OSX in a full VM
 task:
-  matrix:
-    - name: OSX x86_64
-      env:
-        TARGET: x86_64-apple-darwin
+  name: OSX x86_64
+  env:
+    TARGET: x86_64-apple-darwin
   osx_instance:
     image: catalina-xcode
   setup_script:
@@ -192,6 +196,8 @@ task:
     # https://github.com/rust-embedded/cross/issues/535
     - name: iOS aarch64
       env:
+        # cargo hack tries to invoke the iphonesimulator SDK for iOS
+        NOHACK: 1
         TARGET: aarch64-apple-ios
         # Rustup only supports cross-building from arbitrary hosts for iOS at
         # 1.49.0 and above.  Below that it's possible to cross-build from an OSX
@@ -199,6 +205,8 @@ task:
         TOOLCHAIN: 1.49.0
     - name: iOS x86_64
       env:
+        # cargo hack tries to invoke the iphonesimulator SDK for iOS
+        NOHACK: 1
         TARGET: x86_64-apple-ios
         TOOLCHAIN: 1.49.0
     # Cross testing on powerpc fails with "undefined reference to renameat2".
@@ -222,6 +230,8 @@ task:
         TARGET: x86_64-unknown-netbsd
     - name: Redox x86_64
       env:
+        # cargo-hack needs a newer compiler
+        NOHACK: 1
         TARGET: x86_64-unknown-redox
         # Redox requires a nightly compiler.
         # If stuff breaks, change nightly to the date in the toolchain_*
@@ -269,6 +279,6 @@ task:
     image: rustlang/rust:nightly
   setup_script:
     - cargo update -Zminimal-versions
-  script:
+  check_script:
     - cargo check
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.23.0] - 2021-09-28
 ### Added
 
+- Added fine-grained features flags.  Most Nix functionality can now be
+  conditionally enabled.  By default, all features are enabled.
+  (#[TODO](https://github.com/nix-rust/nix/pull/TODO))
 - Added the `LocalPeerCred` sockopt.
   (#[1482](https://github.com/nix-rust/nix/pull/1482))
 - Added `TimeSpec::from_duration` and `TimeSpec::from_timespec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.23.0] - 2021-09-28
+## [Unreleased] - ReleaseDate
 ### Added
 
 - Added fine-grained features flags.  Most Nix functionality can now be
   conditionally enabled.  By default, all features are enabled.
-  (#[TODO](https://github.com/nix-rust/nix/pull/TODO))
+  (#[1498](https://github.com/nix-rust/nix/pull/1498))
+
+### Changed
+### Fixed
+### Removed
+
+## [0.23.0] - 2021-09-28
+### Added
+
 - Added the `LocalPeerCred` sockopt.
   (#[1482](https://github.com/nix-rust/nix/pull/1482))
 - Added `TimeSpec::from_duration` and `TimeSpec::from_timespec`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,10 @@ memoffset = "0.6.3"
 [features]
 default = [
   "acct", "aio", "dir", "env", "event", "features", "fs",
-  "hostname",
-  "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
-  "net", "personality", "process", "poll", "pthread", "ptrace", "quota",
-  "reboot",
-  "resource", "sched", "signal",
-  "socket",
-  "term", "time", "ucontext", "uio",
-  "users", "zerocopy",
+  "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
+  "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
+  "reboot", "resource", "sched", "signal", "socket", "term", "time",
+  "ucontext", "uio", "users", "zerocopy",
 ]
 
 acct = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories  = ["os::unix-apis"]
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
   "x86_64-unknown-linux-gnu",
   "aarch64-linux-android",
@@ -31,6 +32,52 @@ cfg-if = "1.0"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 memoffset = "0.6.3"
+
+[features]
+default = [
+  "acct", "aio", "dir", "env", "event", "features", "fs",
+  "hostname",
+  "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
+  "net", "personality", "process", "poll", "pthread", "ptrace", "quota",
+  "reboot",
+  "resource", "sched", "signal",
+  "socket",
+  "term", "time", "ucontext", "uio",
+  "users", "zerocopy",
+]
+
+acct = []
+aio = []
+dir = ["fs"]
+env = []
+event = []
+features = []
+fs = []
+hostname = []
+inotify = []
+ioctl = []
+kmod = []
+mman = []
+mount = ["uio"]
+mqueue = ["fs"]
+net = ["socket"]
+personality = []
+poll = []
+pthread = []
+ptrace = ["process"]
+quota = []
+process = []
+reboot = []
+resource = []
+sched = ["process"]
+signal = ["process"]
+socket = []
+term = []
+time = []
+ucontext = ["signal"]
+uio = []
+users = ["features"]
+zerocopy = ["fs", "uio"]
 
 [target.'cfg(target_os = "dragonfly")'.build-dependencies]
 cc = "1"

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -53,11 +53,13 @@ libc_bitflags!(
         O_ACCMODE;
         /// Use alternate I/O semantics.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_ALT_IO;
         /// Open the file in append-only mode.
         O_APPEND;
         /// Generate a signal when input or output becomes possible.
         #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_ASYNC;
         /// Closes the file descriptor once an `execve` call is made.
         ///
@@ -71,9 +73,11 @@ libc_bitflags!(
                   target_os = "freebsd",
                   target_os = "linux",
                   target_os = "netbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DIRECT;
         /// If the specified path isn't a directory, fail.
         #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DIRECTORY;
         /// Implicitly follow each `write()` with an `fdatasync()`.
         #[cfg(any(target_os = "android",
@@ -82,11 +86,13 @@ libc_bitflags!(
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DSYNC;
         /// Error out if a file was not created.
         O_EXCL;
         /// Open for execute only.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_EXEC;
         /// Open with an exclusive file lock.
         #[cfg(any(target_os = "dragonfly",
@@ -96,6 +102,7 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_EXLOCK;
         /// Same as `O_SYNC`.
         #[cfg(any(target_os = "dragonfly",
@@ -106,18 +113,23 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_FSYNC;
         /// Allow files whose sizes can't be represented in an `off_t` to be opened.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_LARGEFILE;
         /// Do not update the file last access time during `read(2)`s.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOATIME;
         /// Don't attach the device as the process' controlling terminal.
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOCTTY;
         /// Same as `O_NONBLOCK`.
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NDELAY;
         /// `open()` will fail if the given path is a symbolic link.
         O_NOFOLLOW;
@@ -125,11 +137,13 @@ libc_bitflags!(
         O_NONBLOCK;
         /// Don't deliver `SIGPIPE`.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOSIGPIPE;
         /// Obtain a file descriptor for low-level access.
         ///
         /// The file itself is not opened and other file operations will fail.
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_PATH;
         /// Only allow reading.
         ///
@@ -141,9 +155,11 @@ libc_bitflags!(
         O_RDWR;
         /// Similar to `O_DSYNC` but applies to `read`s instead.
         #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_RSYNC;
         /// Skip search permission checks.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SEARCH;
         /// Open with a shared file lock.
         #[cfg(any(target_os = "dragonfly",
@@ -153,17 +169,21 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SHLOCK;
         /// Implicitly follow each `write()` with an `fsync()`.
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SYNC;
         /// Create an unnamed temporary file.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_TMPFILE;
         /// Truncate an existing regular file to 0 length if it allows writing.
         O_TRUNC;
         /// Restore default TTY attributes.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_TTY_INIT;
         /// Only allow writing.
         ///

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -172,7 +172,7 @@ libc_bitflags!(
     }
 );
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 // The conversion is not identical on all operating systems.
@@ -235,7 +235,7 @@ libc_bitflags! {
     }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 #[cfg(all(
     target_os = "linux",
@@ -392,7 +392,7 @@ libc_bitflags!(
     }
 );
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 #[cfg(not(target_os = "redox"))]
@@ -532,7 +532,7 @@ libc_bitflags! {
     }
 }
 
-feature!{
+feature! {
 #![feature = "zerocopy"]
 
 /// Copy a range of data from one file to another
@@ -658,7 +658,7 @@ libc_bitflags!(
     }
 );
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 /// Manipulates file space.
@@ -707,7 +707,7 @@ mod posix_fadvise {
         }
     }
 
-    feature!{
+    feature! {
     #![feature = "fs"]
     pub fn posix_fadvise(
         fd: RawFd,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -366,8 +366,10 @@ pub(crate) fn at_rawfd(fd: Option<RawFd>) -> raw::c_int {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "fs")]
 libc_bitflags!(
     /// Additional flags for file sealing, which allows for limiting operations on a file.
+    #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
     pub struct SealFlag: c_int {
         /// Prevents further calls to `fcntl()` with `F_ADD_SEALS`.
         F_SEAL_SEAL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,18 +61,18 @@ pub use libc;
 
 // Public crates
 #[cfg(not(target_os = "redox"))]
-feature!{
+feature! {
     #![feature = "dir"]
     #[allow(missing_docs)]
     pub mod dir;
 }
-feature!{
+feature! {
     #![feature = "env"]
     pub mod env;
 }
 #[allow(missing_docs)]
 pub mod errno;
-feature!{
+feature! {
     #![feature = "features"]
 
     #[deny(missing_docs)]
@@ -80,7 +80,7 @@ feature!{
 }
 #[allow(missing_docs)]
 pub mod fcntl;
-feature!{
+feature! {
     #![feature = "net"]
 
     #[cfg(any(target_os = "android",
@@ -100,7 +100,7 @@ feature!{
 }
 #[cfg(any(target_os = "android",
           target_os = "linux"))]
-feature!{
+feature! {
     #![feature = "kmod"]
     #[allow(missing_docs)]
     pub mod kmod;
@@ -108,7 +108,7 @@ feature!{
 #[cfg(any(target_os = "android",
           target_os = "freebsd",
           target_os = "linux"))]
-feature!{
+feature! {
     #![feature = "mount"]
     pub mod mount;
 }
@@ -117,27 +117,27 @@ feature!{
           target_os = "fushsia",
           target_os = "linux",
           target_os = "netbsd"))]
-feature!{
+feature! {
     #![feature = "mqueue"]
     #[allow(missing_docs)]
     pub mod mqueue;
 }
-feature!{
+feature! {
     #![feature = "poll"]
     pub mod poll;
 }
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
-feature!{
+feature! {
     #![feature = "term"]
     #[deny(missing_docs)]
     pub mod pty;
 }
-feature!{
+feature! {
     #![feature = "sched"]
     pub mod sched;
 }
 pub mod sys;
-feature!{
+feature! {
     #![feature = "time"]
     #[allow(missing_docs)]
     pub mod time;
@@ -146,7 +146,7 @@ feature!{
 // provides bindings for them.
 #[cfg(all(target_os = "linux",
           any(target_arch = "x86", target_arch = "x86_64")))]
-feature!{
+feature! {
     #![feature = "ucontext"]
     #[allow(missing_docs)]
     pub mod ucontext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,56 @@
 //!
 //! Modules are structured according to the C header file that they would be
 //! defined in.
+//!
+//! # Features
+//!
+//! Nix uses the following Cargo features to enable optional functionality.
+//! They may be enabled in any combination.
+//! * `acct` - Process accounting
+//! * `aio` - POSIX AIO
+//! * `dir` - Stuff relating to directory iteration
+//! * `env` - Manipulate environment variables
+//! * `event` - Event-driven APIs, like `kqueue` and `epoll`
+//! * `features` - Query characteristics of the OS at runtime
+//! * `fs` - File system functionality
+//! * `hostname` - Get and set the system's hostname
+//! * `inotify` - Linux's `inotify` file system notification API
+//! * `ioctl` - The `ioctl` syscall, and wrappers for my specific instances
+//! * `kmod` - Load and unload kernel modules
+//! * `mman` - Stuff relating to memory management
+//! * `mount` - Mount and unmount file systems
+//! * `mqueue` - POSIX message queues
+//! * `net` - Networking-related functionality
+//! * `personality` - Set the process execution domain
+//! * `process` - Stuff relating to running processes
+//! * `poll` - APIs like `poll` and `select`
+//! * `pthread` - POSIX threads
+//! * `ptrace` - Process tracing and debugging
+//! * `quota` - File system quotas
+//! * `reboot` - Reboot the system
+//! * `resource` - Process resource limits
+//! * `sched` - Manipulate process's scheduling
+//! * `signal` - Send and receive signals to processes
+//! * `term` - Terminal control APIs
+//! * `time` - Query the operating system's clocks
+//! * `ucontext` - User thread context
+//! * `uio` - Vectored I/O
+//! * `users` - Stuff relating to users and groups
+//! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![allow(non_camel_case_types)]
 #![cfg_attr(test, deny(warnings))]
 #![recursion_limit = "500"]
 #![deny(unused)]
+#![allow(unused_macros)]
+#![cfg_attr(not(feature = "default"), allow(unused_imports))]
 #![deny(unstable_features)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs)]
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Re-exported external crates
 pub use libc;
@@ -21,54 +61,96 @@ pub use libc;
 
 // Public crates
 #[cfg(not(target_os = "redox"))]
-#[allow(missing_docs)]
-pub mod dir;
-pub mod env;
+feature!{
+    #![feature = "dir"]
+    #[allow(missing_docs)]
+    pub mod dir;
+}
+feature!{
+    #![feature = "env"]
+    pub mod env;
+}
 #[allow(missing_docs)]
 pub mod errno;
-pub mod features;
+feature!{
+    #![feature = "features"]
+
+    #[deny(missing_docs)]
+    pub mod features;
+}
 #[allow(missing_docs)]
 pub mod fcntl;
-#[cfg(any(target_os = "android",
-          target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "ios",
-          target_os = "linux",
-          target_os = "macos",
-          target_os = "netbsd",
-          target_os = "illumos",
-          target_os = "openbsd"))]
-pub mod ifaddrs;
+feature!{
+    #![feature = "net"]
+
+    #[cfg(any(target_os = "android",
+              target_os = "dragonfly",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "linux",
+              target_os = "macos",
+              target_os = "netbsd",
+              target_os = "illumos",
+              target_os = "openbsd"))]
+    #[deny(missing_docs)]
+    pub mod ifaddrs;
+    #[cfg(not(target_os = "redox"))]
+    #[deny(missing_docs)]
+    pub mod net;
+}
 #[cfg(any(target_os = "android",
           target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod kmod;
+feature!{
+    #![feature = "kmod"]
+    #[allow(missing_docs)]
+    pub mod kmod;
+}
 #[cfg(any(target_os = "android",
           target_os = "freebsd",
           target_os = "linux"))]
-pub mod mount;
+feature!{
+    #![feature = "mount"]
+    pub mod mount;
+}
 #[cfg(any(target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "fushsia",
           target_os = "linux",
           target_os = "netbsd"))]
-#[allow(missing_docs)]
-pub mod mqueue;
-#[cfg(not(target_os = "redox"))]
-pub mod net;
-pub mod poll;
+feature!{
+    #![feature = "mqueue"]
+    #[allow(missing_docs)]
+    pub mod mqueue;
+}
+feature!{
+    #![feature = "poll"]
+    pub mod poll;
+}
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
-pub mod pty;
-pub mod sched;
+feature!{
+    #![feature = "term"]
+    #[deny(missing_docs)]
+    pub mod pty;
+}
+feature!{
+    #![feature = "sched"]
+    pub mod sched;
+}
 pub mod sys;
-#[allow(missing_docs)]
-pub mod time;
+feature!{
+    #![feature = "time"]
+    #[allow(missing_docs)]
+    pub mod time;
+}
 // This can be implemented for other platforms as soon as libc
 // provides bindings for them.
 #[cfg(all(target_os = "linux",
           any(target_arch = "x86", target_arch = "x86_64")))]
-#[allow(missing_docs)]
-pub mod ucontext;
+feature!{
+    #![feature = "ucontext"]
+    #[allow(missing_docs)]
+    pub mod ucontext;
+}
 #[allow(missing_docs)]
 pub mod unistd;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 //! * `mqueue` - POSIX message queues
 //! * `net` - Networking-related functionality
 //! * `personality` - Set the process execution domain
-//! * `process` - Stuff relating to running processes
 //! * `poll` - APIs like `poll` and `select`
+//! * `process` - Stuff relating to running processes
 //! * `pthread` - POSIX threads
 //! * `ptrace` - Process tracing and debugging
 //! * `quota` - File system quotas

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@
 //! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
 #![cfg(unix)]
+#![cfg_attr(docsrs, doc(cfg(all())))]
 #![allow(non_camel_case_types)]
 #![cfg_attr(test, deny(warnings))]
 #![recursion_limit = "500"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,17 @@
+// Thanks to Tokio for this macro
+macro_rules! feature {
+    (
+        #![$meta:meta]
+        $($item:item)*
+    ) => {
+        $(
+            #[cfg($meta)]
+            #[cfg_attr(docsrs, doc(cfg($meta)))]
+            $item
+        )*
+    }
+}
+
 /// The `libc_bitflags!` macro helps with a common use case of defining a public bitflags type
 /// with values from the libc crate. It is used the same way as the `bitflags!` macro, except
 /// that only the name of the flag value has to be given.

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -20,29 +20,36 @@ libc_bitflags!(
     pub struct MntFlags: c_int {
         /// ACL support enabled.
         #[cfg(any(target_os = "netbsd", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_ACLS;
         /// All I/O to the file system should be done asynchronously.
         MNT_ASYNC;
         /// dir should instead be a file system ID encoded as “FSID:val0:val1”.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_BYFSID;
         /// Force a read-write mount even if the file system appears to be
         /// unclean.
         MNT_FORCE;
         /// GEOM journal support enabled.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_GJOURNAL;
         /// MAC support for objects.
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_MULTILABEL;
         /// Disable read clustering.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOCLUSTERR;
         /// Disable write clustering.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOCLUSTERW;
         /// Enable NFS version 4 ACLs.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NFS4ACLS;
         /// Do not update access times.
         MNT_NOATIME;
@@ -52,6 +59,7 @@ libc_bitflags!(
         MNT_NOSUID;
         /// Do not follow symlinks.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOSYMFOLLOW;
         /// Mount read-only.
         MNT_RDONLY;
@@ -62,6 +70,7 @@ libc_bitflags!(
         ///
         /// See [mksnap_ffs(8)](https://www.freebsd.org/cgi/man.cgi?query=mksnap_ffs)
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SNAPSHOT;
         /// Using soft updates.
         #[cfg(any(
@@ -70,10 +79,12 @@ libc_bitflags!(
                 target_os = "netbsd",
                 target_os = "openbsd"
         ))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SOFTDEP;
         /// Directories with the SUID bit set chown new files to their own
         /// owner.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SUIDDIR;
         /// All I/O to the file system should be done synchronously.
         MNT_SYNCHRONOUS;
@@ -83,12 +94,14 @@ libc_bitflags!(
                 target_os = "freebsd",
                 target_os = "netbsd"
         ))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_UNION;
         /// Indicates that the mount command is being applied to an already
         /// mounted file system.
         MNT_UPDATE;
         /// Check vnode use counts.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NONBUSY;
     }
 );
@@ -182,6 +195,7 @@ pub type NmountResult = std::result::Result<(), NmountError>;
 /// * [`nmount(2)`](https://www.freebsd.org/cgi/man.cgi?query=nmount)
 /// * [`nullfs(5)`](https://www.freebsd.org/cgi/man.cgi?query=nullfs)
 #[cfg(target_os = "freebsd")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[derive(Debug, Default)]
 pub struct Nmount<'a>{
     iov: Vec<IoVec<&'a [u8]>>,
@@ -189,6 +203,7 @@ pub struct Nmount<'a>{
 }
 
 #[cfg(target_os = "freebsd")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 impl<'a> Nmount<'a> {
     /// Add an opaque mount option.
     ///

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -397,7 +397,7 @@ impl<'a> Drop for Nmount<'a> {
                 // Free the owned string.  Safe because we recorded ownership,
                 // and Nmount does not implement Clone.
                 unsafe {
-                    CString::from_raw(iov.0.iov_base as *mut c_char);
+                    let _ = CString::from_raw(iov.0.iov_base as *mut c_char);
                 }
             }
         }

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,5 +1,6 @@
 //! Mount file systems
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod linux;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -10,6 +11,7 @@ pub use self::linux::*;
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod bsd;
 
 #[cfg(any(target_os = "dragonfly",

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -37,8 +37,10 @@ pub struct MqAttr {
 // x32 compatibility
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=21279
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type mq_attr_member_t = i64;
 #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type mq_attr_member_t = libc::c_long;
 
 impl MqAttr {

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -45,9 +45,11 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "illumos",
                   target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOTRAILERS;
         /// Interface manages own routes.
         #[cfg(any(target_os = "dragonfly"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SMART;
         /// Resources allocated. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -62,6 +64,7 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_RUNNING;
         /// No arp protocol, L2 destination address not set. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -75,6 +78,7 @@ libc_bitflags!(
         /// Master of a load balancing bundle. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MASTER;
         /// transmission in progress, tx hardware queue is full
         #[cfg(any(target_os = "freebsd",
@@ -82,13 +86,16 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "ios"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_OACTIVE;
         /// Protocol code on board.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_INTELLIGENT;
         /// Slave of a load balancing bundle. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SLAVE;
         /// Can't hear own transmissions.
         #[cfg(any(target_os = "dragonfly",
@@ -97,6 +104,7 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "osx"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SIMPLEX;
         /// Supports multicast. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -108,13 +116,16 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "ios"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK0;
         /// Multicast using broadcast.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MULTI_BCAST;
         /// Is able to select media type via ifmap. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PORTSEL;
         /// Per link layer defined bit.
         #[cfg(any(target_os = "dragonfly",
@@ -123,13 +134,16 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "ios"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK1;
         /// Non-unique address.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_UNNUMBERED;
         /// Auto media selection active. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_AUTOMEDIA;
         /// Per link layer defined bit.
         #[cfg(any(target_os = "dragonfly",
@@ -138,132 +152,174 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "ios"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK2;
         /// Use alternate physical connection.
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "macos",
                   target_os = "ios"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ALTPHYS;
         /// DHCP controls interface.
         #[cfg(any(target_os = "solaris", target_os = "illumos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DHCPRUNNING;
         /// The addresses are lost when the interface goes down. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DYNAMIC;
         /// Do not advertise.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PRIVATE;
         /// Driver signals L1 up. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LOWER_UP;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_POLLING_COMPAT;
         /// Unconfigurable using ioctl(2).
         #[cfg(any(target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_CANTCONFIG;
         /// Do not transmit packets.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOXMIT;
         /// Driver signals dormant. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DORMANT;
         /// User-requested promisc mode.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PPROMISC;
         /// Just on-link subnet.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOLOCAL;
         /// Echo sent packets. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ECHO;
         /// User-requested monitor mode.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MONITOR;
         /// Address is deprecated.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DEPRECATED;
         /// Static ARP.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_STATICARP;
         /// Address from stateless addrconf.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ADDRCONF;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NPOLLING;
         /// Router on interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ROUTER;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IDIRECT;
         /// Interface is winding down
         #[cfg(any(target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DYING;
         /// No NUD on interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NONUD;
         /// Interface is being renamed
         #[cfg(any(target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_RENAMING;
         /// Anycast address.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ANYCAST;
         /// Don't exchange routing info.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NORTEXCH;
         /// Do not provide packet information
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NO_PI as libc::c_int;
         /// TUN device (no Ethernet headers)
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TUN as libc::c_int;
         /// TAP device
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TAP as libc::c_int;
         /// IPv4 interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPV4;
         /// IPv6 interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPV6;
         /// in.mpathd test address
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOFAILOVER;
         /// Interface has failed
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_FAILED;
         /// Interface is a hot-spare
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_STANDBY;
         /// Functioning but not used
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_INACTIVE;
         /// Interface is offline
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_OFFLINE;
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_COS_ENABLED;
         /// Prefer as source addr.
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PREFERRED;
         /// RFC3041
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TEMPORARY;
         /// MTU set with SIOCSLIFMTU
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_FIXEDMTU;
         /// Cannot send / receive packets
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_VIRTUAL;
         /// Local address in use
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DUPLICATE;
         /// IPMP IP interface
         #[cfg(target_os = "solaris")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPMP;
     }
 );
@@ -278,6 +334,7 @@ libc_bitflags!(
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod if_nameindex {
     use super::*;
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,8 +1,4 @@
 //! Wait for events to trigger on specific file descriptors
-#[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
-use crate::sys::time::TimeSpec;
-#[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
-use crate::sys::signal::SigSet;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 use crate::Result;
@@ -142,6 +138,8 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
     Errno::result(res)
 }
 
+feature!{
+#![feature = "signal"]
 /// `ppoll()` allows an application to safely wait until either a file
 /// descriptor becomes ready or until a signal is caught.
 /// ([`poll(2)`](https://man7.org/linux/man-pages/man2/poll.2.html))
@@ -151,7 +149,12 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
 /// specify `None` as `timeout` (it is like `timeout = -1` for `poll`).
 ///
 #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
-pub fn ppoll(fds: &mut [PollFd], timeout: Option<TimeSpec>, sigmask: SigSet) -> Result<libc::c_int> {
+pub fn ppoll(
+    fds: &mut [PollFd],
+    timeout: Option<crate::sys::time::TimeSpec>,
+    sigmask: crate::sys::signal::SigSet
+    ) -> Result<libc::c_int>
+{
     let timeout = timeout.as_ref().map_or(core::ptr::null(), |r| r.as_ref());
     let res = unsafe {
         libc::ppoll(fds.as_mut_ptr() as *mut libc::pollfd,
@@ -160,4 +163,5 @@ pub fn ppoll(fds: &mut [PollFd], timeout: Option<TimeSpec>, sigmask: SigSet) -> 
                     sigmask.as_ref())
     };
     Errno::result(res)
+}
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -77,15 +77,19 @@ libc_bitflags! {
         POLLOUT;
         /// Equivalent to [`POLLIN`](constant.POLLIN.html)
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLRDNORM;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Equivalent to [`POLLOUT`](constant.POLLOUT.html)
         POLLWRNORM;
         /// Priority band data can be read (generally unused on Linux).
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLRDBAND;
         /// Priority data may be written.
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLWRBAND;
         /// Error condition (only returned in
         /// [`PollFd::revents`](struct.PollFd.html#method.revents);

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -138,7 +138,7 @@ pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
     Errno::result(res)
 }
 
-feature!{
+feature! {
 #![feature = "signal"]
 /// `ppoll()` allows an application to safely wait until either a file
 /// descriptor becomes ready or until a signal is caught.

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -26,7 +26,7 @@ pub struct OpenptyResult {
     pub slave: RawFd,
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 /// Representation of a master with a forked pty
 ///
@@ -298,7 +298,7 @@ pub fn openpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b Termios>
     }
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 /// Create a new pseudoterminal, returning the master file descriptor and forked pid.
 /// in `ForkptyResult`

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -9,8 +9,9 @@ use std::mem;
 use std::os::unix::prelude::*;
 
 use crate::sys::termios::Termios;
-use crate::unistd::{self, ForkResult, Pid};
-use crate::{Result, fcntl};
+#[cfg(feature = "process")]
+use crate::unistd::{ForkResult, Pid};
+use crate::{Result, fcntl, unistd};
 use crate::errno::Errno;
 
 /// Representation of a master/slave pty pair
@@ -25,6 +26,8 @@ pub struct OpenptyResult {
     pub slave: RawFd,
 }
 
+feature!{
+#![feature = "process"]
 /// Representation of a master with a forked pty
 ///
 /// This is returned by `forkpty`. Note that this type does *not* implement `Drop`, so the user
@@ -35,6 +38,7 @@ pub struct ForkptyResult {
     pub master: RawFd,
     /// Metadata about forked process
     pub fork_result: ForkResult,
+}
 }
 
 
@@ -294,6 +298,8 @@ pub fn openpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b Termios>
     }
 }
 
+feature!{
+#![feature = "process"]
 /// Create a new pseudoterminal, returning the master file descriptor and forked pid.
 /// in `ForkptyResult`
 /// (see [`forkpty`](https://man7.org/linux/man-pages/man3/forkpty.3.html)).
@@ -345,4 +351,5 @@ pub unsafe fn forkpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b T
         master: master.assume_init(),
         fork_result,
     })
+}
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -192,6 +192,7 @@ pub unsafe fn ptsname(fd: &PtyMaster) -> Result<String> {
 /// This value is useful for opening the slave ptty once the master has already been opened with
 /// `posix_openpt()`.
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[inline]
 pub fn ptsname_r(fd: &PtyMaster) -> Result<String> {
     let mut name_buf = Vec::<libc::c_char>::with_capacity(64);

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -8,6 +8,7 @@ use crate::{Errno, Result};
 pub use self::sched_linux_like::*;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod sched_linux_like {
     use crate::errno::Errno;
     use libc::{self, c_int, c_void};

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -49,6 +49,7 @@ libc_enum! {
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DSYNC
     }
 }
@@ -797,6 +798,7 @@ impl<'a> Drop for AioCb<'a> {
 ///
 /// The basic structure used to issue multiple AIO operations simultaneously.
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub struct LioCb<'a> {
     /// A collection of [`AioCb`]s.  All of these will be issued simultaneously
     /// by the [`listio`] method.
@@ -828,6 +830,7 @@ unsafe impl<'a> Send for LioCb<'a> {}
 unsafe impl<'a> Sync for LioCb<'a> {}
 
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 impl<'a> LioCb<'a> {
     /// Are no [`AioCb`]s contained?
     pub fn is_empty(&self) -> bool {
@@ -1036,6 +1039,7 @@ impl<'a> Debug for LioCb<'a> {
 // LioCbBuilder must use a Vec to make construction possible when the final size
 // is unknown.
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[derive(Debug)]
 pub struct LioCbBuilder<'a> {
     /// A collection of [`AioCb`]s.
@@ -1045,6 +1049,7 @@ pub struct LioCbBuilder<'a> {
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 impl<'a> LioCbBuilder<'a> {
     /// Initialize an empty `LioCb`
     pub fn with_capacity(capacity: usize) -> LioCbBuilder<'a> {

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -19,6 +19,7 @@ libc_bitflags!(
         EPOLLHUP;
         EPOLLRDHUP;
         #[cfg(target_os = "linux")]  // Added in 4.5; not in Android.
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         EPOLLEXCLUSIVE;
         #[cfg(not(target_arch = "mips"))]
         EPOLLWAKEUP;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -21,9 +21,11 @@ libc_bitflags!{
         PROT_EXEC;
         /// Apply protection up to the end of a mapping that grows upwards.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PROT_GROWSDOWN;
         /// Apply protection down to the beginning of a mapping that grows downwards.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PROT_GROWSUP;
     }
 }
@@ -42,6 +44,7 @@ libc_bitflags!{
         /// To be used with `MAP_FIXED`, to forbid the system
         /// to select a different address than the one specified.
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_EXCL;
         /// Synonym for `MAP_ANONYMOUS`.
         MAP_ANON;
@@ -52,98 +55,128 @@ libc_bitflags!{
                       any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "linux", target_env = "musl", any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "freebsd", target_pointer_width = "64")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_32BIT;
         /// Used for stacks; indicates to the kernel that the mapping should extend downward in memory.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_GROWSDOWN;
         /// Compatibility flag. Ignored.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_DENYWRITE;
         /// Compatibility flag. Ignored.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_EXECUTABLE;
         /// Mark the mmaped region to be locked in the same way as `mlock(2)`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_LOCKED;
         /// Do not reserve swap space for this mapping.
         ///
         /// This was removed in FreeBSD 11 and is unused in DragonFlyBSD.
         #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NORESERVE;
         /// Populate page tables for a mapping.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_POPULATE;
         /// Only meaningful when used with `MAP_POPULATE`. Don't perform read-ahead.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NONBLOCK;
         /// Allocate the mapping using "huge pages."
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGETLB;
         /// Make use of 64KB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_64KB;
         /// Make use of 512KB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_512KB;
         /// Make use of 1MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_1MB;
         /// Make use of 2MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_2MB;
         /// Make use of 8MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_8MB;
         /// Make use of 16MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_16MB;
         /// Make use of 32MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_32MB;
         /// Make use of 256MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_256MB;
         /// Make use of 512MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_512MB;
         /// Make use of 1GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_1GB;
         /// Make use of 2GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_2GB;
         /// Make use of 16GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_16GB;
 
         /// Lock the mapped region into memory as with `mlock(2)`.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_WIRED;
         /// Causes dirtied data in the specified range to be flushed to disk only when necessary.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NOSYNC;
         /// Rename private pages to a file.
         ///
         /// This was removed in FreeBSD 11 and is unused in DragonFlyBSD.
         #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_RENAME;
         /// Region may contain semaphores.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HASSEMAPHORE;
         /// Region grows down, like a stack.
         #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_STACK;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NOCACHE;
         /// Allows the W/X bit on the page, it's necessary on aarch64 architecture.
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_JIT;
         /// Allows to use large pages, underlying alignment based on size.
         #[cfg(target_os = "freesd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_ALIGNED_SUPER;
         /// Pages will be discarded in the core dumps.
         #[cfg(target_os = "openbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_CONCEAL;
     }
 }
@@ -154,15 +187,19 @@ libc_bitflags!{
     pub struct MRemapFlags: c_int {
         /// Permit the kernel to relocate the mapping to a new virtual address, if necessary.
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MREMAP_MAYMOVE;
         /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MREMAP_FIXED;
         /// Permits to use the old and new address as hints to relocate the mapping.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_FIXED;
         /// Allows to duplicate the mapping to be able to apply different flags on the copy.
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_REMAPDUP;
     }
 }
@@ -186,23 +223,29 @@ libc_enum!{
         MADV_DONTNEED,
         /// Free up a given range of pages and its associated backing store.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_REMOVE,
         /// Do not make pages in this range available to the child after a `fork(2)`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DONTFORK,
         /// Undo the effect of `MADV_DONTFORK`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DOFORK,
         /// Poison the given pages.
         ///
         /// Subsequent references to those pages are treated like hardware memory corruption.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_HWPOISON,
         /// Enable Kernel Samepage Merging (KSM) for the given pages.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_MERGEABLE,
         /// Undo the effect of `MADV_MERGEABLE`
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_UNMERGEABLE,
         /// Preserve the memory of each page but offline the original page.
         #[cfg(any(target_os = "android",
@@ -217,46 +260,61 @@ libc_enum!{
         MADV_SOFT_OFFLINE,
         /// Enable Transparent Huge Pages (THP) for pages in the given range.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_HUGEPAGE,
         /// Undo the effect of `MADV_HUGEPAGE`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOHUGEPAGE,
         /// Exclude the given range from a core dump.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DONTDUMP,
         /// Undo the effect of an earlier `MADV_DONTDUMP`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DODUMP,
         /// Specify that the application no longer needs the pages in the given range.
         MADV_FREE,
         /// Request that the system not flush the current range to disk unless it needs to.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOSYNC,
         /// Undoes the effects of `MADV_NOSYNC` for any future pages dirtied within the given range.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_AUTOSYNC,
         /// Region is not included in a core file.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOCORE,
         /// Include region in a core file
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_CORE,
         #[cfg(any(target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_PROTECT,
         /// Invalidate the hardware page table for the given region.
         #[cfg(target_os = "dragonfly")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_INVAL,
         /// Set the offset of the page directory page to `value` for the virtual page table.
         #[cfg(target_os = "dragonfly")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_SETMAP,
         /// Indicates that the application will not need the data in the given range.
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_ZERO_WIRED_PAGES,
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_FREE_REUSABLE,
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_FREE_REUSE,
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_CAN_REUSE,
     }
 }
@@ -270,9 +328,11 @@ libc_bitflags!{
         MS_INVALIDATE;
         /// Invalidate pages, but leave them mapped.
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MS_KILLPAGES;
         /// Deactivate pages, but leave them mapped.
         #[cfg(any(target_os = "ios", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MS_DEACTIVATE;
         /// Perform an update and wait for it to complete.
         MS_SYNC;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -437,7 +437,7 @@ pub unsafe fn msync(addr: *mut c_void, length: size_t, flags: MsFlags) -> Result
 }
 
 #[cfg(not(target_os = "android"))]
-feature!{
+feature! {
 #![feature = "fs"]
 pub fn shm_open<P>(
     name: &P,

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,12 +5,12 @@
           target_os = "linux",
           target_os = "macos",
           target_os = "netbsd"))]
-feature!{
+feature! {
     #![feature = "aio"]
     pub mod aio;
 }
 
-feature!{
+feature! {
     #![feature = "event"]
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -47,27 +47,27 @@ feature!{
 pub mod ioctl;
 
 #[cfg(target_os = "linux")]
-feature!{
+feature! {
     #![feature = "fs"]
     #[allow(missing_docs)]
     pub mod memfd;
 }
 
 #[cfg(not(target_os = "redox"))]
-feature!{
+feature! {
     #![feature = "mman"]
     #[allow(missing_docs)]
     pub mod mman;
 }
 
 #[cfg(target_os = "linux")]
-feature!{
+feature! {
     #![feature = "personality"]
     #[allow(missing_docs)]
     pub mod personality;
 }
 
-feature!{
+feature! {
     #![feature = "pthread"]
     pub mod pthread;
 }
@@ -79,33 +79,33 @@ feature!{
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd"))]
-feature!{
+feature! {
     #![feature = "ptrace"]
     #[allow(missing_docs)]
     pub mod ptrace;
 }
 
 #[cfg(target_os = "linux")]
-feature!{
+feature! {
     #![feature = "quota"]
     pub mod quota;
 }
 
 #[cfg(target_os = "linux")]
-feature!{
+feature! {
     #![feature = "reboot"]
     #[allow(missing_docs)]
     pub mod reboot;
 }
 
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos")))]
-feature!{
+feature! {
     #![feature = "resource"]
     pub mod resource;
 }
 
 #[cfg(not(target_os = "redox"))]
-feature!{
+feature! {
     #![feature = "poll"]
     pub mod select;
 }
@@ -115,7 +115,7 @@ feature!{
           target_os = "ios",
           target_os = "linux",
           target_os = "macos"))]
-feature!{
+feature! {
     #![feature = "zerocopy"]
     pub mod sendfile;
 }
@@ -123,20 +123,20 @@ feature!{
 pub mod signal;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-feature!{
+feature! {
     #![feature = "signal"]
     #[allow(missing_docs)]
     pub mod signalfd;
 }
 
 #[cfg(not(target_os = "redox"))]
-feature!{
+feature! {
     #![feature = "socket"]
     #[allow(missing_docs)]
     pub mod socket;
 }
 
-feature!{
+feature! {
     #![feature = "fs"]
     #[allow(missing_docs)]
     pub mod stat;
@@ -150,12 +150,12 @@ feature!{
           target_os = "macos",
           target_os = "openbsd"
 ))]
-feature!{
+feature! {
     #![feature = "fs"]
     pub mod statfs;
 }
 
-feature!{
+feature! {
     #![feature = "fs"]
     pub mod statvfs;
 }
@@ -164,7 +164,7 @@ feature!{
 #[allow(missing_docs)]
 pub mod sysinfo;
 
-feature!{
+feature! {
     #![feature = "term"]
     #[allow(missing_docs)]
     pub mod termios;
@@ -173,30 +173,30 @@ feature!{
 #[allow(missing_docs)]
 pub mod time;
 
-feature!{
+feature! {
     #![feature = "uio"]
     pub mod uio;
 }
 
-feature!{
+feature! {
     #![feature = "features"]
     pub mod utsname;
 }
 
-feature!{
+feature! {
     #![feature = "process"]
     pub mod wait;
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-feature!{
+feature! {
     #![feature = "inotify"]
     #[allow(missing_docs)]
     pub mod inotify;
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-feature!{
+feature! {
     #![feature = "time"]
     #[allow(missing_docs)]
     pub mod timerfd;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,24 +5,31 @@
           target_os = "linux",
           target_os = "macos",
           target_os = "netbsd"))]
-pub mod aio;
+feature!{
+    #![feature = "aio"]
+    pub mod aio;
+}
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod epoll;
+feature!{
+    #![feature = "event"]
 
-#[cfg(any(target_os = "dragonfly",
-          target_os = "freebsd",
-          target_os = "ios",
-          target_os = "macos",
-          target_os = "netbsd",
-          target_os = "openbsd"))]
-#[allow(missing_docs)]
-pub mod event;
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[allow(missing_docs)]
+    pub mod epoll;
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod eventfd;
+    #[cfg(any(target_os = "dragonfly",
+              target_os = "freebsd",
+              target_os = "ios",
+              target_os = "macos",
+              target_os = "netbsd",
+              target_os = "openbsd"))]
+    #[allow(missing_docs)]
+    pub mod event;
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[allow(missing_docs)]
+    pub mod eventfd;
+}
 
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",
@@ -34,22 +41,36 @@ pub mod eventfd;
           target_os = "netbsd",
           target_os = "illumos",
           target_os = "openbsd"))]
+#[cfg(feature = "ioctl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
 #[macro_use]
 pub mod ioctl;
 
 #[cfg(target_os = "linux")]
-#[allow(missing_docs)]
-pub mod memfd;
+feature!{
+    #![feature = "fs"]
+    #[allow(missing_docs)]
+    pub mod memfd;
+}
 
 #[cfg(not(target_os = "redox"))]
-#[allow(missing_docs)]
-pub mod mman;
+feature!{
+    #![feature = "mman"]
+    #[allow(missing_docs)]
+    pub mod mman;
+}
 
 #[cfg(target_os = "linux")]
-#[allow(missing_docs)]
-pub mod personality;
+feature!{
+    #![feature = "personality"]
+    #[allow(missing_docs)]
+    pub mod personality;
+}
 
-pub mod pthread;
+feature!{
+    #![feature = "pthread"]
+    pub mod pthread;
+}
 
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",
@@ -58,41 +79,68 @@ pub mod pthread;
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd"))]
-#[allow(missing_docs)]
-pub mod ptrace;
+feature!{
+    #![feature = "ptrace"]
+    #[allow(missing_docs)]
+    pub mod ptrace;
+}
 
 #[cfg(target_os = "linux")]
-pub mod quota;
+feature!{
+    #![feature = "quota"]
+    pub mod quota;
+}
 
-#[cfg(any(target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod reboot;
+#[cfg(target_os = "linux")]
+feature!{
+    #![feature = "reboot"]
+    #[allow(missing_docs)]
+    pub mod reboot;
+}
 
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos")))]
-pub mod resource;
+feature!{
+    #![feature = "resource"]
+    pub mod resource;
+}
 
 #[cfg(not(target_os = "redox"))]
-pub mod select;
+feature!{
+    #![feature = "poll"]
+    pub mod select;
+}
 
 #[cfg(any(target_os = "android",
           target_os = "freebsd",
           target_os = "ios",
           target_os = "linux",
           target_os = "macos"))]
-pub mod sendfile;
+feature!{
+    #![feature = "zerocopy"]
+    pub mod sendfile;
+}
 
 pub mod signal;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod signalfd;
+feature!{
+    #![feature = "signal"]
+    #[allow(missing_docs)]
+    pub mod signalfd;
+}
 
 #[cfg(not(target_os = "redox"))]
-#[allow(missing_docs)]
-pub mod socket;
+feature!{
+    #![feature = "socket"]
+    #[allow(missing_docs)]
+    pub mod socket;
+}
 
-#[allow(missing_docs)]
-pub mod stat;
+feature!{
+    #![feature = "fs"]
+    #[allow(missing_docs)]
+    pub mod stat;
+}
 
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",
@@ -102,30 +150,54 @@ pub mod stat;
           target_os = "macos",
           target_os = "openbsd"
 ))]
-pub mod statfs;
+feature!{
+    #![feature = "fs"]
+    pub mod statfs;
+}
 
-pub mod statvfs;
+feature!{
+    #![feature = "fs"]
+    pub mod statvfs;
+}
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[allow(missing_docs)]
 pub mod sysinfo;
 
-#[allow(missing_docs)]
-pub mod termios;
+feature!{
+    #![feature = "term"]
+    #[allow(missing_docs)]
+    pub mod termios;
+}
 
 #[allow(missing_docs)]
 pub mod time;
 
-pub mod uio;
+feature!{
+    #![feature = "uio"]
+    pub mod uio;
+}
 
-pub mod utsname;
+feature!{
+    #![feature = "features"]
+    pub mod utsname;
+}
 
-pub mod wait;
+feature!{
+    #![feature = "process"]
+    pub mod wait;
+}
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod inotify;
+feature!{
+    #![feature = "inotify"]
+    #[allow(missing_docs)]
+    pub mod inotify;
+}
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[allow(missing_docs)]
-pub mod timerfd;
+feature!{
+    #![feature = "time"]
+    #[allow(missing_docs)]
+    pub mod timerfd;
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -161,6 +161,7 @@ feature! {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[allow(missing_docs)]
 pub mod sysinfo;
 

--- a/src/sys/pthread.rs
+++ b/src/sys/pthread.rs
@@ -4,8 +4,6 @@
 use crate::errno::Errno;
 #[cfg(not(target_os = "redox"))]
 use crate::Result;
-#[cfg(not(target_os = "redox"))]
-use crate::sys::signal::Signal;
 use libc::{self, pthread_t};
 
 /// Identifies an individual thread.
@@ -21,6 +19,9 @@ pub fn pthread_self() -> Pthread {
     unsafe { libc::pthread_self() }
 }
 
+feature!{
+#![feature = "signal"]
+
 /// Send a signal to a thread (see [`pthread_kill(3)`]).
 ///
 /// If `signal` is `None`, `pthread_kill` will only preform error checking and
@@ -28,11 +29,14 @@ pub fn pthread_self() -> Pthread {
 ///
 /// [`pthread_kill(3)`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_kill.html
 #[cfg(not(target_os = "redox"))]
-pub fn pthread_kill<T: Into<Option<Signal>>>(thread: Pthread, signal: T) -> Result<()> {
+pub fn pthread_kill<T>(thread: Pthread, signal: T) -> Result<()>
+    where T: Into<Option<crate::sys::signal::Signal>>
+{
     let sig = match signal.into() {
         Some(s) => s as libc::c_int,
         None => 0,
     };
     let res = unsafe { libc::pthread_kill(thread, sig) };
     Errno::result(res).map(drop)
+}
 }

--- a/src/sys/pthread.rs
+++ b/src/sys/pthread.rs
@@ -19,7 +19,7 @@ pub fn pthread_self() -> Pthread {
     unsafe { libc::pthread_self() }
 }
 
-feature!{
+feature! {
 #![feature = "signal"]
 
 /// Send a signal to a thread (see [`pthread_kill(3)`]).

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -30,10 +30,12 @@ libc_enum! {
         PT_READ_I,
         PT_READ_D,
         #[cfg(target_os = "macos")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_READ_U,
         PT_WRITE_I,
         PT_WRITE_D,
         #[cfg(target_os = "macos")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_WRITE_U,
         PT_CONTINUE,
         PT_KILL,
@@ -47,10 +49,13 @@ libc_enum! {
         PT_ATTACH,
         PT_DETACH,
         #[cfg(target_os = "macos")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_SIGEXC,
         #[cfg(target_os = "macos")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_THUPDATE,
         #[cfg(target_os = "macos")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_ATTACHEXC
     }
 }

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -99,8 +99,10 @@ libc_enum!{
                                                target_arch = "mips64"))))]
         PTRACE_SETREGSET,
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PTRACE_SEIZE,
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PTRACE_INTERRUPT,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
                                                target_arch = "mips64"))))]
@@ -171,7 +173,6 @@ libc_bitflags! {
         PTRACE_O_TRACESECCOMP;
         /// Send a SIGKILL to the tracee if the tracer exits.  This is useful
         /// for ptrace jailers to prevent tracees from escaping their control.
-        #[cfg(any(target_os = "android", target_os = "linux"))]
         PTRACE_O_EXITKILL;
     }
 }
@@ -340,6 +341,7 @@ pub fn attach(pid: Pid) -> Result<()> {
 ///
 /// Attaches to the process specified in pid, making it a tracee of the calling process.
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn seize(pid: Pid, options: Options) -> Result<()> {
     unsafe {
         ptrace_other(
@@ -388,6 +390,7 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 ///
 /// This request is equivalent to `ptrace(PTRACE_INTERRUPT, ...)`
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn interrupt(pid: Pid) -> Result<()> {
     unsafe {
         ptrace_other(Request::PTRACE_INTERRUPT, pid, ptr::null_mut(), ptr::null_mut()).map(drop)

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -54,6 +54,7 @@ libc_enum! {
                     target_os = "netbsd",
                     target_os = "openbsd"
         )))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum amount (in bytes) of virtual memory the process is
         /// allowed to map.
         RLIMIT_AS,
@@ -72,69 +73,83 @@ libc_enum! {
         RLIMIT_STACK,
 
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of kqueues this user id is allowed to create.
         RLIMIT_KQUEUES,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the combined number of flock locks and fcntl leases that
         /// this process may establish.
         RLIMIT_LOCKS,
 
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "openbsd", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) which a process may lock into memory
         /// using the mlock(2) system call.
         RLIMIT_MEMLOCK,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the number of bytes that can be allocated for POSIX
         /// message queues  for  the  real  user  ID  of  the  calling process.
         RLIMIT_MSGQUEUE,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A ceiling to which the process's nice value can be raised using
         /// setpriority or nice.
         RLIMIT_NICE,
 
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "openbsd", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of simultaneous processes for this user id.
         RLIMIT_NPROC,
 
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of pseudo-terminals this user id is allowed to
         /// create.
         RLIMIT_NPTS,
 
         #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "openbsd", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// When there is memory pressure and swap is available, prioritize
         /// eviction of a process' resident pages beyond this amount (in bytes).
         RLIMIT_RSS,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A ceiling on the real-time priority that may be set for this process
         /// using sched_setscheduler and  sched_set‐ param.
         RLIMIT_RTPRIO,
 
         #[cfg(any(target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit (in microseconds) on the amount of CPU time that a process
         /// scheduled under a real-time scheduling policy may con‐ sume without
         /// making a blocking system call.
         RLIMIT_RTTIME,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the number of signals that may be queued for the real
         /// user ID of the  calling  process.
         RLIMIT_SIGPENDING,
 
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) of socket buffer usage for this user.
         RLIMIT_SBSIZE,
 
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) of the swap space that may be reserved
         /// or used by all of this user id's processes.
         RLIMIT_SWAP,
 
         #[cfg(target_os = "freebsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// An alias for RLIMIT_AS.
         RLIMIT_VMEM,
     }

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -7,7 +7,6 @@ use std::ptr::{null, null_mut};
 use libc::{self, c_int};
 use crate::Result;
 use crate::errno::Errno;
-use crate::sys::signal::SigSet;
 use crate::sys::time::{TimeSpec, TimeVal};
 
 pub use libc::FD_SETSIZE;
@@ -202,6 +201,11 @@ where
     Errno::result(res)
 }
 
+feature!{
+#![feature = "signal"]
+
+use crate::sys::signal::SigSet;
+
 /// Monitors file descriptors for readiness with an altered signal mask.
 ///
 /// Returns the total number of ready file descriptors in all sets. The sets are changed so that all
@@ -272,7 +276,7 @@ where
 
     Errno::result(res)
 }
-
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -201,7 +201,7 @@ where
     Errno::result(res)
 }
 
-feature!{
+feature! {
 #![feature = "signal"]
 
 use crate::sys::signal::SigSet;

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -22,6 +22,7 @@ use crate::errno::Errno;
 ///
 /// For more information, see [the sendfile(2) man page.](https://man7.org/linux/man-pages/man2/sendfile.2.html)
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn sendfile(
     out_fd: RawFd,
     in_fd: RawFd,
@@ -48,6 +49,7 @@ pub fn sendfile(
 ///
 /// For more information, see [the sendfile(2) man page.](https://man7.org/linux/man-pages/man2/sendfile.2.html)
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn sendfile64(
     out_fd: RawFd,
     in_fd: RawFd,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -380,7 +380,7 @@ const SIGNALS: [Signal; 31] = [
     SIGEMT,
     SIGINFO];
 
-feature!{
+feature! {
 #![feature = "signal"]
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -469,7 +469,7 @@ libc_enum! {
     }
 }
 
-feature!{
+feature! {
 #![feature = "signal"]
 
 use crate::unistd::Pid;
@@ -938,7 +938,7 @@ pub fn raise(signal: Signal) -> Result<()> {
 }
 
 
-feature!{
+feature! {
 #![any(feature = "aio", feature = "signal")]
 
 /// Identifies a thread for [`SigevNotify::SigevThreadId`]
@@ -991,7 +991,7 @@ pub enum SigevNotify {
 
 #[cfg(not(any(target_os = "openbsd", target_os = "redox")))]
 mod sigevent {
-    feature!{
+    feature! {
     #![any(feature = "aio", feature = "signal")]
 
     use std::mem;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -91,6 +91,7 @@ libc_enum!{
         SIGIO,
         #[cfg(any(target_os = "android", target_os = "emscripten",
                   target_os = "fuchsia", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Power failure imminent.
         SIGPWR,
         /// Bad system call
@@ -98,11 +99,13 @@ libc_enum!{
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
                       target_os = "redox")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Emulator trap
         SIGEMT,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
                       target_os = "redox")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Information request
         SIGINFO,
     }
@@ -565,6 +568,7 @@ impl SigSet {
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
     #[cfg(not(target_os = "redox"))] // RedoxFS does not yet support sigwait
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn wait(&self) -> Result<Signal> {
         use std::convert::TryFrom;
 
@@ -596,6 +600,7 @@ pub enum SigHandler {
     /// Use the given signal-catching function, which takes in the signal, information about how
     /// the signal was generated, and a pointer to the threads `ucontext_t`.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigAction(extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void))
 }
 
@@ -659,6 +664,7 @@ impl SigAction {
 
     /// Returns the action's handler.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn handler(&self) -> SigHandler {
         match self.sigaction.sa_sigaction {
             libc::SIG_DFL => SigHandler::SigDfl,
@@ -693,6 +699,7 @@ impl SigAction {
 
     /// Returns the action's handler.
     #[cfg(target_os = "redox")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn handler(&self) -> SigHandler {
         match self.sigaction.sa_handler {
             libc::SIG_DFL => SigHandler::SigDfl,
@@ -969,6 +976,7 @@ pub enum SigevNotify {
     // expose a way to set the union members needed by SIGEV_THREAD.
     /// Notify by delivering an event to a kqueue.
     #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigevKevent {
         /// File descriptor of the kqueue to notify.
         kq: RawFd,
@@ -977,6 +985,7 @@ pub enum SigevNotify {
     },
     /// Notify by delivering a signal to a thread.
     #[cfg(any(target_os = "freebsd", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigevThreadId {
         /// Signal to send
         signal: Signal,
@@ -990,6 +999,7 @@ pub enum SigevNotify {
 }
 
 #[cfg(not(any(target_os = "openbsd", target_os = "redox")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod sigevent {
     feature! {
     #![any(feature = "aio", feature = "signal")]

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -823,7 +823,7 @@ impl SockAddr {
     /// unsafe because it takes a raw pointer as argument.  The caller must
     /// ensure that the pointer is valid.
     #[cfg(not(target_os = "fuchsia"))]
-    #[cfg(any(feature = "net", feature = "uio"))]
+    #[cfg(feature = "net")]
     pub(crate) unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
         if addr.is_null() {
             None

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -264,7 +264,7 @@ impl AddressFamily {
     }
 }
 
-feature!{
+feature! {
 #![feature = "net"]
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -743,7 +743,7 @@ pub enum SockAddr {
 }
 
 impl SockAddr {
-    feature!{
+    feature! {
     #![feature = "net"]
     pub fn new_inet(addr: InetAddr) -> SockAddr {
         SockAddr::Inet(addr)
@@ -764,7 +764,7 @@ impl SockAddr {
         SockAddr::Alg(AlgAddr::new(alg_type, alg_name))
     }
 
-    feature!{
+    feature! {
     #![feature = "ioctl"]
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     pub fn new_sys_control(sockfd: RawFd, name: &str, unit: u32) -> Result<SockAddr> {
@@ -1095,7 +1095,7 @@ pub mod alg {
     }
 }
 
-feature!{
+feature! {
 #![feature = "ioctl"]
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub mod sys_control {
@@ -1172,7 +1172,7 @@ pub mod sys_control {
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
 mod datalink {
-    feature!{
+    feature! {
     #![feature = "net"]
     use super::{fmt, AddressFamily};
 
@@ -1248,7 +1248,7 @@ mod datalink {
           target_os = "netbsd",
           target_os = "openbsd"))]
 mod datalink {
-    feature!{
+    feature! {
     #![feature = "net"]
     use super::{fmt, AddressFamily};
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -44,6 +44,7 @@ pub enum AddressFamily {
     Inet6 = libc::AF_INET6,
     /// Kernel user interface device (see [`netlink(7)`](https://man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Netlink = libc::AF_NETLINK,
     /// Low level packet interface (see [`packet(7)`](https://man7.org/linux/man-pages/man7/packet.7.html))
     #[cfg(any(target_os = "android",
@@ -51,84 +52,117 @@ pub enum AddressFamily {
               target_os = "illumos",
               target_os = "fuchsia",
               target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Packet = libc::AF_PACKET,
     /// KEXT Controls and Notifications
     #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     System = libc::AF_SYSTEM,
     /// Amateur radio AX.25 protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ax25 = libc::AF_AX25,
     /// IPX - Novell protocols
     Ipx = libc::AF_IPX,
     /// AppleTalk
     AppleTalk = libc::AF_APPLETALK,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetRom = libc::AF_NETROM,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Bridge = libc::AF_BRIDGE,
     /// Access to raw ATM PVCs
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AtmPvc = libc::AF_ATMPVC,
     /// ITU-T X.25 / ISO-8208 protocol (see [`x25(7)`](https://man7.org/linux/man-pages/man7/x25.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     X25 = libc::AF_X25,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Rose = libc::AF_ROSE,
     Decnet = libc::AF_DECnet,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetBeui = libc::AF_NETBEUI,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Security = libc::AF_SECURITY,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Key = libc::AF_KEY,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ash = libc::AF_ASH,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Econet = libc::AF_ECONET,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AtmSvc = libc::AF_ATMSVC,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Rds = libc::AF_RDS,
     Sna = libc::AF_SNA,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Irda = libc::AF_IRDA,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Pppox = libc::AF_PPPOX,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Wanpipe = libc::AF_WANPIPE,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Llc = libc::AF_LLC,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ib = libc::AF_IB,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Mpls = libc::AF_MPLS,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Can = libc::AF_CAN,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Tipc = libc::AF_TIPC,
     #[cfg(not(any(target_os = "illumos",
                   target_os = "ios",
                   target_os = "macos",
                   target_os = "solaris")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Bluetooth = libc::AF_BLUETOOTH,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Iucv = libc::AF_IUCV,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxRpc = libc::AF_RXRPC,
     #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Isdn = libc::AF_ISDN,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Phonet = libc::AF_PHONET,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ieee802154 = libc::AF_IEEE802154,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Caif = libc::AF_CAIF,
     /// Interface to kernel crypto API
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Alg = libc::AF_ALG,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Nfc = libc::AF_NFC,
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Vsock = libc::AF_VSOCK,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -136,6 +170,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ImpLink = libc::AF_IMPLINK,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -143,6 +178,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Pup = libc::AF_PUP,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -150,11 +186,13 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Chaos = libc::AF_CHAOS,
     #[cfg(any(target_os = "ios",
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ns = libc::AF_NS,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -162,6 +200,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Iso = libc::AF_ISO,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -169,6 +208,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Datakit = libc::AF_DATAKIT,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -176,6 +216,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ccitt = libc::AF_CCITT,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -183,6 +224,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Dli = libc::AF_DLI,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -190,6 +232,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Lat = libc::AF_LAT,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -197,6 +240,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Hylink = libc::AF_HYLINK,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -205,6 +249,7 @@ pub enum AddressFamily {
               target_os = "illumos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Link = libc::AF_LINK,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -212,6 +257,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Coip = libc::AF_COIP,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -219,6 +265,7 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Cnt = libc::AF_CNT,
     #[cfg(any(target_os = "dragonfly",
               target_os = "freebsd",
@@ -226,9 +273,11 @@ pub enum AddressFamily {
               target_os = "macos",
               target_os = "netbsd",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Natm = libc::AF_NATM,
     /// Unspecified address family, (see [`getaddrinfo(3)`](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Unspec = libc::AF_UNSPEC,
 }
 
@@ -591,6 +640,7 @@ impl UnixAddr {
     /// This is a Linux-specific extension, primarily used to allow chrooted
     /// processes to communicate with processes having a different filesystem view.
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_abstract(path: &[u8]) -> Result<UnixAddr> {
         unsafe {
             let mut ret = libc::sockaddr_un {
@@ -649,6 +699,7 @@ impl UnixAddr {
     /// For abstract sockets only the bare name is returned, without the
     /// leading null byte. `None` is returned for unnamed or path-backed sockets.
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn as_abstract(&self) -> Option<&[u8]> {
         match self.kind() {
             UnixAddrKind::Abstract(name) => Some(name),
@@ -719,8 +770,10 @@ pub enum SockAddr {
     Inet(InetAddr),
     Unix(UnixAddr),
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Netlink(NetlinkAddr),
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Alg(AlgAddr),
     #[cfg(all(feature = "ioctl", any(target_os = "ios", target_os = "macos")))]
     #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
@@ -739,6 +792,7 @@ pub enum SockAddr {
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Link(LinkAddr),
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     Vsock(VsockAddr),
 }
 
@@ -755,11 +809,13 @@ impl SockAddr {
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_netlink(pid: u32, groups: u32) -> SockAddr {
         SockAddr::Netlink(NetlinkAddr::new(pid, groups))
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_alg(alg_type: &str, alg_name: &str) -> SockAddr {
         SockAddr::Alg(AlgAddr::new(alg_type, alg_name))
     }
@@ -773,6 +829,7 @@ impl SockAddr {
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_vsock(cid: u32, port: u32) -> SockAddr {
         SockAddr::Vsock(VsockAddr::new(cid, port))
     }
@@ -998,6 +1055,7 @@ impl fmt::Display for SockAddr {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod netlink {
     use crate::sys::socket::addr::AddressFamily;
     use libc::{sa_family_t, sockaddr_nl};
@@ -1033,6 +1091,7 @@ pub mod netlink {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod alg {
     use libc::{AF_ALG, sockaddr_alg, c_char};
     use std::{fmt, mem, str};
@@ -1171,6 +1230,7 @@ pub mod sys_control {
 
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod datalink {
     feature! {
     #![feature = "net"]
@@ -1247,6 +1307,7 @@ mod datalink {
           target_os = "illumos",
           target_os = "netbsd",
           target_os = "openbsd"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 mod datalink {
     feature! {
     #![feature = "net"]
@@ -1259,6 +1320,7 @@ mod datalink {
     impl LinkAddr {
         /// Total length of sockaddr
         #[cfg(not(target_os = "illumos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         pub fn len(&self) -> usize {
             self.0.sdl_len as usize
         }
@@ -1338,6 +1400,7 @@ mod datalink {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod vsock {
     use crate::sys::socket::addr::AddressFamily;
     use libc::{sa_family_t, sockaddr_vm};

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -117,68 +117,84 @@ pub enum SockProtocol {
     /// Allows applications and other KEXTs to be notified when certain kernel events occur
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     KextEvent = libc::SYSPROTO_EVENT,
     /// Allows applications to configure and control a KEXT
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     KextControl = libc::SYSPROTO_CONTROL,
     /// Receives routing and link updates and may be used to modify the routing tables (both IPv4 and IPv6), IP addresses, link
     // parameters, neighbor setups, queueing disciplines, traffic classes and packet classifiers
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkRoute = libc::NETLINK_ROUTE,
     /// Reserved for user-mode socket protocols
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkUserSock = libc::NETLINK_USERSOCK,
     /// Query information about sockets of various protocol families from the kernel
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSockDiag = libc::NETLINK_SOCK_DIAG,
     /// SELinux event notifications.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSELinux = libc::NETLINK_SELINUX,
     /// Open-iSCSI
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkISCSI = libc::NETLINK_ISCSI,
     /// Auditing
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkAudit = libc::NETLINK_AUDIT,
     /// Access to FIB lookup from user space
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkFIBLookup = libc::NETLINK_FIB_LOOKUP,
     /// Netfilter subsystem
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkNetFilter = libc::NETLINK_NETFILTER,
     /// SCSI Transports
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSCSITransport = libc::NETLINK_SCSITRANSPORT,
     /// Infiniband RDMA
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkRDMA = libc::NETLINK_RDMA,
     /// Transport IPv6 packets from netfilter to user space.  Used by ip6_queue kernel module.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkIPv6Firewall = libc::NETLINK_IP6_FW,
     /// DECnet routing messages
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkDECNetRoutingMessage = libc::NETLINK_DNRTMSG,
     /// Kernel messages to user space
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkKObjectUEvent = libc::NETLINK_KOBJECT_UEVENT,
     /// Netlink interface to request information about ciphers registered with the kernel crypto API as well as allow
     /// configuration of the kernel crypto API.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkCrypto = libc::NETLINK_CRYPTO,
 }
 
@@ -193,6 +209,7 @@ libc_bitflags!{
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_NONBLOCK;
         /// Set close-on-exec on the new descriptor
         #[cfg(any(target_os = "android",
@@ -202,13 +219,16 @@ libc_bitflags!{
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_CLOEXEC;
         /// Return `EPIPE` instead of raising `SIGPIPE`
         #[cfg(target_os = "netbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_NOSIGPIPE;
         /// For domains `AF_INET(6)`, only allow `connect(2)`, `sendto(2)`, or `sendmsg(2)`
         /// to the DNS port (typically 53)
         #[cfg(target_os = "openbsd")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_DNS;
     }
 }
@@ -257,6 +277,7 @@ libc_bitflags!{
         /// the socket error queue. (For more details, see
         /// [recvfrom(2)](https://linux.die.net/man/2/recvfrom))
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_ERRQUEUE;
         /// Set the `close-on-exec` flag for the file descriptor received via a UNIX domain
         /// file descriptor using the `SCM_RIGHTS` operation (described in
@@ -271,6 +292,7 @@ libc_bitflags!{
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_CMSG_CLOEXEC;
     }
 }
@@ -557,9 +579,11 @@ pub enum ControlMessageOwned {
     ScmRights(Vec<RawFd>),
     /// Received version of [`ControlMessage::ScmCredentials`]
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCredentials(UnixCredentials),
     /// Received version of [`ControlMessage::ScmCreds`]
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCreds(UnixCredentials),
     /// A message of type `SCM_TIMESTAMP`, containing the time the
     /// packet was received by the kernel.
@@ -621,6 +645,7 @@ pub enum ControlMessageOwned {
     ///
     /// [Further reading](https://www.kernel.org/doc/html/latest/networking/timestamping.html)
     #[cfg(all(target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmTimestampns(TimeSpec),
     #[cfg(any(
         target_os = "android",
@@ -688,13 +713,18 @@ pub enum ControlMessageOwned {
     /// `RxqOvfl` socket option should be enabled on a socket
     /// to allow receiving the drop counter.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxqOvfl(u32),
 
     /// Socket error queue control messages read with the `MSG_ERRQUEUE` flag.
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(feature = "net")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv4RecvErr(libc::sock_extended_err, Option<sockaddr_in>),
     /// Socket error queue control messages read with the `MSG_ERRQUEUE` flag.
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(feature = "net")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv6RecvErr(libc::sock_extended_err, Option<sockaddr_in6>),
 
     /// Catch-all variant for unimplemented cmsg types.
@@ -806,11 +836,13 @@ impl ControlMessageOwned {
                 ControlMessageOwned::RxqOvfl(drop_counter)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
+            #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVERR) => {
                 let (err, addr) = Self::recv_err_helper::<sockaddr_in>(p, len);
                 ControlMessageOwned::Ipv4RecvErr(err, addr)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
+            #[cfg(feature = "net")]
             (libc::IPPROTO_IPV6, libc::IPV6_RECVERR) => {
                 let (err, addr) = Self::recv_err_helper::<sockaddr_in6>(p, len);
                 ControlMessageOwned::Ipv6RecvErr(err, addr)
@@ -824,6 +856,7 @@ impl ControlMessageOwned {
     }
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(feature = "net")]
     unsafe fn recv_err_helper<T>(p: *mut libc::c_uchar, len: usize) -> (libc::sock_extended_err, Option<T>) {
         let ee = p as *const libc::sock_extended_err;
         let err = ptr::read_unaligned(ee);
@@ -873,6 +906,7 @@ pub enum ControlMessage<'a> {
     /// For further information, please refer to the
     /// [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html) man page.
     #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCredentials(&'a UnixCredentials),
     /// A message of type `SCM_CREDS`, containing the pid, uid, euid, gid and groups of
     /// a process connected to the socket.
@@ -887,6 +921,7 @@ pub enum ControlMessage<'a> {
     /// For further information, please refer to the
     /// [`unix(4)`](https://www.freebsd.org/cgi/man.cgi?query=unix) man page.
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCreds,
 
     /// Set IV for `AF_ALG` crypto API.
@@ -897,6 +932,7 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetIv(&'a [u8]),
     /// Set crypto operation for `AF_ALG` crypto API. It may be one of
     /// `ALG_OP_ENCRYPT` or `ALG_OP_DECRYPT`
@@ -907,6 +943,7 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetOp(&'a libc::c_int),
     /// Set the length of associated authentication data (AAD) (applicable only to AEAD algorithms)
     /// for `AF_ALG` crypto API.
@@ -917,6 +954,7 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetAeadAssoclen(&'a u32),
 
     /// UDP GSO makes it possible for applications to generate network packets
@@ -965,6 +1003,7 @@ pub enum ControlMessage<'a> {
     /// socket between the last recieved packet and this
     /// received packet.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxqOvfl(&'a u32),
 }
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -411,7 +411,7 @@ cfg_if!{
     }
 }
 
-feature!{
+feature! {
 #![feature = "net"]
 /// Request for multicast socket operations
 ///
@@ -450,7 +450,7 @@ impl Ipv6MembershipRequest {
 }
 }
 
-feature!{
+feature! {
 #![feature = "uio"]
 
 /// Create a buffer large enough for storing some control messages as returned

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -17,6 +17,7 @@ use std::os::unix::ffi::OsStrExt;
 // Constants
 // TCP_CA_NAME_MAX isn't defined in user space include files
 #[cfg(any(target_os = "freebsd", target_os = "linux"))] 
+#[cfg(feature = "net")]
 const TCP_CA_NAME_MAX: usize = 16;
 
 /// Helper for implementing `SetSockOpt` for a given socket option. See
@@ -251,7 +252,9 @@ sockopt_impl!(
     /// Permits multiple AF_INET or AF_INET6 sockets to be bound to an
     /// identical socket address.
     ReusePort, Both, libc::SOL_SOCKET, libc::SO_REUSEPORT, bool);
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Under most circumstances, TCP sends data when it is presented; when
     /// outstanding data has not yet been acknowledged, it gathers small amounts
     /// of output to be sent in a single packet once an acknowledgement is
@@ -265,20 +268,28 @@ sockopt_impl!(
     /// queued messages for the socket have been successfully sent or the
     /// linger timeout has been reached.
     Linger, Both, libc::SOL_SOCKET, libc::SO_LINGER, libc::linger);
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Join a multicast group
     IpAddMembership, SetOnly, libc::IPPROTO_IP, libc::IP_ADD_MEMBERSHIP,
     super::IpMembershipRequest);
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Leave a multicast group.
     IpDropMembership, SetOnly, libc::IPPROTO_IP, libc::IP_DROP_MEMBERSHIP,
     super::IpMembershipRequest);
 cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
+        #[cfg(feature = "net")]
         sockopt_impl!(
+            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
             /// Join an IPv6 multicast group.
             Ipv6AddMembership, SetOnly, libc::IPPROTO_IPV6, libc::IPV6_ADD_MEMBERSHIP, super::Ipv6MembershipRequest);
+        #[cfg(feature = "net")]
         sockopt_impl!(
+            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
             /// Leave an IPv6 multicast group.
             Ipv6DropMembership, SetOnly, libc::IPPROTO_IPV6, libc::IPV6_DROP_MEMBERSHIP, super::Ipv6MembershipRequest);
     } else if #[cfg(any(target_os = "dragonfly",
@@ -289,26 +300,36 @@ cfg_if! {
                         target_os = "netbsd",
                         target_os = "openbsd",
                         target_os = "solaris"))] {
+        #[cfg(feature = "net")]
         sockopt_impl!(
+            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
             /// Join an IPv6 multicast group.
             Ipv6AddMembership, SetOnly, libc::IPPROTO_IPV6,
             libc::IPV6_JOIN_GROUP, super::Ipv6MembershipRequest);
+        #[cfg(feature = "net")]
         sockopt_impl!(
+            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
             /// Leave an IPv6 multicast group.
             Ipv6DropMembership, SetOnly, libc::IPPROTO_IPV6,
             libc::IPV6_LEAVE_GROUP, super::Ipv6MembershipRequest);
     }
 }
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set or read the time-to-live value of outgoing multicast packets for
     /// this socket.
     IpMulticastTtl, Both, libc::IPPROTO_IP, libc::IP_MULTICAST_TTL, u8);
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set or read a boolean integer argument that determines whether sent
     /// multicast packets should be looped back to the local sockets.
     IpMulticastLoop, Both, libc::IPPROTO_IP, libc::IP_MULTICAST_LOOP, bool);
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// If enabled, this boolean option allows binding to an IP address that
     /// is nonlocal or does not (yet) exist.
     IpFreebind, Both, libc::IPPROTO_IP, libc::IP_FREEBIND, bool);
@@ -347,7 +368,9 @@ sockopt_impl!(
     PeerCredentials, GetOnly, libc::SOL_SOCKET, libc::SO_PEERCRED, super::UnixCredentials);
 #[cfg(any(target_os = "ios",
           target_os = "macos"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Specify the amount of time, in seconds, that the connection must be idle
     /// before keepalive probes (if enabled) are sent.
     TcpKeepAlive, Both, libc::IPPROTO_TCP, libc::TCP_KEEPALIVE, u32);
@@ -356,7 +379,9 @@ sockopt_impl!(
           target_os = "freebsd",
           target_os = "linux",
           target_os = "nacl"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The time (in seconds) the connection needs to remain idle before TCP
     /// starts sending keepalive probes
     TcpKeepIdle, Both, libc::IPPROTO_TCP, libc::TCP_KEEPIDLE, u32);
@@ -372,7 +397,9 @@ cfg_if! {
     }
 }
 #[cfg(not(target_os = "openbsd"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The maximum number of keepalive probes TCP should send before
     /// dropping the connection.
     TcpKeepCount, Both, libc::IPPROTO_TCP, libc::TCP_KEEPCNT, u32);
@@ -384,11 +411,15 @@ sockopt_impl!(
     // Not documented by Linux!
     TcpRepair, Both, libc::IPPROTO_TCP, libc::TCP_REPAIR, u32);
 #[cfg(not(target_os = "openbsd"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The time (in seconds) between individual keepalive probes.
     TcpKeepInterval, Both, libc::IPPROTO_TCP, libc::TCP_KEEPINTVL, u32);
 #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Specifies the maximum amount of time in milliseconds that transmitted
     /// data may remain unacknowledged before TCP will forcibly close the
     /// corresponding connection
@@ -423,7 +454,9 @@ sockopt_impl!(
     /// Bind this socket to a particular device like “eth0”.
     BindToDevice, Both, libc::SOL_SOCKET, libc::SO_BINDTODEVICE, OsString<[u8; libc::IFNAMSIZ]>);
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     #[allow(missing_docs)]
     // Not documented by Linux!
     OriginalDst, GetOnly, libc::SOL_IP, libc::SO_ORIGINAL_DST, libc::sockaddr_in);
@@ -440,16 +473,22 @@ sockopt_impl!(
     /// Enable or disable the receiving of the `SO_TIMESTAMPNS` control message.
     ReceiveTimestampns, Both, libc::SOL_SOCKET, libc::SO_TIMESTAMPNS, bool);
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Setting this boolean option enables transparent proxying on this socket.
     IpTransparent, Both, libc::SOL_IP, libc::IP_TRANSPARENT, bool);
 #[cfg(target_os = "openbsd")]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Allows the socket to be bound to addresses which are not local to the
     /// machine, so it can be used to make a transparent proxy.
     BindAny, Both, libc::SOL_SOCKET, libc::SO_BINDANY, bool);
 #[cfg(target_os = "freebsd")]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Can `bind(2)` to any address, even one not bound to any available
     /// network interface in the system.
     BindAny, Both, libc::IPPROTO_IP, libc::IP_BINDANY, bool);
@@ -464,7 +503,9 @@ sockopt_impl!(
     /// message.
     PassCred, Both, libc::SOL_SOCKET, libc::SO_PASSCRED, bool);
 #[cfg(any(target_os = "freebsd", target_os = "linux"))] 
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// This option allows the caller to set the TCP congestion control
     /// algorithm to be used,  on a per-socket basis.
     TcpCongestion, Both, libc::IPPROTO_TCP, libc::TCP_CONGESTION, OsString<[u8; TCP_CA_NAME_MAX]>);
@@ -475,7 +516,9 @@ sockopt_impl!(
     target_os = "macos",
     target_os = "netbsd",
 ))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Pass an `IP_PKTINFO` ancillary message that contains a pktinfo
     /// structure that supplies some information about the incoming packet.
     Ipv4PacketInfo, Both, libc::IPPROTO_IP, libc::IP_PKTINFO, bool);
@@ -488,7 +531,9 @@ sockopt_impl!(
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set delivery of the `IPV6_PKTINFO` control message on incoming
     /// datagrams.
     Ipv6RecvPacketInfo, Both, libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO, bool);
@@ -499,7 +544,9 @@ sockopt_impl!(
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The `recvmsg(2)` call returns a `struct sockaddr_dl` corresponding to
     /// the interface on which the packet was received.
     Ipv4RecvIf, Both, libc::IPPROTO_IP, libc::IP_RECVIF, bool);
@@ -510,17 +557,23 @@ sockopt_impl!(
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The `recvmsg(2)` call will return the destination IP address for a UDP
     /// datagram.
     Ipv4RecvDstAddr, Both, libc::IPPROTO_IP, libc::IP_RECVDSTADDR, bool);
 #[cfg(target_os = "linux")]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     #[allow(missing_docs)]
     // Not documented by Linux!
     UdpGsoSegment, Both, libc::SOL_UDP, libc::UDP_SEGMENT, libc::c_int);
 #[cfg(target_os = "linux")]
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     #[allow(missing_docs)]
     // Not documented by Linux!
     UdpGroSegment, Both, libc::IPPROTO_UDP, libc::UDP_GRO, bool);
@@ -530,7 +583,9 @@ sockopt_impl!(
     /// be attached to received skbs indicating the number of packets dropped by
     /// the socket since its creation.
     RxqOvfl, Both, libc::SOL_SOCKET, libc::SO_RXQ_OVFL, libc::c_int);
+#[cfg(feature = "net")]
 sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// The socket is restricted to sending and receiving IPv6 packets only.
     Ipv6V6Only, Both, libc::IPPROTO_IPV6, libc::IPV6_V6ONLY, bool);
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -54,6 +54,7 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
 
 /// Create a special or ordinary file, relative to a given directory.
 #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mknodat<P: ?Sized + NixPath>(
     dirfd: RawFd,
     path: &P,
@@ -69,18 +70,21 @@ pub fn mknodat<P: ?Sized + NixPath>(
 }
 
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn major(dev: dev_t) -> u64 {
     ((dev >> 32) & 0xffff_f000) |
     ((dev >>  8) & 0x0000_0fff)
 }
 
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn minor(dev: dev_t) -> u64 {
     ((dev >> 12) & 0xffff_ff00) |
     ((dev      ) & 0x0000_00ff)
 }
 
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn makedev(major: u64, minor: u64) -> dev_t {
     ((major & 0xffff_f000) << 32) |
     ((major & 0x0000_0fff) <<  8) |
@@ -129,6 +133,7 @@ pub fn fstat(fd: RawFd) -> Result<FileStat> {
 }
 
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn fstatat<P: ?Sized + NixPath>(dirfd: RawFd, pathname: &P, f: AtFlags) -> Result<FileStat> {
     let mut dst = mem::MaybeUninit::uninit();
     let res = pathname.with_nix_path(|cstr| {
@@ -175,6 +180,7 @@ pub enum FchmodatFlags {
 ///
 /// [fchmodat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn fchmodat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -233,6 +239,7 @@ pub fn utimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -
           target_os = "macos",
           target_os = "freebsd",
           target_os = "netbsd"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn lutimes<P: ?Sized + NixPath>(path: &P, atime: &TimeVal, mtime: &TimeVal) -> Result<()> {
     let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = path.with_nix_path(|cstr| unsafe {
@@ -280,6 +287,7 @@ pub enum UtimensatFlags {
 ///
 /// [utimensat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn utimensat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -306,6 +314,7 @@ pub fn utimensat<P: ?Sized + NixPath>(
 }
 
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mkdirat<P: ?Sized + NixPath>(fd: RawFd, path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe { libc::mkdirat(fd, cstr.as_ptr(), mode.bits() as mode_t) }

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -11,9 +11,11 @@ use crate::{NixPath, Result, errno::Errno};
 
 /// Identifies a mounted file system
 #[cfg(target_os = "android")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type fsid_t = libc::__fsid_t;
 /// Identifies a mounted file system
 #[cfg(not(target_os = "android"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type fsid_t = libc::fsid_t;
 
 /// Describes a mounted file system
@@ -142,12 +144,14 @@ impl Statfs {
         target_os = "ios",
         target_os = "macos"
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn filesystem_type(&self) -> FsType {
         FsType(self.0.f_type)
     }
 
     /// Magic code defining system type
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn filesystem_type_name(&self) -> &str {
         let c_str = unsafe { CStr::from_ptr(self.0.f_fstypename.as_ptr()) };
         c_str.to_str().unwrap()
@@ -155,18 +159,21 @@ impl Statfs {
 
     /// Optimal transfer block size
     #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> i32 {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "openbsd")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -176,30 +183,35 @@ impl Statfs {
         target_os = "android",
         all(target_os = "linux", target_env = "musl")
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
 
     /// Optimal transfer block size
     #[cfg(all(target_os = "linux", not(any(target_arch = "s390x", target_env = "musl"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::__fsword_t {
         self.0.f_bsize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::c_long {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "freebsd")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u64 {
         self.0.f_iosize
     }
 
     /// Size of a block
     #[cfg(any(target_os = "ios", target_os = "macos", target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -207,6 +219,7 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -214,6 +227,7 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
@@ -221,54 +235,63 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", not(any(target_arch = "s390x", target_env = "musl"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::__fsword_t {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "freebsd")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u64 {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "android")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_long {
         self.0.f_bsize
     }
 
     /// Maximum length of filenames
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namemax
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::c_ulong {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", not(any(target_arch = "s390x", target_env = "musl"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::__fsword_t {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(target_os = "android")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::c_ulong {
         self.0.f_namelen
     }
@@ -281,18 +304,21 @@ impl Statfs {
         target_os = "freebsd",
         target_os = "openbsd",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> u64 {
         self.0.f_blocks
     }
 
     /// Total data blocks in filesystem
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> libc::c_long {
         self.0.f_blocks
     }
 
     /// Total data blocks in filesystem
     #[cfg(all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> u64 {
         self.0.f_blocks
     }
@@ -307,6 +333,7 @@ impl Statfs {
         target_os = "dragonfly",
         all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32")))
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> libc::c_ulong {
         self.0.f_blocks
     }
@@ -319,18 +346,21 @@ impl Statfs {
         target_os = "freebsd",
         target_os = "openbsd",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> u64 {
         self.0.f_bfree
     }
 
     /// Free blocks in filesystem
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> libc::c_long {
         self.0.f_bfree
     }
 
     /// Free blocks in filesystem
     #[cfg(all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> u64 {
         self.0.f_bfree
     }
@@ -345,30 +375,35 @@ impl Statfs {
         target_os = "dragonfly",
         all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32")))
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> libc::c_ulong {
         self.0.f_bfree
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(any(target_os = "ios", target_os = "macos", target_os = "android"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> u64 {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> libc::c_long {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> i64 {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> u64 {
         self.0.f_bavail
     }
@@ -383,6 +418,7 @@ impl Statfs {
         target_os = "dragonfly",
         all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32")))
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> libc::c_ulong {
         self.0.f_bavail
     }
@@ -395,18 +431,21 @@ impl Statfs {
         target_os = "freebsd",
         target_os = "openbsd",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> u64 {
         self.0.f_files
     }
 
     /// Total file nodes in filesystem
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> libc::c_long {
         self.0.f_files
     }
 
     /// Total file nodes in filesystem
     #[cfg(all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> libc::fsfilcnt_t {
         self.0.f_files
     }
@@ -421,6 +460,7 @@ impl Statfs {
         target_os = "dragonfly",
         all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32")))
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> libc::c_ulong {
         self.0.f_files
     }
@@ -432,24 +472,28 @@ impl Statfs {
             target_os = "macos",
             target_os = "openbsd"
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> u64 {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(target_os = "dragonfly")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> libc::c_long {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(target_os = "freebsd")]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> i64 {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> libc::fsfilcnt_t {
         self.0.f_ffree
     }
@@ -464,6 +508,7 @@ impl Statfs {
         target_os = "dragonfly",
         all(target_os = "linux", any(target_env = "musl", all(target_arch = "x86_64", target_pointer_width = "32")))
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> libc::c_ulong {
         self.0.f_ffree
     }

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -21,33 +21,43 @@ libc_bitflags!(
         ST_NOSUID;
         /// Do not interpret character or block-special devices
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NODEV;
         /// Do not allow execution of binaries on the filesystem
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NOEXEC;
         /// All IO should be done synchronously
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_SYNCHRONOUS;
         /// Allow mandatory locks on the filesystem
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_MANDLOCK;
         /// Write on file/directory/symlink
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_WRITE;
         /// Append-only file
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_APPEND;
         /// Immutable file
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_IMMUTABLE;
         /// Do not update access times on files
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NOATIME;
         /// Do not update access times on files
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NODIRATIME;
         /// Update access time relative to modify/change time
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_env = "musl"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_RELATIME;
     }
 );
@@ -109,6 +119,7 @@ impl Statvfs {
 
     /// Get the mount flags
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn flags(&self) -> FsFlags {
         FsFlags::from_bits_truncate(self.0.f_flag)
     }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -996,7 +996,7 @@ pub fn tcsendbreak(fd: RawFd, duration: c_int) -> Result<()> {
     Errno::result(unsafe { libc::tcsendbreak(fd, duration) }).map(drop)
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 /// Get the session controlled by the given terminal (see
 /// [tcgetsid(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetsid.html)).

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -277,6 +277,7 @@ libc_enum!{
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B7200,
         B9600,
         #[cfg(any(target_os = "dragonfly",
@@ -284,6 +285,7 @@ libc_enum!{
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B14400,
         B19200,
         #[cfg(any(target_os = "dragonfly",
@@ -291,6 +293,7 @@ libc_enum!{
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B28800,
         B38400,
         B57600,
@@ -299,12 +302,15 @@ libc_enum!{
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B76800,
         B115200,
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B153600,
         B230400,
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B307200,
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -312,10 +318,13 @@ libc_enum!{
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B460800,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B500000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B576000,
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -323,22 +332,31 @@ libc_enum!{
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B921600,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1000000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1152000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1500000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B2000000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B2500000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B3000000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B3500000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         B4000000,
     }
     impl TryFrom<libc::speed_t>
@@ -421,6 +439,7 @@ libc_enum! {
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VDSUSP,
         VEOF,
         VEOL,
@@ -430,12 +449,14 @@ libc_enum! {
                   target_os = "freebsd",
                   target_os = "illumos",
                   target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VERASE2,
         VINTR,
         VKILL,
         VLNEXT,
         #[cfg(not(any(all(target_os = "linux", target_arch = "sparc64"),
                 target_os = "illumos", target_os = "solaris")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VMIN,
         VQUIT,
         VREPRINT,
@@ -447,18 +468,23 @@ libc_enum! {
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSTATUS,
         VSTOP,
         VSUSP,
         #[cfg(target_os = "linux")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSWTC,
         #[cfg(any(target_os = "haiku", target_os = "illumos", target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSWTCH,
         #[cfg(not(any(all(target_os = "linux", target_arch = "sparc64"),
                 target_os = "illumos", target_os = "solaris")))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VTIME,
         VWERASE,
         #[cfg(target_os = "dragonfly")]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VCHECKPT,
     }
 }
@@ -477,6 +503,7 @@ pub use libc::NCCS;
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub use libc::_POSIX_VDISABLE;
 
 libc_bitflags! {
@@ -494,10 +521,13 @@ libc_bitflags! {
         IXON;
         IXOFF;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IXANY;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IMAXBEL;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         IUTF8;
     }
 }
@@ -510,6 +540,7 @@ libc_bitflags! {
                   target_os = "haiku",
                   target_os = "linux",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         OLCUC;
         ONLCR;
         OCRNL as tcflag_t;
@@ -520,48 +551,56 @@ libc_bitflags! {
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         OFILL as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         OFDEL as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         NL0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         NL1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR2 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR3 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -569,18 +608,21 @@ libc_bitflags! {
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB2 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -588,44 +630,52 @@ libc_bitflags! {
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB3 as tcflag_t;
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         XTABS;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         BS0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         BS1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VT0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VT1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         FF0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         FF1 as tcflag_t;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
@@ -633,12 +683,14 @@ libc_bitflags! {
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         OXTABS;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ONOEOT as tcflag_t;
 
         // Bitmasks for use with OutputFlags to select specific settings
@@ -650,12 +702,14 @@ libc_bitflags! {
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         NLDLY as tcflag_t; // FIXME: Datatype needs to be corrected in libc for mac
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -663,24 +717,28 @@ libc_bitflags! {
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         TABDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         BSDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         VTDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "ios",
                   target_os = "linux",
                   target_os = "macos"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         FFDLY as tcflag_t;
     }
 }
@@ -694,6 +752,7 @@ libc_bitflags! {
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CIGNORE;
         CS5;
         CS6;
@@ -706,43 +765,54 @@ libc_bitflags! {
         HUPCL;
         CLOCAL;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRTSCTS;
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CBAUD;
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "mips"))))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CMSPAR;
         #[cfg(any(target_os = "android",
                   all(target_os = "linux",
                       not(any(target_arch = "powerpc", target_arch = "powerpc64")))))]
         CIBAUD;
         #[cfg(any(target_os = "android", target_os = "linux"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CBAUDEX;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         MDMBUF;
         #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CHWFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CCTS_OFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRTS_IFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CDTR_IFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CDSR_OFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         CCAR_OFLOW;
 
         // Bitmasks for use with ControlFlags to select specific settings
@@ -757,14 +827,17 @@ libc_bitflags! {
     /// Flags for setting any local modes
     pub struct LocalFlags: tcflag_t {
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOKE;
         ECHOE;
         ECHOK;
         ECHO;
         ECHONL;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOPRT;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOCTL;
         ISIG;
         ICANON;
@@ -774,12 +847,15 @@ libc_bitflags! {
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         ALTWERASE;
         IEXTEN;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         EXTPROC;
         TOSTOP;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         FLUSHO;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
@@ -787,8 +863,10 @@ libc_bitflags! {
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         NOKERNINFO;
         #[cfg(not(target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         PENDIN;
         NOFLSH;
     }
@@ -928,6 +1006,7 @@ pub fn cfmakeraw(termios: &mut Termios) {
 ///
 /// Note that this is a non-standard function, available on FreeBSD.
 #[cfg(target_os = "freebsd")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn cfmakesane(termios: &mut Termios) {
     let inner_termios = unsafe { termios.get_libc_termios_mut() };
     unsafe {

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -160,6 +160,7 @@ use std::convert::From;
 use std::mem;
 use std::os::unix::io::RawFd;
 
+#[cfg(feature = "process")]
 use crate::unistd::Pid;
 
 /// Stores settings for the termios API
@@ -995,12 +996,15 @@ pub fn tcsendbreak(fd: RawFd, duration: c_int) -> Result<()> {
     Errno::result(unsafe { libc::tcsendbreak(fd, duration) }).map(drop)
 }
 
+feature!{
+#![feature = "process"]
 /// Get the session controlled by the given terminal (see
 /// [tcgetsid(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetsid.html)).
 pub fn tcgetsid(fd: RawFd) -> Result<Pid> {
     let res = unsafe { libc::tcgetsid(fd) };
 
     Errno::result(res).map(Pid::from_raw)
+}
 }
 
 #[cfg(test)]

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -101,7 +101,7 @@ pub struct RemoteIoVec {
     pub len: usize,
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 
 /// Write data directly to another process's virtual memory

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -31,6 +31,7 @@ pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
 ///
 /// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
                offset: off_t) -> Result<usize> {
     let res = unsafe {
@@ -48,6 +49,7 @@ pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
 ///
 /// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn preadv(fd: RawFd, iov: &[IoVec<&mut [u8]>],
               offset: off_t) -> Result<usize> {
     let res = unsafe {
@@ -92,6 +94,7 @@ pub fn pread(fd: RawFd, buf: &mut [u8], offset: off_t) -> Result<usize>{
 /// is used with [`process_vm_readv`](fn.process_vm_readv.html)
 /// and [`process_vm_writev`](fn.process_vm_writev.html).
 #[cfg(target_os = "linux")]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RemoteIoVec {

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -101,6 +101,9 @@ pub struct RemoteIoVec {
     pub len: usize,
 }
 
+feature!{
+#![feature = "process"]
+
 /// Write data directly to another process's virtual memory
 /// (see [`process_vm_writev`(2)]).
 ///
@@ -170,6 +173,7 @@ pub fn process_vm_readv(
 
     Errno::result(res).map(|r| r as usize)
 }
+}
 
 /// A vector of buffers.
 ///
@@ -195,7 +199,7 @@ impl<T> IoVec<T> {
 }
 
 impl<'a> IoVec<&'a [u8]> {
-    #[cfg(target_os = "freebsd")]
+    #[cfg(all(feature = "mount", target_os = "freebsd"))]
     pub(crate) fn from_raw_parts(base: *mut c_void, len: usize) -> Self {
         IoVec(libc::iovec {
             iov_base: base,

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -27,6 +27,7 @@ libc_bitflags!(
                   target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         WEXITED;
         /// Report the status of selected processes that have continued from a
         /// job control stop by receiving a
@@ -41,6 +42,7 @@ libc_bitflags!(
                   target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         WSTOPPED;
         /// Don't reap, just poll status.
         #[cfg(any(target_os = "android",
@@ -51,15 +53,19 @@ libc_bitflags!(
                   target_os = "redox",
                   target_os = "macos",
                   target_os = "netbsd"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         WNOWAIT;
         /// Don't wait on children of other threads in this group
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WNOTHREAD;
         /// Wait on all children, regardless of type
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WALL;
         /// Wait for "clone" children only.
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WCLONE;
     }
 );
@@ -97,6 +103,7 @@ pub enum WaitStatus {
     /// [`nix::sys::ptrace`]: ../ptrace/index.html
     /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PtraceEvent(Pid, Signal, c_int),
     /// The traced process was stopped by execution of a system call,
     /// and `PTRACE_O_TRACESYSGOOD` is in effect. See [`ptrace`(2)] for
@@ -104,6 +111,7 @@ pub enum WaitStatus {
     ///
     /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PtraceSyscall(Pid),
     /// The process was previously stopped but has resumed execution
     /// after receiving a `SIGCONT` signal. This is only reported if

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,7 +25,7 @@ impl ClockId {
         ClockId(clk_id)
     }
 
-    feature!{
+    feature! {
     #![feature = "process"]
     /// Returns `ClockId` of a `pid` CPU-time clock
     #[cfg(any(

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,6 +6,7 @@ use crate::sys::time::TimeSpec;
     target_os = "android",
     target_os = "emscripten",
 ))]
+#[cfg(feature = "process")]
 use crate::unistd::Pid;
 use crate::{Errno, Result};
 use libc::{self, clockid_t};
@@ -24,6 +25,8 @@ impl ClockId {
         ClockId(clk_id)
     }
 
+    feature!{
+    #![feature = "process"]
     /// Returns `ClockId` of a `pid` CPU-time clock
     #[cfg(any(
         target_os = "freebsd",
@@ -34,6 +37,7 @@ impl ClockId {
     ))]
     pub fn pid_cpu_clock_id(pid: Pid) -> Result<Self> {
         clock_getcpuclockid(pid)
+    }
     }
 
     /// Returns resolution of the clock id
@@ -248,6 +252,7 @@ pub fn clock_settime(clock_id: ClockId, timespec: TimeSpec) -> Result<()> {
     target_os = "android",
     target_os = "emscripten",
 ))]
+#[cfg(feature = "process")]
 pub fn clock_getcpuclockid(pid: Pid) -> Result<ClockId> {
     let mut clk_id: MaybeUninit<libc::clockid_t> = MaybeUninit::uninit();
     let ret = unsafe { libc::clock_getcpuclockid(pid.into(), clk_id.as_mut_ptr()) };

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,6 +35,7 @@ impl ClockId {
         target_os = "android",
         target_os = "emscripten",
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn pid_cpu_clock_id(pid: Pid) -> Result<Self> {
         clock_getcpuclockid(pid)
     }
@@ -42,6 +43,7 @@ impl ClockId {
 
     /// Returns resolution of the clock id
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn res(self) -> Result<TimeSpec> {
         clock_getres(self)
     }
@@ -60,6 +62,7 @@ impl ClockId {
             any(target_os = "redox", target_os = "hermit",),
         ),
     )))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn set_time(self, timespec: TimeSpec) -> Result<()> {
         clock_settime(self, timespec)
     }
@@ -76,6 +79,7 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten"),
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_BOOTTIME: ClockId = ClockId(libc::CLOCK_BOOTTIME);
     #[cfg(any(
         target_os = "fuchsia",
@@ -84,6 +88,7 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_BOOTTIME_ALARM: ClockId = ClockId(libc::CLOCK_BOOTTIME_ALARM);
     pub const CLOCK_MONOTONIC: ClockId = ClockId(libc::CLOCK_MONOTONIC);
     #[cfg(any(
@@ -93,10 +98,13 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_COARSE: ClockId = ClockId(libc::CLOCK_MONOTONIC_COARSE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_FAST: ClockId = ClockId(libc::CLOCK_MONOTONIC_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_PRECISE: ClockId = ClockId(libc::CLOCK_MONOTONIC_PRECISE);
     #[cfg(any(
         target_os = "fuchsia",
@@ -105,6 +113,7 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_RAW: ClockId = ClockId(libc::CLOCK_MONOTONIC_RAW);
     #[cfg(any(
         target_os = "fuchsia",
@@ -118,8 +127,10 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_PROCESS_CPUTIME_ID: ClockId = ClockId(libc::CLOCK_PROCESS_CPUTIME_ID);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_PROF: ClockId = ClockId(libc::CLOCK_PROF);
     pub const CLOCK_REALTIME: ClockId = ClockId(libc::CLOCK_REALTIME);
     #[cfg(any(
@@ -129,6 +140,7 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_ALARM: ClockId = ClockId(libc::CLOCK_REALTIME_ALARM);
     #[cfg(any(
         target_os = "fuchsia",
@@ -137,12 +149,16 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten")
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_COARSE: ClockId = ClockId(libc::CLOCK_REALTIME_COARSE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_FAST: ClockId = ClockId(libc::CLOCK_REALTIME_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_PRECISE: ClockId = ClockId(libc::CLOCK_REALTIME_PRECISE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_SECOND: ClockId = ClockId(libc::CLOCK_SECOND);
     #[cfg(any(
         target_os = "fuchsia",
@@ -154,6 +170,7 @@ impl ClockId {
             )
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_SGI_CYCLE: ClockId = ClockId(libc::CLOCK_SGI_CYCLE);
     #[cfg(any(
         target_os = "fuchsia",
@@ -165,6 +182,7 @@ impl ClockId {
             )
         )
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_TAI: ClockId = ClockId(libc::CLOCK_TAI);
     #[cfg(any(
         target_env = "uclibc",
@@ -178,14 +196,19 @@ impl ClockId {
             any(target_os = "linux", target_os = "android", target_os = "emscripten",),
         ),
     ))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_THREAD_CPUTIME_ID: ClockId = ClockId(libc::CLOCK_THREAD_CPUTIME_ID);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME: ClockId = ClockId(libc::CLOCK_UPTIME);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME_FAST: ClockId = ClockId(libc::CLOCK_UPTIME_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME_PRECISE: ClockId = ClockId(libc::CLOCK_UPTIME_PRECISE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_VIRTUAL: ClockId = ClockId(libc::CLOCK_VIRTUAL);
 }
 
@@ -210,6 +233,7 @@ impl std::fmt::Display for ClockId {
 /// Get the resolution of the specified clock, (see
 /// [clock_getres(2)](https://pubs.opengroup.org/onlinepubs/7908799/xsh/clock_getres.html)).
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn clock_getres(clock_id: ClockId) -> Result<TimeSpec> {
     let mut c_time: MaybeUninit<libc::timespec> = MaybeUninit::uninit();
     let ret = unsafe { libc::clock_getres(clock_id.as_raw(), c_time.as_mut_ptr()) };
@@ -238,6 +262,7 @@ pub fn clock_gettime(clock_id: ClockId) -> Result<TimeSpec> {
         any(target_os = "redox", target_os = "hermit",),
     ),
 )))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn clock_settime(clock_id: ClockId, timespec: TimeSpec) -> Result<()> {
     let ret = unsafe { libc::clock_settime(clock_id.as_raw(), timespec.as_ref()) };
     Errno::result(ret).map(drop)
@@ -253,6 +278,7 @@ pub fn clock_settime(clock_id: ClockId, timespec: TimeSpec) -> Result<()> {
     target_os = "emscripten",
 ))]
 #[cfg(feature = "process")]
+#[cfg_attr(docsrs, doc(cfg(feature = "process")))]
 pub fn clock_getcpuclockid(pid: Pid) -> Result<ClockId> {
     let mut clk_id: MaybeUninit<libc::clockid_t> = MaybeUninit::uninit();
     let ret = unsafe { libc::clock_getcpuclockid(pid.into(), clk_id.as_mut_ptr()) };

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 #[cfg(feature = "fs")]
 use crate::sys::stat::Mode;
 
-feature!{
+feature! {
     #![feature = "fs"]
     #[cfg(any(target_os = "android", target_os = "linux"))]
     pub use self::pivot_root::*;
@@ -37,7 +37,7 @@ pub use self::setres::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::getres::*;
 
-feature!{
+feature! {
 #![feature = "users"]
 
 /// User identifier
@@ -131,7 +131,7 @@ impl fmt::Display for Gid {
 }
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 /// Process identifier
 ///
@@ -316,7 +316,7 @@ pub fn getsid(pid: Option<Pid>) -> Result<Pid> {
 }
 }
 
-feature!{
+feature! {
 #![all(feature = "process", feature = "term")]
 /// Get the terminal foreground process group (see
 /// [tcgetpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetpgrp.html)).
@@ -340,7 +340,7 @@ pub fn tcsetpgrp(fd: c_int, pgrp: Pid) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 /// Get the group id of the calling process (see
 ///[getpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgrp.html)).
@@ -369,7 +369,7 @@ pub fn gettid() -> Pid {
 }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 /// Create a copy of the specified file descriptor (see
 /// [dup(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html)).
@@ -598,7 +598,7 @@ fn reserve_double_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
     Ok(())
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 /// Returns the current directory as a `PathBuf`
@@ -646,7 +646,7 @@ pub fn getcwd() -> Result<PathBuf> {
 }
 }
 
-feature!{
+feature! {
 #![all(feature = "users", feature = "fs")]
 
 /// Computes the raw UID and GID values to pass to a `*chown` call.
@@ -745,7 +745,7 @@ pub fn fchownat<P: ?Sized + NixPath>(
 }
 }
 
-feature!{
+feature! {
 #![feature = "process"]
 fn to_exec_array<S: AsRef<CStr>>(args: &[S]) -> Vec<*const c_char> {
     use std::iter::once;
@@ -930,7 +930,7 @@ pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "hostname"]
 
 /// Set the system host name (see
@@ -1042,7 +1042,7 @@ pub fn write(fd: RawFd, buf: &[u8]) -> Result<usize> {
     Errno::result(res).map(|r| r as usize)
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 /// Directive that tells [`lseek`] and [`lseek64`] what the offset is relative to.
@@ -1112,7 +1112,7 @@ pub fn pipe() -> std::result::Result<(RawFd, RawFd), Error> {
     }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 /// Like `pipe`, but allows setting certain file descriptor flags.
 ///
@@ -1340,7 +1340,7 @@ pub fn fdatasync(fd: RawFd) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "users"]
 
 /// Get a real user ID
@@ -1424,7 +1424,7 @@ pub fn setgid(gid: Gid) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![all(feature = "fs", feature = "users")]
 /// Set the user identity used for filesystem checks per-thread.
 /// On both success and failure, this call returns the previous filesystem user
@@ -1449,7 +1449,7 @@ pub fn setfsgid(gid: Gid) -> Gid {
 }
 }
 
-feature!{
+feature! {
 #![feature = "users"]
 
 /// Get the list of supplementary group IDs of the calling process.
@@ -1682,7 +1682,7 @@ pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "signal"]
 
 /// Suspend the thread until a signal is received.
@@ -1792,7 +1792,7 @@ pub fn sleep(seconds: c_uint) -> c_uint {
     unsafe { libc::sleep(seconds) }
 }
 
-feature!{
+feature! {
 #![feature = "acct"]
 
 #[cfg(not(target_os = "redox"))]
@@ -1821,7 +1821,7 @@ pub mod acct {
 }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 /// Creates a regular file which persists even after process termination
 ///
@@ -1860,7 +1860,7 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 }
 }
 
-feature!{
+feature! {
 #![all(feature = "fs", feature = "features")]
 
 /// Variable names for `pathconf`
@@ -2044,7 +2044,7 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 }
 }
 
-feature!{
+feature! {
 #![feature = "features"]
 
 /// Variable names for `sysconf`
@@ -2548,7 +2548,7 @@ pub fn sysconf(var: SysconfVar) -> Result<Option<c_long>> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -2574,7 +2574,7 @@ mod pivot_root {
 #[cfg(any(target_os = "android", target_os = "freebsd",
           target_os = "linux", target_os = "openbsd"))]
 mod setres {
-    feature!{
+    feature! {
     #![feature = "users"]
 
     use crate::Result;
@@ -2617,7 +2617,7 @@ mod setres {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod getres {
-    feature!{
+    feature! {
     #![feature = "users"]
 
     use crate::Result;
@@ -2696,7 +2696,7 @@ libc_bitflags!{
     }
 }
 
-feature!{
+feature! {
 #![feature = "fs"]
 
 /// Checks the file named by `path` for accessibility according to the flags given by `amode`
@@ -2711,7 +2711,7 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
 }
 }
 
-feature!{
+feature! {
 #![feature = "users"]
 
 /// Representation of a User, based on `libc::passwd`
@@ -3052,7 +3052,7 @@ impl Group {
 }
 }
 
-feature!{
+feature! {
 #![feature = "term"]
 
 /// Get the name of the terminal device that is open on file descriptor fd
@@ -3074,7 +3074,7 @@ pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
 }
 }
 
-feature!{
+feature! {
 #![all(feature = "socket", feature = "users")]
 
 /// Get the effective user ID and group ID associated with a Unix domain socket.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1887,6 +1887,7 @@ pub enum PathconfVar {
               target_os = "netbsd", target_os = "openbsd", target_os = "redox"))]
     /// Minimum number of bits needed to represent, as a signed integer value,
     /// the maximum size of a regular file allowed in the specified directory.
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     FILESIZEBITS = libc::_PC_FILESIZEBITS,
     /// Maximum number of links to a single file.
     LINK_MAX = libc::_PC_LINK_MAX,
@@ -1910,33 +1911,40 @@ pub enum PathconfVar {
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "illumos",
               target_os = "linux", target_os = "netbsd", target_os = "openbsd",
               target_os = "redox", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Symbolic links can be created.
     POSIX2_SYMLINKS = libc::_PC_2_SYMLINKS,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "linux", target_os = "openbsd", target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Minimum number of bytes of storage actually allocated for any portion of
     /// a file.
     POSIX_ALLOC_SIZE_MIN = libc::_PC_ALLOC_SIZE_MIN,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "linux", target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Recommended increment for file transfer sizes between the
     /// `POSIX_REC_MIN_XFER_SIZE` and `POSIX_REC_MAX_XFER_SIZE` values.
     POSIX_REC_INCR_XFER_SIZE = libc::_PC_REC_INCR_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "linux", target_os = "openbsd", target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum recommended file transfer size.
     POSIX_REC_MAX_XFER_SIZE = libc::_PC_REC_MAX_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "linux", target_os = "openbsd", target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Minimum recommended file transfer size.
     POSIX_REC_MIN_XFER_SIZE = libc::_PC_REC_MIN_XFER_SIZE,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "linux", target_os = "openbsd", target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ///  Recommended file transfer buffer alignment.
     POSIX_REC_XFER_ALIGN = libc::_PC_REC_XFER_ALIGN,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "illumos", target_os = "linux", target_os = "netbsd",
               target_os = "openbsd", target_os = "redox", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum number of bytes in a symbolic link.
     SYMLINK_MAX = libc::_PC_SYMLINK_MAX,
     /// The use of `chown` and `fchown` is restricted to a process with
@@ -1952,22 +1960,26 @@ pub enum PathconfVar {
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "illumos", target_os = "linux", target_os = "openbsd",
               target_os = "redox", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Asynchronous input or output operations may be performed for the
     /// associated file.
     _POSIX_ASYNC_IO = libc::_PC_ASYNC_IO,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "illumos", target_os = "linux", target_os = "openbsd",
               target_os = "redox", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Prioritized input or output operations may be performed for the
     /// associated file.
     _POSIX_PRIO_IO = libc::_PC_PRIO_IO,
     #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd",
               target_os = "illumos", target_os = "linux", target_os = "netbsd",
               target_os = "openbsd", target_os = "redox", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Synchronized input or output operations may be performed for the
     /// associated file.
     _POSIX_SYNC_IO = libc::_PC_SYNC_IO,
     #[cfg(any(target_os = "dragonfly", target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The resolution in nanoseconds for all file timestamps.
     _POSIX_TIMESTAMP_RESOLUTION = libc::_PC_TIMESTAMP_RESOLUTION
 }
@@ -2070,14 +2082,17 @@ pub enum SysconfVar {
     /// Maximum number of I/O operations in a single list I/O call supported by
     /// the implementation.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_LISTIO_MAX = libc::_SC_AIO_LISTIO_MAX,
     /// Maximum number of outstanding asynchronous I/O operations supported by
     /// the implementation.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_MAX = libc::_SC_AIO_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The maximum amount by which a process can decrease its asynchronous I/O
     /// priority level from its own scheduling priority.
     AIO_PRIO_DELTA_MAX = libc::_SC_AIO_PRIO_DELTA_MAX,
@@ -2085,18 +2100,23 @@ pub enum SysconfVar {
     ARG_MAX = libc::_SC_ARG_MAX,
     /// Maximum number of functions that may be registered with `atexit`.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     ATEXIT_MAX = libc::_SC_ATEXIT_MAX,
     /// Maximum obase values allowed by the bc utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_BASE_MAX = libc::_SC_BC_BASE_MAX,
     /// Maximum number of elements permitted in an array by the bc utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_DIM_MAX = libc::_SC_BC_DIM_MAX,
     /// Maximum scale value allowed by the bc utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_SCALE_MAX = libc::_SC_BC_SCALE_MAX,
     /// Maximum length of a string constant accepted by the bc utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_STRING_MAX = libc::_SC_BC_STRING_MAX,
     /// Maximum number of simultaneous processes per real user ID.
     CHILD_MAX = libc::_SC_CHILD_MAX,
@@ -2105,29 +2125,35 @@ pub enum SysconfVar {
     /// Maximum number of weights that can be assigned to an entry of the
     /// LC_COLLATE order keyword in the locale definition file
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     COLL_WEIGHTS_MAX = libc::_SC_COLL_WEIGHTS_MAX,
     /// Maximum number of timer expiration overruns.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     DELAYTIMER_MAX = libc::_SC_DELAYTIMER_MAX,
     /// Maximum number of expressions that can be nested within parentheses by
     /// the expr utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     EXPR_NEST_MAX = libc::_SC_EXPR_NEST_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum length of a host name (not including the terminating null) as
     /// returned from the `gethostname` function
     HOST_NAME_MAX = libc::_SC_HOST_NAME_MAX,
     /// Maximum number of iovec structures that one process has available for
     /// use with `readv` or `writev`.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     IOV_MAX = libc::_SC_IOV_MAX,
     /// Unless otherwise noted, the maximum length, in bytes, of a utility's
     /// input line (either standard input or another file), when the utility is
     /// described as processing text files. The length includes room for the
     /// trailing <newline>.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     LINE_MAX = libc::_SC_LINE_MAX,
     /// Maximum length of a login name.
     LOGIN_NAME_MAX = libc::_SC_LOGIN_NAME_MAX,
@@ -2135,211 +2161,267 @@ pub enum SysconfVar {
     NGROUPS_MAX = libc::_SC_NGROUPS_MAX,
     /// Initial size of `getgrgid_r` and `getgrnam_r` data buffers
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     GETGR_R_SIZE_MAX = libc::_SC_GETGR_R_SIZE_MAX,
     /// Initial size of `getpwuid_r` and `getpwnam_r` data buffers
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     GETPW_R_SIZE_MAX = libc::_SC_GETPW_R_SIZE_MAX,
     /// The maximum number of open message queue descriptors a process may hold.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_OPEN_MAX = libc::_SC_MQ_OPEN_MAX,
     /// The maximum number of message priorities supported by the implementation.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_PRIO_MAX = libc::_SC_MQ_PRIO_MAX,
     /// A value one greater than the maximum value that the system may assign to
     /// a newly-created file descriptor.
     OPEN_MAX = libc::_SC_OPEN_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Advisory Information option.
     _POSIX_ADVISORY_INFO = libc::_SC_ADVISORY_INFO,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports barriers.
     _POSIX_BARRIERS = libc::_SC_BARRIERS,
     /// The implementation supports asynchronous input and output.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_ASYNCHRONOUS_IO = libc::_SC_ASYNCHRONOUS_IO,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports clock selection.
     _POSIX_CLOCK_SELECTION = libc::_SC_CLOCK_SELECTION,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Process CPU-Time Clocks option.
     _POSIX_CPUTIME = libc::_SC_CPUTIME,
     /// The implementation supports the File Synchronization option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_FSYNC = libc::_SC_FSYNC,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the IPv6 option.
     _POSIX_IPV6 = libc::_SC_IPV6,
     /// The implementation supports job control.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_JOB_CONTROL = libc::_SC_JOB_CONTROL,
     /// The implementation supports memory mapped Files.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MAPPED_FILES = libc::_SC_MAPPED_FILES,
     /// The implementation supports the Process Memory Locking option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK = libc::_SC_MEMLOCK,
     /// The implementation supports the Range Memory Locking option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK_RANGE = libc::_SC_MEMLOCK_RANGE,
     /// The implementation supports memory protection.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMORY_PROTECTION = libc::_SC_MEMORY_PROTECTION,
     /// The implementation supports the Message Passing option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MESSAGE_PASSING = libc::_SC_MESSAGE_PASSING,
     /// The implementation supports the Monotonic Clock option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MONOTONIC_CLOCK = libc::_SC_MONOTONIC_CLOCK,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "illumos", target_os = "ios", target_os="linux",
               target_os = "macos", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Prioritized Input and Output option.
     _POSIX_PRIORITIZED_IO = libc::_SC_PRIORITIZED_IO,
     /// The implementation supports the Process Scheduling option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_PRIORITY_SCHEDULING = libc::_SC_PRIORITY_SCHEDULING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Raw Sockets option.
     _POSIX_RAW_SOCKETS = libc::_SC_RAW_SOCKETS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports read-write locks.
     _POSIX_READER_WRITER_LOCKS = libc::_SC_READER_WRITER_LOCKS,
     #[cfg(any(target_os = "android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports realtime signals.
     _POSIX_REALTIME_SIGNALS = libc::_SC_REALTIME_SIGNALS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd", target_os = "solaris"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Regular Expression Handling option.
     _POSIX_REGEXP = libc::_SC_REGEXP,
     /// Each process has a saved set-user-ID and a saved set-group-ID.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SAVED_IDS = libc::_SC_SAVED_IDS,
     /// The implementation supports semaphores.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SEMAPHORES = libc::_SC_SEMAPHORES,
     /// The implementation supports the Shared Memory Objects option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SHARED_MEMORY_OBJECTS = libc::_SC_SHARED_MEMORY_OBJECTS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the POSIX shell.
     _POSIX_SHELL = libc::_SC_SHELL,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Spawn option.
     _POSIX_SPAWN = libc::_SC_SPAWN,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports spin locks.
     _POSIX_SPIN_LOCKS = libc::_SC_SPIN_LOCKS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Process Sporadic Server option.
     _POSIX_SPORADIC_SERVER = libc::_SC_SPORADIC_SERVER,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SS_REPL_MAX = libc::_SC_SS_REPL_MAX,
     /// The implementation supports the Synchronized Input and Output option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SYNCHRONIZED_IO = libc::_SC_SYNCHRONIZED_IO,
     /// The implementation supports the Thread Stack Address Attribute option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_ATTR_STACKADDR = libc::_SC_THREAD_ATTR_STACKADDR,
     /// The implementation supports the Thread Stack Size Attribute option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_ATTR_STACKSIZE = libc::_SC_THREAD_ATTR_STACKSIZE,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="netbsd", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread CPU-Time Clocks option.
     _POSIX_THREAD_CPUTIME = libc::_SC_THREAD_CPUTIME,
     /// The implementation supports the Non-Robust Mutex Priority Inheritance
     /// option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_INHERIT = libc::_SC_THREAD_PRIO_INHERIT,
     /// The implementation supports the Non-Robust Mutex Priority Protection option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_PROTECT = libc::_SC_THREAD_PRIO_PROTECT,
     /// The implementation supports the Thread Execution Scheduling option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIORITY_SCHEDULING = libc::_SC_THREAD_PRIORITY_SCHEDULING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread Process-Shared Synchronization
     /// option.
     _POSIX_THREAD_PROCESS_SHARED = libc::_SC_THREAD_PROCESS_SHARED,
     #[cfg(any(target_os="dragonfly", target_os="linux", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Robust Mutex Priority Inheritance option.
     _POSIX_THREAD_ROBUST_PRIO_INHERIT = libc::_SC_THREAD_ROBUST_PRIO_INHERIT,
     #[cfg(any(target_os="dragonfly", target_os="linux", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Robust Mutex Priority Protection option.
     _POSIX_THREAD_ROBUST_PRIO_PROTECT = libc::_SC_THREAD_ROBUST_PRIO_PROTECT,
     /// The implementation supports thread-safe functions.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_SAFE_FUNCTIONS = libc::_SC_THREAD_SAFE_FUNCTIONS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread Sporadic Server option.
     _POSIX_THREAD_SPORADIC_SERVER = libc::_SC_THREAD_SPORADIC_SERVER,
     /// The implementation supports threads.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREADS = libc::_SC_THREADS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports timeouts.
     _POSIX_TIMEOUTS = libc::_SC_TIMEOUTS,
     /// The implementation supports timers.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TIMERS = libc::_SC_TIMERS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace option.
     _POSIX_TRACE = libc::_SC_TRACE,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Event Filter option.
     _POSIX_TRACE_EVENT_FILTER = libc::_SC_TRACE_EVENT_FILTER,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_EVENT_NAME_MAX = libc::_SC_TRACE_EVENT_NAME_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Inherit option.
     _POSIX_TRACE_INHERIT = libc::_SC_TRACE_INHERIT,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Log option.
     _POSIX_TRACE_LOG = libc::_SC_TRACE_LOG,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_NAME_MAX = libc::_SC_TRACE_NAME_MAX,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_SYS_MAX = libc::_SC_TRACE_SYS_MAX,
     #[cfg(any(target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_USER_EVENT_MAX = libc::_SC_TRACE_USER_EVENT_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Typed Memory Objects option.
     _POSIX_TYPED_MEMORY_OBJECTS = libc::_SC_TYPED_MEMORY_OBJECTS,
     /// Integer value indicating version of this standard (C-language binding)
@@ -2349,12 +2431,14 @@ pub enum SysconfVar {
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int`, `long`, `pointer`, and `off_t` types.
     _POSIX_V6_ILP32_OFF32 = libc::_SC_V6_ILP32_OFF32,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int`, `long`, and pointer types and an `off_t` type using at
     /// least 64 bits.
@@ -2362,75 +2446,92 @@ pub enum SysconfVar {
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int` and 64-bit `long`, `pointer`, and `off_t` types.
     _POSIX_V6_LP64_OFF64 = libc::_SC_V6_LP64_OFF64,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with an
     /// `int` type using at least 32 bits and `long`, pointer, and `off_t` types
     /// using at least 64 bits.
     _POSIX_V6_LPBIG_OFFBIG = libc::_SC_V6_LPBIG_OFFBIG,
     /// The implementation supports the C-Language Binding option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_BIND = libc::_SC_2_C_BIND,
     /// The implementation supports the C-Language Development Utilities option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_DEV = libc::_SC_2_C_DEV,
     /// The implementation supports the Terminal Characteristics option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_CHAR_TERM = libc::_SC_2_CHAR_TERM,
     /// The implementation supports the FORTRAN Development Utilities option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_DEV = libc::_SC_2_FORT_DEV,
     /// The implementation supports the FORTRAN Runtime Utilities option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_RUN = libc::_SC_2_FORT_RUN,
     /// The implementation supports the creation of locales by the localedef
     /// utility.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_LOCALEDEF = libc::_SC_2_LOCALEDEF,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Environment Services and Utilities
     /// option.
     _POSIX2_PBS = libc::_SC_2_PBS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Accounting option.
     _POSIX2_PBS_ACCOUNTING = libc::_SC_2_PBS_ACCOUNTING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Checkpoint/Restart option.
     _POSIX2_PBS_CHECKPOINT = libc::_SC_2_PBS_CHECKPOINT,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Locate Batch Job Request option.
     _POSIX2_PBS_LOCATE = libc::_SC_2_PBS_LOCATE,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Job Message Request option.
     _POSIX2_PBS_MESSAGE = libc::_SC_2_PBS_MESSAGE,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Track Batch Job Request option.
     _POSIX2_PBS_TRACK = libc::_SC_2_PBS_TRACK,
     /// The implementation supports the Software Development Utilities option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_SW_DEV = libc::_SC_2_SW_DEV,
     /// The implementation supports the User Portability Utilities option.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_UPE = libc::_SC_2_UPE,
     /// Integer value indicating version of the Shell and Utilities volume of
     /// POSIX.1 to which the implementation conforms.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_VERSION = libc::_SC_2_VERSION,
     /// The size of a system page in bytes.
     ///
@@ -2438,78 +2539,97 @@ pub enum SysconfVar {
     /// enum constants to have the same value, so nix omits `PAGESIZE`.
     PAGE_SIZE = libc::_SC_PAGE_SIZE,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_DESTRUCTOR_ITERATIONS = libc::_SC_THREAD_DESTRUCTOR_ITERATIONS,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_KEYS_MAX = libc::_SC_THREAD_KEYS_MAX,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_STACK_MIN = libc::_SC_THREAD_STACK_MIN,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_THREADS_MAX = libc::_SC_THREAD_THREADS_MAX,
     RE_DUP_MAX = libc::_SC_RE_DUP_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     RTSIG_MAX = libc::_SC_RTSIG_MAX,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SEM_NSEMS_MAX = libc::_SC_SEM_NSEMS_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SEM_VALUE_MAX = libc::_SC_SEM_VALUE_MAX,
     #[cfg(any(target_os = "android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os = "openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SIGQUEUE_MAX = libc::_SC_SIGQUEUE_MAX,
     STREAM_MAX = libc::_SC_STREAM_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="netbsd",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     SYMLOOP_MAX = libc::_SC_SYMLOOP_MAX,
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     TIMER_MAX = libc::_SC_TIMER_MAX,
     TTY_NAME_MAX = libc::_SC_TTY_NAME_MAX,
     TZNAME_MAX = libc::_SC_TZNAME_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Encryption Option Group.
     _XOPEN_CRYPT = libc::_SC_XOPEN_CRYPT,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Issue 4, Version 2 Enhanced
     /// Internationalization Option Group.
     _XOPEN_ENH_I18N = libc::_SC_XOPEN_ENH_I18N,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _XOPEN_LEGACY = libc::_SC_XOPEN_LEGACY,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Realtime Option Group.
     _XOPEN_REALTIME = libc::_SC_XOPEN_REALTIME,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Realtime Threads Option Group.
     _XOPEN_REALTIME_THREADS = libc::_SC_XOPEN_REALTIME_THREADS,
     /// The implementation supports the Issue 4, Version 2 Shared Memory Option
     /// Group.
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     _XOPEN_SHM = libc::_SC_XOPEN_SHM,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
               target_os="linux", target_os = "macos", target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the XSI STREAMS Option Group.
     _XOPEN_STREAMS = libc::_SC_XOPEN_STREAMS,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the XSI option
     _XOPEN_UNIX = libc::_SC_XOPEN_UNIX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
               target_os="openbsd"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Integer value indicating version of the X/Open Portability Guide to
     /// which the implementation conforms.
     _XOPEN_VERSION = libc::_SC_XOPEN_VERSION,
@@ -2744,6 +2864,7 @@ pub struct User {
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub class: CString,
     /// Last password change
     #[cfg(not(any(target_os = "android",
@@ -2751,6 +2872,7 @@ pub struct User {
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub change: libc::time_t,
     /// Expiration time of account
     #[cfg(not(any(target_os = "android",
@@ -2758,6 +2880,7 @@ pub struct User {
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub expire: libc::time_t
 }
 


### PR DESCRIPTION
This PR satisfies a long-running request: to slim down the Nix crate by conditionally enabling certain functionality.  By default everything is enabled, but consumers can reduce that by selecting a subset of features.