### PR TITLE
Print function name and missing capability when skipping tests

### DIFF
--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -14,19 +14,19 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
         #[macro_export] macro_rules! require_capability {
-            ($capname:ident) => {
+            ($name:expr, $capname:ident) => {
                 use ::caps::{Capability, CapSet, has_cap};
 
                 if !has_cap(None, CapSet::Effective, Capability::$capname)
                     .unwrap()
                 {
-                    skip!("Insufficient capabilities. Skipping test.");
+                    skip!("{} requires capability {}. Skipping test.", $name, Capability::$capname);
                 }
             }
         }
     } else if #[cfg(not(target_os = "redox"))] {
         #[macro_export] macro_rules! require_capability {
-            ($capname:ident) => {}
+            ($name:expr, $capname:ident) => {}
         }
     }
 }

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -13,7 +13,7 @@ use crate::*;
 fn test_ptrace() {
     // Just make sure ptrace can be called at all, for now.
     // FIXME: qemu-user doesn't implement ptrace on all arches, so permit ENOSYS
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace", CAP_SYS_PTRACE);
     let err = ptrace::attach(getpid()).unwrap_err();
     assert!(err == Errno::EPERM || err == Errno::EINVAL ||
             err == Errno::ENOSYS);
@@ -23,7 +23,7 @@ fn test_ptrace() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_setoptions() {
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_setoptions", CAP_SYS_PTRACE);
     let err = ptrace::setoptions(getpid(), Options::PTRACE_O_TRACESYSGOOD).unwrap_err();
     assert!(err != Errno::EOPNOTSUPP);
 }
@@ -32,7 +32,7 @@ fn test_ptrace_setoptions() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_getevent() {
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_getevent", CAP_SYS_PTRACE);
     let err = ptrace::getevent(getpid()).unwrap_err();
     assert!(err != Errno::EOPNOTSUPP);
 }
@@ -41,7 +41,7 @@ fn test_ptrace_getevent() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_getsiginfo() {
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_getsiginfo", CAP_SYS_PTRACE);
     if let Err(Errno::EOPNOTSUPP) = ptrace::getsiginfo(getpid()) {
         panic!("ptrace_getsiginfo returns Errno::EOPNOTSUPP!");
     }
@@ -51,7 +51,7 @@ fn test_ptrace_getsiginfo() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn test_ptrace_setsiginfo() {
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_setsiginfo", CAP_SYS_PTRACE);
     let siginfo = unsafe { mem::zeroed() };
     if let Err(Errno::EOPNOTSUPP) = ptrace::setsiginfo(getpid(), &siginfo) {
         panic!("ptrace_setsiginfo returns Errno::EOPNOTSUPP!");
@@ -67,7 +67,7 @@ fn test_ptrace_cont() {
     use nix::unistd::fork;
     use nix::unistd::ForkResult::*;
 
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_cont", CAP_SYS_PTRACE);
 
     let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
@@ -125,7 +125,7 @@ fn test_ptrace_interrupt() {
     use std::thread::sleep;
     use std::time::Duration;
 
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_interrupt", CAP_SYS_PTRACE);
 
     let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
@@ -171,7 +171,7 @@ fn test_ptrace_syscall() {
     use nix::unistd::getpid;
     use nix::unistd::ForkResult::*;
 
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_ptrace_syscall", CAP_SYS_PTRACE);
 
     let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -49,7 +49,7 @@ pub fn test_local_peercred_stream() {
 fn is_so_mark_functional() {
     use nix::sys::socket::sockopt;
 
-    require_capability!(CAP_NET_ADMIN);
+    require_capability!("is_so_mark_functional", CAP_NET_ADMIN);
 
     let s = socket(AddressFamily::Inet, SockType::Stream, SockFlag::empty(), None).unwrap();
     setsockopt(s, sockopt::Mark, &1337).unwrap();

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -213,7 +213,7 @@ fn test_process_vm_readv() {
     use nix::sys::wait::*;
     use crate::*;
 
-    require_capability!(CAP_SYS_PTRACE);
+    require_capability!("test_process_vm_readv", CAP_SYS_PTRACE);
     let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
     // Pre-allocate memory in the child, since allocation isn't safe

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -96,7 +96,7 @@ mod ptrace {
 
     #[test]
     fn test_wait_ptrace() {
-        require_capability!(CAP_SYS_PTRACE);
+        require_capability!("test_wait_ptrace", CAP_SYS_PTRACE);
         let _m = crate::FORK_MTX.lock().expect("Mutex got poisoned by another test");
 
         match unsafe{fork()}.expect("Error: Fork Failed") {

--- a/test/test_kmod/mod.rs
+++ b/test/test_kmod/mod.rs
@@ -41,7 +41,7 @@ use std::io::Read;
 
 #[test]
 fn test_finit_and_delete_module() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_finit_and_delete_module", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -58,8 +58,8 @@ fn test_finit_and_delete_module() {
 }
 
 #[test]
-fn test_finit_and_delete_modul_with_params() {
-    require_capability!(CAP_SYS_MODULE);
+fn test_finit_and_delete_module_with_params() {
+    require_capability!("test_finit_and_delete_module_with_params", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -80,7 +80,7 @@ fn test_finit_and_delete_modul_with_params() {
 
 #[test]
 fn test_init_and_delete_module() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_init_and_delete_module", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -100,7 +100,7 @@ fn test_init_and_delete_module() {
 
 #[test]
 fn test_init_and_delete_module_with_params() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_init_and_delete_module_with_params", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -121,7 +121,7 @@ fn test_init_and_delete_module_with_params() {
 
 #[test]
 fn test_finit_module_invalid() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_finit_module_invalid", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -135,7 +135,7 @@ fn test_finit_module_invalid() {
 
 #[test]
 fn test_finit_module_twice_and_delete_module() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_finit_module_twice_and_delete_module", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 
@@ -157,7 +157,7 @@ fn test_finit_module_twice_and_delete_module() {
 
 #[test]
 fn test_delete_module_not_loaded() {
-    require_capability!(CAP_SYS_MODULE);
+    require_capability!("test_delete_module_not_loaded", CAP_SYS_MODULE);
     let _m0 = crate::KMOD_MTX.lock().expect("Mutex got poisoned by another test");
     let _m1 = crate::CWD_LOCK.read().expect("Mutex got poisoned by another test");
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -549,7 +549,7 @@ cfg_if!{
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
         macro_rules! require_acct{
             () => {
-                require_capability!(CAP_SYS_PACCT);
+                require_capability!("test_acct", CAP_SYS_PACCT);
             }
         }
     } else if #[cfg(target_os = "freebsd")] {
@@ -1040,7 +1040,7 @@ fn test_user_into_passwd() {
 fn test_setfsuid() {
     use std::os::unix::fs::PermissionsExt;
     use std::{fs, io, thread};
-    require_capability!(CAP_SETUID);
+    require_capability!("test_setfsuid", CAP_SETUID);
 
     // get the UID of the "nobody" user
     let nobody = User::from_name("nobody").unwrap().unwrap();


### PR DESCRIPTION
Currently when a test is skipped due to missing capabilities, a nondescript message is logged to stderr.

Improve that message to include both the function name and missing capability, making it possible to inspect stderr to see which capabilities are missing, and which tests they impact.