### PR TITLE
Mark x86_64-unknown-illumos as Tier 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Tier 2:
   * s390x-unknown-linux-gnu
   * x86_64-apple-ios
   * x86_64-linux-android
+  * x86_64-unknown-illumos
   * x86_64-unknown-netbsd
 
 Tier 3:


### PR DESCRIPTION
Illumos support is automatically built, but the README does not reflect this.