### PR TITLE
Allow Android to use timerfd

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -135,6 +135,6 @@ pub mod wait;
 #[allow(missing_docs)]
 pub mod inotify;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 #[allow(missing_docs)]
 pub mod timerfd;

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -41,5 +41,5 @@ mod test_pthread;
           target_os = "netbsd",
           target_os = "openbsd"))]
 mod test_ptrace;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_timerfd;


### PR DESCRIPTION
This is a continuation of #1336 which also enables the timerfd tests.

```
running 3 tests
test sys::test_timerfd::test_timerfd_unset ... ok
test sys::test_timerfd::test_timerfd_oneshot ... ok
test sys::test_timerfd::test_timerfd_interval ... ok
```