### PR TITLE
Implement AsRawFd for PollFd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1511](https://github.com/nix-rust/nix/pull/1511))
 - Added `Ipv4RecvErr` and `Ipv6RecvErr` sockopts and associated control messages.
   (#[1514](https://github.com/nix-rust/nix/pull/1514))
+- Added `AsRawFd` implementation on `PollFd`.
+  (#[1516](https://github.com/nix-rust/nix/pull/1516))
 
 ### Changed
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -3,7 +3,7 @@
 use crate::sys::time::TimeSpec;
 #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
 use crate::sys::signal::SigSet;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 
 use crate::Result;
 use crate::errno::Errno;
@@ -38,6 +38,12 @@ impl PollFd {
     /// Returns the events that occured in the last call to `poll` or `ppoll`.
     pub fn revents(self) -> Option<PollFlags> {
         PollFlags::from_bits(self.pollfd.revents)
+    }
+}
+
+impl AsRawFd for PollFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.pollfd.fd
     }
 }
 

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -64,3 +64,11 @@ fn test_ppoll() {
     assert_eq!(nfds, 1);
     assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 }
+
+#[test]
+fn test_pollfd_fd() {
+    use std::os::unix::io::AsRawFd;
+
+    let pfd = PollFd::new(0x1234, PollFlags::empty());
+    assert_eq!(pfd.as_raw_fd(), 0x1234);
+}


### PR DESCRIPTION
Implement the trait on PollFd, providing an `as_raw_fd()` accessor to
get the RawFd associated with the PollFd.

Subsumes #1147, #1286.  Closes #1146.

Test: `cargo test --test test test_pollfd_fd`