### PR TITLE
Fix #411 - Provide accessors for 'events' in PollFd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1531](https://github.com/nix-rust/nix/pull/1531))
 - Added `MAP_ANONYMOUS` for all operating systems.
   (#[1534](https://github.com/nix-rust/nix/pull/1534))
+- Added read/write accessors for 'events' on `PollFd`.
+  (#[1517](https://github.com/nix-rust/nix/pull/1517))
 
 ### Changed
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -35,9 +35,20 @@ impl PollFd {
         }
     }
 
-    /// Returns the events that occured in the last call to `poll` or `ppoll`.
+    /// Returns the events that occured in the last call to `poll` or `ppoll`.  Will only return
+    /// `None` if the kernel provides status flags that Nix does not know about.
     pub fn revents(self) -> Option<PollFlags> {
         PollFlags::from_bits(self.pollfd.revents)
+    }
+
+    /// The events of interest for this `PollFd`.
+    pub fn events(self) -> PollFlags {
+        PollFlags::from_bits(self.pollfd.events).unwrap()
+    }
+
+    /// Modify the events of interest for this `PollFd`.
+    pub fn set_events(&mut self, events: PollFlags) {
+        self.pollfd.events = events.bits();
     }
 }
 

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -72,3 +72,11 @@ fn test_pollfd_fd() {
     let pfd = PollFd::new(0x1234, PollFlags::empty());
     assert_eq!(pfd.as_raw_fd(), 0x1234);
 }
+
+#[test]
+fn test_pollfd_events() {
+    let mut pfd = PollFd::new(-1, PollFlags::POLLIN);
+    assert_eq!(pfd.events(), PollFlags::POLLIN);
+    pfd.set_events(PollFlags::POLLOUT);
+    assert_eq!(pfd.events(), PollFlags::POLLOUT);
+}


### PR DESCRIPTION
Test: `cargo test --test test test_pollfd_events`