### PR TITLE
Make Errno::result() inline

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -103,6 +103,7 @@ impl Errno {
 
     /// Returns `Ok(value)` if it does not contain the sentinel value. This
     /// should not be used when `-1` is not the errno sentinel value.
+    #[inline]
     pub fn result<S: ErrnoSentinel + PartialEq<S>>(value: S) -> Result<S> {
         if value == S::sentinel() {
             Err(Self::last())


### PR DESCRIPTION
This makes the success case a single `cmpl $-1, %eax` followed with a non-taken conditional jump, instead of the current `callq` which is always taken.

I have not benchmarked the difference, but it is an obvious improvement.