### PR TITLE
Update version in Cargo.toml to match crates.io version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
 edition     = "2018"
-version     = "0.22.0"
+version     = "0.22.1"
 authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"


### PR DESCRIPTION
It looks like 0.22.1 was released on crates.io, but the in-tree Cargo.toml wasn't updated. Using `[patch]` in Cargo.toml is easier when the git version is up to date with the registry version.
