### PR TITLE
mman: Add mincore binding fixes #1528

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1515](https://github.com/nix-rust/nix/pull/1515))
 - Added `MAP_EXCL` mmap flag for freebsd.
   (#[1525](https://github.com/nix-rust/nix/pull/1525))
+- Add `mincore` binding
+  (#[1530](https://github.com/nix-rust/nix/pull/1530))
 
 ### Changed
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -334,6 +334,7 @@ pub type mincore_vec_char_t = std::os::raw::c_char;
 /// # Safety
 ///
 /// `addr` and `vec` must meet all the requirements described in the `mincore(2)` man page.
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 pub fn mincore(addr: *mut c_void, length: size_t, vec: *mut mincore_vec_char_t) -> Result<()> {
     unsafe { Errno::result(libc::mincore(addr, length, vec)) }.map(drop)
 }

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -324,6 +324,20 @@ pub fn munlockall() -> Result<()> {
     unsafe { Errno::result(libc::munlockall()) }.map(drop)
 }
 
+#[cfg(any(target_os = "linux"))]
+pub type mincore_vec_char_t = std::os::raw::c_uchar;
+#[cfg(any(target_os = "freebsd", target_os = "macos"))]
+pub type mincore_vec_char_t = std::os::raw::c_char;
+
+/// Inspect page residency in memory at the address `addr` continuing for `length` bytes.
+///
+/// # Safety
+///
+/// `addr` and `vec` must meet all the requirements described in the `mincore(2)` man page.
+pub fn mincore(addr: *mut c_void, length: size_t, vec: *mut mincore_vec_char_t) -> Result<()> {
+    unsafe { Errno::result(libc::mincore(addr, length, vec)) }.map(drop)
+}
+
 /// allocate memory, or map files or devices into memory
 ///
 /// # Safety

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -43,3 +43,4 @@ mod test_pthread;
 mod test_ptrace;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_timerfd;
+mod test_mman;

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -43,4 +43,8 @@ mod test_pthread;
 mod test_ptrace;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_timerfd;
+#[cfg(any(target_os = "linux",
+          target_os = "netbsd",
+          target_os = "freebsd",
+          target_os = "macos"))]
 mod test_mman;

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,6 +1,4 @@
-use nix::Error;
-use nix::libc::{c_void, size_t};
-use nix::sys::mman::{mmap, MapFlags, ProtFlags, mincore, mincore_vec_char_t};
+use nix::sys::mman::{mincore, mincore_vec_char_t, mmap, MapFlags, ProtFlags};
 
 #[cfg(target_os = "linux")]
 use nix::sys::mman::{mremap, MRemapFlags};

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -10,7 +10,7 @@ fn test_mmap_anonymous() {
     let ref mut byte = unsafe {
         let ptr = mmap(std::ptr::null_mut(), 1,
                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                       MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS, -1, 0)
+                       MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON, -1, 0)
                       .unwrap();
         *(ptr as * mut u8)
     };
@@ -26,7 +26,7 @@ fn test_mremap_grow() {
     let slice : &mut[u8] = unsafe {
         let mem = mmap(std::ptr::null_mut(), ONE_K,
                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                       MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE, -1, 0)
+                       MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE, -1, 0)
                       .unwrap();
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)
     };
@@ -62,7 +62,7 @@ fn test_mremap_shrink() {
     let slice : &mut[u8] = unsafe {
         let mem = mmap(std::ptr::null_mut(), 10 * ONE_K,
                        ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                       MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE, -1, 0)
+                       MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE, -1, 0)
                       .unwrap();
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)
     };
@@ -79,7 +79,7 @@ fn test_mremap_shrink() {
         // same.
         #[cfg(target_os = "linux")]
         let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
-                         MRemapFlags::MAP_FIXED), None)
+                         MRemapFlags::MAP_FIXED, None)
                       .unwrap();
         assert_eq !(mem, slice.as_mut_ptr() as * mut c_void);
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -56,9 +56,13 @@ fn test_mremap_grow() {
 }
 
 #[test]
-// calling mremap to shrink could cause segfaults on 32bit architecture likely due to qemu bug
+// calling mremap to shrink could cause segfaults on some 32bit architecture likely due to qemu bug
 // refs: https://bugs.launchpad.net/qemu/+bug/1876373
-#[cfg(all(any(target_os = "linux", target_os = "netbsd")), target_pointer_width = "64")]
+#[cfg(all(any(target_os = "linux", target_os = "netbsd"),
+          not(any(target_arch = "mips",
+                  target_arch = "mipsel",
+                  target_arch = "arm",
+                  target_arch = "armv7"))))]
 fn test_mremap_shrink() {
     use nix::libc::{c_void, size_t};
 

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -71,7 +71,7 @@ fn test_mremap_shrink() {
 
     let slice : &mut[u8] = unsafe {
         #[cfg(target_os = "linux")]
-        let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
+        mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
                          MRemapFlags::empty(), None)
                       .unwrap();
         // Since we didn't supply MREMAP_MAYMOVE, the address should be the

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -81,7 +81,7 @@ fn test_mremap_shrink() {
         // same.
         #[cfg(target_os = "linux")]
         let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
-                         MRemapFlags::MREMAP_FIXED, None)
+                         MRemapFlags::MREMAP_FIXED | MRemapFlags::MREMAP_MAYMOVE, None)
                       .unwrap();
         assert_eq !(mem, slice.as_mut_ptr() as * mut c_void);
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,5 +1,4 @@
-use nix::libc::{c_void, size_t};
-use nix::sys::mman::{mincore, mincore_vec_char_t, mmap, MapFlags, ProtFlags};
+use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 
 #[cfg(target_os = "linux")]
 use nix::sys::mman::{mremap, MRemapFlags};
@@ -21,6 +20,8 @@ fn test_mmap_anonymous() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn test_mremap_grow() {
+    use nix::libc::{c_void, size_t};
+
     const ONE_K : size_t = 1024;
     let slice : &mut[u8] = unsafe {
         let mem = mmap(std::ptr::null_mut(), ONE_K,
@@ -57,6 +58,8 @@ fn test_mremap_grow() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn test_mremap_shrink() {
+    use nix::libc::{c_void, size_t};
+
     const ONE_K : size_t = 1024;
     let slice : &mut[u8] = unsafe {
         let mem = mmap(std::ptr::null_mut(), 10 * ONE_K,
@@ -92,6 +95,7 @@ fn test_mremap_shrink() {
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 fn test_mincore() {
     use std::os::unix::io::AsRawFd;
+    use nix::sys::mman::{mincore, mincore_vec_char_t};
 
     let page_size = nix::unistd::sysconf(nix::unistd::SysconfVar::PAGE_SIZE)
         .ok()

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,3 +1,4 @@
+use nix::libc::{c_void, size_t};
 use nix::sys::mman::{mincore, mincore_vec_char_t, mmap, MapFlags, ProtFlags};
 
 #[cfg(target_os = "linux")]
@@ -77,7 +78,7 @@ fn test_mremap_shrink() {
         // same.
         #[cfg(target_os = "linux")]
         let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
-                         MRemapFlags::MAP_FIXED, None)
+                         MRemapFlags::MREMAP_FIXED, None)
                       .unwrap();
         assert_eq !(mem, slice.as_mut_ptr() as * mut c_void);
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,6 +1,6 @@
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use nix::sys::mman::{mremap, MRemapFlags};
 
 #[test]


### PR DESCRIPTION
## Summary
- This PR adds `mincore` binding for Tier1 targets (linux, freebsd, macos)
- Also make `mman` tests runnable by adding it in parent module, with fixing some previous outdated mman tests