### PR TITLE
mman: Fix mman tests to be runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed potential undefined behavior in `Signal::try_from` on some platforms.
   (#[1484](https://github.com/nix-rust/nix/pull/1484))
 
+- Fixed mman tests to be runnable.
+  (#[1535](https://github.com/nix-rust/nix/pull/1535))
+
 ### Removed
 
 - Removed a couple of termios constants on redox that were never actually

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -43,3 +43,6 @@ mod test_pthread;
 mod test_ptrace;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_timerfd;
+#[cfg(any(target_os = "linux",
+          target_os = "netbsd"))]
+mod test_mman;


### PR DESCRIPTION
# Summary
- (This change is submitted as #1530 originally and separated as new PR)
- Make mman tests runnable by adding it in parent module, with fixing some previous outdated mman tests