### PR TITLE
Lower limits in setrlimit example

### DIFF
--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -200,8 +200,8 @@ pub fn getrlimit(resource: Resource) -> Result<(Option<rlim_t>, Option<rlim_t>)>
 /// ```
 /// # use nix::sys::resource::{setrlimit, Resource};
 ///
-/// let soft_limit = Some(1024);
-/// let hard_limit = Some(1048576);
+/// let soft_limit = Some(512);
+/// let hard_limit = Some(1024);
 /// setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit).unwrap();
 /// ```
 ///


### PR DESCRIPTION
The current values causes the doc test to fail on Fedora 34 for unprivileged users. The values can be lowered without meaningfully changing the example.

Previously the example failed with EPERM.