### PR TITLE
DragonFly BSD supports `sched_getaffinity()` and `sched_setaffinity()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1567](https://github.com/nix-rust/nix/pull/1567))
 - Added `fdatasync` for FreeBSD, Fuchsia, NetBSD, and OpenBSD.
   (#[1581](https://github.com/nix-rust/nix/pull/1581))
+- Added `sched_setaffinity` and `sched_getaffinity` on DragonFly.
+  (#[1537](https://github.com/nix-rust/nix/pull/1537))
 
 ### Changed
 ### Fixed

--- a/test/test.rs
+++ b/test/test.rs
@@ -29,6 +29,7 @@ mod test_poll;
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
 mod test_pty;
 #[cfg(any(target_os = "android",
+          target_os = "dragonfly",
           target_os = "linux"))]
 mod test_sched;
 #[cfg(any(target_os = "android",


### PR DESCRIPTION
Move `CpuSet`, `sched_getaffinity()`, and `sched_setaffinity()` from the `sched_linux_like` namespace to `sched_affinity`. Declare support for DragonFly BSD.

`test_sched_affinity()` passes locally on DragonFly BSD.