### PR TITLE
posix_fadvise doesn't return -1 as sentinel value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,11 +83,15 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `posix_fadvise` now returns errors in the conventional way, rather than as a
+  non-zero value in `Ok()`.
+  (#[1538](https://github.com/nix-rust/nix/pull/1538))
 - Added more errno definitions for better backwards compatibility with
   Nix 0.21.0.
   (#[1467](https://github.com/nix-rust/nix/pull/1467))
 - Fixed potential undefined behavior in `Signal::try_from` on some platforms.
   (#[1484](https://github.com/nix-rust/nix/pull/1484))
+
 
 ### Removed
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -667,9 +667,14 @@ mod posix_fadvise {
         offset: libc::off_t,
         len: libc::off_t,
         advice: PosixFadviseAdvice,
-    ) -> Result<libc::c_int> {
+    ) -> Result<()> {
         let res = unsafe { libc::posix_fadvise(fd, offset, len, advice as libc::c_int) };
-        Errno::result(res)
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(Errno::from_i32(res))
+        }
     }
 }
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -473,17 +473,16 @@ mod test_posix_fadvise {
     fn test_success() {
         let tmp = NamedTempFile::new().unwrap();
         let fd = tmp.as_raw_fd();
-        let res = posix_fadvise(fd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED).unwrap();
+        let res = posix_fadvise(fd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED);
 
-        assert_eq!(res, 0);
+        assert!(res.is_ok());
     }
 
     #[test]
     fn test_errno() {
         let (rd, _wr) = pipe().unwrap();
-        let errno = posix_fadvise(rd as RawFd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED)
-                                 .unwrap();
-        assert_eq!(errno, Errno::ESPIPE as i32);
+        let res = posix_fadvise(rd as RawFd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED);
+        assert_eq!(res, Err(Errno::ESPIPE));
     }
 }
 


### PR DESCRIPTION
## Summary
- `posix_fadvise(2)` does return error number directly (i.e. not through `errno`)
  * refs: https://man7.org/linux/man-pages/man2/posix_fadvise.2.html , https://man7.org/linux/man-pages/man2/posix_fadvise.2.html
- However `posix_fadvise`-binding uses `Errno::result` to translate the error now, which is mis-use.