### PR TITLE
Revert "Expose SockAddr::from_raw_sockaddr"

### DIFF
--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -46,8 +46,8 @@ impl InterfaceAddress {
     /// Create an `InterfaceAddress` from the libc struct.
     fn from_libc_ifaddrs(info: &libc::ifaddrs) -> InterfaceAddress {
         let ifname = unsafe { ffi::CStr::from_ptr(info.ifa_name) };
-        let address = unsafe { SockAddr::from_raw_sockaddr(info.ifa_addr) };
-        let netmask = unsafe { SockAddr::from_raw_sockaddr(info.ifa_netmask) };
+        let address = unsafe { SockAddr::from_libc_sockaddr(info.ifa_addr) };
+        let netmask = unsafe { SockAddr::from_libc_sockaddr(info.ifa_netmask) };
         let mut addr = InterfaceAddress {
             interface_name: ifname.to_string_lossy().to_string(),
             flags: InterfaceFlags::from_bits_truncate(info.ifa_flags as i32),
@@ -59,9 +59,9 @@ impl InterfaceAddress {
 
         let ifu = get_ifu_from_sockaddr(info);
         if addr.flags.contains(InterfaceFlags::IFF_POINTOPOINT) {
-            addr.destination = unsafe { SockAddr::from_raw_sockaddr(ifu) };
+            addr.destination = unsafe { SockAddr::from_libc_sockaddr(ifu) };
         } else if addr.flags.contains(InterfaceFlags::IFF_BROADCAST) {
-            addr.broadcast = unsafe { SockAddr::from_raw_sockaddr(ifu) };
+            addr.broadcast = unsafe { SockAddr::from_libc_sockaddr(ifu) };
         }
 
         addr

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -802,7 +802,7 @@ impl SockAddr {
     /// unsafe because it takes a raw pointer as argument.  The caller must
     /// ensure that the pointer is valid.
     #[cfg(not(target_os = "fuchsia"))]
-    pub unsafe fn from_raw_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
+    pub(crate) unsafe fn from_libc_sockaddr(addr: *const libc::sockaddr) -> Option<SockAddr> {
         if addr.is_null() {
             None
         } else {
@@ -1381,7 +1381,7 @@ mod tests {
     fn test_macos_loopback_datalink_addr() {
         let bytes = [20i8, 18, 1, 0, 24, 3, 0, 0, 108, 111, 48, 0, 0, 0, 0, 0];
         let sa = bytes.as_ptr() as *const libc::sockaddr;
-        let _sock_addr = unsafe { SockAddr::from_raw_sockaddr(sa) };
+        let _sock_addr = unsafe { SockAddr::from_libc_sockaddr(sa) };
         assert!(_sock_addr.is_none());
     }
 
@@ -1396,7 +1396,7 @@ mod tests {
         let bytes = [20i8, 18, 7, 0, 6, 3, 6, 0, 101, 110, 48, 24, 101, -112, -35, 76, -80];
         let ptr = bytes.as_ptr();
         let sa = ptr as *const libc::sockaddr;
-        let _sock_addr = unsafe { SockAddr::from_raw_sockaddr(sa) };
+        let _sock_addr = unsafe { SockAddr::from_libc_sockaddr(sa) };
 
         assert!(_sock_addr.is_some());
 
@@ -1418,7 +1418,7 @@ mod tests {
         let bytes = [25u8, 0, 0, 0, 6, 0, 6, 0, 24, 101, 144, 221, 76, 176];
         let ptr = bytes.as_ptr();
         let sa = ptr as *const libc::sockaddr;
-        let _sock_addr = unsafe { SockAddr::from_raw_sockaddr(sa) };
+        let _sock_addr = unsafe { SockAddr::from_libc_sockaddr(sa) };
 
         assert!(_sock_addr.is_some());
 


### PR DESCRIPTION
This reverts commit ed43d2c65e65dd68c9cf2dcf06f5ec45a44aaccd.

As discussed in #1544 the API of this function needs to change.  For
now, revert the PR that made it public, because it has not yet been
included in any release.