### PR TITLE
Downgrade bitflags to 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ targets = [
 
 [dependencies]
 libc = { version = "0.2.102", features = [ "extra_traits" ] }
-bitflags = "1.3.1"
+bitflags = "1.2"
 cfg-if = "1.0"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]


### PR DESCRIPTION
Fixes #1555

None of the 1.3 features were being used

Tested with `cargo +nightly generate-lockfile -Zminimal-versions`
