### PR TITLE
Declare the MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
 edition     = "2018"
 version     = "0.23.0"
+rust-version = "1.46"
 authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"


### PR DESCRIPTION
This is a new feature in Cargo 1.56.0, currently in beta.  Once Nix's
MSRV is >= 1.56.0, this feature will prevent future problems like the
bitflags 1.3.0 fiasco.

Issue #1491
Issue #1510
Issue #1548
Issue #1555