### PR TITLE
Update features::socket_atomic_cloexec

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -94,7 +94,14 @@ mod os {
     }
 }
 
-#[cfg(any(target_os = "illumos"))]
+#[cfg(any(
+        target_os = "dragonfly",    // Since ???
+        target_os = "freebsd",      // Since 10.0
+        target_os = "illumos",      // Since ???
+        target_os = "netbsd",       // Since 6.0
+        target_os = "openbsd",      // Since 5.7
+        target_os = "redox",        // Since 1-july-2020
+))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets
     pub const fn socket_atomic_cloexec() -> bool {
@@ -102,10 +109,9 @@ mod os {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "freebsd",
-          target_os = "dragonfly", target_os = "ios",
-          target_os = "openbsd", target_os = "netbsd",
-          target_os = "redox", target_os = "fuchsia",
+#[cfg(any(target_os = "macos",
+          target_os = "ios",
+          target_os = "fuchsia",
           target_os = "solaris"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets


### PR DESCRIPTION
Several platforms have long supported SOCK_OCLOEXEC.  Mark them as
supporting this feature.