### PR TITLE
Correct definition of MADV_SOFT_OFFLINE on ppc

### DIFF
--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -210,7 +210,8 @@ libc_enum!{
             all(target_os = "linux", any(
                 target_arch = "aarch64",
                 target_arch = "arm",
-                target_arch = "ppc",
+                target_arch = "powerpc",
+                target_arch = "powerpc64",
                 target_arch = "s390x",
                 target_arch = "x86",
                 target_arch = "x86_64",


### PR DESCRIPTION
Rust has no "ppc" target_arch.  It should be "powerpc" or "powerpc64".