### PR TITLE
Recent versions of Android support EPOLLEXCLUSIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added fine-grained features flags.  Most Nix functionality can now be
   conditionally enabled.  By default, all features are enabled.
   (#[1611](https://github.com/nix-rust/nix/pull/1611))
+- Added `EPOLLEXCLUSIVE` on Android.
+  (#[1567](https://github.com/nix-rust/nix/pull/1567))
 
 ### Changed
 ### Fixed

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -18,8 +18,6 @@ libc_bitflags!(
         EPOLLERR;
         EPOLLHUP;
         EPOLLRDHUP;
-        #[cfg(target_os = "linux")]  // Added in 4.5; not in Android.
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         EPOLLEXCLUSIVE;
         #[cfg(not(target_arch = "mips"))]
         EPOLLWAKEUP;

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -30,7 +30,7 @@ mod test_ioctl;
 mod test_wait;
 mod test_uio;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_epoll;
 #[cfg(target_os = "linux")]
 mod test_inotify;


### PR DESCRIPTION
[Corresponding libc change](https://github.com/rust-lang/libc/commit/36be4cd4f65c326f2a30d3afee50db78c014f07f).

Enable the epoll tests on Android, because they are passing.