### PR TITLE
Fix unsoundness in FdSet methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Added
+### Changed
+### Fixed
+
+- Fixed soundness issues in `FdSet::insert`, `FdSet::remove`, and
+  `FdSet::contains` involving file descriptors outside of the range
+  `0..FD_SETSIZE`.
+  (#[1575](https://github.com/nix-rust/nix/pull/1575))
+
+### Removed
+
 ## [0.23.0] - 2021-09-28
 ### Added
 

--- a/test/sys/test_select.rs
+++ b/test/sys/test_select.rs
@@ -52,3 +52,31 @@ pub fn test_pselect_nfds2() {
     assert!(fd_set.contains(r1));
     assert!(!fd_set.contains(r2));
 }
+
+macro_rules! generate_fdset_bad_fd_tests {
+    ($fd:expr, $($method:ident),* $(,)?) => {
+        $(
+            #[test]
+            #[should_panic]
+            fn $method() {
+                FdSet::new().$method($fd);
+            }
+        )*
+    }
+}
+
+mod test_fdset_negative_fd {
+    use super::*;
+    generate_fdset_bad_fd_tests!(-1, insert, remove, contains);
+}
+
+mod test_fdset_too_large_fd {
+    use super::*;
+    use std::convert::TryInto;
+    generate_fdset_bad_fd_tests!(
+        FD_SETSIZE.try_into().unwrap(),
+        insert,
+        remove,
+        contains,
+    );
+}


### PR DESCRIPTION
Ensure file descriptors are nonnegative and less than `FD_SETSIZE`. (Fixes #1572.)