### PR TITLE
DragonFly 6.0 added fexecve(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added `fexecve` on DragonFly.
+  (#[1577](https://github.com/nix-rust/nix/pull/1577))
 - Added fine-grained features flags.  Most Nix functionality can now be
   conditionally enabled.  By default, all features are enabled.
   (#[1611](https://github.com/nix-rust/nix/pull/1611))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.102", features = [ "extra_traits" ] }
+libc = { version = "0.2.112", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -848,11 +848,9 @@ pub fn execvpe<SA: AsRef<CStr>, SE: AsRef<CStr>>(filename: &CStr, args: &[SA], e
 ///
 /// This function is similar to `execve`, except that the program to be executed
 /// is referenced as a file descriptor instead of a path.
-// Note for NetBSD and OpenBSD: although rust-lang/libc includes it (under
-// unix/bsd/netbsdlike/) fexecve is not currently implemented on NetBSD nor on
-// OpenBSD.
 #[cfg(any(target_os = "android",
           target_os = "linux",
+          target_os = "dragonfly",
           target_os = "freebsd"))]
 #[inline]
 pub fn fexecve<SA: AsRef<CStr> ,SE: AsRef<CStr>>(fd: RawFd, args: &[SA], env: &[SE]) -> Result<Infallible> {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -363,25 +363,21 @@ cfg_if!{
     if #[cfg(target_os = "android")] {
         execve_test_factory!(test_execve, execve, CString::new("/system/bin/sh").unwrap().as_c_str());
         execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
-    } else if #[cfg(any(target_os = "freebsd",
+    } else if #[cfg(any(target_os = "dragonfly",
+                        target_os = "freebsd",
                         target_os = "linux"))] {
         // These tests frequently fail on musl, probably due to
         // https://github.com/nix-rust/nix/issues/555
         execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap().as_c_str());
         execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap().into_raw_fd());
-    } else if #[cfg(any(target_os = "dragonfly",
-                        target_os = "illumos",
+    } else if #[cfg(any(target_os = "illumos",
                         target_os = "ios",
                         target_os = "macos",
                         target_os = "netbsd",
                         target_os = "openbsd",
                         target_os = "solaris"))] {
         execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap().as_c_str());
-        // No fexecve() on DragonFly, ios, macos, NetBSD, OpenBSD.
-        //
-        // Note for NetBSD and OpenBSD: although rust-lang/libc includes it
-        // (under unix/bsd/netbsdlike/) fexecve is not currently implemented on
-        // NetBSD nor on OpenBSD.
+        // No fexecve() on ios, macos, NetBSD, OpenBSD.
     }
 }
 


### PR DESCRIPTION
Enable `fexecve()` on DragonFly, as it was added in the 6.0 release.