### PR TITLE
Temporarily use Rust 1.51.0 for testing cross-based builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,6 +77,10 @@ task:
     PATH: $HOME/.cargo/bin:$PATH
     RUSTFLAGS: --cfg qemu -D warnings
     TOOL: cross
+    # cross-based builds must temporarily use Rust 1.51.0 due to this bug:
+    # https://github.com/gimli-rs/object/issues/394
+    TOOLCHAIN: 1.51.0
+    CLIPPYFLAGS: -D warnings -A clippy::upper_case_acronyms -A clippy::unnecessary-wraps
   matrix:
     - name: Linux arm gnueabi
       env:


### PR DESCRIPTION
A bug in gimli-rs/object is causing the build to fail at the
"cargo install cross" step.  Until that's fixed, we must use Rust 1.51.0
or newer for cross-based builds.

https://github.com/gimli-rs/object/issues/394