### PR TITLE
Revert "Temporarily use Rust 1.51.0 for testing cross-based builds"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,10 +77,6 @@ task:
     PATH: $HOME/.cargo/bin:$PATH
     RUSTFLAGS: --cfg qemu -D warnings
     TOOL: cross
-    # cross-based builds must temporarily use Rust 1.51.0 due to this bug:
-    # https://github.com/gimli-rs/object/issues/394
-    TOOLCHAIN: 1.51.0
-    CLIPPYFLAGS: -D warnings -A clippy::upper_case_acronyms -A clippy::unnecessary-wraps
   matrix:
     - name: Linux arm gnueabi
       env:


### PR DESCRIPTION
This reverts commit 5e7c5f6e885753cb1d8ac2459da5a40b361ac684.

Upstream swiftly fixed the bug.