### PR TITLE
Add fdatasync for missing platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1611](https://github.com/nix-rust/nix/pull/1611))
 - Added `EPOLLEXCLUSIVE` on Android.
   (#[1567](https://github.com/nix-rust/nix/pull/1567))
+- Added `fdatasync` for FreeBSD, Fuchsia, NetBSD, and OpenBSD.
+  (#[1581](https://github.com/nix-rust/nix/pull/1581))
 
 ### Changed
 ### Fixed

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1323,11 +1323,13 @@ pub fn fsync(fd: RawFd) -> Result<()> {
 ///
 /// See also
 /// [fdatasync(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdatasync.html)
-// `fdatasync(2) is in POSIX, but in libc it is only defined in `libc::notbsd`.
-// TODO: exclude only Apple systems after https://github.com/rust-lang/libc/pull/211
 #[cfg(any(target_os = "linux",
           target_os = "android",
           target_os = "emscripten",
+          target_os = "freebsd",
+          target_os = "fuchsia",
+          target_os = "netbsd",
+          target_os = "openbsd",
           target_os = "illumos",
           target_os = "solaris"))]
 #[inline]


### PR DESCRIPTION
These platforms stub out `fdatasync()` by just calling `fsync()`, but that is a conforming implementation.

DragonFly recently provided [an implementation](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/74fa2560ac77f9db4a34b2a7c72450126fec4ed6), but it has not made it into a release or rust-lang/libc.