### PR TITLE
Remove unsafe in with_nix_path() for [u8]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,9 @@ pub mod unistd;
  *
  */
 
-use libc::{c_char, PATH_MAX};
+use libc::PATH_MAX;
 
-use std::{ptr, result};
+use std::result;
 use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -184,16 +184,10 @@ impl NixPath for [u8] {
             return Err(Errno::ENAMETOOLONG)
         }
 
-        match self.iter().position(|b| *b == 0) {
-            Some(_) => Err(Errno::EINVAL),
-            None => {
-                unsafe {
-                    // TODO: Replace with bytes::copy_memory. rust-lang/rust#24028
-                    ptr::copy_nonoverlapping(self.as_ptr(), buf.as_mut_ptr(), self.len());
-                    Ok(f(CStr::from_ptr(buf.as_ptr() as *const c_char)))
-                }
-
-            }
+        buf[..self.len()].copy_from_slice(self);
+        match CStr::from_bytes_with_nul(&buf[..=self.len()]) {
+            Ok(s) => Ok(f(s)),
+            Err(_) => Err(Errno::EINVAL),
         }
     }
 }


### PR DESCRIPTION
Remove use of `unsafe` in the implementation of `with_nix_path()` for `[u8]`. This also comes with a nice determinism win across input sizes, and is fairly performance neutral (slightly slower for small strings, much faster for large strings).

I suspect the performance degradation in the existing implementation is related to the following note in the `CStr::from_ptr()` documentation:

> Note: This operation is intended to be a 0-cost cast but it is currently implemented with an up-front calculation of the length of the string. This is not guaranteed to always be the case.

---

Tested with `cargo 1.57.0-nightly (7fbbf4e8f 2021-10-19)`, with variations of the following benchmarking code:

```rs
#[bench]
fn bench_with_nix_path_1024(b: &mut test::Bencher) {
    let bytes = std::hint::black_box([70u8; 1024]);
    b.iter(|| {
        bytes.with_nix_path(|cstr| {
            std::hint::black_box(&cstr);
        }).unwrap();
    })
}
```

| Length |     Before Change     |      After Change     |
|--------|-----------------------|-----------------------|
|    16  |   37 ns/iter (+/- 0)  |   44 ns/iter (+/- 0)  |
|    64  |   39 ns/iter (+/- 0)  |   44 ns/iter (+/- 0)  |
|   256  |   84 ns/iter (+/- 0)  |   48 ns/iter (+/- 0)  |
|  1024  |  232 ns/iter (+/- 1)  |   50 ns/iter (+/- 1)  |
|  4095  |  796 ns/iter (+/- 8)  |   62 ns/iter (+/- 2)  |