### PR TITLE
wait: implement waitid()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1664](https://github.com/nix-rust/nix/pull/1664))
 - Added `MSG_NOSIGNAL` for Android, Dragonfly, FreeBSD, Fuchsia, Haiku, Illumos, Linux, NetBSD, OpenBSD and Solaris.
   (#[1670](https://github.com/nix-rust/nix/pull/1670))
+- Added `waitid`.
+  (#[1584](https://github.com/nix-rust/nix/pull/1584))
 
 ### Changed
 

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -6,6 +6,11 @@ use crate::Result;
 use cfg_if::cfg_if;
 use libc::{self, c_int};
 use std::convert::TryFrom;
+#[cfg(any(
+    target_os = "android",
+    all(target_os = "linux", not(target_env = "uclibc")),
+))]
+use std::os::unix::io::RawFd;
 
 libc_bitflags!(
     /// Controls the behavior of [`waitpid`].
@@ -233,6 +238,61 @@ impl WaitStatus {
             WaitStatus::Continued(pid)
         })
     }
+
+    /// Convert a `siginfo_t` as returned by `waitid` to a `WaitStatus`
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Error` corresponding to `EINVAL` for invalid values.
+    ///
+    /// # Safety
+    ///
+    /// siginfo_t is actually a union, not all fields may be initialized.
+    /// The functions si_pid() and si_status() must be valid to call on
+    /// the passed siginfo_t.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "haiku",
+        all(target_os = "linux", not(target_env = "uclibc")),
+    ))]
+    unsafe fn from_siginfo(siginfo: &libc::siginfo_t) -> Result<WaitStatus> {
+        let si_pid = siginfo.si_pid();
+        if si_pid == 0 {
+            return Ok(WaitStatus::StillAlive);
+        }
+
+        assert_eq!(siginfo.si_signo, libc::SIGCHLD);
+
+        let pid = Pid::from_raw(si_pid);
+        let si_status = siginfo.si_status();
+
+        let status = match siginfo.si_code {
+            libc::CLD_EXITED => WaitStatus::Exited(pid, si_status),
+            libc::CLD_KILLED | libc::CLD_DUMPED => WaitStatus::Signaled(
+                pid,
+                Signal::try_from(si_status)?,
+                siginfo.si_code == libc::CLD_DUMPED,
+            ),
+            libc::CLD_STOPPED => WaitStatus::Stopped(pid, Signal::try_from(si_status)?),
+            libc::CLD_CONTINUED => WaitStatus::Continued(pid),
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            libc::CLD_TRAPPED => {
+                if si_status == libc::SIGTRAP | 0x80 {
+                    WaitStatus::PtraceSyscall(pid)
+                } else {
+                    WaitStatus::PtraceEvent(
+                        pid,
+                        Signal::try_from(si_status & 0xff)?,
+                        (si_status >> 8) as c_int,
+                    )
+                }
+            }
+            _ => return Err(Errno::EINVAL),
+        };
+
+        Ok(status)
+    }
 }
 
 /// Wait for a process to change status
@@ -267,4 +327,55 @@ pub fn waitpid<P: Into<Option<Pid>>>(pid: P, options: Option<WaitPidFlag>) -> Re
 /// See also [wait(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html)
 pub fn wait() -> Result<WaitStatus> {
     waitpid(None, None)
+}
+
+/// The ID argument for `waitid`
+#[cfg(any(
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "haiku",
+    all(target_os = "linux", not(target_env = "uclibc")),
+))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Id {
+    /// Wait for any child
+    All,
+    /// Wait for the child whose process ID matches the given PID
+    Pid(Pid),
+    /// Wait for the child whose process group ID matches the given PID
+    ///
+    /// If the PID is zero, the caller's process group is used since Linux 5.4.
+    PGid(Pid),
+    /// Wait for the child referred to by the given PID file descriptor
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    PIDFd(RawFd),
+}
+
+/// Wait for a process to change status
+///
+/// See also [waitid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/waitid.html)
+#[cfg(any(
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "haiku",
+    all(target_os = "linux", not(target_env = "uclibc")),
+))]
+pub fn waitid(id: Id, flags: WaitPidFlag) -> Result<WaitStatus> {
+    let (idtype, idval) = match id {
+        Id::All => (libc::P_ALL, 0),
+        Id::Pid(pid) => (libc::P_PID, pid.as_raw() as libc::id_t),
+        Id::PGid(pid) => (libc::P_PGID, pid.as_raw() as libc::id_t),
+        #[cfg(any(target_os = "android", target_os = "linux"))]
+        Id::PIDFd(fd) => (libc::P_PIDFD, fd as libc::id_t),
+    };
+
+    let siginfo = unsafe {
+        // Memory is zeroed rather than uninitialized, as not all platforms
+        // initialize the memory in the StillAlive case
+        let mut siginfo: libc::siginfo_t = std::mem::zeroed();
+        Errno::result(libc::waitid(idtype, idval, &mut siginfo, flags.bits()))?;
+        siginfo
+    };
+
+    unsafe { WaitStatus::from_siginfo(&siginfo) }
 }


### PR DESCRIPTION
waitid() has a number of additional features that waitpid() is missing:

- WNOWAIT is only accepted for waitid() on Linux (and possibly other platforms)
- Support for waiting on PID file descriptors on Linux

For now support is added for all platforms with waitid() that have proper siginfo_t support in libc. NetBSD support is currently a work in progress [1].

Tests for the signal/exit code are currently skipped on MIPS platforms due to multiple bugs in qemu-user in the translation of siginfo_t (one fixed in January [2], one currently under review [3]).

[1] rust-lang/libc#2476
[2] https://lists.nongnu.org/archive/html/qemu-devel/2021-01/msg04810.html
[3] https://lists.nongnu.org/archive/html/qemu-devel/2021-10/msg05433.html