### PR TITLE
Disable pwritev and preadv for 'macos' (fixes #1588)

### DIFF
--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -30,7 +30,7 @@ pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
 /// or an error occurs. The file offset is not changed.
 ///
 /// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "macos", target_os = "redox")))]
 pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
                offset: off_t) -> Result<usize> {
     let res = unsafe {
@@ -47,7 +47,7 @@ pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
 /// changed.
 ///
 /// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "macos", target_os = "redox")))]
 pub fn preadv(fd: RawFd, iov: &[IoVec<&mut [u8]>],
               offset: off_t) -> Result<usize> {
     let res = unsafe {

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -141,7 +141,7 @@ fn test_pread() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(not(any(target_os = "macos", target_os = "redox")))]
 fn test_pwritev() {
     use std::io::Read;
 
@@ -171,7 +171,7 @@ fn test_pwritev() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(not(any(target_os = "macos", target_os = "redox")))]
 fn test_preadv() {
     use std::io::Write;
 


### PR DESCRIPTION
Fixes #1588.

Please merge; we're using a patched vendored version until you're able to fix this...