### PR TITLE
Test preadv and pwritev on more operating systems

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,12 +54,11 @@ task:
 
 # Test OSX in a full VM
 task:
-  matrix:
-    - name: OSX x86_64
-      env:
-        TARGET: x86_64-apple-darwin
+  name: OSX x86_64
+  env:
+    TARGET: x86_64-apple-darwin
   osx_instance:
-    image: catalina-xcode
+    image: big-sur-xcode
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -256,6 +256,32 @@ task:
   << : *BUILD
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
+# DragonflyBSD temporarily needs a pinned nightly toolchain
+# rustc is broken on DragonflyBSD as of Dec-5, probably by
+# https://github.com/rust-lang/rust/commit/e68887e67cc6b7bb4ea5113a40eaa4c0831bda13
+task:
+  container:
+    image: rust:1.46
+  name: DragonFly BSD x86_64
+  env:
+    BUILD: check
+    ZFLAGS: -Zbuild-std
+    TARGET: x86_64-unknown-dragonfly
+    # Redox requires a nightly compiler.
+    # If stuff breaks, change nightly to the date at
+    # https://gitlab.redox-os.org/redox-os/redox/-/blob/master/rust-toolchain
+    TOOLCHAIN: nightly-2021-12-04
+    # Temporarily allow deprecation on DragonflyBSD until an alternative is
+    # available.
+    #https://github.com/rust-lang/libc/pull/2522
+    RUSTFLAGS: -D warnings -A deprecated
+  setup_script:
+    - rustup toolchain add $TOOLCHAIN --profile minimal
+    - rustup component add rust-src --toolchain $TOOLCHAIN
+    - rustup component add clippy --toolchain $TOOLCHAIN
+  << : *BUILD
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
+
 # Rust Tier 3 targets can't use Rustup
 task:
   container:
@@ -265,13 +291,6 @@ task:
     TOOLCHAIN: nightly
     ZFLAGS: -Zbuild-std
   matrix:
-    - name: DragonFly BSD x86_64
-      env:
-        TARGET: x86_64-unknown-dragonfly
-        # Temporarily allow deprecation on DragonflyBSD until an alternative is
-        # available.
-        #https://github.com/rust-lang/libc/pull/2522
-        RUSTFLAGS: -D warnings -A deprecated
     - name: OpenBSD x86_64
       env:
         TARGET: x86_64-unknown-openbsd

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -141,7 +141,7 @@ fn test_pread() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "redox"))]
 fn test_pwritev() {
     use std::io::Read;
 
@@ -171,7 +171,7 @@ fn test_pwritev() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "redox"))]
 fn test_preadv() {
     use std::io::Write;
 


### PR DESCRIPTION
This was an oversight from PR #1511.  Also, update the OSX test environment for Big Sur.  Big Sur is the first OSX version that supports preadv/pwritev