### PR TITLE
Fix warning when running cargo release

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-no-dev-version = true
 pre-release-replacements = [
 	{ file="CHANGELOG.md", search="Unreleased", replace="{{version}}" },
 	{ file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}" }


### PR DESCRIPTION
`cargo release` is returning the following warning: `WARN  cargo_release::config] Negative config values are deprecated ('no_', 'disable_')`.

The root cause is `cargo-release` changing its behavior to default to not bumping the version: https://github.com/crate-ci/cargo-release/pull/340. Remove the `no-dev-version flag` from release.toml to match.
