### PR TITLE
Re-enable deprecation warnings on DragonFly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -265,32 +265,6 @@ task:
   << : *BUILD
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-# DragonflyBSD temporarily needs a pinned nightly toolchain
-# rustc is broken on DragonflyBSD as of Dec-5, probably by
-# https://github.com/rust-lang/rust/commit/e68887e67cc6b7bb4ea5113a40eaa4c0831bda13
-task:
-  container:
-    image: rust:1.46
-  name: DragonFly BSD x86_64
-  env:
-    BUILD: check
-    ZFLAGS: -Zbuild-std
-    TARGET: x86_64-unknown-dragonfly
-    # Redox requires a nightly compiler.
-    # If stuff breaks, change nightly to the date at
-    # https://gitlab.redox-os.org/redox-os/redox/-/blob/master/rust-toolchain
-    TOOLCHAIN: nightly-2021-12-04
-    # Temporarily allow deprecation on DragonflyBSD until an alternative is
-    # available.
-    #https://github.com/rust-lang/libc/pull/2522
-    RUSTFLAGS: -D warnings -A deprecated
-  setup_script:
-    - rustup toolchain add $TOOLCHAIN --profile minimal
-    - rustup component add rust-src --toolchain $TOOLCHAIN
-    - rustup component add clippy --toolchain $TOOLCHAIN
-  << : *BUILD
-  before_cache_script: rm -rf $CARGO_HOME/registry/index
-
 # Rust Tier 3 targets can't use Rustup
 task:
   container:
@@ -300,6 +274,9 @@ task:
     TOOLCHAIN: nightly
     ZFLAGS: -Zbuild-std
   matrix:
+    - name: DragonFly BSD x86_64
+      env:
+        TARGET: x86_64-unknown-dragonfly
     - name: OpenBSD x86_64
       env:
         TARGET: x86_64-unknown-openbsd

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -38,12 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +98,9 @@ checksum = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "lock_api"
@@ -128,12 +122,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "assert-impl",
  "bitflags",
  "caps",
- "cc",
  "cfg-if 1.0.0",
  "lazy_static",
  "libc",


### PR DESCRIPTION
Reverts 0df82ded4704caf78c32df941c170cdacc9688dc and ac159d9c4e4165d74af25dc8b4913e6b7efe7272.