### PR TITLE
Fix clippy warning by adding #[must_use]

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1065,6 +1065,7 @@ impl<'a> LioCbBuilder<'a> {
     ///
     /// [`LioCb`]: struct.LioCb.html
     /// [`AioCb::from_slice`]: struct.AioCb.html#method.from_slice
+    #[must_use]
     pub fn emplace_slice(mut self, fd: RawFd, offs: off_t, buf: &'a [u8],
                          prio: libc::c_int, sigev_notify: SigevNotify,
                          opcode: LioOpcode) -> Self
@@ -1081,6 +1082,7 @@ impl<'a> LioCbBuilder<'a> {
     ///
     /// [`LioCb`]: struct.LioCb.html
     /// [`AioCb::from_mut_slice`]: struct.AioCb.html#method.from_mut_slice
+    #[must_use]
     pub fn emplace_mut_slice(mut self, fd: RawFd, offs: off_t,
                              buf: &'a mut [u8], prio: libc::c_int,
                              sigev_notify: SigevNotify, opcode: LioOpcode)


### PR DESCRIPTION
Clippy added a lint for non-constructor methods which return `self`, encouraging them to be marked as `#[must_use]`.

Mark the methods which are failing with the latest nightly's clippy.

```
$ cargo clippy
warning: missing `#[must_use]` attribute on a method returning `Self`
    --> src/sys/aio.rs:1068:5
     |
1068 | /     pub fn emplace_slice(mut self, fd: RawFd, offs: off_t, buf: &'a [u8],
1069 | |                          prio: libc::c_int, sigev_notify: SigevNotify,
1070 | |                          opcode: LioOpcode) -> Self
1071 | |     {
...    |
1074 | |         self
1075 | |     }
     | |_____^
     |
     = note: `#[warn(clippy::return_self_not_must_use)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

warning: missing `#[must_use]` attribute on a method returning `Self`
    --> src/sys/aio.rs:1084:5
     |
1084 | /     pub fn emplace_mut_slice(mut self, fd: RawFd, offs: off_t,
1085 | |                              buf: &'a mut [u8], prio: libc::c_int,
1086 | |                              sigev_notify: SigevNotify, opcode: LioOpcode)
1087 | |         -> Self
...    |
1091 | |         self
1092 | |     }
     | |_____^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use

warning: `nix` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
```