### PR TITLE
Disable mknod and mknodat tests on DragonFly

### DIFF
--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -308,7 +308,8 @@ fn test_mkdirat_fail() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd",
+#[cfg(not(any(target_os = "dragonfly",
+              target_os = "freebsd",
               target_os = "ios",
               target_os = "macos",
               target_os = "redox")))]
@@ -325,7 +326,8 @@ fn test_mknod() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "freebsd",
+#[cfg(not(any(target_os = "dragonfly",
+              target_os = "freebsd",
               target_os = "illumos",
               target_os = "ios",
               target_os = "macos",


### PR DESCRIPTION
Like FreeBSD, DragonFly does not support creating regular files (i.e. `S_IFREG`) with `mknod` or `mknodat`. These tests should be disabled as they always fail.

There are still a few other failing tests on DragonFly, but it is unclear to me if they are due to faulty/inapplicable test logic or a bug in DragonFly.