### PR TITLE
Added getters for the MqAttr struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1537](https://github.com/nix-rust/nix/pull/1537))
 - Added the `SO_TIMESTAMPING` support
   (#[1547](https://github.com/nix-rust/nix/pull/1547))
+- Added getter methods to `MqAttr` struct
+  (#[1619](https://github.com/nix-rust/nix/pull/1619))
 
 ### Changed
 ### Fixed

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -64,6 +64,21 @@ impl MqAttr {
     pub const fn flags(&self) -> mq_attr_member_t {
         self.mq_attr.mq_flags
     }
+
+    /// The max number of messages that can be held by the queue
+    pub const fn maxmsg(&self) -> mq_attr_member_t {
+        self.mq_attr.mq_maxmsg
+    }
+
+    /// The maximum size of each message (in bytes)
+    pub const fn msgsize(&self) -> mq_attr_member_t {
+        self.mq_attr.mq_msgsize
+    }
+
+    /// The number of messages currently held in the queue
+    pub const fn curmsgs(&self) -> mq_attr_member_t {
+        self.mq_attr.mq_curmsgs
+    }
 }
 
 


### PR DESCRIPTION
With the existing code, if you call `mq_getattr()`, there does not appear to be a way to get any of the attributes from the returned `MqAttr` struct, other than the flags. This adds getter functions to retrieve the size parameters of the queue, and the current number of messages in the queue.