### PR TITLE
Add posix_fallocate on DragonFly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1581](https://github.com/nix-rust/nix/pull/1581))
 - Added `sched_setaffinity` and `sched_getaffinity` on DragonFly.
   (#[1537](https://github.com/nix-rust/nix/pull/1537))
+- Added `posix_fallocate` on DragonFly.
+  (#[1621](https://github.com/nix-rust/nix/pull/1621))
 - Added the `SO_TIMESTAMPING` support
   (#[1547](https://github.com/nix-rust/nix/pull/1547))
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -749,6 +749,7 @@ mod posix_fadvise {
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "fuchsia",
     any(target_os = "wasi", target_env = "wasi"),

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -488,6 +488,7 @@ mod test_posix_fadvise {
 
 #[cfg(any(target_os = "linux",
           target_os = "android",
+          target_os = "dragonfly",
           target_os = "emscripten",
           target_os = "fuchsia",
           any(target_os = "wasi", target_env = "wasi"),


### PR DESCRIPTION
Enable the existing `posix_fallocate()` tests as they are passing locally.