### PR TITLE
Correct MAP_FIXED documentation for NetBSD

### DIFF
--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -195,7 +195,7 @@ libc_bitflags!{
         #[cfg(target_os = "linux")]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         MREMAP_FIXED;
-        /// Permits to use the old and new address as hints to relocate the mapping.
+        /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "netbsd")]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_FIXED;

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -73,16 +73,11 @@ fn test_mremap_shrink() {
     assert_eq !(slice[ONE_K - 1], 0xFF);
 
     let slice : &mut[u8] = unsafe {
-        #[cfg(target_os = "linux")]
         let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
                          MRemapFlags::empty(), None)
                       .unwrap();
         // Since we didn't supply MREMAP_MAYMOVE, the address should be the
         // same.
-        #[cfg(target_os = "netbsd")]
-        let mem = mremap(slice.as_mut_ptr() as * mut c_void, 10 * ONE_K, ONE_K,
-                         MRemapFlags::MAP_FIXED, None)
-                      .unwrap();
         assert_eq !(mem, slice.as_mut_ptr() as * mut c_void);
         std::slice::from_raw_parts_mut(mem as * mut u8, ONE_K)
     };


### PR DESCRIPTION
The previous documentation described the default behavior, rather than the behavior when the flag was set.

Also fix a test which is failing due to passing this flag erroneously.