### PR TITLE
Remove EventFlag::EV_SYSFLAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Removed public access to the inner fields of `NetlinkAddr`, `AlgAddr`,
   `SysControlAddr`, `LinkAddr`, and `VsockAddr`.
   (#[1614](https://github.com/nix-rust/nix/pull/1614))
+- Removed `EventFlag::EV_SYSFLAG`.
+  (#[1635](https://github.com/nix-rust/nix/pull/1635))
 
 ## [0.23.1] - 2021-12-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.112", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "e470e3b6a1f940e0024d40d3b79fc73fe29c7f17", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -114,7 +114,6 @@ libc_bitflags!{
                   target_os = "ios", target_os = "macos",
                   target_os = "netbsd", target_os = "openbsd"))]
         EV_RECEIPT;
-        EV_SYSFLAGS;
     }
 }
 


### PR DESCRIPTION
It is not stable across OpenBSD versions and is reserved by the system on FreeBSD and NetBSD.

This should fix the nix build for OpenBSD, which is failing due to https://github.com/rust-lang/libc/pull/2596. Bump the libc dependency to uptake that change.