### PR TITLE
Fix Clippy warnings on FreeBSD with the latest nightly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ task:
   freebsd_instance:
     image: freebsd-12-2-release-amd64
   setup_script:
+    - kldload mqueuefs
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1636](https://github.com/nix-rust/nix/pull/1636))
 
 ### Changed
+
+- `mqueue` functions now operate on a distinct type, `nix::mqueue::MqdT`.
+  Accessors take this type by reference, not by value.
+  (#[1639](https://github.com/nix-rust/nix/pull/1639))
+
 ### Fixed
 ### Removed
 

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -167,6 +167,9 @@ pub fn step<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 }
 
 /// Reads a word from a processes memory at the given address
+// Technically, ptrace doesn't dereference the pointer.  It passes it directly
+// to the kernel.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn read(pid: Pid, addr: AddressType) -> Result<c_int> {
     unsafe {
         // Traditionally there was a difference between reading data or
@@ -176,6 +179,9 @@ pub fn read(pid: Pid, addr: AddressType) -> Result<c_int> {
 }
 
 /// Writes a word into the processes memory at the given address
+// Technically, ptrace doesn't dereference the pointer.  It passes it directly
+// to the kernel.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn write(pid: Pid, addr: AddressType, data: c_int) -> Result<()> {
     unsafe { ptrace_other(Request::PT_WRITE_D, pid, addr, data).map(drop) }
 }

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -41,13 +41,13 @@ fn test_mq_send_and_receive() {
     };
     let mqd0 = r0.unwrap();
     let msg_to_send = "msg_1";
-    mq_send(mqd0, msg_to_send.as_bytes(), 1).unwrap();
+    mq_send(&mqd0, msg_to_send.as_bytes(), 1).unwrap();
 
     let oflag1 = MQ_OFlag::O_CREAT | MQ_OFlag::O_RDONLY;
     let mqd1 = mq_open(mq_name, oflag1, mode, Some(&attr)).unwrap();
     let mut buf = [0u8; 32];
     let mut prio = 0u32;
-    let len = mq_receive(mqd1, &mut buf, &mut prio).unwrap();
+    let len = mq_receive(&mqd1, &mut buf, &mut prio).unwrap();
     assert_eq!(prio, 1);
 
     mq_close(mqd1).unwrap();
@@ -71,7 +71,7 @@ fn test_mq_getattr() {
     };
     let mqd = r.unwrap();
 
-    let read_attr = mq_getattr(mqd).unwrap();
+    let read_attr = mq_getattr(&mqd).unwrap();
     assert_attr_eq!(read_attr, initial_attr);
     mq_close(mqd).unwrap();
 }
@@ -98,20 +98,20 @@ fn test_mq_setattr() {
     let mqd = r.unwrap();
 
     let new_attr = MqAttr::new(0, 20, MSG_SIZE * 2, 100);
-    let old_attr = mq_setattr(mqd, &new_attr).unwrap();
+    let old_attr = mq_setattr(&mqd, &new_attr).unwrap();
     assert_attr_eq!(old_attr, initial_attr);
 
     // No changes here because according to the Linux man page only
     // O_NONBLOCK can be set (see tests below)
     #[cfg(not(any(target_os = "dragonfly", target_os = "netbsd")))]
     {
-        let new_attr_get = mq_getattr(mqd).unwrap();
+        let new_attr_get = mq_getattr(&mqd).unwrap();
         assert_ne!(new_attr_get, new_attr);
     }
 
     let new_attr_non_blocking = MqAttr::new(MQ_OFlag::O_NONBLOCK.bits() as mq_attr_member_t, 10, MSG_SIZE, 0);
-    mq_setattr(mqd, &new_attr_non_blocking).unwrap();
-    let new_attr_get = mq_getattr(mqd).unwrap();
+    mq_setattr(&mqd, &new_attr_non_blocking).unwrap();
+    let new_attr_get = mq_getattr(&mqd).unwrap();
 
     // now the O_NONBLOCK flag has been set
     #[cfg(not(any(target_os = "dragonfly", target_os = "netbsd")))]
@@ -142,12 +142,12 @@ fn test_mq_set_nonblocking() {
         return;
     };
     let mqd = r.unwrap();
-    mq_set_nonblock(mqd).unwrap();
-    let new_attr = mq_getattr(mqd);
+    mq_set_nonblock(&mqd).unwrap();
+    let new_attr = mq_getattr(&mqd);
     let o_nonblock_bits = MQ_OFlag::O_NONBLOCK.bits() as mq_attr_member_t;
     assert_eq!(new_attr.unwrap().flags() & o_nonblock_bits, o_nonblock_bits);
-    mq_remove_nonblock(mqd).unwrap();
-    let new_attr = mq_getattr(mqd);
+    mq_remove_nonblock(&mqd).unwrap();
+    let new_attr = mq_getattr(&mqd);
     assert_eq!(new_attr.unwrap().flags() & o_nonblock_bits, 0);
     mq_close(mqd).unwrap();
 }


### PR DESCRIPTION
* Better type safety for mqueue
* Suppress clippy::not_unsafe_ptr_arg_deref warnings in ptrace on BSD