### PR TITLE
Replace the IoVec struct with IoSlice and IoSliceMut from the standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ignoring failures from libc.  And getters on the `UtsName` struct now return
   an `&OsStr` instead of `&str`.
   (#[1672](https://github.com/nix-rust/nix/pull/1672))
+- Replaced `IoVec` with `IoSlice` and `IoSliceMut`, and replaced `IoVec::from_slice` with
+  `IoSlice::new`. (#[1643](https://github.com/nix-rust/nix/pull/1643))
 
 ### Fixed
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -629,7 +629,7 @@ pub fn tee(fd_in: RawFd, fd_out: RawFd, len: usize, flags: SpliceFFlags) -> Resu
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn vmsplice(
     fd: RawFd,
-    iov: &[crate::sys::uio::IoVec<&[u8]>],
+    iov: &[std::io::IoSlice<'_>],
     flags: SpliceFFlags
     ) -> Result<usize>
 {

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -68,13 +68,13 @@ cfg_if! {
                  target_os = "freebsd",
                  target_os = "ios",
                  target_os = "macos"))] {
-        use crate::sys::uio::IoVec;
+        use std::io::IoSlice;
 
-        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        #[derive(Clone, Debug)]
         struct SendfileHeaderTrailer<'a>(
             libc::sf_hdtr,
-            Option<Vec<IoVec<&'a [u8]>>>,
-            Option<Vec<IoVec<&'a [u8]>>>,
+            Option<Vec<IoSlice<'a>>>,
+            Option<Vec<IoSlice<'a>>>,
         );
 
         impl<'a> SendfileHeaderTrailer<'a> {
@@ -82,10 +82,10 @@ cfg_if! {
                 headers: Option<&'a [&'a [u8]]>,
                 trailers: Option<&'a [&'a [u8]]>
             ) -> SendfileHeaderTrailer<'a> {
-                let header_iovecs: Option<Vec<IoVec<&[u8]>>> =
-                    headers.map(|s| s.iter().map(|b| IoVec::from_slice(b)).collect());
-                let trailer_iovecs: Option<Vec<IoVec<&[u8]>>> =
-                    trailers.map(|s| s.iter().map(|b| IoVec::from_slice(b)).collect());
+                let header_iovecs: Option<Vec<IoSlice<'_>>> =
+                    headers.map(|s| s.iter().map(|b| IoSlice::new(b)).collect());
+                let trailer_iovecs: Option<Vec<IoSlice<'_>>> =
+                    trailers.map(|s| s.iter().map(|b| IoSlice::new(b)).collect());
                 SendfileHeaderTrailer(
                     libc::sf_hdtr {
                         headers: {

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -3,13 +3,21 @@
 use crate::Result;
 use crate::errno::Errno;
 use libc::{self, c_int, c_void, size_t, off_t};
+use std::io::{IoSlice, IoSliceMut};
 use std::marker::PhantomData;
 use std::os::unix::io::RawFd;
 
 /// Low-level vectored write to a raw file descriptor
 ///
 /// See also [writev(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/writev.html)
-pub fn writev(fd: RawFd, iov: &[IoVec<&[u8]>]) -> Result<usize> {
+pub fn writev(fd: RawFd, iov: &[IoSlice<'_>]) -> Result<usize> {
+    // SAFETY: to quote the documentation for `IoSlice`:
+    // 
+    // [IoSlice] is semantically a wrapper around a &[u8], but is 
+    // guaranteed to be ABI compatible with the iovec type on Unix
+    // platforms.
+    //
+    // Because it is ABI compatible, a pointer cast here is valid
     let res = unsafe { libc::writev(fd, iov.as_ptr() as *const libc::iovec, iov.len() as c_int) };
 
     Errno::result(res).map(|r| r as usize)
@@ -18,7 +26,8 @@ pub fn writev(fd: RawFd, iov: &[IoVec<&[u8]>]) -> Result<usize> {
 /// Low-level vectored read from a raw file descriptor
 ///
 /// See also [readv(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/readv.html)
-pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
+pub fn readv(fd: RawFd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
+    // SAFETY: same as in writev(), IoSliceMut is ABI-compatible with iovec
     let res = unsafe { libc::readv(fd, iov.as_ptr() as *const libc::iovec, iov.len() as c_int) };
 
     Errno::result(res).map(|r| r as usize)
@@ -32,10 +41,13 @@ pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
 /// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
+pub fn pwritev(fd: RawFd, iov: &[IoSlice<'_>],
                offset: off_t) -> Result<usize> {
+
     #[cfg(target_env = "uclibc")]
     let offset = offset as libc::off64_t; // uclibc doesn't use off_t
+
+    // SAFETY: same as in writev()
     let res = unsafe {
         libc::pwritev(fd, iov.as_ptr() as *const libc::iovec, iov.len() as c_int, offset)
     };
@@ -52,10 +64,12 @@ pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
 /// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn preadv(fd: RawFd, iov: &[IoVec<&mut [u8]>],
+pub fn preadv(fd: RawFd, iov: &mut [IoSliceMut<'_>],
               offset: off_t) -> Result<usize> {
     #[cfg(target_env = "uclibc")]
     let offset = offset as libc::off64_t; // uclibc doesn't use off_t
+
+    // SAFETY: same as in readv()
     let res = unsafe {
         libc::preadv(fd, iov.as_ptr() as *const libc::iovec, iov.len() as c_int, offset)
     };
@@ -92,9 +106,9 @@ pub fn pread(fd: RawFd, buf: &mut [u8], offset: off_t) -> Result<usize>{
 /// A slice of memory in a remote process, starting at address `base`
 /// and consisting of `len` bytes.
 ///
-/// This is the same underlying C structure as [`IoVec`](struct.IoVec.html),
+/// This is the same underlying C structure as `IoSlice`,
 /// except that it refers to memory in some other process, and is
-/// therefore not represented in Rust by an actual slice as `IoVec` is. It
+/// therefore not represented in Rust by an actual slice as `IoSlice` is. It
 /// is used with [`process_vm_readv`](fn.process_vm_readv.html)
 /// and [`process_vm_writev`](fn.process_vm_writev.html).
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -108,13 +122,82 @@ pub struct RemoteIoVec {
     pub len: usize,
 }
 
+/// A vector of buffers.
+///
+/// Vectored I/O methods like [`writev`] and [`readv`] use this structure for
+/// both reading and writing.  Each `IoVec` specifies the base address and
+/// length of an area in memory.
+#[deprecated(
+    since = "0.24.0",
+    note = "`IoVec` is no longer used in the public interface, use `IoSlice` or `IoSliceMut` instead"
+)]
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct IoVec<T>(pub(crate) libc::iovec, PhantomData<T>);
+
+#[allow(deprecated)]
+impl<T> IoVec<T> {
+    /// View the `IoVec` as a Rust slice.
+    #[deprecated(
+        since = "0.24.0",
+        note = "Use the `Deref` impl of `IoSlice` or `IoSliceMut` instead"
+    )]
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        use std::slice;
+
+        unsafe {
+            slice::from_raw_parts(
+                self.0.iov_base as *const u8,
+                self.0.iov_len as usize)
+        }
+    }
+}
+
+#[allow(deprecated)]
+impl<'a> IoVec<&'a [u8]> {
+    /// Create an `IoVec` from a Rust slice.
+    #[deprecated(
+        since = "0.24.0",
+        note = "Use `IoSlice::new` instead"
+    )]
+    pub fn from_slice(buf: &'a [u8]) -> IoVec<&'a [u8]> {
+        IoVec(libc::iovec {
+            iov_base: buf.as_ptr() as *mut c_void,
+            iov_len: buf.len() as size_t,
+        }, PhantomData)
+    }
+}
+
+#[allow(deprecated)]
+impl<'a> IoVec<&'a mut [u8]> {
+    /// Create an `IoVec` from a mutable Rust slice.
+    #[deprecated(
+        since = "0.24.0",
+        note = "Use `IoSliceMut::new` instead"
+    )]
+    pub fn from_mut_slice(buf: &'a mut [u8]) -> IoVec<&'a mut [u8]> {
+        IoVec(libc::iovec {
+            iov_base: buf.as_ptr() as *mut c_void,
+            iov_len: buf.len() as size_t,
+        }, PhantomData)
+    }
+}
+
+// The only reason IoVec isn't automatically Send+Sync is because libc::iovec
+// contains raw pointers.
+#[allow(deprecated)]
+unsafe impl<T> Send for IoVec<T> where T: Send {}
+#[allow(deprecated)]
+unsafe impl<T> Sync for IoVec<T> where T: Sync {}
+
 feature! {
 #![feature = "process"]
 
 /// Write data directly to another process's virtual memory
 /// (see [`process_vm_writev`(2)]).
 ///
-/// `local_iov` is a list of [`IoVec`]s containing the data to be written,
+/// `local_iov` is a list of [`IoSlice`]s containing the data to be written,
 /// and `remote_iov` is a list of [`RemoteIoVec`]s identifying where the
 /// data should be written in the target process. On success, returns the
 /// number of bytes written, which will always be a whole
@@ -129,12 +212,12 @@ feature! {
 ///
 /// [`process_vm_writev`(2)]: https://man7.org/linux/man-pages/man2/process_vm_writev.2.html
 /// [ptrace]: ../ptrace/index.html
-/// [`IoVec`]: struct.IoVec.html
+/// [`IoSlice`]: https://doc.rust-lang.org/std/io/struct.IoSlice.html
 /// [`RemoteIoVec`]: struct.RemoteIoVec.html
 #[cfg(all(any(target_os = "linux", target_os = "android"), not(target_env = "uclibc")))]
 pub fn process_vm_writev(
     pid: crate::unistd::Pid,
-    local_iov: &[IoVec<&[u8]>],
+    local_iov: &[IoSlice<'_>],
     remote_iov: &[RemoteIoVec]) -> Result<usize>
 {
     let res = unsafe {
@@ -149,7 +232,7 @@ pub fn process_vm_writev(
 /// Read data directly from another process's virtual memory
 /// (see [`process_vm_readv`(2)]).
 ///
-/// `local_iov` is a list of [`IoVec`]s containing the buffer to copy
+/// `local_iov` is a list of [`IoSliceMut`]s containing the buffer to copy
 /// data into, and `remote_iov` is a list of [`RemoteIoVec`]s identifying
 /// where the source data is in the target process. On success,
 /// returns the number of bytes written, which will always be a whole
@@ -164,12 +247,12 @@ pub fn process_vm_writev(
 ///
 /// [`process_vm_readv`(2)]: https://man7.org/linux/man-pages/man2/process_vm_readv.2.html
 /// [`ptrace`]: ../ptrace/index.html
-/// [`IoVec`]: struct.IoVec.html
+/// [`IoSliceMut`]: https://doc.rust-lang.org/std/io/struct.IoSliceMut.html
 /// [`RemoteIoVec`]: struct.RemoteIoVec.html
 #[cfg(all(any(target_os = "linux", target_os = "android"), not(target_env = "uclibc")))]
 pub fn process_vm_readv(
     pid: crate::unistd::Pid,
-    local_iov: &[IoVec<&mut [u8]>],
+    local_iov: &mut [IoSliceMut<'_>],
     remote_iov: &[RemoteIoVec]) -> Result<usize>
 {
     let res = unsafe {
@@ -181,59 +264,3 @@ pub fn process_vm_readv(
     Errno::result(res).map(|r| r as usize)
 }
 }
-
-/// A vector of buffers.
-///
-/// Vectored I/O methods like [`writev`] and [`readv`] use this structure for
-/// both reading and writing.  Each `IoVec` specifies the base address and
-/// length of an area in memory.
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct IoVec<T>(pub(crate) libc::iovec, PhantomData<T>);
-
-impl<T> IoVec<T> {
-    /// View the `IoVec` as a Rust slice.
-    #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        use std::slice;
-
-        unsafe {
-            slice::from_raw_parts(
-                self.0.iov_base as *const u8,
-                self.0.iov_len as usize)
-        }
-    }
-}
-
-impl<'a> IoVec<&'a [u8]> {
-    #[cfg(all(feature = "mount", target_os = "freebsd"))]
-    pub(crate) fn from_raw_parts(base: *mut c_void, len: usize) -> Self {
-        IoVec(libc::iovec {
-            iov_base: base,
-            iov_len: len
-        }, PhantomData)
-    }
-
-    /// Create an `IoVec` from a Rust slice.
-    pub fn from_slice(buf: &'a [u8]) -> IoVec<&'a [u8]> {
-        IoVec(libc::iovec {
-            iov_base: buf.as_ptr() as *mut c_void,
-            iov_len: buf.len() as size_t,
-        }, PhantomData)
-    }
-}
-
-impl<'a> IoVec<&'a mut [u8]> {
-    /// Create an `IoVec` from a mutable Rust slice.
-    pub fn from_mut_slice(buf: &'a mut [u8]) -> IoVec<&'a mut [u8]> {
-        IoVec(libc::iovec {
-            iov_base: buf.as_ptr() as *mut c_void,
-            iov_len: buf.len() as size_t,
-        }, PhantomData)
-    }
-}
-
-// The only reason IoVec isn't automatically Send+Sync is because libc::iovec
-// contains raw pointers.
-unsafe impl<T> Send for IoVec<T> where T: Send {}
-unsafe impl<T> Sync for IoVec<T> where T: Sync {}

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -218,12 +218,11 @@ fn test_readlink() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux_android {
     use std::io::prelude::*;
-    use std::io::SeekFrom;
+    use std::io::{IoSlice, SeekFrom};
     use std::os::unix::prelude::*;
     use libc::loff_t;
 
     use nix::fcntl::*;
-    use nix::sys::uio::IoVec;
     use nix::unistd::{close, pipe, read, write};
 
     use tempfile::tempfile;
@@ -323,8 +322,8 @@ mod linux_android {
         let buf1 = b"abcdef";
         let buf2 = b"defghi";
         let iovecs = vec![
-            IoVec::from_slice(&buf1[0..3]),
-            IoVec::from_slice(&buf2[0..3])
+            IoSlice::new(&buf1[0..3]),
+            IoSlice::new(&buf2[0..3])
         ];
 
         let res = vmsplice(wr, &iovecs[..], SpliceFFlags::empty()).unwrap();


### PR DESCRIPTION
As per discussion in #1637, the `IoVec<&[u8]>` and `IoVec<&mut [u8]>` types have been replaced with `std::io::IoSlice` and `IoSliceMut`, respectively. Notable changes made in this pull request include:

- The complete replacement of `IoVec` with `IoSlice*` types in both public API, private API, and tests.
- Replacing `IoVec` with `IoSlice` in docs.
- Replacing `&[IoVec<&mut [u8]>]` with `&mut [IoSliceMut]`, note that the slice requires a mutable reference now. This is how it's done in the standard library, and there might be a soundness issue in doing it the other way.

Resolves #1637 