### PR TITLE
Make memoffset dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = "1.1"
 cfg-if = "1.0"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
-memoffset = "0.6.3"
+memoffset = { version = "0.6.3", optional = true }
 
 [features]
 default = [
@@ -68,7 +68,7 @@ reboot = []
 resource = []
 sched = ["process"]
 signal = ["process"]
-socket = []
+socket = ["memoffset"]
 term = []
 time = []
 ucontext = ["signal"]


### PR DESCRIPTION
Only the socket feature depends on memoffset. Allow clients to skip pulling memoffset in as a dependency if they don't need it.