### PR TITLE
Add accept4 on DragonFly, Emscripten, Fuchsia, Illumos, and NetBSD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1636](https://github.com/nix-rust/nix/pull/1636))
 - Added `fspacectl` on FreeBSD
   (#[1640](https://github.com/nix-rust/nix/pull/1640))
+- Added `accept4` on DragonFly, Emscripten, Fuchsia, Illumos, and NetBSD.
+  (#[1654](https://github.com/nix-rust/nix/pull/1654))
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1794,8 +1794,13 @@ pub fn accept(sockfd: RawFd) -> Result<RawFd> {
                 target_arch = "x86_64"
             )
           ),
+          target_os = "dragonfly",
+          target_os = "emscripten",
           target_os = "freebsd",
+          target_os = "fuchsia",
+          target_os = "illumos",
           target_os = "linux",
+          target_os = "netbsd",
           target_os = "openbsd"))]
 pub fn accept4(sockfd: RawFd, flags: SockFlag) -> Result<RawFd> {
     let res = unsafe { libc::accept4(sockfd, ptr::null_mut(), ptr::null_mut(), flags.bits()) };


### PR DESCRIPTION
Expand accept4 support to more platforms.