### PR TITLE
Enforce code style with rustfmt

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -311,4 +311,4 @@ task:
   container:
     image: rustlang/rust:nightly
   check_script:
-    - git diff --name-only --diff-filter=ACMRT $CIRRUS_BASE_SHA HEAD -- '*.rs' | xargs rustfmt --check
+    - git diff --name-only --diff-filter=ACMRT $CIRRUS_BASE_SHA HEAD -- '*.rs' | xargs --no-run-if-empty rustfmt --check

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,3 +303,12 @@ task:
   check_script:
     - cargo check
   before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+task:
+  name: Fmt check
+  env:
+    TOOLCHAIN: nightly
+  container:
+    image: rustlang/rust:nightly
+  check_script:
+    - git diff --name-only --diff-filter=ACMRT $CIRRUS_BASE_SHA HEAD -- '*.rs' | xargs rustfmt --check


### PR DESCRIPTION
Is this a desirable change? Or maybe a better question: is there a reason this hasn't been done before?