### PR TITLE
Define _POSIX_VDISABLE on Android to fix doc test

### DIFF
--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -497,7 +497,8 @@ impl SpecialCharacterIndices {
 }
 
 pub use libc::NCCS;
-#[cfg(any(target_os = "dragonfly",
+#[cfg(any(target_os = "android",
+          target_os = "dragonfly",
           target_os = "freebsd",
           target_os = "linux",
           target_os = "macos",


### PR DESCRIPTION
This fixes the compilation [this](https://github.com/rtzoeller/nix/blob/1a2ee3da3026a14d42498f5ca4e4b2c1a75bc81d/src/sys/termios.rs#L27) example documentation on Android. Tested on Termux.