### PR TITLE
Make `uname` always safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecated `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` in favor of their equivalents
   from the standard library.
   (#[1685](https://github.com/nix-rust/nix/pull/1685))
+- `uname` now returns a `Result` instead of blindly assuming the call never fails.
+- Getters on the `UtsName` struct now return a `&OsStr` instead of `&str`.
 
 ### Fixed
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -3,7 +3,9 @@ pub use self::os::*;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod os {
+    use std::os::unix::ffi::OsStrExt;
     use crate::sys::utsname::uname;
+    use crate::Result;
 
     // Features:
     // * atomic cloexec on socket: 2.6.27
@@ -22,15 +24,15 @@ mod os {
         *dst += (b - b'0') as usize;
     }
 
-    fn parse_kernel_version() -> usize {
-        let u = uname();
+    fn parse_kernel_version() -> Result<usize> {
+        let u = uname()?;
 
         let mut curr:  usize = 0;
         let mut major: usize = 0;
         let mut minor: usize = 0;
         let mut patch: usize = 0;
 
-        for b in u.release().bytes() {
+        for &b in u.release().as_bytes() {
             if curr >= 3 {
                 break;
             }
@@ -50,7 +52,7 @@ mod os {
             }
         }
 
-        if major >= 3 {
+        Ok(if major >= 3 {
             VERS_3
         } else if major >= 2 {
             if minor >= 7 {
@@ -68,29 +70,29 @@ mod os {
             }
         } else {
             VERS_UNKNOWN
-        }
+        })
     }
 
-    fn kernel_version() -> usize {
+    fn kernel_version() -> Result<usize> {
         static mut KERNEL_VERS: usize = 0;
 
         unsafe {
             if KERNEL_VERS == 0 {
-                KERNEL_VERS = parse_kernel_version();
+                KERNEL_VERS = parse_kernel_version()?;
             }
 
-            KERNEL_VERS
+            Ok(KERNEL_VERS)
         }
     }
 
     /// Check if the OS supports atomic close-on-exec for sockets
     pub fn socket_atomic_cloexec() -> bool {
-        kernel_version() >= VERS_2_6_27
+        kernel_version().map(|version| version >= VERS_2_6_27).unwrap_or(false)
     }
 
     #[test]
     pub fn test_parsing_kernel_version() {
-        assert!(kernel_version() > 0);
+        assert!(kernel_version().unwrap() > 0);
     }
 }
 

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -111,15 +111,15 @@ cfg_if! {
                 let version_requirement = VersionReq::parse($version_requirement)
                         .expect("Bad match_version provided");
 
-                let uname = nix::sys::utsname::uname();
-                println!("{}", uname.sysname());
-                println!("{}", uname.nodename());
-                println!("{}", uname.release());
-                println!("{}", uname.version());
-                println!("{}", uname.machine());
+                let uname = nix::sys::utsname::uname().unwrap();
+                println!("{}", uname.sysname().to_str().unwrap());
+                println!("{}", uname.nodename().to_str().unwrap());
+                println!("{}", uname.release().to_str().unwrap());
+                println!("{}", uname.version().to_str().unwrap());
+                println!("{}", uname.machine().to_str().unwrap());
 
                 // Fix stuff that the semver parser can't handle
-                let fixed_release = &uname.release().to_string()
+                let fixed_release = &uname.release().to_str().unwrap().to_string()
                     // Fedora 33 reports version as 4.18.el8_2.x86_64 or
                     // 5.18.200-fc33.x86_64.  Remove the underscore.
                     .replace("_", "-")


### PR DESCRIPTION
Currently `uname` doesn't check for errors and just blindly assumes that it always succeeds. According to the manpage this function can fail, even though no actual errors are defined:

```
RETURN VALUE
       Upon successful completion, a non-negative value shall be returned.  Otherwise, -1 shall be returned and errno set to indicate the error.

ERRORS
       No errors are defined.

       The following sections are informative.
```

Looking at [the glibc's sources](https://github.com/bminor/glibc/blob/b92a49359f33a461db080a33940d73f47c756126/posix/uname.c#L29) we can see that it indeed could fail if the internal `gethostname` call fails for some reason.

This code also assumes that every field of `utsname` is going to be initialized by the call to `uname`, which apparently is also not true. Even though the interface doesn't expose this field so it's not a problem in practice (although it might be UB since we do call `assume_init` on the whole struct) [the `utsname` does have a `domainname` field](https://docs.rs/libc/0.2.119/libc/struct.utsname.html) which glibc doesn't initialize.

The code also assumes that every field is a valid UTF-8 string, which is also technically not guaranteed.

The code also assumes that every field will be null terminated, which might not be true if any of the strings are too long (since glibc uses `strncpy` which will *not* null-terminate the string if it ends up running out of space).

This PR should fix all of these problems.

This is a breaking change.