### PR TITLE
Fix a panic in Linkaddr::addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - `InetAddr::from_std` now sets the `sin_len`/`sin6_len` fields on the BSDs.
   (#[1642](https://github.com/nix-rust/nix/pull/1642))
+- Fixed a panic in `LinkAddr::addr`.  That function now returns an `Option`.
+  (#[1675](https://github.com/nix-rust/nix/pull/1675))
 
 ### Removed
 


### PR DESCRIPTION
The function assumed something about the values of the sockaddr_dl's
fields.  But because the inner type is public, we musn't do that.  The
only solution is to change the function's signature to return an Option.