### PR TITLE
Use the same signature for LinkAddr::addr on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1642](https://github.com/nix-rust/nix/pull/1642))
 - Fixed a panic in `LinkAddr::addr`.  That function now returns an `Option`.
   (#[1675](https://github.com/nix-rust/nix/pull/1675))
+  (#[1677](https://github.com/nix-rust/nix/pull/1677))
 
 ### Removed
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1351,28 +1351,32 @@ mod datalink {
         }
 
         /// Physical-layer address (MAC)
-        pub fn addr(&self) -> [u8; 6] {
-            [
+        // Returns an Option just for cross-platform compatibility
+        pub fn addr(&self) -> Option<[u8; 6]> {
+            Some([
                 self.0.sll_addr[0] as u8,
                 self.0.sll_addr[1] as u8,
                 self.0.sll_addr[2] as u8,
                 self.0.sll_addr[3] as u8,
                 self.0.sll_addr[4] as u8,
                 self.0.sll_addr[5] as u8,
-            ]
+            ])
         }
     }
 
     impl fmt::Display for LinkAddr {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            let addr = self.addr();
-            write!(f, "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-                addr[0],
-                addr[1],
-                addr[2],
-                addr[3],
-                addr[4],
-                addr[5])
+            if let Some(addr) = self.addr() {
+                write!(f, "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                    addr[0],
+                    addr[1],
+                    addr[2],
+                    addr[3],
+                    addr[4],
+                    addr[5])
+            } else {
+                Ok(())
+            }
         }
     }
     }


### PR DESCRIPTION
This should've been done as part of #1675