### PR TITLE
Fix build for Redox and uclibc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.115", features = [ "extra_traits" ] }
+libc = { version = "0.2.121", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -39,7 +39,7 @@ libc_enum! {
     //
     // https://gcc.gnu.org/legacy-ml/gcc/2015-08/msg00441.html
     // https://github.com/rust-lang/libc/blob/master/src/unix/linux_like/linux/gnu/mod.rs
-    #[cfg_attr(all(target_os = "linux", target_env = "gnu"), repr(u32))]
+    #[cfg_attr(all(target_os = "linux", any(target_env = "gnu", target_env = "uclibc")), repr(u32))]
     #[cfg_attr(any(
             target_os = "freebsd",
             target_os = "openbsd",
@@ -48,7 +48,7 @@ libc_enum! {
             target_os = "ios",
             target_os = "android",
             target_os = "dragonfly",
-            all(target_os = "linux", not(target_env = "gnu"))
+            all(target_os = "linux", not(any(target_env = "gnu", target_env = "uclibc")))
         ), repr(i32))]
     #[non_exhaustive]
     pub enum Resource {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -670,21 +670,12 @@ impl SigAction {
     /// is the `SigAction` variant). `mask` specifies other signals to block during execution of
     /// the signal-catching function.
     pub fn new(handler: SigHandler, flags: SaFlags, mask: SigSet) -> SigAction {
-        #[cfg(target_os = "redox")]
-        unsafe fn install_sig(p: *mut libc::sigaction, handler: SigHandler) {
-            (*p).sa_handler = match handler {
-                SigHandler::SigDfl => libc::SIG_DFL,
-                SigHandler::SigIgn => libc::SIG_IGN,
-                SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
-            };
-        }
-
-        #[cfg(not(target_os = "redox"))]
         unsafe fn install_sig(p: *mut libc::sigaction, handler: SigHandler) {
             (*p).sa_sigaction = match handler {
                 SigHandler::SigDfl => libc::SIG_DFL,
                 SigHandler::SigIgn => libc::SIG_IGN,
                 SigHandler::Handler(f) => f as *const extern fn(libc::c_int) as usize,
+                #[cfg(not(target_os = "redox"))]
                 SigHandler::SigAction(f) => f as *const extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
             };
         }
@@ -716,12 +707,11 @@ impl SigAction {
     }
 
     /// Returns the action's handler.
-    #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn handler(&self) -> SigHandler {
         match self.sigaction.sa_sigaction {
             libc::SIG_DFL => SigHandler::SigDfl,
             libc::SIG_IGN => SigHandler::SigIgn,
+            #[cfg(not(target_os = "redox"))]
             p if self.flags().contains(SaFlags::SA_SIGINFO) =>
                 SigHandler::SigAction(
                 // Safe for one of two reasons:
@@ -735,28 +725,6 @@ impl SigAction {
                          as *const extern fn(_, _, _))
                 }
                 as extern fn(_, _, _)),
-            p => SigHandler::Handler(
-                // Safe for one of two reasons:
-                // * The SigHandler was created by SigHandler::new, in which
-                //   case the pointer is correct, or
-                // * The SigHandler was created by signal or sigaction, which
-                //   are unsafe functions, so the caller should've somehow
-                //   ensured that it is correctly initialized.
-                unsafe{
-                    *(&p as *const usize
-                         as *const extern fn(libc::c_int))
-                }
-                as extern fn(libc::c_int)),
-        }
-    }
-
-    /// Returns the action's handler.
-    #[cfg(target_os = "redox")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
-    pub fn handler(&self) -> SigHandler {
-        match self.sigaction.sa_handler {
-            libc::SIG_DFL => SigHandler::SigDfl,
-            libc::SIG_IGN => SigHandler::SigIgn,
             p => SigHandler::Handler(
                 // Safe for one of two reasons:
                 // * The SigHandler was created by SigHandler::new, in which


### PR DESCRIPTION
- Redox renamed `sigaction.sa_handler` to `.sa_sigaction`, which lets us drop some specialized code for the platform.
- uclibc now uses a `u32` for the `RLIMIT` definitions, like Linux GNU.