### PR TITLE
Deprecate IpAddr, Ipv4Addr, and Ipv6Addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecated `InetAddr` and `SockAddr` in favor of `SockaddrIn`, `SockaddrIn6`,
   and `SockaddrStorage`.
   (#[1684](https://github.com/nix-rust/nix/pull/1684))
+- Deprecated `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` in favor of their equivalents
+  from the standard library.
+  (#[1685](https://github.com/nix-rust/nix/pull/1685))
 
 ### Fixed
 

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1833,7 +1833,7 @@ mod linux_errqueue {
                     if let Some(origin) = err_addr {
                         // Validate that our network error originated from 127.0.0.1:0.
                         assert_eq!(origin.sin_family, AddressFamily::Inet as _);
-                        assert_eq!(Ipv4Addr(origin.sin_addr), Ipv4Addr::new(127, 0, 0, 1));
+                        assert_eq!(origin.sin_addr.s_addr, u32::from_be(0x7f000001));
                         assert_eq!(origin.sin_port, 0);
                     } else {
                         panic!("Expected some error origin");
@@ -1877,8 +1877,8 @@ mod linux_errqueue {
                         // Validate that our network error originated from localhost:0.
                         assert_eq!(origin.sin6_family, AddressFamily::Inet6 as _);
                         assert_eq!(
-                            Ipv6Addr(origin.sin6_addr),
-                            Ipv6Addr::from_std(&"::1".parse().unwrap()),
+                            origin.sin6_addr.s6_addr,
+                            std::net::Ipv6Addr::LOCALHOST.octets()
                         );
                         assert_eq!(origin.sin6_port, 0);
                     } else {


### PR DESCRIPTION
Because they're redundant with types in the standard library.

Fixes #1681