### PR TITLE
Enable statfs magic constants for target_os = "android"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added fine-grained features flags.  Most Nix functionality can now be
   conditionally enabled.  By default, all features are enabled.
   (#[1611](https://github.com/nix-rust/nix/pull/1611))
+- Added statfs FS type magic constants for `target_os = "android"`
+  and synced constants with libc v0.2.121.
+  (#[1690](https://github.com/nix-rust/nix/pull/1690))
 - Added `fexecve` on DragonFly.
   (#[1577](https://github.com/nix-rust/nix/pull/1577))
 - `sys::uio::IoVec` is now `Send` and `Sync`

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -49,96 +49,162 @@ pub struct FsType(pub fs_type_t);
 
 // These constants are defined without documentation in the Linux headers, so we
 // can't very well document them here.
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
 pub const ADFS_SUPER_MAGIC: FsType = FsType(libc::ADFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
 pub const AFFS_SUPER_MAGIC: FsType = FsType(libc::AFFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
-pub const CODA_SUPER_MAGIC: FsType = FsType(libc::CODA_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+pub const AFS_SUPER_MAGIC: FsType = FsType(libc::AFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
-pub const CRAMFS_MAGIC: FsType = FsType(libc::CRAMFS_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+pub const AUTOFS_SUPER_MAGIC: FsType = FsType(libc::AUTOFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
-pub const EFS_SUPER_MAGIC: FsType = FsType(libc::EFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+pub const BPF_FS_MAGIC: FsType = FsType(libc::BPF_FS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
-pub const EXT2_SUPER_MAGIC: FsType = FsType(libc::EXT2_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const EXT3_SUPER_MAGIC: FsType = FsType(libc::EXT3_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const EXT4_SUPER_MAGIC: FsType = FsType(libc::EXT4_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(any(target_env = "musl", target_env = "uclibc"))))]
-#[allow(missing_docs)]
-pub const FUSE_SUPER_MAGIC: FsType = FsType(libc::FUSE_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const HPFS_SUPER_MAGIC: FsType = FsType(libc::HPFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const HUGETLBFS_MAGIC: FsType = FsType(libc::HUGETLBFS_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const ISOFS_SUPER_MAGIC: FsType = FsType(libc::ISOFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const JFFS2_SUPER_MAGIC: FsType = FsType(libc::JFFS2_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const MINIX_SUPER_MAGIC: FsType = FsType(libc::MINIX_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const MINIX_SUPER_MAGIC2: FsType = FsType(libc::MINIX_SUPER_MAGIC2 as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const MINIX2_SUPER_MAGIC: FsType = FsType(libc::MINIX2_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const MINIX2_SUPER_MAGIC2: FsType = FsType(libc::MINIX2_SUPER_MAGIC2 as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const MSDOS_SUPER_MAGIC: FsType = FsType(libc::MSDOS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const NCP_SUPER_MAGIC: FsType = FsType(libc::NCP_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const NFS_SUPER_MAGIC: FsType = FsType(libc::NFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const OPENPROM_SUPER_MAGIC: FsType = FsType(libc::OPENPROM_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const OVERLAYFS_SUPER_MAGIC: FsType = FsType(libc::OVERLAYFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const PROC_SUPER_MAGIC: FsType = FsType(libc::PROC_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const QNX4_SUPER_MAGIC: FsType = FsType(libc::QNX4_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const REISERFS_SUPER_MAGIC: FsType = FsType(libc::REISERFS_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const SMB_SUPER_MAGIC: FsType = FsType(libc::SMB_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const TMPFS_MAGIC: FsType = FsType(libc::TMPFS_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const USBDEVICE_SUPER_MAGIC: FsType = FsType(libc::USBDEVICE_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
-#[allow(missing_docs)]
-pub const CGROUP_SUPER_MAGIC: FsType = FsType(libc::CGROUP_SUPER_MAGIC as fs_type_t);
-#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+pub const BTRFS_SUPER_MAGIC: FsType = FsType(libc::BTRFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
 #[allow(missing_docs)]
 pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const CGROUP_SUPER_MAGIC: FsType = FsType(libc::CGROUP_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const CODA_SUPER_MAGIC: FsType = FsType(libc::CODA_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const CRAMFS_MAGIC: FsType = FsType(libc::CRAMFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const DEBUGFS_MAGIC: FsType = FsType(libc::DEBUGFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const DEVPTS_SUPER_MAGIC: FsType = FsType(libc::DEVPTS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const ECRYPTFS_SUPER_MAGIC: FsType = FsType(libc::ECRYPTFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const EFS_SUPER_MAGIC: FsType = FsType(libc::EFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const EXT2_SUPER_MAGIC: FsType = FsType(libc::EXT2_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const EXT3_SUPER_MAGIC: FsType = FsType(libc::EXT3_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const EXT4_SUPER_MAGIC: FsType = FsType(libc::EXT4_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const F2FS_SUPER_MAGIC: FsType = FsType(libc::F2FS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const FUSE_SUPER_MAGIC: FsType = FsType(libc::FUSE_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const FUTEXFS_SUPER_MAGIC: FsType = FsType(libc::FUTEXFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const HOSTFS_SUPER_MAGIC: FsType = FsType(libc::HOSTFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const HPFS_SUPER_MAGIC: FsType = FsType(libc::HPFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const HUGETLBFS_MAGIC: FsType = FsType(libc::HUGETLBFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const ISOFS_SUPER_MAGIC: FsType = FsType(libc::ISOFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const JFFS2_SUPER_MAGIC: FsType = FsType(libc::JFFS2_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MINIX2_SUPER_MAGIC2: FsType = FsType(libc::MINIX2_SUPER_MAGIC2 as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MINIX2_SUPER_MAGIC: FsType = FsType(libc::MINIX2_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MINIX3_SUPER_MAGIC: FsType = FsType(libc::MINIX3_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MINIX_SUPER_MAGIC2: FsType = FsType(libc::MINIX_SUPER_MAGIC2 as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MINIX_SUPER_MAGIC: FsType = FsType(libc::MINIX_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const MSDOS_SUPER_MAGIC: FsType = FsType(libc::MSDOS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const NCP_SUPER_MAGIC: FsType = FsType(libc::NCP_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const NFS_SUPER_MAGIC: FsType = FsType(libc::NFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const NILFS_SUPER_MAGIC: FsType = FsType(libc::NILFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const OCFS2_SUPER_MAGIC: FsType = FsType(libc::OCFS2_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const OPENPROM_SUPER_MAGIC: FsType = FsType(libc::OPENPROM_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const OVERLAYFS_SUPER_MAGIC: FsType = FsType(libc::OVERLAYFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const PROC_SUPER_MAGIC: FsType = FsType(libc::PROC_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const QNX4_SUPER_MAGIC: FsType = FsType(libc::QNX4_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const QNX6_SUPER_MAGIC: FsType = FsType(libc::QNX6_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const RDTGROUP_SUPER_MAGIC: FsType = FsType(libc::RDTGROUP_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const REISERFS_SUPER_MAGIC: FsType = FsType(libc::REISERFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const SECURITYFS_MAGIC: FsType = FsType(libc::SECURITYFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const SELINUX_MAGIC: FsType = FsType(libc::SELINUX_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const SMACK_MAGIC: FsType = FsType(libc::SMACK_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const SMB_SUPER_MAGIC: FsType = FsType(libc::SMB_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const SYSFS_MAGIC: FsType = FsType(libc::SYSFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const TMPFS_MAGIC: FsType = FsType(libc::TMPFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const TRACEFS_MAGIC: FsType = FsType(libc::TRACEFS_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const UDF_SUPER_MAGIC: FsType = FsType(libc::UDF_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const USBDEVICE_SUPER_MAGIC: FsType = FsType(libc::USBDEVICE_SUPER_MAGIC as fs_type_t);
+#[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+#[allow(missing_docs)]
+pub const XENFS_SUPER_MAGIC: FsType = FsType(libc::XENFS_SUPER_MAGIC as fs_type_t);
 
 
 impl Statfs {


### PR DESCRIPTION
The statfs magic constants of file systems types are available on
target_os android and the cfg guard is updated accordingly.

Sync the list of constant with the constants declared in libc.

Fixes #1689