### PR TITLE
Use singular number for all feature names

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -286,11 +286,26 @@ task:
     - name: OpenBSD x86_64
       env:
         TARGET: x86_64-unknown-openbsd
-    - name: Linux armv7 uclibceabihf
-      env:
-        TARGET: armv7-unknown-linux-uclibceabihf
   setup_script:
     - rustup component add rust-src
+  << : *BUILD
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+# uclibc needs its own task for now, due to Rust bug 95866
+# https://github.com/rust-lang/rust/issues/95866
+task:
+  name: Linux armv7 uclibceabihf
+  container:
+    image: rustlang/rust:nightly
+  env:
+    BUILD: check
+    ZFLAGS: -Zbuild-std
+    TARGET: armv7-unknown-linux-uclibceabihf
+    TOOLCHAIN: nightly-2022-04-01
+  setup_script:
+    - rustup toolchain install $TOOLCHAIN --profile minimal
+    - rustup component add --toolchain $TOOLCHAIN rust-src
+    - rustup component add --toolchain $TOOLCHAIN clippy
   << : *BUILD
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ memoffset = { version = "0.6.3", optional = true }
 
 [features]
 default = [
-  "acct", "aio", "dir", "env", "event", "features", "fs",
+  "acct", "aio", "dir", "env", "event", "feature", "fs",
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "users", "zerocopy",
+  "ucontext", "uio", "user", "zerocopy",
 ]
 
 acct = []
@@ -48,7 +48,7 @@ aio = []
 dir = ["fs"]
 env = []
 event = []
-features = []
+feature = []
 fs = []
 hostname = []
 inotify = []
@@ -73,7 +73,7 @@ term = []
 time = []
 ucontext = ["signal"]
 uio = []
-users = ["features"]
+user = ["feature"]
 zerocopy = ["fs", "uio"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! * `dir` - Stuff relating to directory iteration
 //! * `env` - Manipulate environment variables
 //! * `event` - Event-driven APIs, like `kqueue` and `epoll`
-//! * `features` - Query characteristics of the OS at runtime
+//! * `feature` - Query characteristics of the OS at runtime
 //! * `fs` - File system functionality
 //! * `hostname` - Get and set the system's hostname
 //! * `inotify` - Linux's `inotify` file system notification API
@@ -37,7 +37,7 @@
 //! * `time` - Query the operating system's clocks
 //! * `ucontext` - User thread context
 //! * `uio` - Vectored I/O
-//! * `users` - Stuff relating to users and groups
+//! * `user` - Stuff relating to users and groups
 //! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
 #![cfg(unix)]
@@ -75,7 +75,7 @@ feature! {
 #[allow(missing_docs)]
 pub mod errno;
 feature! {
-    #![feature = "features"]
+    #![feature = "feature"]
 
     #[deny(missing_docs)]
     pub mod features;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -177,7 +177,7 @@ feature! {
 }
 
 feature! {
-    #![feature = "features"]
+    #![feature = "feature"]
     pub mod utsname;
 }
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -45,7 +45,7 @@ pub use self::setres::*;
 pub use self::getres::*;
 
 feature! {
-#![feature = "users"]
+#![feature = "user"]
 
 /// User identifier
 ///
@@ -591,7 +591,7 @@ pub fn symlinkat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
 
 // Double the buffer capacity up to limit. In case it already has
 // reached the limit, return Errno::ERANGE.
-#[cfg(any(feature = "fs", feature = "users"))]
+#[cfg(any(feature = "fs", feature = "user"))]
 fn reserve_double_buffer_size<T>(buf: &mut Vec<T>, limit: usize) -> Result<()> {
     use std::cmp::min;
 
@@ -654,7 +654,7 @@ pub fn getcwd() -> Result<PathBuf> {
 }
 
 feature! {
-#![all(feature = "users", feature = "fs")]
+#![all(feature = "user", feature = "fs")]
 
 /// Computes the raw UID and GID values to pass to a `*chown` call.
 // The cast is not unnecessary on all platforms.
@@ -1348,7 +1348,7 @@ pub fn fdatasync(fd: RawFd) -> Result<()> {
 }
 
 feature! {
-#![feature = "users"]
+#![feature = "user"]
 
 /// Get a real user ID
 ///
@@ -1432,7 +1432,7 @@ pub fn setgid(gid: Gid) -> Result<()> {
 }
 
 feature! {
-#![all(feature = "fs", feature = "users")]
+#![all(feature = "fs", feature = "user")]
 /// Set the user identity used for filesystem checks per-thread.
 /// On both success and failure, this call returns the previous filesystem user
 /// ID of the caller.
@@ -1457,7 +1457,7 @@ pub fn setfsgid(gid: Gid) -> Gid {
 }
 
 feature! {
-#![feature = "users"]
+#![feature = "user"]
 
 /// Get the list of supplementary group IDs of the calling process.
 ///
@@ -1868,7 +1868,7 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
 }
 
 feature! {
-#![all(feature = "fs", feature = "features")]
+#![all(feature = "fs", feature = "feature")]
 
 /// Variable names for `pathconf`
 ///
@@ -2064,7 +2064,7 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
 }
 
 feature! {
-#![feature = "features"]
+#![feature = "feature"]
 
 /// Variable names for `sysconf`
 ///
@@ -2705,7 +2705,7 @@ mod pivot_root {
           target_os = "openbsd"))]
 mod setres {
     feature! {
-    #![feature = "users"]
+    #![feature = "user"]
 
     use crate::Result;
     use crate::errno::Errno;
@@ -2752,7 +2752,7 @@ mod setres {
           target_os = "openbsd"))]
 mod getres {
     feature! {
-    #![feature = "users"]
+    #![feature = "user"]
 
     use crate::Result;
     use crate::errno::Errno;
@@ -2846,7 +2846,7 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
 }
 
 feature! {
-#![feature = "users"]
+#![feature = "user"]
 
 /// Representation of a User, based on `libc::passwd`
 ///
@@ -3212,7 +3212,7 @@ pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
 }
 
 feature! {
-#![all(feature = "socket", feature = "users")]
+#![all(feature = "socket", feature = "user")]
 
 /// Get the effective user ID and group ID associated with a Unix domain socket.
 ///


### PR DESCRIPTION
features => feature
users => user

Neither of these features have yet been included in a release, so it's
ok to rename them.