### PR TITLE
Revert "Pin nightly compiler used in CI for uclibc"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -286,26 +286,11 @@ task:
     - name: OpenBSD x86_64
       env:
         TARGET: x86_64-unknown-openbsd
+    - name: Linux armv7 uclibceabihf
+      env:
+        TARGET: armv7-unknown-linux-uclibceabihf
   setup_script:
     - rustup component add rust-src
-  << : *BUILD
-  before_cache_script: rm -rf $CARGO_HOME/registry/index
-
-# uclibc needs its own task for now, due to Rust bug 95866
-# https://github.com/rust-lang/rust/issues/95866
-task:
-  name: Linux armv7 uclibceabihf
-  container:
-    image: rustlang/rust:nightly
-  env:
-    BUILD: check
-    ZFLAGS: -Zbuild-std
-    TARGET: armv7-unknown-linux-uclibceabihf
-    TOOLCHAIN: nightly-2022-04-01
-  setup_script:
-    - rustup toolchain install $TOOLCHAIN --profile minimal
-    - rustup component add --toolchain $TOOLCHAIN rust-src
-    - rustup component add --toolchain $TOOLCHAIN clippy
   << : *BUILD
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.121", features = [ "extra_traits" ] }
+libc = { version = "0.2.124", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 


### PR DESCRIPTION
This reverts commit 23f18dfc18929965c95e0bcbdb8731645f07e401.

libc v0.2.124 fixes the problem.