### PR TITLE
Fix UnixAddr::size on Linux and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+### Added
+### Changed
+### Fixed
+
+- Fixed `UnixAddr::size` on Linux-based OSes.
+  (#[1702](https://github.com/nix-rust/nix/pull/1702))
+
+### Removed
+
 ## [0.24.0] - 2022-04-21
 ### Added
 


### PR DESCRIPTION
SockaddrLike::size() is meant to return the amount of space that can be
used to store the sockaddr.  But on Linux-based OSes, UnixAddr contains
an extra field to store the address's length.  This field is not part of
the address, and should not contribute to the value of size().

This bug can't cause an out-of-bounds write, and every OS that we test
on can tolerate the greater-than-expected length, but it might confuse
applications that implement functions similar to getsockname in
userland.