### PR TITLE
add haiku support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -298,6 +298,9 @@ task:
     - name: Linux armv7 uclibceabihf
       env:
         TARGET: armv7-unknown-linux-uclibceabihf
+    - name: Haiku x86_64
+      env:
+        TARGET: x86_64-unknown-haiku
   setup_script:
     - rustup component add rust-src
   << : *BUILD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - impl From<SockaddrIn> for std::net::SocketAddrV4 and
   impl From<SockaddrIn6> for std::net::SocketAddrV6.
   (#[1711](https://github.com/nix-rust/nix/pull/1711))
+- Fixed compilation and updated support on Haiku
+- Added support for the `x86_64-unknown-haiku` target.
+  (#[1703](https://github.com/nix-rust/nix/pull/1703))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Tier 3:
   * armv7-unknown-linux-uclibceabihf
   * x86_64-fuchsia
   * x86_64-unknown-dragonfly
+  * x86_64-unknown-haiku
   * x86_64-unknown-linux-gnux32
   * x86_64-unknown-openbsd
   * x86_64-unknown-redox

--- a/bors.toml
+++ b/bors.toml
@@ -36,6 +36,7 @@ status = [
   "iOS aarch64",
   "iOS x86_64",
   "Illumos",
+  "Haiku x86_64",
 ]
 
 # Set bors's timeout to 1 hour

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -226,7 +226,7 @@ impl Entry {
     /// notably, some Linux filesystems don't implement this. The caller should use `stat` or
     /// `fstat` if this returns `None`.
     pub fn file_type(&self) -> Option<Type> {
-        #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+        #[cfg(not(any(target_os = "illumos", target_os = "solaris", target_os = "haiku")))]
         match self.0.d_type {
             libc::DT_FIFO => Some(Type::Fifo),
             libc::DT_CHR => Some(Type::CharacterDevice),
@@ -238,8 +238,8 @@ impl Entry {
             /* libc::DT_UNKNOWN | */ _ => None,
         }
 
-        // illumos and Solaris systems do not have the d_type member at all:
-        #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        // illumos, Solaris, and Haiku systems do not have the d_type member at all:
+        #[cfg(any(target_os = "illumos", target_os = "solaris", target_os = "haiku"))]
         None
     }
 }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -30,6 +30,10 @@ cfg_if! {
         unsafe fn errno_location() -> *mut c_int {
             libc::___errno()
         }
+    } else if #[cfg(any(target_os = "haiku",))] {
+        unsafe fn errno_location() -> *mut c_int {
+            libc::_errnop()
+        }
     }
 }
 
@@ -201,6 +205,7 @@ fn desc(errno: Errno) -> &'static str {
         ENOMEM          => "Out of memory",
         EACCES          => "Permission denied",
         EFAULT          => "Bad address",
+        #[cfg(not(target_os = "haiku"))]
         ENOTBLK         => "Block device required",
         EBUSY           => "Device or resource busy",
         EEXIST          => "File exists",
@@ -237,8 +242,11 @@ fn desc(errno: Errno) -> &'static str {
         EPROTOTYPE      => "Protocol wrong type for socket",
         ENOPROTOOPT     => "Protocol not available",
         EPROTONOSUPPORT => "Protocol not supported",
+        #[cfg(not(target_os = "haiku"))]
         ESOCKTNOSUPPORT => "Socket type not supported",
+        #[cfg(not(target_os = "haiku"))]
         EPFNOSUPPORT    => "Protocol family not supported",
+        #[cfg(not(target_os = "haiku"))]
         EAFNOSUPPORT    => "Address family not supported by protocol",
         EADDRINUSE      => "Address already in use",
         EADDRNOTAVAIL   => "Cannot assign requested address",
@@ -251,6 +259,7 @@ fn desc(errno: Errno) -> &'static str {
         EISCONN         => "Transport endpoint is already connected",
         ENOTCONN        => "Transport endpoint is not connected",
         ESHUTDOWN       => "Cannot send after transport endpoint shutdown",
+        #[cfg(not(target_os = "haiku"))]
         ETOOMANYREFS    => "Too many references: cannot splice",
         ETIMEDOUT       => "Connection timed out",
         ECONNREFUSED    => "Connection refused",
@@ -409,7 +418,7 @@ fn desc(errno: Errno) -> &'static str {
         EBADMSG         => "Trying to read unreadable message",
 
         #[cfg(any(target_os = "linux", target_os = "android",
-                  target_os = "fuchsia"))]
+                  target_os = "fuchsia", target_os = "haiku"))]
         EOVERFLOW       => "Value too large for defined data type",
 
         #[cfg(any(target_os = "linux", target_os = "android",
@@ -516,7 +525,7 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "linux", target_os = "android",
                   target_os = "illumos", target_os = "solaris",
-                  target_os = "fuchsia"))]
+                  target_os = "fuchsia", target_os = "haiku"))]
         ECANCELED       => "Operation canceled",
 
         #[cfg(any(target_os = "linux", target_os = "android",
@@ -587,24 +596,26 @@ fn desc(errno: Errno) -> &'static str {
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "netbsd", target_os = "redox"))]
+                  target_os = "netbsd", target_os = "redox",
+                  target_os = "haiku"))]
         EILSEQ          => "Illegal byte sequence",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
-                  target_os = "openbsd", target_os = "netbsd"))]
+                  target_os = "openbsd", target_os = "netbsd",
+                  target_os = "haiku"))]
         ENOATTR         => "Attribute not found",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
                   target_os = "openbsd", target_os = "netbsd",
-                  target_os = "redox"))]
+                  target_os = "redox", target_os = "haiku"))]
         EBADMSG         => "Bad message",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
                   target_os = "openbsd", target_os = "netbsd",
-                  target_os = "redox"))]
+                  target_os = "redox", target_os = "haiku"))]
         EPROTO          => "Protocol error",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -620,7 +631,8 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
                   target_os = "openbsd", target_os = "netbsd",
-                  target_os = "illumos", target_os = "solaris"))]
+                  target_os = "illumos", target_os = "solaris",
+                  target_os = "haiku"))]
         ENOTSUP         => "Operation not supported",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -638,14 +650,14 @@ fn desc(errno: Errno) -> &'static str {
                   target_os = "dragonfly", target_os = "ios",
                   target_os = "openbsd", target_os = "netbsd",
                   target_os = "redox", target_os = "illumos",
-                  target_os = "solaris"))]
+                  target_os = "solaris", target_os = "haiku"))]
         EDQUOT          => "Disc quota exceeded",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
                   target_os = "dragonfly", target_os = "ios",
                   target_os = "openbsd", target_os = "netbsd",
                   target_os = "redox", target_os = "illumos",
-                  target_os = "solaris"))]
+                  target_os = "solaris", target_os = "haiku"))]
         ESTALE          => "Stale NFS file handle",
 
         #[cfg(any(target_os = "macos", target_os = "freebsd",
@@ -714,7 +726,7 @@ fn desc(errno: Errno) -> &'static str {
         EBADMACHO       => "Malformed Macho file",
 
         #[cfg(any(target_os = "macos", target_os = "ios",
-                  target_os = "netbsd"))]
+                  target_os = "netbsd", target_os = "haiku"))]
         EMULTIHOP       => "Reserved",
 
         #[cfg(any(target_os = "macos", target_os = "ios",
@@ -722,7 +734,7 @@ fn desc(errno: Errno) -> &'static str {
         ENODATA         => "No message available on STREAM",
 
         #[cfg(any(target_os = "macos", target_os = "ios",
-                  target_os = "netbsd"))]
+                  target_os = "netbsd", target_os = "haiku"))]
         ENOLINK         => "Reserved",
 
         #[cfg(any(target_os = "macos", target_os = "ios",
@@ -2725,3 +2737,178 @@ mod consts {
         }
     }
 }
+
+#[cfg(target_os = "haiku")]
+mod consts {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(i32)]
+    #[non_exhaustive]
+    pub enum Errno {
+        UnknownErrno    = 0,
+        EPERM           = libc::EPERM,
+        ENOENT          = libc::ENOENT,
+        ESRCH           = libc::ESRCH,
+        EINTR           = libc::EINTR,
+        EIO             = libc::EIO,
+        ENXIO           = libc::ENXIO,
+        E2BIG           = libc::E2BIG,
+        ENOEXEC         = libc::ENOEXEC,
+        EBADF           = libc::EBADF,
+        ECHILD          = libc::ECHILD,
+        EDEADLK         = libc::EDEADLK,
+        ENOMEM          = libc::ENOMEM,
+        EACCES          = libc::EACCES,
+        EFAULT          = libc::EFAULT,
+        EBUSY           = libc::EBUSY,
+        EEXIST          = libc::EEXIST,
+        EXDEV           = libc::EXDEV,
+        ENODEV          = libc::ENODEV,
+        ENOTDIR         = libc::ENOTDIR,
+        EISDIR          = libc::EISDIR,
+        EINVAL          = libc::EINVAL,
+        ENFILE          = libc::ENFILE,
+        EMFILE          = libc::EMFILE,
+        ENOTTY          = libc::ENOTTY,
+        ETXTBSY         = libc::ETXTBSY,
+        EFBIG           = libc::EFBIG,
+        ENOSPC          = libc::ENOSPC,
+        ESPIPE          = libc::ESPIPE,
+        EROFS           = libc::EROFS,
+        EMLINK          = libc::EMLINK,
+        EPIPE           = libc::EPIPE,
+        EDOM            = libc::EDOM,
+        ERANGE          = libc::ERANGE,
+        EAGAIN          = libc::EAGAIN,
+        EINPROGRESS     = libc::EINPROGRESS,
+        EALREADY        = libc::EALREADY,
+        ENOTSOCK        = libc::ENOTSOCK,
+        EDESTADDRREQ    = libc::EDESTADDRREQ,
+        EMSGSIZE        = libc::EMSGSIZE,
+        EPROTOTYPE      = libc::EPROTOTYPE,
+        ENOPROTOOPT     = libc::ENOPROTOOPT,
+        EPROTONOSUPPORT = libc::EPROTONOSUPPORT,
+        ENOTSUP         = libc::ENOTSUP,
+        EADDRINUSE      = libc::EADDRINUSE,
+        EADDRNOTAVAIL   = libc::EADDRNOTAVAIL,
+        ENETDOWN        = libc::ENETDOWN,
+        ENETUNREACH     = libc::ENETUNREACH,
+        ENETRESET       = libc::ENETRESET,
+        ECONNABORTED    = libc::ECONNABORTED,
+        ECONNRESET      = libc::ECONNRESET,
+        ENOBUFS         = libc::ENOBUFS,
+        EISCONN         = libc::EISCONN,
+        ENOTCONN        = libc::ENOTCONN,
+        ESHUTDOWN       = libc::ESHUTDOWN,
+        ETIMEDOUT       = libc::ETIMEDOUT,
+        ECONNREFUSED    = libc::ECONNREFUSED,
+        ELOOP           = libc::ELOOP,
+        ENAMETOOLONG    = libc::ENAMETOOLONG,
+        EHOSTDOWN       = libc::EHOSTDOWN,
+        EHOSTUNREACH    = libc::EHOSTUNREACH,
+        ENOTEMPTY       = libc::ENOTEMPTY,
+        EDQUOT          = libc::EDQUOT,
+        ESTALE          = libc::ESTALE,
+        ENOLCK          = libc::ENOLCK,
+        ENOSYS          = libc::ENOSYS,
+        EIDRM           = libc::EIDRM,
+        ENOMSG          = libc::ENOMSG,
+        EOVERFLOW       = libc::EOVERFLOW,
+        ECANCELED       = libc::ECANCELED,
+        EILSEQ          = libc::EILSEQ,
+        ENOATTR         = libc::ENOATTR,
+        EBADMSG         = libc::EBADMSG,
+        EMULTIHOP       = libc::EMULTIHOP,
+        ENOLINK         = libc::ENOLINK,
+        EPROTO          = libc::EPROTO,
+    }
+
+    impl Errno {
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const EDEADLOCK:   Errno = Errno::EDEADLK;
+        pub const EOPNOTSUPP:  Errno = Errno::ENOTSUP;
+    }
+
+    pub const fn from_i32(e: i32) -> Errno {
+        use self::Errno::*;
+
+        match e {
+            libc::EPERM => EPERM,
+            libc::ENOENT => ENOENT,
+            libc::ESRCH => ESRCH,
+            libc::EINTR => EINTR,
+            libc::EIO => EIO,
+            libc::ENXIO => ENXIO,
+            libc::E2BIG => E2BIG,
+            libc::ENOEXEC => ENOEXEC,
+            libc::EBADF => EBADF,
+            libc::ECHILD => ECHILD,
+            libc::EDEADLK => EDEADLK,
+            libc::ENOMEM => ENOMEM,
+            libc::EACCES => EACCES,
+            libc::EFAULT => EFAULT,
+            libc::EBUSY => EBUSY,
+            libc::EEXIST => EEXIST,
+            libc::EXDEV => EXDEV,
+            libc::ENODEV => ENODEV,
+            libc::ENOTDIR => ENOTDIR,
+            libc::EISDIR => EISDIR,
+            libc::EINVAL => EINVAL,
+            libc::ENFILE => ENFILE,
+            libc::EMFILE => EMFILE,
+            libc::ENOTTY => ENOTTY,
+            libc::ETXTBSY => ETXTBSY,
+            libc::EFBIG => EFBIG,
+            libc::ENOSPC => ENOSPC,
+            libc::ESPIPE => ESPIPE,
+            libc::EROFS => EROFS,
+            libc::EMLINK => EMLINK,
+            libc::EPIPE => EPIPE,
+            libc::EDOM => EDOM,
+            libc::ERANGE => ERANGE,
+            libc::EAGAIN => EAGAIN,
+            libc::EINPROGRESS => EINPROGRESS,
+            libc::EALREADY => EALREADY,
+            libc::ENOTSOCK => ENOTSOCK,
+            libc::EDESTADDRREQ => EDESTADDRREQ,
+            libc::EMSGSIZE => EMSGSIZE,
+            libc::EPROTOTYPE => EPROTOTYPE,
+            libc::ENOPROTOOPT => ENOPROTOOPT,
+            libc::EPROTONOSUPPORT => EPROTONOSUPPORT,
+            libc::ENOTSUP => ENOTSUP,
+            libc::EADDRINUSE => EADDRINUSE,
+            libc::EADDRNOTAVAIL => EADDRNOTAVAIL,
+            libc::ENETDOWN => ENETDOWN,
+            libc::ENETUNREACH => ENETUNREACH,
+            libc::ENETRESET => ENETRESET,
+            libc::ECONNABORTED => ECONNABORTED,
+            libc::ECONNRESET => ECONNRESET,
+            libc::ENOBUFS => ENOBUFS,
+            libc::EISCONN => EISCONN,
+            libc::ENOTCONN => ENOTCONN,
+            libc::ESHUTDOWN => ESHUTDOWN,
+            libc::ETIMEDOUT => ETIMEDOUT,
+            libc::ECONNREFUSED => ECONNREFUSED,
+            libc::ELOOP => ELOOP,
+            libc::ENAMETOOLONG => ENAMETOOLONG,
+            libc::EHOSTDOWN => EHOSTDOWN,
+            libc::EHOSTUNREACH => EHOSTUNREACH,
+            libc::ENOTEMPTY => ENOTEMPTY,
+            libc::EDQUOT => EDQUOT,
+            libc::ESTALE => ESTALE,
+            libc::ENOLCK => ENOLCK,
+            libc::ENOSYS => ENOSYS,
+            libc::EIDRM => EIDRM,
+            libc::ENOMSG => ENOMSG,
+            libc::EOVERFLOW => EOVERFLOW,
+            libc::ECANCELED => ECANCELED,
+            libc::EILSEQ => EILSEQ,
+            libc::ENOATTR => ENOATTR,
+            libc::EBADMSG => EBADMSG,
+            libc::EMULTIHOP => EMULTIHOP,
+            libc::ENOLINK => ENOLINK,
+            libc::EPROTO => EPROTO,
+            _   => UnknownErrno,
+        }
+    }
+}
+

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -58,7 +58,7 @@ libc_bitflags!(
         /// Open the file in append-only mode.
         O_APPEND;
         /// Generate a signal when input or output becomes possible.
-        #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+        #[cfg(not(any(target_os = "illumos", target_os = "solaris", target_os = "haiku")))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         O_ASYNC;
         /// Closes the file descriptor once an `execve` call is made.
@@ -128,7 +128,7 @@ libc_bitflags!(
         #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOCTTY;
         /// Same as `O_NONBLOCK`.
-        #[cfg(not(target_os = "redox"))]
+        #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NDELAY;
         /// `open()` will fail if the given path is a symbolic link.

--- a/src/features.rs
+++ b/src/features.rs
@@ -114,6 +114,7 @@ mod os {
 #[cfg(any(target_os = "macos",
           target_os = "ios",
           target_os = "fuchsia",
+          target_os = "haiku",
           target_os = "solaris"))]
 mod os {
     /// Check if the OS supports atomic close-on-exec for sockets

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -28,6 +28,7 @@ libc_bitflags!(
         IFF_BROADCAST;
         /// Internal debugging flag. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
+        #[cfg(not(target_os = "haiku"))]
         IFF_DEBUG;
         /// Interface is a loopback interface. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -236,6 +236,7 @@ pub use self::linux::*;
           target_os = "ios",
           target_os = "macos",
           target_os = "netbsd",
+          target_os = "haiku",
           target_os = "openbsd"))]
 #[macro_use]
 mod bsd;
@@ -246,6 +247,7 @@ mod bsd;
           target_os = "ios",
           target_os = "macos",
           target_os = "netbsd",
+          target_os = "haiku",
           target_os = "openbsd"))]
 pub use self::bsd::*;
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -351,6 +351,7 @@ libc_bitflags!{
     }
 }
 
+#[cfg(not(target_os = "haiku"))]
 libc_bitflags!{
     /// Flags for [`mlockall`].
     pub struct MlockAllFlags: c_int {
@@ -393,6 +394,7 @@ pub unsafe fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
 /// Locked pages never move to the swap area. For more information, see [`mlockall(2)`].
 ///
 /// [`mlockall(2)`]: https://man7.org/linux/man-pages/man2/mlockall.2.html
+#[cfg(not(target_os = "haiku"))]
 pub fn mlockall(flags: MlockAllFlags) -> Result<()> {
     unsafe { Errno::result(libc::mlockall(flags.bits())) }.map(drop)
 }
@@ -402,6 +404,7 @@ pub fn mlockall(flags: MlockAllFlags) -> Result<()> {
 /// For more information, see [`munlockall(2)`].
 ///
 /// [`munlockall(2)`]: https://man7.org/linux/man-pages/man2/munlockall.2.html
+#[cfg(not(target_os = "haiku"))]
 pub fn munlockall() -> Result<()> {
     unsafe { Errno::result(libc::munlockall()) }.map(drop)
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -94,7 +94,7 @@ feature! {
     pub mod reboot;
 }
 
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos", target_os = "haiku")))]
 feature! {
     #![feature = "resource"]
     pub mod resource;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -89,6 +89,8 @@ libc_enum!{
         /// Window size changes
         SIGWINCH,
         /// Input/output possible signal
+        #[cfg(not(target_os = "haiku"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
         SIGIO,
         #[cfg(any(target_os = "android", target_os = "emscripten",
                   target_os = "fuchsia", target_os = "linux"))]
@@ -99,13 +101,13 @@ libc_enum!{
         SIGSYS,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
-                      target_os = "redox")))]
+                      target_os = "redox", target_os = "haiku")))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Emulator trap
         SIGEMT,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
-                      target_os = "redox")))]
+                      target_os = "redox", target_os = "haiku")))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Information request
         SIGINFO,
@@ -150,6 +152,7 @@ impl FromStr for Signal {
             "SIGVTALRM" => Signal::SIGVTALRM,
             "SIGPROF" => Signal::SIGPROF,
             "SIGWINCH" => Signal::SIGWINCH,
+            #[cfg(not(target_os = "haiku"))]
             "SIGIO" => Signal::SIGIO,
             #[cfg(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux"))]
@@ -157,11 +160,11 @@ impl FromStr for Signal {
             "SIGSYS" => Signal::SIGSYS,
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
                           target_os = "fuchsia", target_os = "linux",
-                          target_os = "redox")))]
+                          target_os = "redox", target_os = "haiku")))]
             "SIGEMT" => Signal::SIGEMT,
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
                           target_os = "fuchsia", target_os = "linux",
-                          target_os = "redox")))]
+                          target_os = "redox", target_os = "haiku")))]
             "SIGINFO" => Signal::SIGINFO,
             _ => return Err(Errno::EINVAL),
         })
@@ -208,6 +211,7 @@ impl Signal {
             Signal::SIGVTALRM => "SIGVTALRM",
             Signal::SIGPROF => "SIGPROF",
             Signal::SIGWINCH => "SIGWINCH",
+            #[cfg(not(target_os = "haiku"))]
             Signal::SIGIO => "SIGIO",
             #[cfg(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux"))]
@@ -215,11 +219,11 @@ impl Signal {
             Signal::SIGSYS => "SIGSYS",
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
                           target_os = "fuchsia", target_os = "linux",
-                          target_os = "redox")))]
+                          target_os = "redox", target_os = "haiku")))]
             Signal::SIGEMT => "SIGEMT",
             #[cfg(not(any(target_os = "android", target_os = "emscripten",
                           target_os = "fuchsia", target_os = "linux",
-                          target_os = "redox")))]
+                          target_os = "redox", target_os = "haiku")))]
             Signal::SIGINFO => "SIGINFO",
         }
     }
@@ -273,6 +277,37 @@ const SIGNALS: [Signal; 29] = [
     SIGPROF,
     SIGWINCH,
     SIGIO,
+    SIGSYS];
+#[cfg(target_os = "haiku")]
+#[cfg(feature = "signal")]
+const SIGNALS: [Signal; 28] = [
+    SIGHUP,
+    SIGINT,
+    SIGQUIT,
+    SIGILL,
+    SIGTRAP,
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGKILL,
+    SIGUSR1,
+    SIGSEGV,
+    SIGUSR2,
+    SIGPIPE,
+    SIGALRM,
+    SIGTERM,
+    SIGCHLD,
+    SIGCONT,
+    SIGSTOP,
+    SIGTSTP,
+    SIGTTIN,
+    SIGTTOU,
+    SIGURG,
+    SIGXCPU,
+    SIGXFSZ,
+    SIGVTALRM,
+    SIGPROF,
+    SIGWINCH,
     SIGSYS];
 #[cfg(all(any(target_os = "linux", target_os = "android",
               target_os = "emscripten", target_os = "fuchsia"),
@@ -349,7 +384,7 @@ const SIGNALS: [Signal; 30] = [
     SIGSYS];
 #[cfg(not(any(target_os = "linux", target_os = "android",
               target_os = "fuchsia", target_os = "emscripten",
-              target_os = "redox")))]
+              target_os = "redox", target_os = "haiku")))]
 #[cfg(feature = "signal")]
 const SIGNALS: [Signal; 31] = [
     SIGHUP,
@@ -417,6 +452,7 @@ impl Signal {
 /// Alias for [`SIGABRT`]
 pub const SIGIOT : Signal = SIGABRT;
 /// Alias for [`SIGIO`]
+#[cfg(not(target_os = "haiku"))]
 pub const SIGPOLL : Signal = SIGIO;
 /// Alias for [`SIGSYS`]
 pub const SIGUNUSED : Signal = SIGSYS;

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -26,6 +26,7 @@ use crate::sys::socket::addr::sys_control::SysControlAddr;
           target_os = "illumos",
           target_os = "netbsd",
           target_os = "openbsd",
+          target_os = "haiku",
           target_os = "fuchsia"))]
 #[cfg(feature = "net")]
 pub use self::datalink::LinkAddr;
@@ -120,6 +121,7 @@ pub enum AddressFamily {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     Rose = libc::AF_ROSE,
     /// DECet protocol sockets.
+    #[cfg(not(target_os = "haiku"))]
     Decnet = libc::AF_DECnet,
     /// Reserved for "802.2LLC project"; never used.
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -151,6 +153,7 @@ pub enum AddressFamily {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     Rds = libc::AF_RDS,
     /// IBM SNA
+    #[cfg(not(target_os = "haiku"))]
     Sna = libc::AF_SNA,
     /// Socket interface over IrDA
     #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -202,7 +205,7 @@ pub enum AddressFamily {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     RxRpc = libc::AF_RXRPC,
     /// New "modular ISDN" driver interface protocol
-    #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+    #[cfg(not(any(target_os = "illumos", target_os = "solaris", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     Isdn = libc::AF_ISDN,
     /// Nokia cellular modem IPC/RPC interface
@@ -1158,6 +1161,7 @@ impl SockaddrIn {
                   target_os = "ios",
                   target_os = "macos",
                   target_os = "netbsd",
+                  target_os = "haiku",
                   target_os = "openbsd"))]
             sin_len: Self::size() as u8,
             sin_family: AddressFamily::Inet as sa_family_t,
@@ -1442,6 +1446,7 @@ impl SockaddrLike for SockaddrStorage {
                           target_os = "macos",
                           target_os = "illumos",
                           target_os = "netbsd",
+                          target_os = "haiku",
                           target_os = "openbsd"))]
                 #[cfg(feature = "net")]
                 libc::AF_LINK => LinkAddr::from_raw(addr, l)
@@ -2411,6 +2416,7 @@ mod datalink {
           target_os = "macos",
           target_os = "illumos",
           target_os = "netbsd",
+          target_os = "haiku",
           target_os = "openbsd"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 mod datalink {
@@ -2425,11 +2431,13 @@ mod datalink {
 
     impl LinkAddr {
         /// interface index, if != 0, system given index for interface
+        #[cfg(not(target_os = "haiku"))]
         pub fn ifindex(&self) -> usize {
             self.0.sdl_index as usize
         }
 
         /// Datalink type
+        #[cfg(not(target_os = "haiku"))]
         pub fn datalink_type(&self) -> u8 {
             self.0.sdl_type
         }
@@ -2445,6 +2453,7 @@ mod datalink {
         }
 
         /// link layer selector length
+        #[cfg(not(target_os = "haiku"))]
         pub fn slen(&self) -> usize {
             self.0.sdl_slen as usize
         }
@@ -2737,7 +2746,8 @@ mod tests {
                       target_os = "macos",
                       target_os = "netbsd",
                       target_os = "illumos",
-                      target_os = "openbsd"))]
+                      target_os = "openbsd",
+                      target_os = "haiku"))]
             let l = mem::size_of::<libc::sockaddr_dl>();
             #[cfg(any(
                     target_os = "android",

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -38,7 +38,7 @@ pub use self::addr::{
     UnixAddr,
 };
 #[allow(deprecated)]
-#[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
+#[cfg(not(any(target_os = "illumos", target_os = "solaris", target_os = "haiku")))]
 #[cfg(feature = "net")]
 pub use self::addr::{
     InetAddr,
@@ -57,7 +57,7 @@ pub use self::addr::{
     UnixAddr,
 };
 #[allow(deprecated)]
-#[cfg(any(target_os = "illumos", target_os = "solaris"))]
+#[cfg(any(target_os = "illumos", target_os = "solaris", target_os = "haiku"))]
 #[cfg(feature = "net")]
 pub use self::addr::{
     InetAddr,
@@ -118,6 +118,7 @@ pub enum SockType {
     Raw = libc::SOCK_RAW,
     /// Provides a reliable datagram layer that does not
     /// guarantee ordering.
+    #[cfg(not(any(target_os = "haiku")))]
     Rdm = libc::SOCK_RDM,
 }
 
@@ -845,6 +846,7 @@ impl ControlMessageOwned {
                 let cred: libc::cmsgcred = ptr::read_unaligned(p as *const _);
                 ControlMessageOwned::ScmCreds(cred.into())
             }
+            #[cfg(not(target_os = "haiku"))]
             (libc::SOL_SOCKET, libc::SCM_TIMESTAMP) => {
                 let tv: libc::timeval = ptr::read_unaligned(p as *const _);
                 ControlMessageOwned::ScmTimestamp(TimeVal::from(tv))

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -399,7 +399,7 @@ cfg_if! {
             TcpMaxSeg, GetOnly, libc::IPPROTO_TCP, libc::TCP_MAXSEG, u32);
     }
 }
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "haiku")))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -413,7 +413,7 @@ sockopt_impl!(
     #[allow(missing_docs)]
     // Not documented by Linux!
     TcpRepair, Both, libc::IPPROTO_TCP, libc::TCP_REPAIR, u32);
-#[cfg(not(target_os = "openbsd"))]
+#[cfg(not(any(target_os = "openbsd", target_os = "haiku")))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -473,6 +473,7 @@ sockopt_impl!(
     /// Specifies exact type of timestamping information collected by the kernel
     /// [Further reading](https://www.kernel.org/doc/html/latest/networking/timestamping.html)
     Timestamping, Both, libc::SOL_SOCKET, libc::SO_TIMESTAMPING, super::TimestampingFlag);
+#[cfg(not(target_os = "haiku"))]
 sockopt_impl!(
     /// Enable or disable the receiving of the `SO_TIMESTAMP` control message.
     ReceiveTimestamp, Both, libc::SOL_SOCKET, libc::SO_TIMESTAMP, bool);

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -53,7 +53,7 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
 }
 
 /// Create a special or ordinary file, relative to a given directory.
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "haiku")))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mknodat<P: ?Sized + NixPath>(
     dirfd: RawFd,

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -16,8 +16,10 @@ libc_bitflags!(
     #[derive(Default)]
     pub struct FsFlags: c_ulong {
         /// Read Only
+        #[cfg(not(target_os = "haiku"))]
         ST_RDONLY;
         /// Do not allow the set-uid bits to have an effect
+        #[cfg(not(target_os = "haiku"))]
         ST_NOSUID;
         /// Do not interpret character or block-special devices
         #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -39,7 +39,7 @@ pub fn readv(fd: RawFd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
 /// or an error occurs. The file offset is not changed.
 ///
 /// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn pwritev(fd: RawFd, iov: &[IoSlice<'_>],
                offset: off_t) -> Result<usize> {
@@ -62,7 +62,7 @@ pub fn pwritev(fd: RawFd, iov: &[IoSlice<'_>],
 /// changed.
 ///
 /// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn preadv(fd: RawFd, iov: &mut [IoSliceMut<'_>],
               offset: off_t) -> Result<usize> {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -549,7 +549,7 @@ pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: Mode) -> Result<()> {
 // mkfifoat is not implemented in OSX or android
 #[inline]
 #[cfg(not(any(
-    target_os = "macos", target_os = "ios",
+    target_os = "macos", target_os = "ios", target_os = "haiku",
     target_os = "android", target_os = "redox")))]
 pub fn mkfifoat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
@@ -1546,7 +1546,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
 /// #
 /// # try_main().unwrap();
 /// ```
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "haiku")))]
 pub fn setgroups(groups: &[Gid]) -> Result<()> {
     cfg_if! {
         if #[cfg(any(target_os = "dragonfly",
@@ -1673,7 +1673,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
 /// #
 /// # try_main().unwrap();
 /// ```
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "haiku")))]
 pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
     cfg_if! {
         if #[cfg(any(target_os = "ios", target_os = "macos"))] {
@@ -1802,7 +1802,7 @@ pub fn sleep(seconds: c_uint) -> c_uint {
 feature! {
 #![feature = "acct"]
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 pub mod acct {
     use crate::{Result, NixPath};
     use crate::errno::Errno;
@@ -2088,12 +2088,12 @@ feature! {
 pub enum SysconfVar {
     /// Maximum number of I/O operations in a single list I/O call supported by
     /// the implementation.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_LISTIO_MAX = libc::_SC_AIO_LISTIO_MAX,
     /// Maximum number of outstanding asynchronous I/O operations supported by
     /// the implementation.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_MAX = libc::_SC_AIO_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
@@ -2110,19 +2110,19 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     ATEXIT_MAX = libc::_SC_ATEXIT_MAX,
     /// Maximum obase values allowed by the bc utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_BASE_MAX = libc::_SC_BC_BASE_MAX,
     /// Maximum number of elements permitted in an array by the bc utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_DIM_MAX = libc::_SC_BC_DIM_MAX,
     /// Maximum scale value allowed by the bc utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_SCALE_MAX = libc::_SC_BC_SCALE_MAX,
     /// Maximum length of a string constant accepted by the bc utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_STRING_MAX = libc::_SC_BC_STRING_MAX,
     /// Maximum number of simultaneous processes per real user ID.
@@ -2131,16 +2131,16 @@ pub enum SysconfVar {
     CLK_TCK = libc::_SC_CLK_TCK,
     /// Maximum number of weights that can be assigned to an entry of the
     /// LC_COLLATE order keyword in the locale definition file
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     COLL_WEIGHTS_MAX = libc::_SC_COLL_WEIGHTS_MAX,
     /// Maximum number of timer expiration overruns.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     DELAYTIMER_MAX = libc::_SC_DELAYTIMER_MAX,
     /// Maximum number of expressions that can be nested within parentheses by
     /// the expr utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     EXPR_NEST_MAX = libc::_SC_EXPR_NEST_MAX,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
@@ -2159,10 +2159,11 @@ pub enum SysconfVar {
     /// input line (either standard input or another file), when the utility is
     /// described as processing text files. The length includes room for the
     /// trailing <newline>.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     LINE_MAX = libc::_SC_LINE_MAX,
     /// Maximum length of a login name.
+    #[cfg(not(target_os = "haiku"))]
     LOGIN_NAME_MAX = libc::_SC_LOGIN_NAME_MAX,
     /// Maximum number of simultaneous supplementary group IDs per process.
     NGROUPS_MAX = libc::_SC_NGROUPS_MAX,
@@ -2175,11 +2176,11 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     GETPW_R_SIZE_MAX = libc::_SC_GETPW_R_SIZE_MAX,
     /// The maximum number of open message queue descriptors a process may hold.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_OPEN_MAX = libc::_SC_MQ_OPEN_MAX,
     /// The maximum number of message priorities supported by the implementation.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_PRIO_MAX = libc::_SC_MQ_PRIO_MAX,
     /// A value one greater than the maximum value that the system may assign to
@@ -2197,7 +2198,7 @@ pub enum SysconfVar {
     /// The implementation supports barriers.
     _POSIX_BARRIERS = libc::_SC_BARRIERS,
     /// The implementation supports asynchronous input and output.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_ASYNCHRONOUS_IO = libc::_SC_ASYNCHRONOUS_IO,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
@@ -2213,7 +2214,7 @@ pub enum SysconfVar {
     /// The implementation supports the Process CPU-Time Clocks option.
     _POSIX_CPUTIME = libc::_SC_CPUTIME,
     /// The implementation supports the File Synchronization option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_FSYNC = libc::_SC_FSYNC,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
@@ -2227,15 +2228,15 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_JOB_CONTROL = libc::_SC_JOB_CONTROL,
     /// The implementation supports memory mapped Files.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MAPPED_FILES = libc::_SC_MAPPED_FILES,
     /// The implementation supports the Process Memory Locking option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK = libc::_SC_MEMLOCK,
     /// The implementation supports the Range Memory Locking option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK_RANGE = libc::_SC_MEMLOCK_RANGE,
     /// The implementation supports memory protection.
@@ -2243,7 +2244,7 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMORY_PROTECTION = libc::_SC_MEMORY_PROTECTION,
     /// The implementation supports the Message Passing option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MESSAGE_PASSING = libc::_SC_MESSAGE_PASSING,
     /// The implementation supports the Monotonic Clock option.
@@ -2257,7 +2258,7 @@ pub enum SysconfVar {
     /// The implementation supports the Prioritized Input and Output option.
     _POSIX_PRIORITIZED_IO = libc::_SC_PRIORITIZED_IO,
     /// The implementation supports the Process Scheduling option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_PRIORITY_SCHEDULING = libc::_SC_PRIORITY_SCHEDULING,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "illumos",
@@ -2293,7 +2294,7 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SEMAPHORES = libc::_SC_SEMAPHORES,
     /// The implementation supports the Shared Memory Objects option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SHARED_MEMORY_OBJECTS = libc::_SC_SHARED_MEMORY_OBJECTS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
@@ -2324,7 +2325,7 @@ pub enum SysconfVar {
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SS_REPL_MAX = libc::_SC_SS_REPL_MAX,
     /// The implementation supports the Synchronized Input and Output option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SYNCHRONIZED_IO = libc::_SC_SYNCHRONIZED_IO,
     /// The implementation supports the Thread Stack Address Attribute option.
@@ -2342,11 +2343,11 @@ pub enum SysconfVar {
     _POSIX_THREAD_CPUTIME = libc::_SC_THREAD_CPUTIME,
     /// The implementation supports the Non-Robust Mutex Priority Inheritance
     /// option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_INHERIT = libc::_SC_THREAD_PRIO_INHERIT,
     /// The implementation supports the Non-Robust Mutex Priority Protection option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_PROTECT = libc::_SC_THREAD_PRIO_PROTECT,
     /// The implementation supports the Thread Execution Scheduling option.
@@ -2369,7 +2370,7 @@ pub enum SysconfVar {
     /// The implementation supports the Robust Mutex Priority Protection option.
     _POSIX_THREAD_ROBUST_PRIO_PROTECT = libc::_SC_THREAD_ROBUST_PRIO_PROTECT,
     /// The implementation supports thread-safe functions.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_SAFE_FUNCTIONS = libc::_SC_THREAD_SAFE_FUNCTIONS,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
@@ -2466,28 +2467,28 @@ pub enum SysconfVar {
     /// using at least 64 bits.
     _POSIX_V6_LPBIG_OFFBIG = libc::_SC_V6_LPBIG_OFFBIG,
     /// The implementation supports the C-Language Binding option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_BIND = libc::_SC_2_C_BIND,
     /// The implementation supports the C-Language Development Utilities option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_DEV = libc::_SC_2_C_DEV,
     /// The implementation supports the Terminal Characteristics option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_CHAR_TERM = libc::_SC_2_CHAR_TERM,
     /// The implementation supports the FORTRAN Development Utilities option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_DEV = libc::_SC_2_FORT_DEV,
     /// The implementation supports the FORTRAN Runtime Utilities option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_RUN = libc::_SC_2_FORT_RUN,
     /// The implementation supports the creation of locales by the localedef
     /// utility.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_LOCALEDEF = libc::_SC_2_LOCALEDEF,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
@@ -2528,16 +2529,16 @@ pub enum SysconfVar {
     /// The implementation supports the Track Batch Job Request option.
     _POSIX2_PBS_TRACK = libc::_SC_2_PBS_TRACK,
     /// The implementation supports the Software Development Utilities option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_SW_DEV = libc::_SC_2_SW_DEV,
     /// The implementation supports the User Portability Utilities option.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_UPE = libc::_SC_2_UPE,
     /// Integer value indicating version of the Shell and Utilities volume of
     /// POSIX.1 to which the implementation conforms.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_VERSION = libc::_SC_2_VERSION,
     /// The size of a system page in bytes.
@@ -2545,18 +2546,19 @@ pub enum SysconfVar {
     /// POSIX also defines an alias named `PAGESIZE`, but Rust does not allow two
     /// enum constants to have the same value, so nix omits `PAGESIZE`.
     PAGE_SIZE = libc::_SC_PAGE_SIZE,
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_DESTRUCTOR_ITERATIONS = libc::_SC_THREAD_DESTRUCTOR_ITERATIONS,
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_KEYS_MAX = libc::_SC_THREAD_KEYS_MAX,
     #[cfg(not(target_os = "redox"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_STACK_MIN = libc::_SC_THREAD_STACK_MIN,
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_THREADS_MAX = libc::_SC_THREAD_THREADS_MAX,
+    #[cfg(not(target_os = "haiku"))]
     RE_DUP_MAX = libc::_SC_RE_DUP_MAX,
     #[cfg(any(target_os="android", target_os="dragonfly", target_os="freebsd",
               target_os = "ios", target_os="linux", target_os = "macos",
@@ -2619,7 +2621,7 @@ pub enum SysconfVar {
     _XOPEN_REALTIME_THREADS = libc::_SC_XOPEN_REALTIME_THREADS,
     /// The implementation supports the Issue 4, Version 2 Shared Memory Option
     /// Group.
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     _XOPEN_SHM = libc::_SC_XOPEN_SHM,
     #[cfg(any(target_os="dragonfly", target_os="freebsd", target_os = "ios",
@@ -2875,6 +2877,7 @@ pub struct User {
     /// Login class
     #[cfg(not(any(target_os = "android",
                   target_os = "fuchsia",
+                  target_os = "haiku",
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
@@ -2883,6 +2886,7 @@ pub struct User {
     /// Last password change
     #[cfg(not(any(target_os = "android",
                   target_os = "fuchsia",
+                  target_os = "haiku",
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
@@ -2891,6 +2895,7 @@ pub struct User {
     /// Expiration time of account
     #[cfg(not(any(target_os = "android",
                   target_os = "fuchsia",
+                  target_os = "haiku",
                   target_os = "illumos",
                   target_os = "linux",
                   target_os = "solaris")))]
@@ -2898,7 +2903,7 @@ pub struct User {
     pub expire: libc::time_t
 }
 
-#[cfg(not(target_os = "redox"))] // RedoxFS does not support passwd
+#[cfg(not(target_os = "redox"))] //RedoxFS does not support passwd
 impl From<&libc::passwd> for User {
     fn from(pw: &libc::passwd) -> User {
         unsafe {
@@ -2913,18 +2918,21 @@ impl From<&libc::passwd> for User {
                 gid: Gid::from_raw((*pw).pw_gid),
                 #[cfg(not(any(target_os = "android",
                               target_os = "fuchsia",
+                              target_os = "haiku",
                               target_os = "illumos",
                               target_os = "linux",
                               target_os = "solaris")))]
                 class: CString::new(CStr::from_ptr((*pw).pw_class).to_bytes()).unwrap(),
                 #[cfg(not(any(target_os = "android",
                               target_os = "fuchsia",
+                              target_os = "haiku",
                               target_os = "illumos",
                               target_os = "linux",
                               target_os = "solaris")))]
                 change: (*pw).pw_change,
                 #[cfg(not(any(target_os = "android",
                               target_os = "fuchsia",
+                              target_os = "haiku",
                               target_os = "illumos",
                               target_os = "linux",
                               target_os = "solaris")))]
@@ -2960,18 +2968,21 @@ impl From<User> for libc::passwd {
             pw_gid: u.gid.0,
             #[cfg(not(any(target_os = "android",
                           target_os = "fuchsia",
+                          target_os = "haiku",
                           target_os = "illumos",
                           target_os = "linux",
                           target_os = "solaris")))]
             pw_class: u.class.into_raw(),
             #[cfg(not(any(target_os = "android",
                           target_os = "fuchsia",
+                          target_os = "haiku",
                           target_os = "illumos",
                           target_os = "linux",
                           target_os = "solaris")))]
             pw_change: u.change,
             #[cfg(not(any(target_os = "android",
                           target_os = "fuchsia",
+                          target_os = "haiku",
                           target_os = "illumos",
                           target_os = "linux",
                           target_os = "solaris")))]

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -15,17 +15,17 @@ mod test_aio;
 mod test_mman;
 #[cfg(target_os = "linux")]
 mod test_signalfd;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 mod test_socket;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox")))]
 mod test_sockopt;
 #[cfg(not(target_os = "redox"))]
 mod test_select;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_sysinfo;
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 mod test_termios;
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 mod test_ioctl;
 mod test_wait;
 mod test_uio;

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -145,7 +145,7 @@ fn test_pread() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_pwritev() {
     use std::io::Read;
 
@@ -175,7 +175,7 @@ fn test_pwritev() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_preadv() {
     use std::io::Write;
 

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -6,7 +6,7 @@ use nix::sys::wait::*;
 use libc::_exit;
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_wait_signal() {
     let _m = crate::FORK_MTX.lock();
 
@@ -27,7 +27,7 @@ fn test_wait_signal() {
 #[cfg(any(
     target_os = "android",
     target_os = "freebsd",
-    target_os = "haiku",
+    //target_os = "haiku",
     all(target_os = "linux", not(target_env = "uclibc")),
 ))]
 #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
@@ -63,6 +63,7 @@ fn test_wait_exit() {
     }
 }
 
+#[cfg(not(target_os = "haiku"))]
 #[test]
 #[cfg(any(
     target_os = "android",

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate cfg_if;
-#[cfg_attr(not(target_os = "redox"), macro_use)]
+#[cfg_attr(not(any(target_os = "redox", target_os = "haiku")), macro_use)]
 extern crate nix;
 #[macro_use]
 extern crate lazy_static;
@@ -26,7 +26,7 @@ mod test_net;
 mod test_nix_path;
 mod test_resource;
 mod test_poll;
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 mod test_pty;
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -50,6 +50,7 @@ fn rewind() {
     assert_eq!(entries2, entries3);
 }
 
+#[cfg(not(target_os = "haiku"))]
 #[test]
 fn ebadf() {
     assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error::EBADF);

--- a/test/test_net.rs
+++ b/test/test_net.rs
@@ -3,8 +3,11 @@ use nix::net::if_::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 const LOOPBACK: &[u8] = b"lo";
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
+#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "haiku")))]
 const LOOPBACK: &[u8] = b"lo0";
+
+#[cfg(target_os = "haiku")]
+const LOOPBACK: &[u8] = b"loop";
 
 #[test]
 fn test_if_nametoindex() {

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos", target_os = "haiku")))]
 use nix::sys::resource::{getrlimit, setrlimit, Resource};
 
 /// Tests the RLIMIT_NOFILE functionality of getrlimit(), where the resource RLIMIT_NOFILE refers
@@ -10,7 +10,7 @@ use nix::sys::resource::{getrlimit, setrlimit, Resource};
 /// to put the new soft limit in effect, and then getrlimit() once more to ensure the limits have
 /// been updated.
 #[test]
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "illumos", target_os = "haiku")))]
 pub fn test_resource_limits_nofile() {
     let (mut soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE).unwrap();
 

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,10 +1,12 @@
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use std::fs;
 use std::fs::File;
 #[cfg(not(target_os = "redox"))]
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::fs::{symlink};
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+use std::os::unix::fs::{PermissionsExt};
 use std::os::unix::prelude::AsRawFd;
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use std::time::{Duration, UNIX_EPOCH};
 #[cfg(not(target_os = "redox"))]
 use std::path::Path;
@@ -18,25 +20,30 @@ use nix::fcntl;
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
 #[cfg(not(target_os = "redox"))]
-use nix::sys::stat::{self, futimens, utimes};
+use nix::sys::stat::{self};
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+use nix::sys::stat::{futimens, utimes};
 use nix::sys::stat::{fchmod, stat};
 #[cfg(not(target_os = "redox"))]
-use nix::sys::stat::{fchmodat, utimensat, mkdirat};
+use nix::sys::stat::{fchmodat, mkdirat};
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+use nix::sys::stat::{utimensat};
 #[cfg(any(target_os = "linux",
-          target_os = "haiku",
           target_os = "ios",
           target_os = "macos",
           target_os = "freebsd",
           target_os = "netbsd"))]
 use nix::sys::stat::lutimes;
 #[cfg(not(target_os = "redox"))]
-use nix::sys::stat::{FchmodatFlags, UtimensatFlags};
+use nix::sys::stat::{FchmodatFlags};
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+use nix::sys::stat::{UtimensatFlags};
 use nix::sys::stat::Mode;
 
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 use nix::sys::stat::FileStat;
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use nix::sys::time::{TimeSpec, TimeVal, TimeValLike};
 #[cfg(not(target_os = "redox"))]
 use nix::unistd::chdir;
@@ -191,7 +198,7 @@ fn test_fchmodat() {
 ///
 /// The atime and mtime are expressed with a resolution of seconds because some file systems
 /// (like macOS's HFS+) do not have higher granularity.
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn assert_times_eq(exp_atime_sec: u64, exp_mtime_sec: u64, attr: &fs::Metadata) {
     assert_eq!(
         Duration::new(exp_atime_sec, 0),
@@ -202,7 +209,7 @@ fn assert_times_eq(exp_atime_sec: u64, exp_mtime_sec: u64, attr: &fs::Metadata) 
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_utimes() {
     let tempdir = tempfile::tempdir().unwrap();
     let fullpath = tempdir.path().join("file");
@@ -214,7 +221,6 @@ fn test_utimes() {
 
 #[test]
 #[cfg(any(target_os = "linux",
-          target_os = "haiku",
           target_os = "ios",
           target_os = "macos",
           target_os = "freebsd",
@@ -238,7 +244,7 @@ fn test_lutimes() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_futimens() {
     let tempdir = tempfile::tempdir().unwrap();
     let fullpath = tempdir.path().join("file");
@@ -251,7 +257,7 @@ fn test_futimens() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_utimensat() {
     let _dr = crate::DirRestore::new();
     let tempdir = tempfile::tempdir().unwrap();
@@ -283,7 +289,7 @@ fn test_mkdirat_success_path() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_mkdirat_success_mode() {
     let expected_bits = stat::SFlag::S_IFDIR.bits() | stat::Mode::S_IRWXU.bits();
     let tempdir = tempfile::tempdir().unwrap();
@@ -312,6 +318,7 @@ fn test_mkdirat_fail() {
               target_os = "freebsd",
               target_os = "ios",
               target_os = "macos",
+              target_os = "haiku",
               target_os = "redox")))]
 fn test_mknod() {
     use stat::{lstat, mknod, SFlag};
@@ -331,6 +338,7 @@ fn test_mknod() {
               target_os = "illumos",
               target_os = "ios",
               target_os = "macos",
+              target_os = "haiku",
               target_os = "redox")))]
 fn test_mknodat() {
     use fcntl::{AtFlags, OFlag};

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1,5 +1,7 @@
 #[cfg(not(target_os = "redox"))]
-use nix::fcntl::{self, open, readlink};
+use nix::fcntl::{self, open};
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+use nix::fcntl::{readlink};
 use nix::fcntl::OFlag;
 use nix::unistd::*;
 use nix::unistd::ForkResult::*;
@@ -7,7 +9,7 @@ use nix::unistd::ForkResult::*;
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::wait::*;
 use nix::sys::stat::{self, Mode, SFlag};
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 use nix::pty::{posix_openpt, grantpt, unlockpt, ptsname};
 use nix::errno::Errno;
 use std::env;
@@ -18,7 +20,7 @@ use std::fs::DirBuilder;
 use std::fs::{self, File};
 use std::io::Write;
 use std::os::unix::prelude::*;
-#[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "redox", target_os = "haiku")))]
 use std::path::Path;
 use tempfile::{tempdir, tempfile};
 use libc::{_exit, mode_t, off_t};
@@ -114,7 +116,7 @@ fn test_mkfifo_directory() {
 #[test]
 #[cfg(not(any(
     target_os = "macos", target_os = "ios",
-    target_os = "android", target_os = "redox")))]
+    target_os = "android", target_os = "redox", target_os = "haiku")))]
 fn test_mkfifoat_none() {
     let _m = crate::CWD_LOCK.read();
 
@@ -131,7 +133,7 @@ fn test_mkfifoat_none() {
 #[test]
 #[cfg(not(any(
     target_os = "macos", target_os = "ios",
-    target_os = "android", target_os = "redox")))]
+    target_os = "android", target_os = "redox", target_os = "haiku")))]
 fn test_mkfifoat() {
     use nix::fcntl;
 
@@ -149,7 +151,7 @@ fn test_mkfifoat() {
 #[test]
 #[cfg(not(any(
     target_os = "macos", target_os = "ios",
-    target_os = "android", target_os = "redox")))]
+    target_os = "android", target_os = "redox", target_os = "haiku")))]
 fn test_mkfifoat_directory_none() {
     let _m = crate::CWD_LOCK.read();
 
@@ -160,7 +162,7 @@ fn test_mkfifoat_directory_none() {
 #[test]
 #[cfg(not(any(
     target_os = "macos", target_os = "ios",
-    target_os = "android", target_os = "redox")))]
+    target_os = "android", target_os = "redox", target_os = "haiku")))]
 fn test_mkfifoat_directory() {
     // mkfifoat should fail if a directory is given
     let tempdir = tempdir().unwrap();
@@ -201,7 +203,7 @@ mod linux_android {
 
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
     skip_if_not_root!("test_setgroups");
@@ -228,6 +230,7 @@ fn test_setgroups() {
               target_os = "macos",
               target_os = "redox",
               target_os = "fuchsia",
+              target_os = "haiku",
               target_os = "illumos")))]
 fn test_initgroups() {
     // Skip this test when not run as root as `initgroups()` and `setgroups()`
@@ -555,7 +558,7 @@ cfg_if!{
                 skip_if_jailed!("test_acct");
             }
         }
-    } else if #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))] {
+    } else if #[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))] {
         macro_rules! require_acct{
             () => {
                 skip_if_not_root!("test_acct");
@@ -565,7 +568,7 @@ cfg_if!{
 }
 
 #[test]
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 fn test_acct() {
     use tempfile::NamedTempFile;
     use std::process::Command;
@@ -786,7 +789,7 @@ fn test_canceling_alarm() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_symlinkat() {
     let _m = crate::CWD_LOCK.read();
 
@@ -814,7 +817,7 @@ fn test_symlinkat() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_file() {
     let tempdir = tempdir().unwrap();
     let oldfilename = "foo.txt";
@@ -835,7 +838,7 @@ fn test_linkat_file() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_olddirfd_none() {
     let _dr = crate::DirRestore::new();
 
@@ -860,7 +863,7 @@ fn test_linkat_olddirfd_none() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_newdirfd_none() {
     let _dr = crate::DirRestore::new();
 
@@ -885,7 +888,7 @@ fn test_linkat_newdirfd_none() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
+#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox", target_os = "haiku")))]
 fn test_linkat_no_follow_symlink() {
     let _m = crate::CWD_LOCK.read();
 
@@ -922,7 +925,7 @@ fn test_linkat_no_follow_symlink() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_follow_symlink() {
     let _m = crate::CWD_LOCK.read();
 
@@ -1033,7 +1036,13 @@ fn test_access_file_exists() {
 #[test]
 fn test_user_into_passwd() {
     // get the UID of the "nobody" user
-    let nobody = User::from_name("nobody").unwrap().unwrap();
+    #[cfg(not(target_os = "haiku"))]
+    let test_username = "nobody";
+    // "nobody" unavailable on haiku
+    #[cfg(target_os = "haiku")]
+    let test_username = "user";
+
+    let nobody = User::from_name(test_username).unwrap().unwrap();
     let pwd: libc::passwd = nobody.into();
     let _: User = (&pwd).into();
 }
@@ -1078,7 +1087,7 @@ fn test_setfsuid() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 fn test_ttyname() {
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
     assert!(fd.as_raw_fd() > 0);
@@ -1109,7 +1118,7 @@ fn test_ttyname_not_pty() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(not(any(target_os = "redox", target_os = "fuchsia", target_os = "haiku")))]
 fn test_ttyname_invalid_fd() {
     assert_eq!(ttyname(-1), Err(Errno::EBADF));
 }


### PR DESCRIPTION
hello,

the following changeset(s) adds support for compiling on haiku.

below is an sample run showing compilation

```sh
> uname -a
Haiku shredder 1 hrev56040 Apr 22 2022 06:24:48 x86_64 x86_64 Haiku

> cargo build
   Compiling autocfg v1.1.0
   Compiling libc v0.2.123
   Compiling bitflags v1.3.2
   Compiling cfg-if v1.0.0
   Compiling memoffset v0.6.5
   Compiling nix v0.24.1 (/boot/home/src/git/rust-libs/nix)
    Finished dev [unoptimized + debuginfo] target(s) in 11.09s

```

and some results from running ```cargo test```:

```sh

running 32 tests
test sys::select::tests::fdset_clear ... ok
test sys::select::tests::fdset_insert ... ok
test sys::select::tests::fdset_highest ... ok
test sys::select::tests::fdset_fds ... ok
test sys::select::tests::fdset_remove ... ok
test sys::signal::tests::test_clear ... ok
test sys::select::tests::test_select ... ok
test sys::select::tests::test_select_nfds2 ... ok
test sys::signal::tests::test_contains ... ok
test sys::select::tests::test_select_nfds ... ok
test sys::signal::tests::test_extend ... ok
test sys::signal::tests::test_from_and_into_iterator ... ok
test sys::signal::tests::test_from_str_invalid_value ... ok
test sys::signal::tests::test_from_str_round_trips ... ok
test sys::signal::tests::test_sigaction ... ok
test sys::signal::tests::test_sigwait ... ok
test sys::signal::tests::test_thread_signal_set_mask ... ok
test sys::statvfs::test::fstatvfs_call ... ok
test sys::statvfs::test::statvfs_call ... ok
test sys::termios::test::try_from ... ok
test sys::signal::tests::test_thread_signal_swap ... ok
test sys::signal::tests::test_thread_signal_block ... ok
test sys::signal::tests::test_thread_signal_unblock ... ok
test sys::time::test::test_timespec ... ok
test sys::time::test::test_timespec_from ... ok
test sys::time::test::test_timespec_neg ... ok
test sys::time::test::test_timespec_fmt ... ok
test sys::time::test::test_timespec_ord ... ok
test sys::time::test::test_timeval ... ok
test sys::time::test::test_timeval_neg ... ok
test sys::time::test::test_timeval_fmt ... ok
test sys::time::test::test_timeval_ord ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running test/test.rs (target/debug/deps/test-6e8a70ba3d8f7447)

running 73 tests
test sys::test_pthread::test_pthread_kill_none ... ok
test sys::test_pthread::test_pthread_self ... ok
test sys::test_select::test_pselect_nfds2 ... ok
test sys::test_select::test_pselect ... ok
test sys::test_signal::test_kill_none ... ok
test sys::test_signal::test_killpg_none ... ok
test sys::test_signal::test_old_sigaction_flags ... ok
test sys::test_signal::test_signal ... ok
test sys::test_signal::test_sigprocmask ... ok
test sys::test_signal::test_signal_sigaction ... ok
test sys::test_signal::test_sigprocmask_noop ... ok
test sys::test_select::test_fdset_negative_fd::contains - should panic ... ok
test sys::test_select::test_fdset_negative_fd::remove - should panic ... ok
test sys::test_select::test_fdset_negative_fd::insert - should panic ... ok
test sys::test_select::test_fdset_too_large_fd::contains - should panic ... ok
test sys::test_select::test_fdset_too_large_fd::insert - should panic ... ok
test sys::test_select::test_fdset_too_large_fd::remove - should panic ... ok
test sys::test_wait::test_wait_exit ... ok
test sys::test_wait::test_waitid_pid ... ok
test sys::test_uio::test_readv ... ok
test sys::test_wait::test_waitstatus_from_raw ... FAILED
test sys::test_wait::test_waitstatus_pid ... ok
test sys::test_uio::test_writev ... ok
test test_net::test_if_nametoindex ... ok
test test_dir::rewind ... ok
test test_poll::test_pollfd_events ... ok
test test_poll::test_pollfd_fd ... ok
test sys::test_uio::test_pwrite ... ok
test sys::test_uio::test_pread ... ok
test test_fcntl::test_readlink ... ok
test test_fcntl::test_openat ... ok
test test_dir::read ... ok
test test_stat::test_fstatat ... ok
test test_stat::test_mkdirat_fail ... ok
test test_time::test_clock_gettime ... ok
test test_stat::test_fchmod ... ok
test test_stat::test_fchmodat ... ok
test test_time::test_clock_id_now ... ok
test test_fcntl::test_renameat ... ok
test test_stat::test_mkdirat_success_path ... ok
test test_stat::test_stat_and_fstat ... ok
test test_unistd::test_execvpe::test_cstr_ref ... ok
test test_unistd::test_access_not_existing ... ok
test test_unistd::test_execvpe::test_cstring ... ok
test test_unistd::test_access_file_exists ... ok
test test_stat::test_stat_fstat_lstat ... ok
test test_unistd::test_fchdir ... ok
test test_unistd::test_fork_and_waitpid ... ok
test test_unistd::test_fchown ... ok
test test_unistd::test_chown ... ok
test test_unistd::test_getpid ... ok
test test_unistd::test_getsid ... ok
test test_unistd::test_fpathconf_limited ... ok
test test_unistd::test_lseek ... ok
test test_unistd::test_mkfifo_directory ... ok
test test_unistd::test_fchownat ... ok
test test_unistd::test_mkstemp_directory ... ok
test test_unistd::test_pathconf_limited ... ok
test test_unistd::test_pipe ... ok
test test_unistd::test_sysconf_limited ... ok
test test_unistd::test_mkfifo ... ok
test test_unistd::test_ttyname_not_pty ... ok
test test_unistd::test_ftruncate ... ok
test test_unistd::test_mkstemp ... ok
test test_poll::test_poll ... ok
test test_unistd::test_wait ... ok
test test_unistd::test_unlinkat_dir_removedir ... ok
test test_unistd::test_unlinkat_file ... ok
test test_unistd::test_unlinkat_dir_noremovedir ... ok
test test_unistd::test_truncate ... ok
test test_unistd::test_getcwd ... ok
test test_unistd::test_alarm ... ok
test test_unistd::test_canceling_alarm ... ok

failures:

---- sys::test_wait::test_waitstatus_from_raw stdout ----
thread 'sys::test_wait::test_waitstatus_from_raw' panicked at 'assertion failed: `(left == right)`
  left: `Ok(Exited(Pid(1), 2))`,
 right: `Ok(Signaled(Pid(1), SIGINT, false))`', test/sys/test_wait.rs:93:5


failures:
    sys::test_wait::test_waitstatus_from_raw

test result: FAILED. 72 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s

error: test failed, to rerun pass '--test test'
```