### PR TITLE
Upgrade dev-dependencies to the latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,14 +78,14 @@ zerocopy = ["fs", "uio"]
 
 [dev-dependencies]
 assert-impl = "0.1"
-lazy_static = "1.2"
+lazy_static = "1.4"
 parking_lot = "0.11.2"
 rand = "0.8"
-tempfile = "3.2.0"
-semver = "1.0.0"
+tempfile = "3.3.0"
+semver = "1.0.7"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
-caps = "0.5.1"
+caps = "0.5.3"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 sysctl = "0.4"


### PR DESCRIPTION
Don't change how the versions are specified (i.e. whether a patch version is listed).

parking_lot cannot be upgraded due to 0.12.0 bumping the MSRV to 1.49.

In many cases, nix was one of the only consumers of the current versions (i.e. we are late to upgrade).