### PR TITLE
Fix a warning on Redox with the latest nightly compiler.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -94,6 +94,9 @@ macro_rules! libc_bitflags {
 ///     }
 /// }
 /// ```
+// Some targets don't use all rules.
+#[allow(unknown_lints)]
+#[allow(unused_macro_rules)]
 macro_rules! libc_enum {
     // Exit rule.
     (@make_enum

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -129,6 +129,9 @@ macro_rules! getsockopt_impl {
 /// * `$ty:ty`: type of the value that will be get/set.
 /// * `$getter:ty`: `Get` implementation; optional; only for `GetOnly` and `Both`.
 /// * `$setter:ty`: `Set` implementation; optional; only for `SetOnly` and `Both`.
+// Some targets don't use all rules.
+#[allow(unknown_lints)]
+#[allow(unused_macro_rules)]
 macro_rules! sockopt_impl {
     ($(#[$attr:meta])* $name:ident, GetOnly, $level:expr, $flag:path, bool) => {
         sockopt_impl!($(#[$attr])*


### PR DESCRIPTION
It just so happens that Redox doesn't use any of the libc_enum entries
that aren't followed by a comma.