### PR TITLE
Fix nightly clippy in tests

### DIFF
--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -253,7 +253,7 @@ fn test_process_vm_readv() {
             }
             let _ = write(w, b"\0");
             let _ = close(w);
-            loop { let _ = pause(); }
+            loop { pause(); }
         },
     }
 }


### PR DESCRIPTION
`cargo +nightly clippy --tests` currently produces

```
warning: this let-binding has unit value
   --> test/sys/test_uio.rs:256:20
    |
256 |             loop { let _ = pause(); }
    |                    ^^^^^^^^^^^^^^^^ help: omit the `let` binding: `pause();`
    |
    = note: `#[warn(clippy::let_unit_value)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value
```