### PR TITLE
Add From<uid_t> and From<gid_t>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added `aio_writev` and `aio_readv`.
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
 
+- impl `From<uid_t>` for `Uid` and `From<gid_t>` for `Gid`
+  (#[1727](https://github.com/nix-rust/nix/pull/1727))
 - impl From<SockaddrIn> for std::net::SocketAddrV4 and
   impl From<SockaddrIn6> for std::net::SocketAddrV6.
   (#[1711](https://github.com/nix-rust/nix/pull/1711))

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -87,6 +87,12 @@ impl From<Uid> for uid_t {
     }
 }
 
+impl From<uid_t> for Uid {
+    fn from(uid: uid_t) -> Self {
+        Uid(uid)
+    }
+}
+
 impl fmt::Display for Uid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
@@ -128,6 +134,12 @@ impl Gid {
 impl From<Gid> for gid_t {
     fn from(gid: Gid) -> Self {
         gid.0
+    }
+}
+
+impl From<gid_t> for Gid {
+    fn from(gid: gid_t) -> Self {
+        Gid(gid)
     }
 }
 


### PR DESCRIPTION
Conversions to/from primitive uid_t and gid_t to newtype Uid and Gid types are valid and infallible, but are only implemented in one direction. This provides the counterparts in the other direction.

These conversions are identical in behavior to the from_raw methods. However, using the more idiomatic From trait enables easier interoperability with other crates (e.g., deserialization with serde)