### PR TITLE
Ignore doctests for unexported macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! feature {
 /// The `libc` crate must be in scope with the name `libc`.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// libc_bitflags!{
 ///     pub struct ProtFlags: libc::c_int {
 ///         PROT_NONE;
@@ -39,7 +39,7 @@ macro_rules! feature {
 /// various flags have different types, so we cast the broken ones to the right
 /// type.
 ///
-/// ```
+/// ```ignore
 /// libc_bitflags!{
 ///     pub struct SaFlags: libc::c_ulong {
 ///         SA_NOCLDSTOP as libc::c_ulong;
@@ -80,7 +80,7 @@ macro_rules! libc_bitflags {
 /// The `libc` crate must be in scope with the name `libc`.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// libc_enum!{
 ///     pub enum ProtFlags {
 ///         PROT_NONE,


### PR DESCRIPTION
Due to rust-lang/rust#97030, cargo test will fail to doctest macros unless they are exported, breaking the examples for `libc_bitflags!` and `libc_enum!`.

Adds `ignore` to the examples for these macros to stop tests from failing.

`cargo test` already fails on cargo 1.62.0-beta.2, and the above issue makes it seem unlikely that this will be changed on the Rust side. If rust-lang/rust#96630 *does* get reverted, this PR can be closed/unmerged, although the test wasn't running beforehand, and it might be worth making this explicit regardless.