### PR TITLE
Cleanup cfg blocks

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -42,7 +42,6 @@ pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
     cfg_if! {
         if #[cfg(any(target_os = "fuchsia",
                      target_os = "wasi",
-                     target_env = "wasi",
                      target_env = "uclibc",
                      target_os = "linux",
                      target_os = "android",

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -20,7 +20,7 @@ use crate::{
     target_os = "android",
     target_os = "emscripten",
     target_os = "fuchsia",
-    any(target_os = "wasi", target_env = "wasi"),
+    target_os = "wasi",
     target_env = "uclibc",
     target_os = "freebsd"
 ))]
@@ -828,7 +828,7 @@ pub fn fspacectl_all(fd: RawFd, offset: libc::off_t, len: libc::off_t)
     target_os = "android",
     target_os = "emscripten",
     target_os = "fuchsia",
-    any(target_os = "wasi", target_env = "wasi"),
+    target_os = "wasi",
     target_env = "uclibc",
     target_os = "freebsd"
 ))]
@@ -877,7 +877,7 @@ mod posix_fadvise {
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "fuchsia",
-    any(target_os = "wasi", target_env = "wasi"),
+    target_os = "wasi",
     target_os = "freebsd"
 ))]
 pub fn posix_fallocate(fd: RawFd, offset: libc::off_t, len: libc::off_t) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@ feature! {
 }
 #[cfg(any(target_os = "dragonfly",
           target_os = "freebsd",
-          target_os = "fushsia",
           target_os = "linux",
           target_os = "netbsd"))]
 feature! {

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -103,8 +103,7 @@ libc_bitflags!(
                   target_os = "freebsd",
                   target_os = "macos",
                   target_os = "netbsd",
-                  target_os = "openbsd",
-                  target_os = "osx"))]
+                  target_os = "openbsd"))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SIMPLEX;
         /// Supports multicast. (see

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -380,8 +380,7 @@ sockopt_impl!(
 #[cfg(any(target_os = "android",
           target_os = "dragonfly",
           target_os = "freebsd",
-          target_os = "linux",
-          target_os = "nacl"))]
+          target_os = "linux"))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -993,8 +992,7 @@ mod test {
     }
 
     #[cfg(any(target_os = "freebsd",
-              target_os = "linux",
-              target_os = "nacl"))]
+              target_os = "linux"))]
     #[test]
     fn can_get_listen_on_tcp_socket() {
         use super::super::*;

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -170,8 +170,7 @@ fn test_so_tcp_keepalive() {
     #[cfg(any(target_os = "android",
               target_os = "dragonfly",
               target_os = "freebsd",
-              target_os = "linux",
-              target_os = "nacl"))] {
+              target_os = "linux"))] {
         let x = getsockopt(fd, sockopt::TcpKeepIdle).unwrap();
         setsockopt(fd, sockopt::TcpKeepIdle, &(x + 1)).unwrap();
         assert_eq!(getsockopt(fd, sockopt::TcpKeepIdle).unwrap(), x + 1);

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -462,7 +462,7 @@ mod linux_android {
           target_os = "android",
           target_os = "emscripten",
           target_os = "fuchsia",
-          any(target_os = "wasi", target_env = "wasi"),
+          target_os = "wasi",
           target_env = "uclibc",
           target_os = "freebsd"))]
 mod test_posix_fadvise {
@@ -495,7 +495,7 @@ mod test_posix_fadvise {
           target_os = "dragonfly",
           target_os = "emscripten",
           target_os = "fuchsia",
-          any(target_os = "wasi", target_env = "wasi"),
+          target_os = "wasi",
           target_os = "freebsd"))]
 mod test_posix_fallocate {
 


### PR DESCRIPTION
Remove obsolete references to target_env = wasi, target_os = nacl, target_os = osx, and a typo'd target_os = fushsia that didn't compile when fixed.

 - target_env = wasi is dead: https://github.com/rust-lang/rust/pull/60117
 - target_os = nacl is dead: https://github.com/rust-lang/rust/pull/45041
 - target_os = osx is dead, but I can't find a link.

Found while exploring `--check-cfg`, as mentioned in #1734.