### PR TITLE
Fix socket address family checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Enabled `SockaddrStorage::{as_link_addr, as_link_addr_mut}` for Linux-like
   operating systems.
   (#[1729](https://github.com/nix-rust/nix/pull/1729))
+- Fixed `SockaddrLike::from_raw` implementations for `VsockAddr` and
+  `SysControlAddr`.
+  (#[1736](https://github.com/nix-rust/nix/pull/1736))
 
 ### Removed
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2259,7 +2259,7 @@ pub mod sys_control {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_INET6 as i32 {
+            if (*addr).sa_family as i32 != libc::AF_SYSTEM as i32 {
                 return None;
             }
             Some(SysControlAddr(*(addr as *const libc::sockaddr_ctl)))

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2566,7 +2566,7 @@ pub mod vsock {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_INET6 as i32 {
+            if (*addr).sa_family as i32 != libc::AF_VSOCK as i32 {
                 return None;
             }
             Some(VsockAddr(*(addr as *const libc::sockaddr_vm)))


### PR DESCRIPTION
The `SockaddrLike::from_raw` implementations for `VsockAddr` and `SysControlAddr` were checking against the wrong address family constant. This PR makes them consistent with the values matched against in `SockaddrStorage::from_raw`.