### PR TITLE
Fix the test_acct test

### DIFF
--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -583,7 +583,10 @@ fn test_acct() {
     acct::enable(path).unwrap();
 
     loop {
-        Command::new("echo").arg("Hello world");
+        Command::new("echo")
+            .arg("Hello world")
+            .output()
+            .unwrap();
         let len = fs::metadata(path).unwrap().len();
         if len > 0 { break; }
         thread::sleep(time::Duration::from_millis(10));


### PR DESCRIPTION
It has never actually executed its command, so the only reason that it
ever worked is that on most systems there are usually processes starting
and exiting all the time.