### PR TITLE
ppoll: make sigmask parameter optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Changes the type of the `priority` arguments to `i32`.
   * Changes the return type of `aio_return` to `usize`.
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
+- `nix::poll::ppoll`: `sigmask` parameter is now optional.
+  (#[1739](https://github.com/nix-rust/nix/pull/1739))
 
 ### Fixed
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -151,20 +151,24 @@ feature! {
 /// `ppoll` behaves like `poll`, but let you specify what signals may interrupt it
 /// with the `sigmask` argument. If you want `ppoll` to block indefinitely,
 /// specify `None` as `timeout` (it is like `timeout = -1` for `poll`).
+/// If `sigmask` is `None`, then no signal mask manipulation is performed,
+/// so in that case `ppoll` differs from `poll` only in the precision of the
+/// timeout argument.
 ///
 #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux"))]
 pub fn ppoll(
     fds: &mut [PollFd],
     timeout: Option<crate::sys::time::TimeSpec>,
-    sigmask: crate::sys::signal::SigSet
+    sigmask: Option<crate::sys::signal::SigSet>
     ) -> Result<libc::c_int>
 {
     let timeout = timeout.as_ref().map_or(core::ptr::null(), |r| r.as_ref());
+    let sigmask = sigmask.as_ref().map_or(core::ptr::null(), |r| r.as_ref());
     let res = unsafe {
         libc::ppoll(fds.as_mut_ptr() as *mut libc::pollfd,
                     fds.len() as libc::nfds_t,
                     timeout,
-                    sigmask.as_ref())
+                    sigmask)
     };
     Errno::result(res)
 }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -53,14 +53,14 @@ fn test_ppoll() {
 
     // Poll an idle pipe.  Should timeout
     let sigset = SigSet::empty();
-    let nfds = loop_while_eintr!(ppoll(&mut fds, Some(timeout), sigset));
+    let nfds = loop_while_eintr!(ppoll(&mut fds, Some(timeout), Some(sigset)));
     assert_eq!(nfds, 0);
     assert!(!fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 
     write(w, b".").unwrap();
 
     // Poll a readable pipe.  Should return an event.
-    let nfds = ppoll(&mut fds, Some(timeout), SigSet::empty()).unwrap();
+    let nfds = ppoll(&mut fds, Some(timeout), None).unwrap();
     assert_eq!(nfds, 1);
     assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 }


### PR DESCRIPTION
ppoll(2) supports 'sigmask' as NULL. In that case no signal mask
manipulation is performed.

Let's make `sigmask` parameter of `nix::poll::ppoll` optional
to allow that behaviour.

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>