### PR TITLE
SigSet: A new unsafe helper method to create a SigSet from a sigset_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1747](https://github.com/nix-rust/nix/pull/1747))
 - Added the `DontRoute` SockOpt
   (#[1752](https://github.com/nix-rust/nix/pull/1752))
+- Added `signal::SigSet::from_sigset_t_unchecked()`.
+  (#[1741](https://github.com/nix-rust/nix/pull/1741))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1739](https://github.com/nix-rust/nix/pull/1739))
 - Changed `gethostname` to return an owned `OsString`.
   (#[1745](https://github.com/nix-rust/nix/pull/1745))
+- `signal:SigSet` is now marked as `repr(transparent)`.
+  (#[1741](https://github.com/nix-rust/nix/pull/1741))
 
 ### Fixed
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -465,6 +465,9 @@ use std::iter::FromIterator;
 use std::iter::IntoIterator;
 
 /// Specifies a set of [`Signal`]s that may be blocked, waited for, etc.
+// We are using `transparent` here to be super sure that `SigSet`
+// is represented exactly like the `sigset_t` struct from C.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SigSet {
     sigset: libc::sigset_t


### PR DESCRIPTION
Currently,  the only way to create a `SigSet` from a `sigset_t` object
is by using pointer casts, like:

```
unsafe {
    let sigset = *(&sigset as *const libc::sigset_t as *const SigSet)
};
```

This is un-ergonomic for library creators with interfaces to C.
So, let's add a new unsafe method that creates a `SigSet` from a 
`libc::sigset_t` object.

We can't implement `From` since converting from `libc::sigset_t` to
`SigSet` is unsafe, because objects of type `libc::sigset_t` must be
initialized by calling either `sigemptyset(3)` or `sigfillset(3)`
before being used. In other case, the results are undefined.
We can't implement `TryFrom` either, because there is no way to check
if an object of type `libc::sigset_t` is initialized.

Signed-off-by: German Maglione <gmaglione@redhat.com>