### PR TITLE
reimplement sendmmsg/recvmmsg with better API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Reimplemented sendmmsg/recvmmsg to avoid allocations and with better API
+  (#[1744](https://github.com/nix-rust/nix/pull/1744))
+
 - Rewrote the aio module.  The new module:
   * Does more type checking at compile time rather than runtime.
   * Gives the caller control over whether and when to `Box` an aio operation.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1841,7 +1841,7 @@ mod test {
         let recv = super::recvmmsg(rsock, &mut data, recv_iovs.iter(), flags, Some(t))?;
 
         for rmsg in recv {
-            #[cfg(not(qemu))]
+            #[cfg(not(any(qemu, target_arch = "aarch64")))]
             let mut saw_time = false;
             let mut recvd = 0;
             for cmsg in rmsg.cmsgs() {
@@ -1856,14 +1856,14 @@ mod test {
                         sys_time - ts
                     };
                     assert!(std::time::Duration::from(diff).as_secs() < 60);
-                    #[cfg(not(qemu))]
+                    #[cfg(not(any(qemu, target_arch = "aarch64")))]
                     {
                         saw_time = true;
                     }
                 }
             }
 
-            #[cfg(not(qemu))]
+            #[cfg(not(any(qemu, target_arch = "aarch64")))]
             assert!(saw_time);
 
             for iov in rmsg.iovs() {

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1635,6 +1635,11 @@ impl<S> MultiHeaders<S> {
 /// call to recvmmsg(). In the current implementation, however, the error code can be
 /// overwritten in the meantime by an unrelated network event on a socket, for example an
 /// incoming ICMP packet.
+
+// On aarch64 linux using recvmmsg and trying to get hardware/kernel timestamps might not
+// always produce the desired results - see https://github.com/nix-rust/nix/pull/1744 for more
+// details
+
 #[cfg(any(
     target_os = "linux",
     target_os = "android",


### PR DESCRIPTION
Motivation is explained in #1602, new version allows to receive data without performing allocations inside the receive loop and to use received data without extra copying.

This pull request contains a breaking change to API `recvmmsg` (obviously) and also affects `recvmsg` - new version does not set length of control message buffer if one is passed. Later change can be avoided with a bit more copy-paste.

Fixes #1602