### PR TITLE
Change gethostname to use a buffer of MaybeUninit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
 - `nix::poll::ppoll`: `sigmask` parameter is now optional.
   (#[1739](https://github.com/nix-rust/nix/pull/1739))
+- Changed `gethostname` to use a buffer of `MaybeUninit` values.
+  (#[1745](https://github.com/nix-rust/nix/pull/1745))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
 - `nix::poll::ppoll`: `sigmask` parameter is now optional.
   (#[1739](https://github.com/nix-rust/nix/pull/1739))
-- Changed `gethostname` to use a buffer of `MaybeUninit` values.
+- Changed `gethostname` to return an owned `OsString`.
   (#[1745](https://github.com/nix-rust/nix/pull/1745))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ call:
 pub unsafe extern fn gethostname(name: *mut c_char, len: size_t) -> c_int;
 
 // nix api (returns a nix::Result<CStr>)
-pub fn gethostname<'a>(buffer: &'a mut [u8]) -> Result<&'a CStr>;
+pub fn gethostname<'a>(buffer: &'a mut [mem::MaybeUninit<u8>]) -> Result<&'a CStr>;
 ```
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ call:
 // libc api (unsafe, requires handling return code/errno)
 pub unsafe extern fn gethostname(name: *mut c_char, len: size_t) -> c_int;
 
-// nix api (returns a nix::Result<CStr>)
-pub fn gethostname<'a>(buffer: &'a mut [mem::MaybeUninit<u8>]) -> Result<&'a CStr>;
+// nix api (returns a nix::Result<OsString>)
+pub fn gethostname() -> Result<OsString>;
 ```
 
 ## Supported Platforms


### PR DESCRIPTION
Changing `gethostname` to accept a buffer of `MaybeUninit` bytes allows the user to avoid needlessly initializing a buffer. This is a breaking API change.