### PR TITLE
Add getrusage wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1703](https://github.com/nix-rust/nix/pull/1703))
 - Added `ptrace::read_user` and `ptrace::write_user` for Linux.
   (#[1697](https://github.com/nix-rust/nix/pull/1697))
+- Added `getrusage` and helper types `UsageWho` and `Usage`
+  (#[1747](https://github.com/nix-rust/nix/pull/1747))
 
 ### Changed
 


### PR DESCRIPTION
Includes an enum to specify what to get resource usage for, and a new
struct that provides a more readable view into libc::rusage, including
using TimeVal for user and system CPU time.

Signed-off-by: Gustavo Noronha Silva <gustavo@noronha.dev.br>