### PR TITLE
Add missing DontRoute SockOpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1697](https://github.com/nix-rust/nix/pull/1697))
 - Added `getrusage` and helper types `UsageWho` and `Usage`
   (#[1747](https://github.com/nix-rust/nix/pull/1747))
+- Added the `DontRoute` SockOpt
+  (#[1752](https://github.com/nix-rust/nix/pull/1752))
 
 ### Changed
 

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -353,6 +353,9 @@ sockopt_impl!(
     /// Get and clear the pending socket error.
     SocketError, GetOnly, libc::SOL_SOCKET, libc::SO_ERROR, i32);
 sockopt_impl!(
+    /// Set or get the don't route flag.
+    DontRoute, Both, libc::SOL_SOCKET, libc::SO_DONTROUTE, bool);
+sockopt_impl!(
     /// Enable sending of keep-alive messages on connection-oriented sockets.
     KeepAlive, Both, libc::SOL_SOCKET, libc::SO_KEEPALIVE, bool);
 #[cfg(any(


### PR DESCRIPTION
I'm not sure, but according to [unix standard](https://pubs.opengroup.org/onlinepubs/7908799/xns/setsockopt.html), SO_DONTROUTE should appear in all unix systems.
Does this need a test?