### PR TITLE
Make memfd available on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1747](https://github.com/nix-rust/nix/pull/1747))
 - Added the `DontRoute` SockOpt
   (#[1752](https://github.com/nix-rust/nix/pull/1752))
+- Added `memfd_create` on Android.
+  (#[1753](https://github.com/nix-rust/nix/pull/1753))
 
 ### Changed
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,7 +50,7 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 feature! {
     #![feature = "fs"]
     pub mod memfd;


### PR DESCRIPTION
Android also supports memfd so allow the relevant items to be used when
targeting Android.