### PR TITLE
Add const constructors for TimeSpec and TimeVal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added const constructors for `TimeSpec` and `TimeVal`
+  (#[1760](https://github.com/nix-rust/nix/pull/1760))
 - Added `aio_writev` and `aio_readv`.
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
-
 - impl `From<uid_t>` for `Uid` and `From<gid_t>` for `Gid`
   (#[1727](https://github.com/nix-rust/nix/pull/1727))
 - impl From<SockaddrIn> for std::net::SocketAddrV4 and

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -330,6 +330,15 @@ impl TimeValLike for TimeSpec {
 }
 
 impl TimeSpec {
+    /// Construct a new `TimeSpec` from its components
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    pub const fn new(seconds: time_t, nanoseconds: timespec_tv_nsec_t) -> Self {
+        Self(timespec {
+            tv_sec: seconds,
+            tv_nsec: nanoseconds,
+        })
+    }
+
     fn nanos_mod_sec(&self) -> timespec_tv_nsec_t {
         if self.tv_sec() < 0 && self.tv_nsec() > 0 {
             self.tv_nsec() - NANOS_PER_SEC as timespec_tv_nsec_t
@@ -564,6 +573,15 @@ impl TimeValLike for TimeVal {
 }
 
 impl TimeVal {
+    /// Construct a new `TimeVal` from its components
+    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    pub const fn new(seconds: time_t, microseconds: suseconds_t) -> Self {
+        Self(timeval {
+            tv_sec: seconds,
+            tv_usec: microseconds,
+        })
+    }
+
     fn micros_mod_sec(&self) -> suseconds_t {
         if self.tv_sec() < 0 && self.tv_usec() > 0 {
             self.tv_usec() - MICROS_PER_SEC as suseconds_t


### PR DESCRIPTION
These are basically the same as From<libc::timespec> and
From<libc::timeval>, but they're const and require less typing.