### PR TITLE
Add ETH_P_ALL protocol number to SockProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added ETH_P_ALL to SockProtocol enum
+  (#[1768](https://github.com/nix-rust/nix/pull/1768))
 - Added four non-standard Linux `SysconfVar` variants
   (#[1761](https://github.com/nix-rust/nix/pull/1761))
 - Added const constructors for `TimeSpec` and `TimeVal`

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -214,6 +214,13 @@ pub enum SockProtocol {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkCrypto = libc::NETLINK_CRYPTO,
+    /// Non-DIX type protocol number defined for the Ethernet IEEE 802.3 interface that allows packets of all protocols
+    /// defined in the interface to be received.
+    /// ([ref](https://man7.org/linux/man-pages/man7/packet.7.html))
+    // The protocol number is fed into the socket syscall in network byte order.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    EthAll = libc::ETH_P_ALL.to_be(),
 }
 
 #[cfg(any(target_os = "linux"))]


### PR DESCRIPTION
Hi. I am working on a networking project that uses [packet sockets](https://man7.org/linux/man-pages/man7/packet.7.html) and noticed that ETH_P_ALL is not there in the `SockProtocol` enum. I thought it would be nice to have it here alongside IPPROTO_TCP and IPPROTO_UDP instead of having to separately import it from the libc crate.