### PR TITLE
Fix SockaddrLike::from_raw with unaligned inputs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ build: &BUILD
     - $TOOL +$TOOLCHAIN $BUILD $ZFLAGS --target $TARGET --all-targets
     - $TOOL +$TOOLCHAIN doc $ZFLAGS --no-deps --target $TARGET
     - $TOOL +$TOOLCHAIN clippy $ZFLAGS --target $TARGET --all-targets -- -D warnings
-    - if [ -z "$NOHACK" ]; then $TOOL +$TOOLCHAIN install cargo-hack; fi
+    - if [ -z "$NOHACK" ]; then $TOOL +$TOOLCHAIN install --version 0.5.14 cargo-hack; fi
     - if [ -z "$NOHACK" ]; then $TOOL +$TOOLCHAIN hack $ZFLAGS check --target $TARGET --each-feature; fi
 
 # Tests that do require executing the binaries

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::cast_ptr_alignment)]
 
 // Re-exported external crates
 pub use libc;

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -949,6 +949,7 @@ impl ControlMessageOwned {
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[cfg(feature = "net")]
+    #[allow(clippy::cast_ptr_alignment)]    // False positive
     unsafe fn recv_err_helper<T>(p: *mut libc::c_uchar, len: usize) -> (libc::sock_extended_err, Option<T>) {
         let ee = p as *const libc::sock_extended_err;
         let err = ptr::read_unaligned(ee);


### PR DESCRIPTION
The major users of this function are functions like gethostname, which
will always properly align their buffers.  But out-of-crate consumers
could manually construct an unaligned buffer.  Handle that correctly.

Enable Clippy's cast_ptr_alignment lint.  It's disabled by default as it
reports many false positives, but it would've caught this problem.

Reported-by:	Miri
Fixes:		1769