### PR TITLE
Add memfd for target_os = "android"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added `memfd` on Android.
+  (#[1773](https://github.com/nix-rust/nix/pull/1773))
 - Added ETH_P_ALL to SockProtocol enum
   (#[1768](https://github.com/nix-rust/nix/pull/1768))
 - Added four non-standard Linux `SysconfVar` variants

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,7 +50,7 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_is = "android", target_os = "linux"))]
 feature! {
     #![feature = "fs"]
     pub mod memfd;


### PR DESCRIPTION
Memory fds (`memfd`) are implemented and exported by Androids bionic.
Export the `memfd` module if the target os is `android`.

https://cs.android.com/android/platform/superproject/+/master:bionic/libc/include/sys/mman.h;drc=23c7543b8e608ebcbb38b952761b54bb56065577;bpv=1;bpt=1;l=182