### PR TITLE
Fix typo guarding memfd export on android.

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,7 +50,7 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(any(target_is = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 feature! {
     #![feature = "fs"]
     pub mod memfd;


### PR DESCRIPTION
Extremely minor but crucial typo on import guard from #1773. @flxo 