### PR TITLE
Add support for the IP_SENDSRCADDR control message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1772](https://github.com/nix-rust/nix/pull/1772))
 - Added IPV6_ORIGDSTADDR using Ipv6OrigDstAddr in setsockopt and recvmsg.
   (#[1772](https://github.com/nix-rust/nix/pull/1772))
+- Added `IP_SENDSRCADDR` using `Ipv4SendSrcAddr` in `sendmsg`.
+  (#[1776](https://github.com/nix-rust/nix/pull/1776))
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1117,6 +1117,17 @@ pub enum ControlMessage<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv6PacketInfo(&'a libc::in6_pktinfo),
 
+    /// Configure the IPv4 source address with `IP_SENDSRCADDR`.
+    #[cfg(any(
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+    ))]
+    #[cfg(feature = "net")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    Ipv4SendSrcAddr(&'a libc::in_addr),
+
     /// SO_RXQ_OVFL indicates that an unsigned 32 bit value
     /// ancilliary msg (cmsg) should be attached to recieved
     /// skbs indicating the number of packets dropped by the
@@ -1226,6 +1237,10 @@ impl<'a> ControlMessage<'a> {
                       target_os = "android", target_os = "ios",))]
             #[cfg(feature = "net")]
             ControlMessage::Ipv6PacketInfo(info) => info as *const _ as *const u8,
+            #[cfg(any(target_os = "netbsd", target_os = "freebsd",
+                      target_os = "openbsd", target_os = "dragonfly"))]
+            #[cfg(feature = "net")]
+            ControlMessage::Ipv4SendSrcAddr(addr) => addr as *const _ as *const u8,
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             ControlMessage::RxqOvfl(drop_count) => {
                 drop_count as *const _ as *const u8
@@ -1285,6 +1300,10 @@ impl<'a> ControlMessage<'a> {
               target_os = "android", target_os = "ios",))]
             #[cfg(feature = "net")]
             ControlMessage::Ipv6PacketInfo(info) => mem::size_of_val(info),
+            #[cfg(any(target_os = "netbsd", target_os = "freebsd",
+                      target_os = "openbsd", target_os = "dragonfly"))]
+            #[cfg(feature = "net")]
+            ControlMessage::Ipv4SendSrcAddr(addr) => mem::size_of_val(addr),
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             ControlMessage::RxqOvfl(drop_count) => {
                 mem::size_of_val(drop_count)
@@ -1320,6 +1339,10 @@ impl<'a> ControlMessage<'a> {
               target_os = "android", target_os = "ios",))]
             #[cfg(feature = "net")]
             ControlMessage::Ipv6PacketInfo(_) => libc::IPPROTO_IPV6,
+            #[cfg(any(target_os = "netbsd", target_os = "freebsd",
+                      target_os = "openbsd", target_os = "dragonfly"))]
+            #[cfg(feature = "net")]
+            ControlMessage::Ipv4SendSrcAddr(_) => libc::IPPROTO_IP,
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             ControlMessage::RxqOvfl(_) => libc::SOL_SOCKET,
             #[cfg(target_os = "linux")]
@@ -1362,6 +1385,10 @@ impl<'a> ControlMessage<'a> {
                       target_os = "android", target_os = "ios",))]
             #[cfg(feature = "net")]
             ControlMessage::Ipv6PacketInfo(_) => libc::IPV6_PKTINFO,
+            #[cfg(any(target_os = "netbsd", target_os = "freebsd",
+                      target_os = "openbsd", target_os = "dragonfly"))]
+            #[cfg(feature = "net")]
+            ControlMessage::Ipv4SendSrcAddr(_) => libc::IP_SENDSRCADDR,
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             ControlMessage::RxqOvfl(_) => {
                 libc::SO_RXQ_OVFL


### PR DESCRIPTION
This control message is available on FreeBSD, NetBSD, and OpenBSD. When used with `sendmsg`, it sets the IPv4 source address. This adds support through a new `ControlMessage::Ipv4SendSrcAddr` variant that complements `ControlMessageOwned::Ipv4RecvDstAddr`.

A few notes:
* `IP_SENDSRCADDR` is actually just an alias for `IP_RECVDSTADDR` (though the code doesn't depend on this).
* On NetBSD, `IP_PKTINFO` can be used to accomplish the same thing and is already supported by nix. On FreeBSD and OpenBSD, though, `IP_SENDSRCADDR` is the only method I'm aware of.
* The accompanying test binds a UDP socket to all local interfaces (0.0.0.0). If this is not acceptable, please let me know; however, FreeBSD requires this to use `IP_SENDSRCADDR`.

I'll add a change-log entry once I see the PR number.

Thanks!