### PR TITLE
Upgrade libc to 0.2.127

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "8dbd2c9", features = [ "extra_traits" ] }
+libc = { version = "0.2.127", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }


### PR DESCRIPTION
This is the last version of libc which will support Rust 1.46, per https://github.com/rust-lang/libc/pull/2845.

I think we should ship nix 0.25.0 against this version of libc (at some point, not necessarily now), as it will allow us to maintain an MSRV of 1.46, and subsequently upgrade to a later libc immediately after releasing 0.25.0.