### PR TITLE
Remove deprecated items

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -233,8 +233,8 @@ mod sched_affinity {
     /// use nix::unistd::Pid;
     ///
     /// let mut cpu_set = CpuSet::new();
-    /// cpu_set.set(0);
-    /// sched_setaffinity(Pid::from_raw(0), &cpu_set);
+    /// cpu_set.set(0).unwrap();
+    /// sched_setaffinity(Pid::from_raw(0), &cpu_set).unwrap();
     /// ```
     pub fn sched_setaffinity(pid: Pid, cpuset: &CpuSet) -> Result<()> {
         let res = unsafe {

--- a/src/sys/personality.rs
+++ b/src/sys/personality.rs
@@ -86,7 +86,7 @@ pub fn get() -> Result<Persona> {
 /// # use nix::sys::personality::{self, Persona};
 /// let mut pers = personality::get().unwrap();
 /// assert!(!pers.contains(Persona::ADDR_NO_RANDOMIZE));
-/// personality::set(pers | Persona::ADDR_NO_RANDOMIZE).unwrap().unwrap();
+/// personality::set(pers | Persona::ADDR_NO_RANDOMIZE).unwrap();
 /// ```
 pub fn set(persona: Persona) -> Result<Persona> {
     let res = unsafe {

--- a/src/sys/personality.rs
+++ b/src/sys/personality.rs
@@ -86,7 +86,7 @@ pub fn get() -> Result<Persona> {
 /// # use nix::sys::personality::{self, Persona};
 /// let mut pers = personality::get().unwrap();
 /// assert!(!pers.contains(Persona::ADDR_NO_RANDOMIZE));
-/// personality::set(pers | Persona::ADDR_NO_RANDOMIZE);
+/// personality::set(pers | Persona::ADDR_NO_RANDOMIZE).unwrap().unwrap();
 /// ```
 pub fn set(persona: Persona) -> Result<Persona> {
     let res = unsafe {

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -6,11 +6,11 @@
 //!
 //! ```rust,no_run
 //! # use nix::sys::quota::{Dqblk, quotactl_on, quotactl_set, QuotaFmt, QuotaType, QuotaValidFlags};
-//! quotactl_on(QuotaType::USRQUOTA, "/dev/sda1", QuotaFmt::QFMT_VFS_V1, "aquota.user");
+//! quotactl_on(QuotaType::USRQUOTA, "/dev/sda1", QuotaFmt::QFMT_VFS_V1, "aquota.user").unwrap();
 //! let mut dqblk: Dqblk = Default::default();
 //! dqblk.set_blocks_hard_limit(10000);
 //! dqblk.set_blocks_soft_limit(8000);
-//! quotactl_set(QuotaType::USRQUOTA, "/dev/sda1", 50, &dqblk, QuotaValidFlags::QIF_BLIMITS);
+//! quotactl_set(QuotaType::USRQUOTA, "/dev/sda1", 50, &dqblk, QuotaValidFlags::QIF_BLIMITS).unwrap();
 //! ```
 use std::default::Default;
 use std::{mem, ptr};

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -677,7 +677,7 @@ pub enum ControlMessageOwned {
     ///     None).unwrap();
     /// setsockopt(in_socket, sockopt::ReceiveTimestamp, &true).unwrap();
     /// let localhost = SockaddrIn::from_str("127.0.0.1:0").unwrap();
-    /// bind(in_socket, &localhost);
+    /// bind(in_socket, &localhost).unwrap();
     /// let address: SockaddrIn = getsockname(in_socket).unwrap();
     /// // Get initial time
     /// let time0 = SystemTime::now();

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -982,7 +982,7 @@ mod test {
         let a_cred = getsockopt(a, super::PeerCredentials).unwrap();
         let b_cred = getsockopt(b, super::PeerCredentials).unwrap();
         assert_eq!(a_cred, b_cred);
-        assert!(a_cred.pid() != 0);
+        assert_ne!(a_cred.pid(), 0);
     }
 
     #[test]

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -64,9 +64,9 @@
 //! # use nix::sys::termios::{BaudRate, cfsetispeed, cfsetospeed, cfsetspeed, Termios};
 //! # fn main() {
 //! # let mut t: Termios = unsafe { std::mem::zeroed() };
-//! cfsetispeed(&mut t, BaudRate::B9600);
-//! cfsetospeed(&mut t, BaudRate::B9600);
-//! cfsetspeed(&mut t, BaudRate::B9600);
+//! cfsetispeed(&mut t, BaudRate::B9600).unwrap();
+//! cfsetospeed(&mut t, BaudRate::B9600).unwrap();
+//! cfsetspeed(&mut t, BaudRate::B9600).unwrap();
 //! # }
 //! ```
 //!
@@ -76,10 +76,10 @@
 //! # use nix::sys::termios::{BaudRate, cfgetispeed, cfgetospeed, cfsetispeed, cfsetspeed, Termios};
 //! # fn main() {
 //! # let mut t: Termios = unsafe { std::mem::zeroed() };
-//! # cfsetspeed(&mut t, BaudRate::B9600);
+//! # cfsetspeed(&mut t, BaudRate::B9600).unwrap();
 //! let speed = cfgetispeed(&t);
 //! assert_eq!(speed, cfgetospeed(&t));
-//! cfsetispeed(&mut t, speed);
+//! cfsetispeed(&mut t, speed).unwrap();
 //! # }
 //! ```
 //!

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -7,17 +7,17 @@ use std::time::Duration;
 use std::{cmp, fmt, ops};
 
 #[cfg(any(
-all(feature = "time", any(target_os = "android", target_os = "linux")),
-all(
-any(
-target_os = "freebsd",
-target_os = "illumos",
-target_os = "linux",
-target_os = "netbsd"
-),
-feature = "time",
-feature = "signal"
-)
+    all(feature = "time", any(target_os = "android", target_os = "linux")),
+    all(
+        any(
+            target_os = "freebsd",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd"
+        ),
+        feature = "time",
+        feature = "signal"
+    )
 ))]
 pub(crate) mod timer {
     use crate::sys::time::TimeSpec;
@@ -98,10 +98,10 @@ pub(crate) mod timer {
         }
     }
     #[cfg(any(
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "dragonfly",
-    target_os = "illumos"
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "illumos"
     ))]
     bitflags! {
         /// Flags that are used for arming the timer.
@@ -114,17 +114,17 @@ pub(crate) mod timer {
         fn from(timerspec: TimerSpec) -> Expiration {
             match timerspec {
                 TimerSpec(libc::itimerspec {
-                              it_interval:
-                              libc::timespec {
-                                  tv_sec: 0,
-                                  tv_nsec: 0,
-                              },
-                              it_value: ts,
-                          }) => Expiration::OneShot(ts.into()),
+                    it_interval:
+                        libc::timespec {
+                            tv_sec: 0,
+                            tv_nsec: 0,
+                        },
+                    it_value: ts,
+                }) => Expiration::OneShot(ts.into()),
                 TimerSpec(libc::itimerspec {
-                              it_interval: int_ts,
-                              it_value: val_ts,
-                          }) => {
+                    it_interval: int_ts,
+                    it_value: val_ts,
+                }) => {
                     if (int_ts.tv_sec == val_ts.tv_sec)
                         && (int_ts.tv_nsec == val_ts.tv_nsec)
                     {

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -7,17 +7,17 @@ use std::time::Duration;
 use std::{cmp, fmt, ops};
 
 #[cfg(any(
-    all(feature = "time", any(target_os = "android", target_os = "linux")),
-    all(
-        any(
-            target_os = "freebsd",
-            target_os = "illumos",
-            target_os = "linux",
-            target_os = "netbsd"
-        ),
-        feature = "time",
-        feature = "signal"
-    )
+all(feature = "time", any(target_os = "android", target_os = "linux")),
+all(
+any(
+target_os = "freebsd",
+target_os = "illumos",
+target_os = "linux",
+target_os = "netbsd"
+),
+feature = "time",
+feature = "signal"
+)
 ))]
 pub(crate) mod timer {
     use crate::sys::time::TimeSpec;
@@ -98,10 +98,10 @@ pub(crate) mod timer {
         }
     }
     #[cfg(any(
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "dragonfly",
-        target_os = "illumos"
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
+    target_os = "illumos"
     ))]
     bitflags! {
         /// Flags that are used for arming the timer.
@@ -114,17 +114,17 @@ pub(crate) mod timer {
         fn from(timerspec: TimerSpec) -> Expiration {
             match timerspec {
                 TimerSpec(libc::itimerspec {
-                    it_interval:
-                        libc::timespec {
-                            tv_sec: 0,
-                            tv_nsec: 0,
-                        },
-                    it_value: ts,
-                }) => Expiration::OneShot(ts.into()),
+                              it_interval:
+                              libc::timespec {
+                                  tv_sec: 0,
+                                  tv_nsec: 0,
+                              },
+                              it_value: ts,
+                          }) => Expiration::OneShot(ts.into()),
                 TimerSpec(libc::itimerspec {
-                    it_interval: int_ts,
-                    it_value: val_ts,
-                }) => {
+                              it_interval: int_ts,
+                              it_value: val_ts,
+                          }) => {
                     if (int_ts.tv_sec == val_ts.tv_sec)
                         && (int_ts.tv_nsec == val_ts.tv_nsec)
                     {
@@ -193,7 +193,7 @@ const SECS_PER_MINUTE: i64 = 60;
 const SECS_PER_HOUR: i64 = 3600;
 
 #[cfg(target_pointer_width = "64")]
-const TS_MAX_SECONDS: i64 = (::std::i64::MAX / NANOS_PER_SEC) - 1;
+const TS_MAX_SECONDS: i64 = (i64::MAX / NANOS_PER_SEC) - 1;
 
 #[cfg(target_pointer_width = "32")]
 const TS_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
@@ -453,7 +453,7 @@ pub struct TimeVal(timeval);
 const MICROS_PER_SEC: i64 = 1_000_000;
 
 #[cfg(target_pointer_width = "64")]
-const TV_MAX_SECONDS: i64 = (::std::i64::MAX / MICROS_PER_SEC) - 1;
+const TV_MAX_SECONDS: i64 = (i64::MAX / MICROS_PER_SEC) - 1;
 
 #[cfg(target_pointer_width = "32")]
 const TV_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
@@ -713,7 +713,7 @@ mod test {
 
     #[test]
     pub fn test_timespec() {
-        assert!(TimeSpec::seconds(1) != TimeSpec::zero());
+        assert_ne!(TimeSpec::seconds(1), TimeSpec::zero());
         assert_eq!(
             TimeSpec::seconds(1) + TimeSpec::seconds(2),
             TimeSpec::seconds(3)
@@ -743,7 +743,7 @@ mod test {
 
     #[test]
     pub fn test_timespec_ord() {
-        assert!(TimeSpec::seconds(1) == TimeSpec::nanoseconds(1_000_000_000));
+        assert_eq!(TimeSpec::seconds(1), TimeSpec::nanoseconds(1_000_000_000));
         assert!(TimeSpec::seconds(1) < TimeSpec::nanoseconds(1_000_000_001));
         assert!(TimeSpec::seconds(1) > TimeSpec::nanoseconds(999_999_999));
         assert!(TimeSpec::seconds(-1) < TimeSpec::nanoseconds(-999_999_999));
@@ -765,7 +765,7 @@ mod test {
 
     #[test]
     pub fn test_timeval() {
-        assert!(TimeVal::seconds(1) != TimeVal::zero());
+        assert_ne!(TimeVal::seconds(1), TimeVal::zero());
         assert_eq!(
             TimeVal::seconds(1) + TimeVal::seconds(2),
             TimeVal::seconds(3)
@@ -778,7 +778,7 @@ mod test {
 
     #[test]
     pub fn test_timeval_ord() {
-        assert!(TimeVal::seconds(1) == TimeVal::microseconds(1_000_000));
+        assert_eq!(TimeVal::seconds(1), TimeVal::microseconds(1_000_000));
         assert!(TimeVal::seconds(1) < TimeVal::microseconds(1_000_001));
         assert!(TimeVal::seconds(1) > TimeVal::microseconds(999_999));
         assert!(TimeVal::seconds(-1) < TimeVal::microseconds(-999_999));

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -196,7 +196,7 @@ const SECS_PER_HOUR: i64 = 3600;
 const TS_MAX_SECONDS: i64 = (i64::MAX / NANOS_PER_SEC) - 1;
 
 #[cfg(target_pointer_width = "32")]
-const TS_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
+const TS_MAX_SECONDS: i64 = isize::MAX as i64;
 
 const TS_MIN_SECONDS: i64 = -TS_MAX_SECONDS;
 
@@ -456,7 +456,7 @@ const MICROS_PER_SEC: i64 = 1_000_000;
 const TV_MAX_SECONDS: i64 = (i64::MAX / MICROS_PER_SEC) - 1;
 
 #[cfg(target_pointer_width = "32")]
-const TV_MAX_SECONDS: i64 = ::std::isize::MAX as i64;
+const TV_MAX_SECONDS: i64 = isize::MAX as i64;
 
 const TV_MIN_SECONDS: i64 = -TV_MAX_SECONDS;
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -7,15 +7,15 @@ use crate::fcntl::{at_rawfd, AtFlags};
 #[cfg(feature = "fs")]
 use crate::fcntl::{fcntl, FcntlArg::F_SETFD, FdFlag, OFlag};
 #[cfg(all(
-feature = "fs",
-any(
-target_os = "openbsd",
-target_os = "netbsd",
-target_os = "freebsd",
-target_os = "dragonfly",
-target_os = "macos",
-target_os = "ios"
-)
+    feature = "fs",
+    any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios"
+    )
 ))]
 use crate::sys::stat::FileFlag;
 #[cfg(feature = "fs")]
@@ -45,20 +45,20 @@ feature! {
 }
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 pub use self::setres::*;
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 pub use self::getres::*;
 
@@ -2752,11 +2752,11 @@ mod pivot_root {
 }
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 mod setres {
     feature! {
@@ -2801,11 +2801,11 @@ mod setres {
 }
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 mod getres {
     feature! {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -7,15 +7,15 @@ use crate::fcntl::{at_rawfd, AtFlags};
 #[cfg(feature = "fs")]
 use crate::fcntl::{fcntl, FcntlArg::F_SETFD, FdFlag, OFlag};
 #[cfg(all(
-    feature = "fs",
-    any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios"
-    )
+feature = "fs",
+any(
+target_os = "openbsd",
+target_os = "netbsd",
+target_os = "freebsd",
+target_os = "dragonfly",
+target_os = "macos",
+target_os = "ios"
+)
 ))]
 use crate::sys::stat::FileFlag;
 #[cfg(feature = "fs")]
@@ -45,20 +45,20 @@ feature! {
 }
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 pub use self::setres::*;
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 pub use self::getres::*;
 
@@ -1572,7 +1572,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
 /// # use std::error::Error;
 /// # use nix::unistd::*;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// let uid = Uid::from_raw(33);
 /// let gid = Gid::from_raw(34);
 /// setgroups(&[gid])?;
@@ -1698,7 +1698,7 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
 /// # use std::ffi::CString;
 /// # use nix::unistd::*;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// let user = CString::new("www-data").unwrap();
 /// let uid = Uid::from_raw(33);
 /// let gid = Gid::from_raw(33);
@@ -2752,11 +2752,11 @@ mod pivot_root {
 }
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 mod setres {
     feature! {
@@ -2801,11 +2801,11 @@ mod setres {
 }
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 mod getres {
     feature! {
@@ -3121,7 +3121,7 @@ impl User {
     /// use nix::unistd::{Uid, User};
     /// // Returns an Result<Option<User>>, thus the double unwrap.
     /// let res = User::from_uid(Uid::from_raw(0)).unwrap().unwrap();
-    /// assert!(res.name == "root");
+    /// assert_eq!(res.name, "root");
     /// ```
     pub fn from_uid(uid: Uid) -> Result<Option<Self>> {
         User::from_anything(|pwd, cbuf, cap, res| {
@@ -3140,7 +3140,7 @@ impl User {
     /// use nix::unistd::User;
     /// // Returns an Result<Option<User>>, thus the double unwrap.
     /// let res = User::from_name("root").unwrap().unwrap();
-    /// assert!(res.name == "root");
+    /// assert_eq!(res.name, "root");
     /// ```
     pub fn from_name(name: &str) -> Result<Option<Self>> {
         let name = CString::new(name).unwrap();

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -11,7 +11,7 @@ fn test_pthread_self() {
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();
-    assert!(tid != 0);
+    assert_ne!(tid, 0);
 }
 
 #[test]

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -1,7 +1,7 @@
 #[cfg(all(
-    target_os = "linux",
-    any(target_arch = "x86_64", target_arch = "x86"),
-    target_env = "gnu"
+target_os = "linux",
+any(target_arch = "x86_64", target_arch = "x86"),
+target_env = "gnu"
 ))]
 use memoffset::offset_of;
 use nix::errno::Errno;
@@ -33,7 +33,7 @@ fn test_ptrace_setoptions() {
     require_capability!("test_ptrace_setoptions", CAP_SYS_PTRACE);
     let err = ptrace::setoptions(getpid(), Options::PTRACE_O_TRACESYSGOOD)
         .unwrap_err();
-    assert!(err != Errno::EOPNOTSUPP);
+    assert_ne!(err, Errno::EOPNOTSUPP);
 }
 
 // Just make sure ptrace_getevent can be called at all, for now.
@@ -42,7 +42,7 @@ fn test_ptrace_setoptions() {
 fn test_ptrace_getevent() {
     require_capability!("test_ptrace_getevent", CAP_SYS_PTRACE);
     let err = ptrace::getevent(getpid()).unwrap_err();
-    assert!(err != Errno::EOPNOTSUPP);
+    assert_ne!(err, Errno::EOPNOTSUPP);
 }
 
 // Just make sure ptrace_getsiginfo can be called at all, for now.
@@ -111,17 +111,17 @@ fn test_ptrace_cont() {
             ptrace::cont(child, Some(Signal::SIGKILL)).unwrap();
             match waitpid(child, None) {
                 Ok(WaitStatus::Signaled(pid, Signal::SIGKILL, _))
-                    if pid == child =>
-                {
-                    // FIXME It's been observed on some systems (apple) the
-                    // tracee may not be killed but remain as a zombie process
-                    // affecting other wait based tests. Add an extra kill just
-                    // to make sure there are no zombies.
-                    let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
-                    while ptrace::cont(child, Some(Signal::SIGKILL)).is_ok() {
+                if pid == child =>
+                    {
+                        // FIXME It's been observed on some systems (apple) the
+                        // tracee may not be killed but remain as a zombie process
+                        // affecting other wait based tests. Add an extra kill just
+                        // to make sure there are no zombies.
                         let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                        while ptrace::cont(child, Some(Signal::SIGKILL)).is_ok() {
+                            let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                        }
                     }
-                }
                 _ => panic!("The process should have been killed"),
             }
         }
@@ -163,13 +163,13 @@ fn test_ptrace_interrupt() {
             ptrace::detach(child, Some(Signal::SIGKILL)).unwrap();
             match waitpid(child, None) {
                 Ok(WaitStatus::Signaled(pid, Signal::SIGKILL, _))
-                    if pid == child =>
-                {
-                    let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
-                    while ptrace::cont(child, Some(Signal::SIGKILL)).is_ok() {
+                if pid == child =>
+                    {
                         let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                        while ptrace::cont(child, Some(Signal::SIGKILL)).is_ok() {
+                            let _ = waitpid(child, Some(WaitPidFlag::WNOHANG));
+                        }
                     }
-                }
                 _ => panic!("The process should have been killed"),
             }
         }
@@ -178,9 +178,9 @@ fn test_ptrace_interrupt() {
 
 // ptrace::{setoptions, getregs} are only available in these platforms
 #[cfg(all(
-    target_os = "linux",
-    any(target_arch = "x86_64", target_arch = "x86"),
-    target_env = "gnu"
+target_os = "linux",
+any(target_arch = "x86_64", target_arch = "x86"),
+target_env = "gnu"
 ))]
 #[test]
 fn test_ptrace_syscall() {
@@ -219,18 +219,18 @@ fn test_ptrace_syscall() {
                 .unwrap();
 
             #[cfg(target_arch = "x86_64")]
-            let get_syscall_id =
+                let get_syscall_id =
                 || ptrace::getregs(child).unwrap().orig_rax as libc::c_long;
 
             #[cfg(target_arch = "x86")]
-            let get_syscall_id =
+                let get_syscall_id =
                 || ptrace::getregs(child).unwrap().orig_eax as libc::c_long;
 
             // this duplicates `get_syscall_id` for the purpose of testing `ptrace::read_user`.
             #[cfg(target_arch = "x86_64")]
-            let rax_offset = offset_of!(libc::user_regs_struct, orig_rax);
+                let rax_offset = offset_of!(libc::user_regs_struct, orig_rax);
             #[cfg(target_arch = "x86")]
-            let rax_offset = offset_of!(libc::user_regs_struct, orig_eax);
+                let rax_offset = offset_of!(libc::user_regs_struct, orig_eax);
 
             let get_syscall_from_user_area = || {
                 // Find the offset of `user.regs.rax` (or `user.regs.eax` for x86)

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -20,7 +20,7 @@ fn flags() -> OFlag {
 fn read() {
     let tmp = tempdir().unwrap();
     File::create(&tmp.path().join("foo")).unwrap();
-    ::std::os::unix::fs::symlink("foo", tmp.path().join("bar")).unwrap();
+    std::os::unix::fs::symlink("foo", tmp.path().join("bar")).unwrap();
     let mut dir = Dir::open(tmp.path(), flags(), Mode::empty()).unwrap();
     let mut entries: Vec<_> = dir.iter().map(|e| e.unwrap()).collect();
     entries.sort_by(|a, b| a.file_name().cmp(b.file_name()));

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -58,7 +58,7 @@ fn test_ptsname_copy() {
     assert_eq!(slave_name1, slave_name2);
     // Also make sure that the string was actually copied and they point to different parts of
     // memory.
-    assert!(slave_name1.as_ptr() != slave_name2.as_ptr());
+    assert_ne!(slave_name1.as_ptr(), slave_name2.as_ptr());
 }
 
 /// Test data copying of `ptsname_r`
@@ -73,7 +73,7 @@ fn test_ptsname_r_copy() {
     let slave_name1 = ptsname_r(&master_fd).unwrap();
     let slave_name2 = ptsname_r(&master_fd).unwrap();
     assert_eq!(slave_name1, slave_name2);
-    assert!(slave_name1.as_ptr() != slave_name2.as_ptr());
+    assert_ne!(slave_name1.as_ptr(), slave_name2.as_ptr());
 }
 
 /// Test that `ptsname` returns different names for different devices
@@ -93,7 +93,7 @@ fn test_ptsname_unique() {
     // Get the name of the slave
     let slave_name1 = unsafe { ptsname(&master1_fd) }.unwrap();
     let slave_name2 = unsafe { ptsname(&master2_fd) }.unwrap();
-    assert!(slave_name1 != slave_name2);
+    assert_ne!(slave_name1, slave_name2);
 }
 
 /// Common setup for testing PTTY pairs

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -20,11 +20,11 @@ use nix::errno::Errno;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl;
 #[cfg(any(
-    target_os = "linux",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "freebsd",
-    target_os = "netbsd"
+target_os = "linux",
+target_os = "ios",
+target_os = "macos",
+target_os = "freebsd",
+target_os = "netbsd"
 ))]
 use nix::sys::stat::lutimes;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
@@ -234,11 +234,11 @@ fn test_utimes() {
 
 #[test]
 #[cfg(any(
-    target_os = "linux",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "freebsd",
-    target_os = "netbsd"
+target_os = "linux",
+target_os = "ios",
+target_os = "macos",
+target_os = "freebsd",
+target_os = "netbsd"
 ))]
 fn test_lutimes() {
     let tempdir = tempfile::tempdir().unwrap();
@@ -299,7 +299,7 @@ fn test_utimensat() {
         &TimeSpec::seconds(678),
         UtimensatFlags::FollowSymlink,
     )
-    .unwrap();
+        .unwrap();
     assert_times_eq(12345, 678, &fs::metadata(&fullpath).unwrap());
 
     chdir(tempdir.path()).unwrap();
@@ -311,7 +311,7 @@ fn test_utimensat() {
         &TimeSpec::seconds(800),
         UtimensatFlags::FollowSymlink,
     )
-    .unwrap();
+        .unwrap();
     assert_times_eq(500, 800, &fs::metadata(&fullpath).unwrap());
 }
 
@@ -356,19 +356,19 @@ fn test_mkdirat_fail() {
         fcntl::OFlag::O_CREAT,
         stat::Mode::empty(),
     )
-    .unwrap();
+        .unwrap();
     let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
     assert_eq!(result, Errno::ENOTDIR);
 }
 
 #[test]
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "haiku",
-    target_os = "redox"
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "ios",
+target_os = "macos",
+target_os = "haiku",
+target_os = "redox"
 )))]
 fn test_mknod() {
     use stat::{lstat, mknod, SFlag};
@@ -378,19 +378,19 @@ fn test_mknod() {
     let target = tempdir.path().join(file_name);
     mknod(&target, SFlag::S_IFREG, Mode::S_IRWXU, 0).unwrap();
     let mode = lstat(&target).unwrap().st_mode as mode_t;
-    assert!(mode & libc::S_IFREG == libc::S_IFREG);
-    assert!(mode & libc::S_IRWXU == libc::S_IRWXU);
+    assert_eq!(mode & libc::S_IFREG, libc::S_IFREG);
+    assert_eq!(mode & libc::S_IRWXU, libc::S_IRWXU);
 }
 
 #[test]
 #[cfg(not(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "haiku",
-    target_os = "redox"
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "illumos",
+target_os = "ios",
+target_os = "macos",
+target_os = "haiku",
+target_os = "redox"
 )))]
 fn test_mknodat() {
     use fcntl::{AtFlags, OFlag};
@@ -408,14 +408,14 @@ fn test_mknodat() {
         Mode::S_IRWXU,
         0,
     )
-    .unwrap();
+        .unwrap();
     let mode = fstatat(
         target_dir.as_raw_fd(),
         file_name,
         AtFlags::AT_SYMLINK_NOFOLLOW,
     )
-    .unwrap()
-    .st_mode as mode_t;
-    assert!(mode & libc::S_IFREG == libc::S_IFREG);
-    assert!(mode & libc::S_IRWXU == libc::S_IRWXU);
+        .unwrap()
+        .st_mode as mode_t;
+    assert_eq!(mode & libc::S_IFREG, libc::S_IFREG);
+    assert_eq!(mode & libc::S_IRWXU, libc::S_IRWXU);
 }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -20,11 +20,11 @@ use nix::errno::Errno;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl;
 #[cfg(any(
-target_os = "linux",
-target_os = "ios",
-target_os = "macos",
-target_os = "freebsd",
-target_os = "netbsd"
+    target_os = "linux",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd"
 ))]
 use nix::sys::stat::lutimes;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
@@ -234,11 +234,11 @@ fn test_utimes() {
 
 #[test]
 #[cfg(any(
-target_os = "linux",
-target_os = "ios",
-target_os = "macos",
-target_os = "freebsd",
-target_os = "netbsd"
+    target_os = "linux",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd"
 ))]
 fn test_lutimes() {
     let tempdir = tempfile::tempdir().unwrap();
@@ -299,7 +299,7 @@ fn test_utimensat() {
         &TimeSpec::seconds(678),
         UtimensatFlags::FollowSymlink,
     )
-        .unwrap();
+    .unwrap();
     assert_times_eq(12345, 678, &fs::metadata(&fullpath).unwrap());
 
     chdir(tempdir.path()).unwrap();
@@ -311,7 +311,7 @@ fn test_utimensat() {
         &TimeSpec::seconds(800),
         UtimensatFlags::FollowSymlink,
     )
-        .unwrap();
+    .unwrap();
     assert_times_eq(500, 800, &fs::metadata(&fullpath).unwrap());
 }
 
@@ -356,19 +356,19 @@ fn test_mkdirat_fail() {
         fcntl::OFlag::O_CREAT,
         stat::Mode::empty(),
     )
-        .unwrap();
+    .unwrap();
     let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
     assert_eq!(result, Errno::ENOTDIR);
 }
 
 #[test]
 #[cfg(not(any(
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "ios",
-target_os = "macos",
-target_os = "haiku",
-target_os = "redox"
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "haiku",
+    target_os = "redox"
 )))]
 fn test_mknod() {
     use stat::{lstat, mknod, SFlag};
@@ -384,13 +384,13 @@ fn test_mknod() {
 
 #[test]
 #[cfg(not(any(
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "illumos",
-target_os = "ios",
-target_os = "macos",
-target_os = "haiku",
-target_os = "redox"
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "haiku",
+    target_os = "redox"
 )))]
 fn test_mknodat() {
     use fcntl::{AtFlags, OFlag};
@@ -408,14 +408,14 @@ fn test_mknodat() {
         Mode::S_IRWXU,
         0,
     )
-        .unwrap();
+    .unwrap();
     let mode = fstatat(
         target_dir.as_raw_fd(),
         file_name,
         AtFlags::AT_SYMLINK_NOFOLLOW,
     )
-        .unwrap()
-        .st_mode as mode_t;
+    .unwrap()
+    .st_mode as mode_t;
     assert_eq!(mode & libc::S_IFREG, libc::S_IFREG);
     assert_eq!(mode & libc::S_IRWXU, libc::S_IRWXU);
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -6,9 +6,9 @@ use nix::fcntl::OFlag;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl::{self, open};
 #[cfg(not(any(
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku"
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku"
 )))]
 use nix::pty::{grantpt, posix_openpt, ptsname, unlockpt};
 #[cfg(not(target_os = "redox"))]
@@ -28,9 +28,9 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::os::unix::prelude::*;
 #[cfg(not(any(
-target_os = "fuchsia",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 use std::path::Path;
 use tempfile::{tempdir, tempfile};
@@ -126,11 +126,11 @@ fn test_mkfifo_directory() {
 
 #[test]
 #[cfg(not(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "android",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 fn test_mkfifoat_none() {
     let _m = crate::CWD_LOCK.read();
@@ -147,11 +147,11 @@ fn test_mkfifoat_none() {
 
 #[test]
 #[cfg(not(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "android",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 fn test_mkfifoat() {
     use nix::fcntl;
@@ -170,11 +170,11 @@ fn test_mkfifoat() {
 
 #[test]
 #[cfg(not(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "android",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 fn test_mkfifoat_directory_none() {
     let _m = crate::CWD_LOCK.read();
@@ -186,11 +186,11 @@ fn test_mkfifoat_directory_none() {
 
 #[test]
 #[cfg(not(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "android",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 fn test_mkfifoat_directory() {
     // mkfifoat should fail if a directory is given
@@ -234,11 +234,11 @@ mod linux_android {
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
 #[cfg(not(any(
-target_os = "ios",
-target_os = "macos",
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku"
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku"
 )))]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
@@ -263,12 +263,12 @@ fn test_setgroups() {
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
 #[cfg(not(any(
-target_os = "ios",
-target_os = "macos",
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku",
-target_os = "illumos"
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "illumos"
 )))]
 fn test_initgroups() {
     // Skip this test when not run as root as `initgroups()` and `setgroups()`
@@ -609,9 +609,9 @@ cfg_if! {
 
 #[test]
 #[cfg(not(any(
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku"
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku"
 )))]
 fn test_acct() {
     use std::process::Command;
@@ -685,11 +685,11 @@ fn test_sysconf_unsupported() {
 }
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 #[test]
 fn test_getresuid() {
@@ -700,11 +700,11 @@ fn test_getresuid() {
 }
 
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "freebsd",
-target_os = "linux",
-target_os = "openbsd"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "openbsd"
 ))]
 #[test]
 fn test_getresgid() {
@@ -733,16 +733,16 @@ fn test_pipe() {
 // pipe2(2) is the same as pipe(2), except it allows setting some flags.  Check
 // that we can set a flag.
 #[cfg(any(
-target_os = "android",
-target_os = "dragonfly",
-target_os = "emscripten",
-target_os = "freebsd",
-target_os = "illumos",
-target_os = "linux",
-target_os = "netbsd",
-target_os = "openbsd",
-target_os = "redox",
-target_os = "solaris"
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris"
 ))]
 #[test]
 fn test_pipe2() {
@@ -918,7 +918,7 @@ fn test_linkat_file() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-        .unwrap();
+    .unwrap();
     assert!(newfilepath.exists());
 }
 
@@ -944,7 +944,7 @@ fn test_linkat_olddirfd_none() {
         fcntl::OFlag::empty(),
         stat::Mode::empty(),
     )
-        .unwrap();
+    .unwrap();
 
     // Attempt hard link file using curent working directory as relative path for old file path
     chdir(tempdir_oldfile.path()).unwrap();
@@ -955,7 +955,7 @@ fn test_linkat_olddirfd_none() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-        .unwrap();
+    .unwrap();
     assert!(newfilepath.exists());
 }
 
@@ -981,7 +981,7 @@ fn test_linkat_newdirfd_none() {
         fcntl::OFlag::empty(),
         stat::Mode::empty(),
     )
-        .unwrap();
+    .unwrap();
 
     // Attempt hard link file using current working directory as relative path for new file path
     chdir(tempdir_newfile.path()).unwrap();
@@ -992,16 +992,16 @@ fn test_linkat_newdirfd_none() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-        .unwrap();
+    .unwrap();
     assert!(newfilepath.exists());
 }
 
 #[test]
 #[cfg(not(any(
-target_os = "ios",
-target_os = "macos",
-target_os = "redox",
-target_os = "haiku"
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "redox",
+    target_os = "haiku"
 )))]
 fn test_linkat_no_follow_symlink() {
     let _m = crate::CWD_LOCK.read();
@@ -1035,7 +1035,7 @@ fn test_linkat_no_follow_symlink() {
         newfilename,
         LinkatFlags::NoSymlinkFollow,
     )
-        .unwrap();
+    .unwrap();
 
     // Assert newfile is actually a symlink to oldfile.
     assert_eq!(
@@ -1078,7 +1078,7 @@ fn test_linkat_follow_symlink() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-        .unwrap();
+    .unwrap();
 
     let newfilestat = stat::stat(&newfilepath).unwrap();
 
@@ -1180,10 +1180,10 @@ fn test_access_file_exists() {
 fn test_user_into_passwd() {
     // get the UID of the "nobody" user
     #[cfg(not(target_os = "haiku"))]
-        let test_username = "nobody";
+    let test_username = "nobody";
     // "nobody" unavailable on haiku
     #[cfg(target_os = "haiku")]
-        let test_username = "user";
+    let test_username = "user";
 
     let nobody = User::from_name(test_username).unwrap().unwrap();
     let pwd: libc::passwd = nobody.into();
@@ -1221,8 +1221,8 @@ fn test_setfsuid() {
         let prev_fuid = setfsuid(Uid::from_raw(-1i32 as u32));
         assert_ne!(prev_fuid, fuid);
     })
-        .join()
-        .unwrap();
+    .join()
+    .unwrap();
 
     // open the temporary file with the current thread filesystem UID
     fs::File::open(temp_path_2).unwrap();
@@ -1230,9 +1230,9 @@ fn test_setfsuid() {
 
 #[test]
 #[cfg(not(any(
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku"
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku"
 )))]
 fn test_ttyname() {
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
@@ -1262,9 +1262,9 @@ fn test_ttyname_not_pty() {
 
 #[test]
 #[cfg(not(any(
-target_os = "redox",
-target_os = "fuchsia",
-target_os = "haiku"
+    target_os = "redox",
+    target_os = "fuchsia",
+    target_os = "haiku"
 )))]
 fn test_ttyname_invalid_fd() {
     assert_eq!(ttyname(-1), Err(Errno::EBADF));
@@ -1272,12 +1272,12 @@ fn test_ttyname_invalid_fd() {
 
 #[test]
 #[cfg(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "freebsd",
-target_os = "openbsd",
-target_os = "netbsd",
-target_os = "dragonfly",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
 ))]
 fn test_getpeereid() {
     use std::os::unix::net::UnixStream;
@@ -1297,12 +1297,12 @@ fn test_getpeereid() {
 
 #[test]
 #[cfg(any(
-target_os = "macos",
-target_os = "ios",
-target_os = "freebsd",
-target_os = "openbsd",
-target_os = "netbsd",
-target_os = "dragonfly",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
 ))]
 fn test_getpeereid_invalid_fd() {
     // getpeereid is not POSIX, so error codes are inconsistent between different Unices.
@@ -1337,8 +1337,8 @@ fn test_faccessat_not_existing() {
             AccessFlags::F_OK,
             AtFlags::empty(),
         )
-            .err()
-            .unwrap(),
+        .err()
+        .unwrap(),
         Errno::ENOENT
     );
 }
@@ -1356,7 +1356,7 @@ fn test_faccessat_none_file_exists() {
         AccessFlags::R_OK | AccessFlags::W_OK,
         AtFlags::empty(),
     )
-        .is_ok());
+    .is_ok());
 }
 
 #[test]
@@ -1374,5 +1374,5 @@ fn test_faccessat_file_exists() {
         AccessFlags::R_OK | AccessFlags::W_OK,
         AtFlags::empty(),
     )
-        .is_ok());
+    .is_ok());
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -6,9 +6,9 @@ use nix::fcntl::OFlag;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl::{self, open};
 #[cfg(not(any(
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku"
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku"
 )))]
 use nix::pty::{grantpt, posix_openpt, ptsname, unlockpt};
 #[cfg(not(target_os = "redox"))]
@@ -28,9 +28,9 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::os::unix::prelude::*;
 #[cfg(not(any(
-    target_os = "fuchsia",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "fuchsia",
+target_os = "redox",
+target_os = "haiku"
 )))]
 use std::path::Path;
 use tempfile::{tempdir, tempfile};
@@ -114,7 +114,7 @@ fn test_mkfifo() {
 
     let stats = stat::stat(&mkfifo_fifo).unwrap();
     let typ = stat::SFlag::from_bits_truncate(stats.st_mode as mode_t);
-    assert!(typ == SFlag::S_IFIFO);
+    assert_eq!(typ, SFlag::S_IFIFO);
 }
 
 #[test]
@@ -126,11 +126,11 @@ fn test_mkfifo_directory() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "macos",
+target_os = "ios",
+target_os = "android",
+target_os = "redox",
+target_os = "haiku"
 )))]
 fn test_mkfifoat_none() {
     let _m = crate::CWD_LOCK.read();
@@ -147,11 +147,11 @@ fn test_mkfifoat_none() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "macos",
+target_os = "ios",
+target_os = "android",
+target_os = "redox",
+target_os = "haiku"
 )))]
 fn test_mkfifoat() {
     use nix::fcntl;
@@ -170,11 +170,11 @@ fn test_mkfifoat() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "macos",
+target_os = "ios",
+target_os = "android",
+target_os = "redox",
+target_os = "haiku"
 )))]
 fn test_mkfifoat_directory_none() {
     let _m = crate::CWD_LOCK.read();
@@ -186,11 +186,11 @@ fn test_mkfifoat_directory_none() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "macos",
+target_os = "ios",
+target_os = "android",
+target_os = "redox",
+target_os = "haiku"
 )))]
 fn test_mkfifoat_directory() {
     // mkfifoat should fail if a directory is given
@@ -234,11 +234,11 @@ mod linux_android {
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
 #[cfg(not(any(
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku"
+target_os = "ios",
+target_os = "macos",
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku"
 )))]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
@@ -263,12 +263,12 @@ fn test_setgroups() {
 #[test]
 // `getgroups()` and `setgroups()` do not behave as expected on Apple platforms
 #[cfg(not(any(
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku",
-    target_os = "illumos"
+target_os = "ios",
+target_os = "macos",
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku",
+target_os = "illumos"
 )))]
 fn test_initgroups() {
     // Skip this test when not run as root as `initgroups()` and `setgroups()`
@@ -300,7 +300,7 @@ fn test_initgroups() {
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
-macro_rules! execve_test_factory(
+macro_rules! execve_test_factory (
     ($test_name:ident, $syscall:ident, $exe: expr $(, $pathname:expr, $flags:expr)*) => (
 
     #[cfg(test)]
@@ -609,9 +609,9 @@ cfg_if! {
 
 #[test]
 #[cfg(not(any(
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku"
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku"
 )))]
 fn test_acct() {
     use std::process::Command;
@@ -685,33 +685,33 @@ fn test_sysconf_unsupported() {
 }
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 #[test]
 fn test_getresuid() {
     let resuids = getresuid().unwrap();
-    assert!(resuids.real.as_raw() != libc::uid_t::max_value());
-    assert!(resuids.effective.as_raw() != libc::uid_t::max_value());
-    assert!(resuids.saved.as_raw() != libc::uid_t::max_value());
+    assert_ne!(resuids.real.as_raw(), libc::uid_t::MAX);
+    assert_ne!(resuids.effective.as_raw(), libc::uid_t::MAX);
+    assert_ne!(resuids.saved.as_raw(), libc::uid_t::MAX);
 }
 
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "openbsd"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "freebsd",
+target_os = "linux",
+target_os = "openbsd"
 ))]
 #[test]
 fn test_getresgid() {
     let resgids = getresgid().unwrap();
-    assert!(resgids.real.as_raw() != libc::gid_t::max_value());
-    assert!(resgids.effective.as_raw() != libc::gid_t::max_value());
-    assert!(resgids.saved.as_raw() != libc::gid_t::max_value());
+    assert_ne!(resgids.real.as_raw(), libc::gid_t::MAX);
+    assert_ne!(resgids.effective.as_raw(), libc::gid_t::MAX);
+    assert_ne!(resgids.saved.as_raw(), libc::gid_t::MAX);
 }
 
 // Test that we can create a pair of pipes.  No need to verify that they pass
@@ -733,16 +733,16 @@ fn test_pipe() {
 // pipe2(2) is the same as pipe(2), except it allows setting some flags.  Check
 // that we can set a flag.
 #[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris"
+target_os = "android",
+target_os = "dragonfly",
+target_os = "emscripten",
+target_os = "freebsd",
+target_os = "illumos",
+target_os = "linux",
+target_os = "netbsd",
+target_os = "openbsd",
+target_os = "redox",
+target_os = "solaris"
 ))]
 #[test]
 fn test_pipe2() {
@@ -918,7 +918,7 @@ fn test_linkat_file() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-    .unwrap();
+        .unwrap();
     assert!(newfilepath.exists());
 }
 
@@ -944,7 +944,7 @@ fn test_linkat_olddirfd_none() {
         fcntl::OFlag::empty(),
         stat::Mode::empty(),
     )
-    .unwrap();
+        .unwrap();
 
     // Attempt hard link file using curent working directory as relative path for old file path
     chdir(tempdir_oldfile.path()).unwrap();
@@ -955,7 +955,7 @@ fn test_linkat_olddirfd_none() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-    .unwrap();
+        .unwrap();
     assert!(newfilepath.exists());
 }
 
@@ -981,7 +981,7 @@ fn test_linkat_newdirfd_none() {
         fcntl::OFlag::empty(),
         stat::Mode::empty(),
     )
-    .unwrap();
+        .unwrap();
 
     // Attempt hard link file using current working directory as relative path for new file path
     chdir(tempdir_newfile.path()).unwrap();
@@ -992,16 +992,16 @@ fn test_linkat_newdirfd_none() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-    .unwrap();
+        .unwrap();
     assert!(newfilepath.exists());
 }
 
 #[test]
 #[cfg(not(any(
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "redox",
-    target_os = "haiku"
+target_os = "ios",
+target_os = "macos",
+target_os = "redox",
+target_os = "haiku"
 )))]
 fn test_linkat_no_follow_symlink() {
     let _m = crate::CWD_LOCK.read();
@@ -1035,7 +1035,7 @@ fn test_linkat_no_follow_symlink() {
         newfilename,
         LinkatFlags::NoSymlinkFollow,
     )
-    .unwrap();
+        .unwrap();
 
     // Assert newfile is actually a symlink to oldfile.
     assert_eq!(
@@ -1078,7 +1078,7 @@ fn test_linkat_follow_symlink() {
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
-    .unwrap();
+        .unwrap();
 
     let newfilestat = stat::stat(&newfilepath).unwrap();
 
@@ -1180,10 +1180,10 @@ fn test_access_file_exists() {
 fn test_user_into_passwd() {
     // get the UID of the "nobody" user
     #[cfg(not(target_os = "haiku"))]
-    let test_username = "nobody";
+        let test_username = "nobody";
     // "nobody" unavailable on haiku
     #[cfg(target_os = "haiku")]
-    let test_username = "user";
+        let test_username = "user";
 
     let nobody = User::from_name(test_username).unwrap().unwrap();
     let pwd: libc::passwd = nobody.into();
@@ -1221,8 +1221,8 @@ fn test_setfsuid() {
         let prev_fuid = setfsuid(Uid::from_raw(-1i32 as u32));
         assert_ne!(prev_fuid, fuid);
     })
-    .join()
-    .unwrap();
+        .join()
+        .unwrap();
 
     // open the temporary file with the current thread filesystem UID
     fs::File::open(temp_path_2).unwrap();
@@ -1230,9 +1230,9 @@ fn test_setfsuid() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku"
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku"
 )))]
 fn test_ttyname() {
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
@@ -1262,9 +1262,9 @@ fn test_ttyname_not_pty() {
 
 #[test]
 #[cfg(not(any(
-    target_os = "redox",
-    target_os = "fuchsia",
-    target_os = "haiku"
+target_os = "redox",
+target_os = "fuchsia",
+target_os = "haiku"
 )))]
 fn test_ttyname_invalid_fd() {
     assert_eq!(ttyname(-1), Err(Errno::EBADF));
@@ -1272,12 +1272,12 @@ fn test_ttyname_invalid_fd() {
 
 #[test]
 #[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "freebsd",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "dragonfly",
+target_os = "macos",
+target_os = "ios",
+target_os = "freebsd",
+target_os = "openbsd",
+target_os = "netbsd",
+target_os = "dragonfly",
 ))]
 fn test_getpeereid() {
     use std::os::unix::net::UnixStream;
@@ -1297,12 +1297,12 @@ fn test_getpeereid() {
 
 #[test]
 #[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "freebsd",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "dragonfly",
+target_os = "macos",
+target_os = "ios",
+target_os = "freebsd",
+target_os = "openbsd",
+target_os = "netbsd",
+target_os = "dragonfly",
 ))]
 fn test_getpeereid_invalid_fd() {
     // getpeereid is not POSIX, so error codes are inconsistent between different Unices.
@@ -1335,10 +1335,10 @@ fn test_faccessat_not_existing() {
             Some(dirfd),
             not_exist_file,
             AccessFlags::F_OK,
-            AtFlags::empty()
+            AtFlags::empty(),
         )
-        .err()
-        .unwrap(),
+            .err()
+            .unwrap(),
         Errno::ENOENT
     );
 }
@@ -1354,9 +1354,9 @@ fn test_faccessat_none_file_exists() {
         None,
         &path,
         AccessFlags::R_OK | AccessFlags::W_OK,
-        AtFlags::empty()
+        AtFlags::empty(),
     )
-    .is_ok());
+        .is_ok());
 }
 
 #[test]
@@ -1372,7 +1372,7 @@ fn test_faccessat_file_exists() {
         Some(dirfd),
         &path,
         AccessFlags::R_OK | AccessFlags::W_OK,
-        AtFlags::empty()
+        AtFlags::empty(),
     )
-    .is_ok());
+        .is_ok());
 }


### PR DESCRIPTION
#### What this pr does
1. Convert `assert!(x == y)` to `assert_eq!(x, y)`
2. Convert `assert!(x != y)` to `assert_ne!(x, y)`
3. Add `.unwrap()` to unused `Result/Option` (in code comments)
4. Convert `std::ixx::MAX` to `ixx::MAX`
5. Convert `Box<Trait>` to `Box<dyn Trait>`