### PR TITLE
issue1787: make FileStat a wrapper type

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -329,7 +329,7 @@ fn inner_readlink<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P) -> Result
         Some(dirfd) => super::sys::stat::fstatat(dirfd, path, AtFlags::AT_SYMLINK_NOFOLLOW),
         None => super::sys::stat::lstat(path)
     }
-        .map(|x| x.st_size)
+        .map(|x| x.size())
         .unwrap_or(0);
     let mut try_size = if reported_size > 0 {
         // Note: even if `lstat`'s apparently valid answer turns out to be

--- a/test/sys/test_stat.rs
+++ b/test/sys/test_stat.rs
@@ -10,18 +10,14 @@ fn test_chflags() {
 
     let f = NamedTempFile::new().unwrap();
 
-    let initial = FileFlag::from_bits_truncate(
-        fstat(f.as_raw_fd()).unwrap().st_flags.into(),
-    );
+    let initial = fstat(f.as_raw_fd()).unwrap().flags();
     // UF_OFFLINE is preserved by all FreeBSD file systems, but not interpreted
     // in any way, so it's handy for testing.
     let commanded = initial ^ FileFlag::UF_OFFLINE;
 
     chflags(f.path(), commanded).unwrap();
 
-    let changed = FileFlag::from_bits_truncate(
-        fstat(f.as_raw_fd()).unwrap().st_flags.into(),
-    );
+    let changed = fstat(f.as_raw_fd()).unwrap().flags();
 
     assert_eq!(commanded, changed);
 }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -390,7 +390,7 @@ mod linux_android {
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(fd).expect("fstat failed").st_ino as usize;
+        let inode = fstat(fd).expect("fstat failed").ino() as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips
@@ -428,7 +428,7 @@ mod linux_android {
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(fd).expect("fstat failed").st_ino as usize;
+        let inode = fstat(fd).expect("fstat failed").ino() as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips


### PR DESCRIPTION
Closes #1787 .

This PR makes `FileStat` a wrapper type and exposes each field of the original struct as a single API.