### PR TITLE
fix microsecond calculation for TimeSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix microsecond calculation for `TimeSpec`.
+  ([#1801](https://github.com/nix-rust/nix/pull/1801))
+
 ### Removed
 
 ## [0.25.0] - 2022-08-13

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -319,7 +319,7 @@ impl TimeValLike for TimeSpec {
     }
 
     fn num_microseconds(&self) -> i64 {
-        self.num_nanoseconds() / 1_000_000_000
+        self.num_nanoseconds() / 1_000
     }
 
     fn num_nanoseconds(&self) -> i64 {


### PR DESCRIPTION
The implementation of `num_microseconds()` for `TimeSpec` returns the number of seconds not microseconds, as it divided by the wrong factor. The number of nanoseconds should be divided by 1000 to get the number of microseconds.