### PR TITLE
Handle unacceptable name gracefully in {User,Group}::from_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fix microsecond calculation for `TimeSpec`.
   ([#1801](https://github.com/nix-rust/nix/pull/1801))
+- Fix `User::from_name` and `Group::from_name` panicking
+  when given a name containing a nul.
+  ([#1815](https://github.com/nix-rust/nix/pull/1815))
 
 ### Removed
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3143,7 +3143,10 @@ impl User {
     /// assert_eq!(res.name, "root");
     /// ```
     pub fn from_name(name: &str) -> Result<Option<Self>> {
-        let name = CString::new(name).unwrap();
+        let name = match CString::new(name) {
+            Ok(c_str) => c_str,
+            Err(_nul_error) => return Ok(None),
+        };
         User::from_anything(|pwd, cbuf, cap, res| {
             unsafe { libc::getpwnam_r(name.as_ptr(), pwd, cbuf, cap, res) }
         })
@@ -3268,7 +3271,10 @@ impl Group {
     /// assert!(res.name == "root");
     /// ```
     pub fn from_name(name: &str) -> Result<Option<Self>> {
-        let name = CString::new(name).unwrap();
+        let name = match CString::new(name) {
+            Ok(c_str) => c_str,
+            Err(_nul_error) => return Ok(None),
+        };
         Group::from_anything(|grp, cbuf, cap, res| {
             unsafe { libc::getgrnam_r(name.as_ptr(), grp, cbuf, cap, res) }
         })


### PR DESCRIPTION
Calling `unwrap` on the result of `CString::new` may cause the current thread to panic, which is a bit surprising undocumented behavior. It would be more reasonable to treat the erroneous name as a non-existing user or group.