### PR TITLE
expose getpwent and getgrent

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3151,6 +3151,139 @@ impl User {
             unsafe { libc::getpwnam_r(name.as_ptr(), pwd, cbuf, cap, res) }
         })
     }
+
+    /// Construct an iterator over all users on the system.
+    ///
+    /// Call [`setpwent(3)`](https://pubs.opengroup.org/onlinepubs/7908799/xsh/setpwent.html),
+    /// [`getpwent(3)`](https://pubs.opengroup.org/onlinepubs/7908799/xsh/getpwent.html),
+    /// [`getpwent_r(3)`](https://man7.org/linux/man-pages/man3/getpwent_r.3.html) and
+    /// [`endpwent(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/endpwent.html)
+    /// under the hood.
+    ///
+    /// When encounters an error, [`AllUsers::next()`] will yield a
+    /// `Some(Err(Errno))`, stop iterating if this happens.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` cause `setpwent()` and `endpwent()`
+    /// will modify a global state, which will result in a data race if we have
+    /// multiple instances running at the same time.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use nix::unistd::User;
+    /// for opt_user in unsafe { User::all_users() } {
+    ///     match opt_user {
+    ///         Ok(user) => println!("{:?}", user),
+    ///         Err(errno) => {
+    ///             eprintln!("{:?}", errno);
+    ///             break;
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    // RedoxFS does not support passwd and android does not have /etc/passwd.
+    #[cfg(not(any(target_os = "redox", target_os = "android")))]
+    pub unsafe fn all_users() -> AllUsers {
+        libc::setpwent();
+
+        AllUsers
+    }
+}
+
+/// An iterator over the users of this system
+///
+/// This struct is constructed by [`User::all_users()`].
+// RedoxFS does not support passwd and android does not have /etc/passwd.
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+#[derive(Debug)]
+pub struct AllUsers;
+
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+impl Iterator for AllUsers {
+    type Item = Result<User>;
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        all(target_os = "linux", target_env = "gnu"),
+    ))]
+    // On these OSes, call `getpwent_r()`
+    fn next(&mut self) -> Option<Self::Item> {
+            #[cfg(target_os = "netbsd")]
+            Errno::clear();
+
+            let mut pwd = mem::MaybeUninit::<libc::passwd>::uninit();
+            let str_buf_size = match sysconf(SysconfVar::GETPW_R_SIZE_MAX) {
+                Ok(Some(n)) => n as usize,
+                Err(_) | Ok(None) => 4096,
+            };
+            let mut str_buf = Vec::with_capacity(str_buf_size);
+            let mut res: *mut libc::passwd = ptr::null_mut();
+            let ret = unsafe{
+                libc::getpwent_r(pwd.as_mut_ptr(), str_buf.as_mut_ptr(),
+                    str_buf_size, &mut res as *mut *mut libc::passwd)
+            };
+
+            // encounters an error
+            #[cfg(not(target_os = "linux"))]
+            if ret != 0 && res.is_null() {
+                #[cfg(target_os = "netbsd")]
+                return Some(Err(Errno::last()));
+                #[cfg(not(target_os = "netbsd"))]
+                return Some(Err(Errno::from_i32(ret)));
+            }
+            #[cfg(target_os = "linux")]
+            if ret != 0 && ret != libc::ENOENT && res.is_null() {
+                return Some(Err(Errno::from_i32(ret)));
+            }
+
+            // Now, all we need to do is to distinguish the successful case and
+            // the case where there are no more entries. Luckily, we can do this
+            // through `res`.
+
+            // no more entries
+            if res.is_null() {
+                None
+            }else {
+                // successful case
+                let pwd = unsafe{pwd.assume_init()};
+                Some(Ok(User::from(&pwd)))
+            }
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        all(target_os = "linux", target_env = "gnu")
+    )))]
+    // On other OSes, use `getpwent()`
+    fn next(&mut self) -> Option<Self::Item> {
+        Errno::clear();
+
+        let pwd = unsafe{libc::getpwent()};
+        if pwd.is_null() {
+                // errno is not set, no more entries
+                if Errno::last()  == Errno::from_i32(0){
+                        None
+                }else{
+                    Some(Err(Errno::last()))
+                }
+        }else {
+            Some(Ok(User::from(unsafe{&*pwd})))
+        }
+    }
+}
+
+
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+impl Drop for AllUsers {
+    fn drop(&mut self) {
+        unsafe{libc::endpwent()};
+    }
 }
 
 /// Representation of a Group, based on `libc::group`
@@ -3278,6 +3411,138 @@ impl Group {
         Group::from_anything(|grp, cbuf, cap, res| {
             unsafe { libc::getgrnam_r(name.as_ptr(), grp, cbuf, cap, res) }
         })
+    }
+
+    /// Construct an iterator over all groups on the system.
+    ///
+    /// Call [`setgrent(3)`](https://pubs.opengroup.org/onlinepubs/007908799/xsh/setgrent.html),
+    /// [`getgrent(3)`](https://pubs.opengroup.org/onlinepubs/7908799/xsh/getgrent.html),
+    /// [`getgrent_r(3)`](https://man7.org/linux/man-pages/man3/getgrent_r.3.html) and
+    /// [`endgrent(3)`](https://pubs.opengroup.org/onlinepubs/7908799/xsh/endgrent.html)
+    /// under the hood.
+    ///
+    /// When encounters an error, [`AllGroups::next()`] will yield a
+    /// `Some(Err(Errno))`, stop iterating if this happens.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` cause `setgrent()` and `endgrent()`
+    /// will modify a global state, which will result in a data race if we have
+    /// multiple instances running at the same time.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use nix::unistd::Group;
+    /// for opt_grp in unsafe { Group::all_groups() } {
+    ///     match opt_grp {
+    ///         Ok(grp) => println!("{:?}", grp),
+    ///         Err(errno) => {
+    ///             eprintln!("{:?}", errno);
+    ///             break;
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    #[cfg(not(any(target_os = "redox", target_os = "android")))]
+    // RedoxFS does not support passwd and android does not have /etc/group.
+    pub unsafe fn all_groups() -> AllGroups {
+        libc::setgrent();
+
+        AllGroups
+    }
+}
+
+/// An iterator over the groups of this system
+///
+/// This struct is constructed by [`Group::all_groups()`].
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+// RedoxFS does not support passwd and android does not have /etc/group.
+#[derive(Debug)]
+pub struct AllGroups;
+
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+impl Iterator for AllGroups {
+    type Item = Result<Group>;
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        all(target_os = "linux", target_env = "gnu"),
+    ))]
+    // On these OSes, call `getgrent_r()`
+    fn next(&mut self) -> Option<Self::Item> {
+            #[cfg(target_os = "netbsd")]
+            Errno::clear();
+
+            let mut grp = mem::MaybeUninit::<libc::group>::uninit();
+            let str_buf_size = match sysconf(SysconfVar::GETGR_R_SIZE_MAX) {
+                Ok(Some(n)) => n as usize,
+                Err(_) | Ok(None) => 4096,
+            };
+            let mut str_buf = Vec::with_capacity(str_buf_size);
+            let mut res: *mut libc::group = ptr::null_mut();
+            let ret = unsafe{
+                libc::getgrent_r(grp.as_mut_ptr(), str_buf.as_mut_ptr(),
+                    str_buf_size, &mut res as *mut *mut libc::group)
+            };
+
+            // encounters an error
+            #[cfg(not(target_os = "linux"))]
+            if ret != 0 && res.is_null() {
+                #[cfg(target_os = "netbsd")]
+                return Some(Err(Errno::last()));
+                #[cfg(not(target_os = "netbsd"))]
+                return Some(Err(Errno::from_i32(ret)));
+            }
+            #[cfg(target_os = "linux")]
+            if ret != 0 && ret != libc::ENOENT && res.is_null() {
+                return Some(Err(Errno::from_i32(ret)));
+            }
+
+            // Now, all we need to do is to distinguish the successful case and
+            // the case where there are no more entries. Luckily, we can do this
+            // through `res`.
+
+            // no more entries
+            if res.is_null() {
+                None
+            }else {
+                // successful case
+                let grp = unsafe{grp.assume_init()};
+                Some(Ok(Group::from(&grp)))
+            }
+    }
+
+    #[cfg(not(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        all(target_os = "linux", target_env = "gnu"),
+    )))]
+    // On other OSes, use `getgrent()`
+    fn next(&mut self) -> Option<Self::Item> {
+        Errno::clear();
+
+        let grp = unsafe{libc::getgrent()};
+        if grp.is_null() {
+                // errno is not set, no more entries
+                if Errno::last()  == Errno::from_i32(0){
+                        None
+                }else{
+                    Some(Err(Errno::last()))
+                }
+        }else {
+            Some(Ok(Group::from(unsafe{&*grp})))
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "redox", target_os = "android")))]
+impl Drop for AllGroups {
+    fn drop(&mut self) {
+        unsafe{libc::endgrent()};
     }
 }
 }


### PR DESCRIPTION
This PR is for issue #1811.

On OSes where `getpwent_r/getgrent_r` is available, it is used. On other OSes, use `getpwent/getgrent`. However, `illumos` and `solaris`, they do have `getpwent_r/getgrent_r`, but the definitions exposed by `libc` are [wrong](https://github.com/rust-lang/libc/issues/2908), so I currently use `getpwent/getgrent` on them.

The implementations of `AllUsers::next` and `AllGroups::next` on platforms where `getpwent_r/getgrent_r` is available are kind of ugly, this is because the return values of these functions are so different:

* freebsd: [getpwent_r man page](https://www.freebsd.org/cgi/man.cgi?query=getpwent&sektion=3)
  1. On success: return 0, `result` will be non-NULL
  2. On error: return the error number, `result` will be NULL
  3. End: return 0, `result` will be NULL. 

* dragonfly: [getpwent_r man page](https://leaf.dragonflybsd.org/cgi/web-man?command=getpwent_r&section=ANY)
  1. On success: return 0 and `result` will be non-NULL
  2. On error: return the error number, `result` will be NULL
  3. End: return 0, `result` will be NULL
 
> The return values on freebsd and dragonfly are the same.

* netbsd: [getpwent_r man page](https://man.netbsd.org/getpwent_r.3)
  1. On success: return 0, `result` will be non-NULL, 
  2. On error: return a non-zero value (errno is set), `result` will be NULL
  2. End: return 0, `result` will be NULL

* Linux: [getpwent_r man page](https://man7.org/linux/man-pages/man3/getpwent_r.3.html)
  1. On success: return 0, `result` will be non-NULL
  2. On error: return the error number (not ENOENT), `result` will be NULL
  3. End: return ENOENT and `result` will be NULL.


Another thing I am not sure about is the return value of `AllUsers::next()/AllGroups::next()`. In my implementation, it is:

```rust
fn next(&mut self) -> Option<Result<User/Group, Errno>>
```
The inner `Result` is used to expose the `errno` value, the drawback of such a design is that the user has to stop iterating when an error occurs.