### PR TITLE
Fix UB in the SO_TYPE sockopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- Fix UB with `sys::socket::sockopt::SockType` using `SOCK_PACKET`.
+  ([#1821](https://github.com/nix-rust/nix/pull/1821))
+
 ### Removed
 
 ## [0.26.0] - 2022-11-29


### PR DESCRIPTION
When reading a value into an enum from getsockopt, we must validate it. Failing to do so can lead to UB for example with SOCK_PACKET on Linux.

Perform the validation in GetSockOpt::get.  Currently SockType is the only type that requires validation.

Fixes #1819