### PR TITLE
Added wrapper around `getrandom` syscall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = [
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy", "getrandom",
+  "ucontext", "uio", "user", "zerocopy", "random",
 ]
 
 acct = []
@@ -66,7 +66,7 @@ ptrace = ["process"]
 quota = []
 process = []
 reboot = []
-getrandom = []
+random = []
 resource = []
 sched = ["process"]
 signal = ["process"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = [
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
+  "ucontext", "uio", "user", "zerocopy", "getrandom",
 ]
 
 acct = []
@@ -66,6 +66,7 @@ ptrace = ["process"]
 quota = []
 process = []
 reboot = []
+getrandom = []
 resource = []
 sched = ["process"]
 signal = ["process"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! * `ptrace` - Process tracing and debugging
 //! * `quota` - File system quotas
 //! * `reboot` - Reboot the system
+//! * `getrandom` - Get random bytes
 //! * `resource` - Process resource limits
 //! * `sched` - Manipulate process's scheduling
 //! * `socket` - Sockets, whether for networking or local use

--- a/src/sys/getrandom.rs
+++ b/src/sys/getrandom.rs
@@ -1,0 +1,48 @@
+//! Wrapper around getrandom.
+
+use crate::Result;
+use libc;
+
+libc_enum! {
+    /// How the random bytes should be filled
+    #[repr(u32)]
+    #[non_exhaustive]
+    pub enum RandomMode{
+        /// If  this  bit is set, then random bytes are drawn from the
+        /// random source (i.e., the same source as the /dev/random device)
+        ///  instead of the urandom source.
+        GRND_RANDOM,
+        /// By default, when reading from the random source, getrandom()
+        /// blocks if no random bytes are available, and when reading
+        /// from the urandom source, it blocks if the entropy pool has
+        /// not yet been initialized. If the GRND_NONBLOCK flag is
+        /// set, then getrandom() does not block in these cases
+        GRND_NONBLOCK,
+    }
+}
+
+/// Returns a vector of random bytes
+pub fn getrandom(size: usize, mode: RandomMode) -> Result<Vec<u8>> {
+    let mut buffer = vec![0; size];
+    unsafe {
+        assert_eq!(
+            libc::getrandom(
+                buffer.as_mut_ptr() as *mut libc::c_void,
+                size,
+                mode as u32,
+            ),
+            size as isize
+        )
+    };
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_getrandom() {
+        let random_bytes = getrandom(1000, RandomMode::GRND_RANDOM).unwrap();
+        assert_eq!(random_bytes.len(), 1000)
+    }
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,7 +50,7 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64")))]
 feature! {
     #![feature = "getrandom"]
     pub mod getrandom;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,9 +50,9 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64")))]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 feature! {
-    #![feature = "getrandom"]
+    #![feature = "random"]
     pub mod getrandom;
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -50,6 +50,12 @@ feature! {
 #[macro_use]
 pub mod ioctl;
 
+#[cfg(target_os = "linux")]
+feature! {
+    #![feature = "getrandom"]
+    pub mod getrandom;
+}
+
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 feature! {
     #![feature = "fs"]


### PR DESCRIPTION
Hi,
Added wrapper around Linux's `getrandom` syscall as mentioned in #1826.
```rust
pub fn getrandom(buffer: &mut [u8], mode: RandomMode) -> Result<isize>
```
returns number of bytes written
 
Thanks :)
Signed-off-by: Stefin <stefin@pm.me>