### PR TITLE
statfs: add namespace fs magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased] - ReleaseDate
 ### Added
 
+- Added `NSFS_MAGIC` FsType on Linux and Android.
+  ([#1829](https://github.com/nix-rust/nix/pull/1829))
 - Added `sched_getcpu` on platforms that support it.
   ([#1825](https://github.com/nix-rust/nix/pull/1825))
 - Added `sched_getaffinity` and `sched_setaffinity` on FreeBSD.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.133", features = [ "extra_traits" ] }
+libc = { version = "0.2.134", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -205,6 +205,9 @@ pub const USBDEVICE_SUPER_MAGIC: FsType = FsType(libc::USBDEVICE_SUPER_MAGIC as 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[allow(missing_docs)]
 pub const XENFS_SUPER_MAGIC: FsType = FsType(libc::XENFS_SUPER_MAGIC as fs_type_t);
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[allow(missing_docs)]
+pub const NSFS_MAGIC: FsType = FsType(libc::NSFS_MAGIC as fs_type_t);
 
 
 impl Statfs {


### PR DESCRIPTION
Namespace filesystem magic is missing from FsType constants.