### PR TITLE
statfs: fixes for s390x+musl

### DIFF
--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -51,7 +51,7 @@ pub struct Statfs(type_of_statfs);
 type fs_type_t = u32;
 #[cfg(target_os = "android")]
 type fs_type_t = libc::c_ulong;
-#[cfg(all(target_os = "linux", target_arch = "s390x"))]
+#[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
 type fs_type_t = libc::c_uint;
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 type fs_type_t = libc::c_ulong;
@@ -314,7 +314,7 @@ impl Statfs {
     }
 
     /// Optimal transfer block size
-    #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -367,7 +367,7 @@ impl Statfs {
 
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
-    #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -440,7 +440,7 @@ impl Statfs {
     }
 
     /// Maximum length of filenames
-    #[cfg(all(target_os = "linux", target_arch = "s390x"))]
+    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namelen
     }


### PR DESCRIPTION
I believe this should fix problems in the log, except the one related to the libc crate. however, I'm not sure how to test these changes.

<details>
<summary>log from an s390x build</summary>
<pre>
   Compiling nix v0.24.2
error[E0428]: the name `fs_type_t` is defined multiple times
  --> /home/buildozer/.cargo/registry/src/github.com-eae4ba8cbf2ce1c7/nix-0.24.2/src/sys/statfs.rs:33:1
   |
31 | type fs_type_t = libc::c_uint;
   | ------------------------------ previous definition of the type `fs_type_t` here
32 | #[cfg(all(target_os = "linux", target_env = "musl"))]
33 | type fs_type_t = libc::c_ulong;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `fs_type_t` redefined here
   |
   = note: `fs_type_t` must be defined only once in the type namespace of this module
   Compiling regex v1.6.0
error[E0425]: cannot find value `O_LARGEFILE` in crate `libc`
   --> /home/buildozer/.cargo/registry/src/github.com-eae4ba8cbf2ce1c7/nix-0.24.2/src/fcntl.rs:121:9
    |
121 |         O_LARGEFILE;
    |         ^^^^^^^^^^^ not found in `libc`
error[E0201]: duplicate definitions with name `optimal_transfer_size`:
   --> /home/buildozer/.cargo/registry/src/github.com-eae4ba8cbf2ce1c7/nix-0.24.2/src/sys/statfs.rs:258:5
    |
248 |     pub fn optimal_transfer_size(&self) -> u32 {
    |     ------------------------------------------ previous definition of `optimal_transfer_size` here
...
258 |     pub fn optimal_transfer_size(&self) -> libc::c_ulong {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
error[E0201]: duplicate definitions with name `block_size`:
   --> /home/buildozer/.cargo/registry/src/github.com-eae4ba8cbf2ce1c7/nix-0.24.2/src/sys/statfs.rs:309:5
    |
301 |     pub fn block_size(&self) -> u32 {
    |     ------------------------------- previous definition of `block_size` here
...
309 |     pub fn block_size(&self) -> libc::c_ulong {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
error[E0201]: duplicate definitions with name `maximum_name_length`:
   --> /home/buildozer/.cargo/registry/src/github.com-eae4ba8cbf2ce1c7/nix-0.24.2/src/sys/statfs.rs:367:5
    |
360 |     pub fn maximum_name_length(&self) -> u32 {
    |     ---------------------------------------- previous definition of `maximum_name_length` here
...
367 |     pub fn maximum_name_length(&self) -> libc::c_ulong {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
Some errors have detailed explanations: E0201, E0425, E0428.
For more information about an error, try `rustc --explain E0201`.
error: could not compile `nix` due to 5 previous errors
</pre>
</details>