### PR TITLE
Fix clippy warnings on nightly

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -208,6 +208,8 @@ pub enum Type {
 impl Entry {
     /// Returns the inode number (`d_ino`) of the underlying `dirent`.
     #[allow(clippy::useless_conversion)]    // Not useless on all OSes
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     pub fn ino(&self) -> u64 {
         cfg_if! {
             if #[cfg(any(target_os = "android",

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -47,7 +47,7 @@ fn clear() {
 
 /// Returns the platform-specific value of errno
 pub fn errno() -> i32 {
-    unsafe { (*errno_location()) as i32 }
+    unsafe { *errno_location() }
 }
 
 impl Errno {

--- a/src/sys/pthread.rs
+++ b/src/sys/pthread.rs
@@ -28,6 +28,7 @@ feature! {
 /// won't send any signal.
 ///
 /// [`pthread_kill(3)`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_kill.html
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[cfg(not(target_os = "redox"))]
 pub fn pthread_kill<T>(thread: Pthread, signal: T) -> Result<()>
     where T: Into<Option<crate::sys::signal::Signal>>

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -935,7 +935,7 @@ impl SockaddrLike for UnixAddr {
                 return None;
             }
         }
-        if (*addr).sa_family as i32 != libc::AF_UNIX as i32 {
+        if (*addr).sa_family as i32 != libc::AF_UNIX {
             return None;
         }
         let mut su: libc::sockaddr_un = mem::zeroed();
@@ -1192,7 +1192,7 @@ impl SockaddrLike for SockaddrIn {
                 return None;
             }
         }
-        if (*addr).sa_family as i32 != libc::AF_INET as i32 {
+        if (*addr).sa_family as i32 != libc::AF_INET {
             return None;
         }
         Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -1298,7 +1298,7 @@ impl SockaddrLike for SockaddrIn6 {
                 return None;
             }
         }
-        if (*addr).sa_family as i32 != libc::AF_INET6 as i32 {
+        if (*addr).sa_family as i32 != libc::AF_INET6 {
             return None;
         }
         Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2101,7 +2101,7 @@ pub mod netlink {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_NETLINK as i32 {
+            if (*addr).sa_family as i32 != libc::AF_NETLINK {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2145,7 +2145,7 @@ pub mod alg {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_ALG as i32 {
+            if (*addr).sa_family as i32 != libc::AF_ALG {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2259,7 +2259,7 @@ pub mod sys_control {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_SYSTEM as i32 {
+            if (*addr).sa_family as i32 != libc::AF_SYSTEM {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2366,12 +2366,12 @@ mod datalink {
         // Returns an Option just for cross-platform compatibility
         pub fn addr(&self) -> Option<[u8; 6]> {
             Some([
-                self.0.sll_addr[0] as u8,
-                self.0.sll_addr[1] as u8,
-                self.0.sll_addr[2] as u8,
-                self.0.sll_addr[3] as u8,
-                self.0.sll_addr[4] as u8,
-                self.0.sll_addr[5] as u8,
+                self.0.sll_addr[0],
+                self.0.sll_addr[1],
+                self.0.sll_addr[2],
+                self.0.sll_addr[3],
+                self.0.sll_addr[4],
+                self.0.sll_addr[5],
             ])
         }
     }
@@ -2402,7 +2402,7 @@ mod datalink {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_PACKET as i32 {
+            if (*addr).sa_family as i32 != libc::AF_PACKET {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2477,6 +2477,8 @@ mod datalink {
         }
 
         /// Physical-layer address (MAC)
+        // The cast is not unnecessary on all platforms.
+        #[allow(clippy::unnecessary_cast)]
         pub fn addr(&self) -> Option<[u8; 6]> {
             let nlen = self.nlen();
             let data = self.0.sdl_data;
@@ -2522,7 +2524,7 @@ mod datalink {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_LINK as i32 {
+            if (*addr).sa_family as i32 != libc::AF_LINK {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))
@@ -2566,7 +2568,7 @@ pub mod vsock {
                     return None;
                 }
             }
-            if (*addr).sa_family as i32 != libc::AF_VSOCK as i32 {
+            if (*addr).sa_family as i32 != libc::AF_VSOCK {
                 return None;
             }
             Some(Self(ptr::read_unaligned(addr as *const _)))

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -863,7 +863,7 @@ struct SetU8 {
 
 impl<'a> Set<'a, u8> for SetU8 {
     fn new(val: &'a u8) -> SetU8 {
-        SetU8 { val: *val as u8 }
+        SetU8 { val: *val }
     }
 
     fn ffi_ptr(&self) -> *const c_void {

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -705,6 +705,8 @@ mod test {
         assert_fs_equals(fs, vfs);
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn assert_fs_equals(fs: Statfs, vfs: Statvfs) {
         assert_eq!(fs.files() as u64, vfs.files() as u64);
         assert_eq!(fs.blocks() as u64, vfs.blocks() as u64);
@@ -752,6 +754,8 @@ mod test {
         assert_fs_equals_strict(fs.unwrap(), vfs.unwrap())
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn assert_fs_equals_strict(fs: Statfs, vfs: Statvfs) {
         assert_eq!(fs.files_free() as u64, vfs.files_free() as u64);
         assert_eq!(fs.blocks_free() as u64, vfs.blocks_free() as u64);

--- a/src/sys/sysinfo.rs
+++ b/src/sys/sysinfo.rs
@@ -30,6 +30,8 @@ impl SysInfo {
     }
 
     /// Returns the time since system boot.
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     pub fn uptime(&self) -> Duration {
         // Truncate negative values to 0
         Duration::from_secs(cmp::max(self.0.uptime, 0) as u64)
@@ -64,6 +66,8 @@ impl SysInfo {
         self.scale_mem(self.0.freeram)
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn scale_mem(&self, units: mem_blocks_t) -> u64 {
         units as u64 * self.0.mem_unit as u64
     }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -933,6 +933,8 @@ cfg_if!{
         /// [cfgetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
         ///
         /// `cfgetispeed()` extracts the input baud rate from the given `Termios` structure.
+        // The cast is not unnecessary on all platforms.
+        #[allow(clippy::unnecessary_cast)]
         pub fn cfgetispeed(termios: &Termios) -> u32 {
             let inner_termios = termios.get_libc_termios();
             unsafe { libc::cfgetispeed(&*inner_termios) as u32 }
@@ -942,6 +944,8 @@ cfg_if!{
         /// [cfgetospeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetospeed.html)).
         ///
         /// `cfgetospeed()` extracts the output baud rate from the given `Termios` structure.
+        // The cast is not unnecessary on all platforms.
+        #[allow(clippy::unnecessary_cast)]
         pub fn cfgetospeed(termios: &Termios) -> u32 {
             let inner_termios = termios.get_libc_termios();
             unsafe { libc::cfgetospeed(&*inner_termios) as u32 }

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -306,6 +306,8 @@ impl TimeValLike for TimeSpec {
         })
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn num_seconds(&self) -> i64 {
         if self.tv_sec() < 0 && self.tv_nsec() > 0 {
             (self.tv_sec() + 1) as i64
@@ -322,6 +324,8 @@ impl TimeValLike for TimeSpec {
         self.num_nanoseconds() / 1_000
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn num_nanoseconds(&self) -> i64 {
         let secs = self.num_seconds() * 1_000_000_000;
         let nsec = self.nanos_mod_sec();
@@ -549,6 +553,8 @@ impl TimeValLike for TimeVal {
         })
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn num_seconds(&self) -> i64 {
         if self.tv_sec() < 0 && self.tv_usec() > 0 {
             (self.tv_sec() + 1) as i64
@@ -561,6 +567,8 @@ impl TimeValLike for TimeVal {
         self.num_microseconds() / 1_000
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     fn num_microseconds(&self) -> i64 {
         let secs = self.num_seconds() * 1_000_000;
         let usec = self.micros_mod_sec();

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -153,7 +153,7 @@ impl<T> IoVec<T> {
         unsafe {
             slice::from_raw_parts(
                 self.0.iov_base as *const u8,
-                self.0.iov_len as usize)
+                self.0.iov_len)
         }
     }
 }

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -30,6 +30,8 @@ ioctl_readwrite_buf!(readwritebuf_test, 0, 0, u32);
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux {
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     #[test]
     fn test_op_none() {
         if cfg!(any(
@@ -46,6 +48,8 @@ mod linux {
         }
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     #[test]
     fn test_op_write() {
         if cfg!(any(
@@ -78,6 +82,8 @@ mod linux {
         }
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     #[test]
     fn test_op_read() {
         if cfg!(any(
@@ -110,6 +116,8 @@ mod linux {
         }
     }
 
+    // The cast is not unnecessary on all platforms.
+    #[allow(clippy::unnecessary_cast)]
     #[test]
     fn test_op_read_write() {
         assert_eq!(request_code_readwrite!(b'z', 10, 1) as u32, 0xC001_7A0A);

--- a/test/sys/test_stat.rs
+++ b/test/sys/test_stat.rs
@@ -1,3 +1,5 @@
+// The conversion is not useless on all platforms.
+#[allow(clippy::useless_conversion)]
 #[cfg(target_os = "freebsd")]
 #[test]
 fn test_chflags() {

--- a/test/test_mount.rs
+++ b/test/test_mount.rs
@@ -108,7 +108,7 @@ exit 23";
 
         // EROFS: Read-only file system
         assert_eq!(
-            EROFS as i32,
+            EROFS,
             File::create(tempdir.path().join("test"))
                 .unwrap_err()
                 .raw_os_error()
@@ -156,7 +156,7 @@ exit 23";
 
         // EACCES: Permission denied
         assert_eq!(
-            EACCES as i32,
+            EACCES,
             Command::new(&test_path)
                 .status()
                 .unwrap_err()


### PR DESCRIPTION
Clippy is now smarter about detecting unnecessary casts and useless conversions, which means we need to be more explicit about when the conversions are needed for a subset of platforms.

Required changes found by repeatedly running the following command against a list of the supported platforms.

`xargs -t -I {} sh -c "cargo clippy -Zbuild-std --target {} --all-targets -- -D warnings || exit 255"`

I removed the casts it complained about, and then restored them with an `#[allow]` if a later target needed the cast.