### PR TITLE
Upgrade parking_lot dev-dependency to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ zerocopy = ["fs", "uio"]
 [dev-dependencies]
 assert-impl = "0.1"
 lazy_static = "1.4"
-parking_lot = "0.11.2"
+parking_lot = "0.12"
 rand = "0.8"
 tempfile = "3.3.0"
 semver = "1.0.7"


### PR DESCRIPTION
We were previously stuck on 0.11 for MSRV reasons, but since bumping nix's MSRV to Rust 1.56 this is no longer the case.