### PR TITLE
add faccessat on illumos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1831](https://github.com/nix-rust/nix/pull/1831))
 - Added `syncfs(2)` on Linux
   ([#1833](https://github.com/nix-rust/nix/pull/1833))
+- Added `faccessat(2)` on illumos
+  ([#1841](https://github.com/nix-rust/nix/pull/1841))
   
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.134", features = [ "extra_traits" ] }
+libc = { version = "0.2.135", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2921,9 +2921,8 @@ pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
 /// # References
 ///
 /// [faccessat(2)](http://pubs.opengroup.org/onlinepubs/9699919799/functions/faccessat.html)
-// illumos: faccessat(2) appears to be supported, but the libc crate does not provide a binding.
 // redox: does not appear to support the *at family of syscalls.
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 pub fn faccessat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: AccessFlags, flags: AtFlags) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {


### PR DESCRIPTION
This binding has been added in [libc#2953](https://github.com/rust-lang/libc/pull/2953)