### PR TITLE
add eaccess on freebsd, dragonfly and linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1833](https://github.com/nix-rust/nix/pull/1833))
 - Added `faccessat(2)` on illumos
   ([#1841](https://github.com/nix-rust/nix/pull/1841))
+- Added `eaccess()` on FreeBSD, DragonFly and Linux (glibc and musl).
+  ([#1842](https://github.com/nix-rust/nix/pull/1842))
   
 ### Changed
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2931,6 +2931,27 @@ pub fn faccessat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Acce
     })?;
     Errno::result(res).map(drop)
 }
+
+/// Checks the file named by `path` for accessibility according to the flags given
+/// by `mode` using effective UID, effective GID and supplementary group lists.
+///
+/// # References
+///
+/// * [FreeBSD man page](https://www.freebsd.org/cgi/man.cgi?query=eaccess&sektion=2&n=1)
+/// * [Linux man page](https://man7.org/linux/man-pages/man3/euidaccess.3.html)
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "uclibc")),
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+pub fn eaccess<P: ?Sized + NixPath>(path: &P, mode: AccessFlags) -> Result<()> {
+    let res = path.with_nix_path(|cstr| {
+        unsafe {
+            libc::eaccess(cstr.as_ptr(), mode.bits)
+        }
+    })?;
+    Errno::result(res).map(drop)
+}
 }
 
 feature! {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1310,7 +1310,7 @@ fn test_getpeereid_invalid_fd() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 fn test_faccessat_none_not_existing() {
     use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
@@ -1324,7 +1324,7 @@ fn test_faccessat_none_not_existing() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 fn test_faccessat_not_existing() {
     use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
@@ -1344,7 +1344,7 @@ fn test_faccessat_not_existing() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 fn test_faccessat_none_file_exists() {
     use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
@@ -1360,7 +1360,7 @@ fn test_faccessat_none_file_exists() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "illumos", target_os = "redox")))]
+#[cfg(not(target_os = "redox"))]
 fn test_faccessat_file_exists() {
     use nix::fcntl::AtFlags;
     let tempdir = tempfile::tempdir().unwrap();
@@ -1375,4 +1375,33 @@ fn test_faccessat_file_exists() {
         AtFlags::empty(),
     )
     .is_ok());
+}
+
+#[test]
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "uclibc")),
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn test_eaccess_not_existing() {
+    let tempdir = tempdir().unwrap();
+    let dir = tempdir.path().join("does_not_exist.txt");
+    assert_eq!(
+        eaccess(&dir, AccessFlags::F_OK).err().unwrap(),
+        Errno::ENOENT
+    );
+}
+
+#[test]
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "uclibc")),
+    target_os = "freebsd",
+    target_os = "dragonfly"
+))]
+fn test_eaccess_file_exists() {
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("does_exist.txt");
+    let _file = File::create(path.clone()).unwrap();
+    eaccess(&path, AccessFlags::R_OK | AccessFlags::W_OK)
+        .expect("assertion failed");
 }


### PR DESCRIPTION
#### man pages
* [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=eaccess&sektion=2&n=1)
* [DragonFly](https://man.dragonflybsd.org/?command=access&section=2)
* [Linux](https://man7.org/linux/man-pages/man3/euidaccess.3.html)

#### difference between `eaccess` and `access/faccessat`
IMHO, `eaccess` uses effective identifiers to perform the permission check while `access/faccessat` use real IDs.

Fixes #1373 