### PR TITLE
add listxattr/getxattr/setxattr/removexattr on Linux and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1841](https://github.com/nix-rust/nix/pull/1841))
 - Added `eaccess()` on FreeBSD, DragonFly and Linux (glibc and musl).
   ([#1842](https://github.com/nix-rust/nix/pull/1842))
+- Added `listxattr/setxattr/getxattr/removexattr` and their variants on Linux 
+  and Android.
+  ([#1847](https://github.com/nix-rust/nix/pull/1847))
   
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = [
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
+  "ucontext", "uio", "user", "zerocopy", "xattr"
 ]
 
 acct = []
@@ -76,6 +76,7 @@ ucontext = ["signal"]
 uio = []
 user = ["feature"]
 zerocopy = ["fs", "uio"]
+xattr = []
 
 [dev-dependencies]
 assert-impl = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = [
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy", "xattr"
+  "ucontext", "uio", "user", "xattr", "zerocopy"
 ]
 
 acct = []
@@ -75,8 +75,8 @@ time = []
 ucontext = ["signal"]
 uio = []
 user = ["feature"]
-zerocopy = ["fs", "uio"]
 xattr = []
+zerocopy = ["fs", "uio"]
 
 [dev-dependencies]
 assert-impl = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! * `uio` - Vectored I/O
 //! * `user` - Stuff relating to users and groups
 //! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
+//! * `xattr` - Extended Attributes related APIs
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![cfg_attr(docsrs, doc(cfg(all())))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@
 //! * `ucontext` - User thread context
 //! * `uio` - Vectored I/O
 //! * `user` - Stuff relating to users and groups
-//! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 //! * `xattr` - Extended Attributes related APIs
+//! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![cfg_attr(docsrs, doc(cfg(all())))]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -226,3 +226,9 @@ feature! {
     #![feature = "time"]
     pub mod timer;
 }
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+feature! {
+    #![feature = "xattr"]
+    pub mod xattr;
+}

--- a/src/sys/xattr.rs
+++ b/src/sys/xattr.rs
@@ -1,0 +1,462 @@
+//! Extended Attributes related APIs
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use crate::{errno::Errno, NixPath, Result};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::{
+    ffi::{CString, OsStr, OsString},
+    os::unix::{
+        ffi::{OsStrExt, OsStringExt},
+        io::RawFd,
+    },
+    ptr::null_mut,
+};
+
+libc_bitflags!(
+    /// `flags` used in setting EAs
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub struct SetxattrFlag: libc::c_int {
+        /// Perform a pure create, which fails if the named attribute exists already.
+        XATTR_CREATE;
+        /// Perform a pure replace operation, which fails if the named attribute does not already exist.
+        XATTR_REPLACE;
+    }
+);
+
+/// Retrieves the list of extended attribute names associated with the given `path`
+/// in the filesystem. If `path` is a symbolic link, it will be dereferenced.
+///
+/// For more infomation, see [listxattr(2)](https://man7.org/linux/man-pages/man2/listxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn listxattr<P: ?Sized + NixPath>(path: &P) -> Result<Vec<OsString>> {
+    // query the buffer size
+    let buffer_size = path.with_nix_path(|path| unsafe {
+        libc::listxattr(path.as_ptr(), null_mut(), 0)
+    })?;
+
+    // no entries, return early
+    if buffer_size == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+    let res = path.with_nix_path(|path| unsafe {
+        libc::listxattr(
+            path.as_ptr(),
+            buffer.as_ptr() as *mut libc::c_char,
+            buffer.capacity(),
+        )
+    })?;
+
+    Errno::result(res).map(|len| {
+        unsafe { buffer.set_len(len as usize) };
+        buffer[..(len - 1) as usize]
+            .split(|&item| item == 0)
+            .map(OsStr::from_bytes)
+            .map(|str| str.to_owned())
+            .collect::<Vec<OsString>>()
+    })
+}
+
+/// Retrieves the list of extended attribute names associated with the given `path`
+/// in the filesystem. If `path` is a symbolic link, the list of names associated
+/// with the link *itself* will be returned.
+///
+/// For more infomation, see [llistxattr(2)](https://man7.org/linux/man-pages/man2/listxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn llistxattr<P: ?Sized + NixPath>(path: &P) -> Result<Vec<OsString>> {
+    // query the buffer size
+    let buffer_size = path.with_nix_path(|path| unsafe {
+        libc::llistxattr(path.as_ptr(), null_mut(), 0)
+    })?;
+
+    // no entries, return early
+    if buffer_size == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+    let res = path.with_nix_path(|path| unsafe {
+        libc::llistxattr(
+            path.as_ptr(),
+            buffer.as_ptr() as *mut libc::c_char,
+            buffer.capacity(),
+        )
+    })?;
+
+    Errno::result(res).map(|len| {
+        unsafe { buffer.set_len(len as usize) };
+        buffer[..(len - 1) as usize]
+            .split(|&item| item == 0)
+            .map(OsStr::from_bytes)
+            .map(|str| str.to_owned())
+            .collect::<Vec<OsString>>()
+    })
+}
+
+/// Retrieves the list of extended attribute names associated with the file
+/// specified by the open file descriptor `fd` in the filesystem.
+///
+/// For more infomation, see [flistxattr(2)](https://man7.org/linux/man-pages/man2/listxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>> {
+    // query the buffer size
+    let buffer_size = unsafe { libc::flistxattr(fd, null_mut(), 0) };
+
+    // no entries, return early
+    if buffer_size == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+    let res = unsafe {
+        libc::flistxattr(
+            fd,
+            buffer.as_ptr() as *mut libc::c_char,
+            buffer.capacity(),
+        )
+    };
+
+    Errno::result(res).map(|len| {
+        unsafe { buffer.set_len(len as usize) };
+        buffer[..(len - 1) as usize]
+            .split(|&item| item == 0)
+            .map(OsStr::from_bytes)
+            .map(|str| str.to_owned())
+            .collect::<Vec<OsString>>()
+    })
+}
+
+/// Retrieves the value of the extended attribute identified by `name` and
+/// associated with the given `path` in the filesystem. If `path` is a symbolic
+/// link, it will be dereferenced.
+///
+/// For more information, see [getxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn getxattr<P, S>(path: &P, name: S) -> Result<OsString>
+where
+    P: ?Sized + NixPath,
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    // query the buffer size
+    let buffer_size = path.with_nix_path(|path| unsafe {
+        libc::getxattr(
+            path.as_ptr(),
+            name.as_ptr() as *mut libc::c_char,
+            null_mut(),
+            0,
+        )
+    })?;
+
+    // The corresponding value is empty, return
+    if buffer_size == 0 {
+        return Ok(OsString::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+
+    let res = path.with_nix_path(|path| unsafe {
+        libc::getxattr(
+            path.as_ptr() as *mut libc::c_char,
+            name.as_ptr() as *mut libc::c_char,
+            buffer.as_ptr() as *mut libc::c_void,
+            buffer_size as usize,
+        )
+    })?;
+
+    Errno::result(res).map(|len| unsafe {
+        buffer.set_len(len as usize);
+        OsString::from_vec(buffer)
+    })
+}
+
+/// Retrieves the value of the extended attribute identified by `name` and
+/// associated with the given `path` in the filesystem. If `path` is a symbolic
+/// link, the list of names associated with the link *itself* will be returned.
+///
+/// For more information, see [lgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn lgetxattr<P, S>(path: &P, name: S) -> Result<OsString>
+where
+    P: ?Sized + NixPath,
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    // query the buffer size
+    let buffer_size = path.with_nix_path(|path| unsafe {
+        libc::lgetxattr(
+            path.as_ptr(),
+            name.as_ptr() as *mut libc::c_char,
+            null_mut(),
+            0,
+        )
+    })?;
+
+    // The corresponding value is empty, return
+    if buffer_size == 0 {
+        return Ok(OsString::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+
+    let res = path.with_nix_path(|path| unsafe {
+        libc::lgetxattr(
+            path.as_ptr() as *mut libc::c_char,
+            name.as_ptr() as *mut libc::c_char,
+            buffer.as_ptr() as *mut libc::c_void,
+            buffer_size as usize,
+        )
+    })?;
+
+    Errno::result(res).map(|len| unsafe {
+        buffer.set_len(len as usize);
+        OsString::from_vec(buffer)
+    })
+}
+
+/// Retrieves the value of the extended attribute identified by `name` and
+/// associated with the file specified by the open file descriptor `fd` in the
+/// filesystem.
+///
+/// For more information, see [fgetxattr(2)](https://man7.org/linux/man-pages/man2/getxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<OsString>
+where
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    // query the buffer size
+    let buffer_size = unsafe {
+        libc::fgetxattr(fd, name.as_ptr() as *mut libc::c_char, null_mut(), 0)
+    };
+
+    // The corresponding value is empty, return
+    if buffer_size == 0 {
+        return Ok(OsString::new());
+    }
+
+    let mut buffer: Vec<u8> =
+        Vec::with_capacity(Errno::result(buffer_size)? as usize);
+
+    let res = unsafe {
+        libc::fgetxattr(
+            fd,
+            name.as_ptr() as *mut libc::c_char,
+            buffer.as_ptr() as *mut libc::c_void,
+            buffer_size as usize,
+        )
+    };
+
+    Errno::result(res).map(|len| unsafe {
+        buffer.set_len(len as usize);
+        OsString::from_vec(buffer)
+    })
+}
+
+/// Removes the extended attribute identified by `name` and associated with the
+/// given `path` in the filesystem. If `path` is a symbolic link, it will be
+/// dereferenced.
+///
+/// For more information, see [removexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn removexattr<P, S>(path: &P, name: S) -> Result<()>
+where
+    P: ?Sized + NixPath,
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+    let res = path.with_nix_path(|path| unsafe {
+        libc::removexattr(path.as_ptr() as *mut libc::c_char, name.as_ptr())
+    })?;
+
+    Errno::result(res).map(drop)
+}
+
+/// Removes the extended attribute identified by `name` and associated with the
+/// given `path` in the filesystem. If `path` is a symbolic link, extended
+/// attribute is removed from the link *itself*.
+///
+/// For more information, see [lremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn lremovexattr<P, S>(path: &P, name: S) -> Result<()>
+where
+    P: ?Sized + NixPath,
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+    let res = path.with_nix_path(|path| unsafe {
+        libc::lremovexattr(path.as_ptr() as *mut libc::c_char, name.as_ptr())
+    })?;
+
+    Errno::result(res).map(drop)
+}
+
+/// Removes the extended attribute identified by `name` and associated with the
+/// file specified by the open file descriptor `fd`.
+///
+/// For more information, see [fremovexattr(2)](https://man7.org/linux/man-pages/man2/removexattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
+where
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    let res = unsafe { libc::fremovexattr(fd, name.as_ptr()) };
+
+    Errno::result(res).map(drop)
+}
+
+/// Sets the `value` of the extended attribute identified by `name` and associated
+/// with the given `path` in the filesystem. If `path` is a symbolic link, it will
+/// be dereferenced.
+///
+/// For more information, see [setxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn setxattr<P, S>(
+    path: &P,
+    name: S,
+    value: S,
+    flags: SetxattrFlag,
+) -> Result<()>
+where
+    P: ?Sized + NixPath,
+    S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    let value_ptr = value.as_ref().as_bytes().as_ptr() as *mut libc::c_void;
+    let value_len = value.as_ref().len();
+
+    let res = path.with_nix_path(|path| unsafe {
+        libc::setxattr(
+            path.as_ptr() as *mut libc::c_char,
+            name.as_ptr(),
+            value_ptr,
+            value_len,
+            flags.bits,
+        )
+    })?;
+
+    Errno::result(res).map(drop)
+}
+
+/// Sets the `value` of the extended attribute identified by `name` and associated
+/// with the given `path` in the filesystem. If `path` is a symbolic link, the
+/// extended attribute is set on the link *itself*.
+///
+/// For more information, see [lsetxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn lsetxattr<P, S>(
+    path: &P,
+    name: S,
+    value: S,
+    flags: SetxattrFlag,
+) -> Result<()>
+    where
+        P: ?Sized + NixPath,
+        S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    let value_ptr = value.as_ref().as_bytes().as_ptr() as *mut libc::c_void;
+    let value_len = value.as_ref().len();
+
+    let res = path.with_nix_path(|path| unsafe {
+        libc::lsetxattr(
+            path.as_ptr() as *mut libc::c_char,
+            name.as_ptr(),
+            value_ptr,
+            value_len,
+            flags.bits,
+        )
+    })?;
+
+    Errno::result(res).map(drop)
+}
+
+/// Sets the `value` of the extended attribute identified by `name` and associated
+/// with the file specified by the open file descriptor `fd`.
+///
+/// For more information, see [fsetxattr(2)](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn fsetxattr<S>(
+    fd: RawFd,
+    name: S,
+    value: S,
+    flags: SetxattrFlag,
+) -> Result<()>
+    where
+        S: AsRef<OsStr>,
+{
+    let name = if let Ok(name) = CString::new(name.as_ref().as_bytes()) {
+        name
+    } else {
+        // if `name` contains 0 bytes, return EINVAL
+        return Err(Errno::EINVAL);
+    };
+
+    let value_ptr = value.as_ref().as_bytes().as_ptr() as *mut libc::c_void;
+    let value_len = value.as_ref().len();
+
+    let res = unsafe {
+        libc::fsetxattr(
+            fd,
+            name.as_ptr(),
+            value_ptr,
+            value_len,
+            flags.bits,
+        )
+    };
+
+    Errno::result(res).map(drop)
+}

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -58,3 +58,5 @@ mod test_pthread;
 mod test_ptrace;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod test_timerfd;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+mod test_xattr;

--- a/test/sys/test_xattr.rs
+++ b/test/sys/test_xattr.rs
@@ -20,7 +20,7 @@ fn test_setxattr_file_exist() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => return,
+        Err(Errno::ENOTSUP) => {},
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -70,7 +70,7 @@ fn test_fsetxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => return,
+        Err(Errno::ENOTSUP) => {},
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -90,7 +90,7 @@ fn test_listxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => return,
+        Err(Errno::ENOTSUP) => {},
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -111,7 +111,7 @@ fn test_flistxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => return,
+        Err(Errno::ENOTSUP) => {},
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }

--- a/test/sys/test_xattr.rs
+++ b/test/sys/test_xattr.rs
@@ -124,7 +124,7 @@ fn test_getxattr() {
         errno::Errno,
         sys::xattr::{getxattr, setxattr, SetxattrFlag},
     };
-    use std::{ffi::OsString, fs::File};
+    use std::fs::File;
 
     let temp_dir = tempfile::tempdir_in("./").unwrap();
     let temp_file_path = temp_dir.path().join("test_getxattr");
@@ -146,7 +146,7 @@ fn test_getxattr() {
     assert!(res.is_ok());
 
     assert_eq!(
-        Ok(OsString::new()),
+        Ok(Vec::new()),
         getxattr(temp_file_path.as_path(), "user.test_getxattr")
     );
 }
@@ -158,7 +158,7 @@ fn test_fgetxattr() {
         errno::Errno,
         sys::xattr::{fgetxattr, fsetxattr, SetxattrFlag},
     };
-    use std::{ffi::OsString, fs::File, os::unix::io::AsRawFd};
+    use std::{fs::File, os::unix::io::AsRawFd};
 
     let temp_dir = tempfile::tempdir_in("./").unwrap();
     let temp_file_path = temp_dir.path().join("test_fgetxattr");
@@ -181,7 +181,7 @@ fn test_fgetxattr() {
     assert!(res.is_ok());
 
     assert_eq!(
-        Ok(OsString::new()),
+        Ok(Vec::new()),
         fgetxattr(temp_file_fd, "user.test_fgetxattr")
     );
 }

--- a/test/sys/test_xattr.rs
+++ b/test/sys/test_xattr.rs
@@ -1,0 +1,294 @@
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_setxattr_file_exist() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{setxattr, SetxattrFlag},
+    };
+    use std::fs::File;
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_setxattr_file_exist");
+    File::create(temp_file_path.as_path()).unwrap();
+
+    let res = setxattr(
+        temp_file_path.as_path(),
+        "user.test_setxattr_file_exist",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    match res {
+        // The underlying file system does not support EA, skip this test.
+        Err(Errno::ENOTSUP) => return,
+        // If EA is supported, then no error should occur
+        _ => assert!(res.is_ok()),
+    }
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_setxattr_file_not_exist() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{setxattr, SetxattrFlag},
+    };
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_setxattr_file_not_exist");
+
+    let res = setxattr(
+        temp_file_path.as_path(),
+        "user.test_setxattr_file_not_exist",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    assert_eq!(res, Err(Errno::ENOENT));
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_fsetxattr() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{fsetxattr, SetxattrFlag},
+    };
+    use std::{fs::File, os::unix::io::AsRawFd};
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_fsetxattr");
+    let temp_file = File::create(temp_file_path.as_path()).unwrap();
+    let temp_file_fd = temp_file.as_raw_fd();
+
+    let res = fsetxattr(
+        temp_file_fd,
+        "user.test_fsetxattr",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    match res {
+        // The underlying file system does not support EA, skip this test.
+        Err(Errno::ENOTSUP) => return,
+        // If EA is supported, then no error should occur
+        _ => assert!(res.is_ok()),
+    }
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_listxattr() {
+    use nix::{errno::Errno, sys::xattr::listxattr};
+    use std::fs::File;
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_listxattr");
+    File::create(temp_file_path.as_path()).unwrap();
+
+    let res = listxattr(temp_file_path.as_path());
+
+    match res {
+        // The underlying file system does not support EA, skip this test.
+        Err(Errno::ENOTSUP) => return,
+        // If EA is supported, then no error should occur
+        _ => assert!(res.is_ok()),
+    }
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_flistxattr() {
+    use nix::{errno::Errno, sys::xattr::flistxattr};
+    use std::{fs::File, os::unix::io::AsRawFd};
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_flistxattr");
+    let temp_file = File::create(temp_file_path.as_path()).unwrap();
+    let temp_file_fd = temp_file.as_raw_fd();
+
+    let res = flistxattr(temp_file_fd);
+
+    match res {
+        // The underlying file system does not support EA, skip this test.
+        Err(Errno::ENOTSUP) => return,
+        // If EA is supported, then no error should occur
+        _ => assert!(res.is_ok()),
+    }
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_getxattr() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{getxattr, setxattr, SetxattrFlag},
+    };
+    use std::{ffi::OsString, fs::File};
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_getxattr");
+    File::create(temp_file_path.as_path()).unwrap();
+
+    let res = setxattr(
+        temp_file_path.as_path(),
+        "user.test_getxattr",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    // The underlying file system does not support EA, skip this test.
+    if let Err(Errno::ENOTSUP) = res {
+        return;
+    }
+
+    // If EA is supported, then no error should occur
+    assert!(res.is_ok());
+
+    assert_eq!(
+        Ok(OsString::new()),
+        getxattr(temp_file_path.as_path(), "user.test_getxattr")
+    );
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_fgetxattr() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{fgetxattr, fsetxattr, SetxattrFlag},
+    };
+    use std::{ffi::OsString, fs::File, os::unix::io::AsRawFd};
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_fgetxattr");
+    let temp_file = File::create(temp_file_path).unwrap();
+    let temp_file_fd = temp_file.as_raw_fd();
+
+    let res = fsetxattr(
+        temp_file_fd,
+        "user.test_fgetxattr",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    // The underlying file system does not support EA, skip this test.
+    if let Err(Errno::ENOTSUP) = res {
+        return;
+    }
+
+    // If EA is supported, then no error should occur
+    assert!(res.is_ok());
+
+    assert_eq!(
+        Ok(OsString::new()),
+        fgetxattr(temp_file_fd, "user.test_fgetxattr")
+    );
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_removexattr_ea_exist() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{removexattr, setxattr, SetxattrFlag},
+    };
+    use std::fs::File;
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_removexattr_ea_exist");
+    File::create(temp_file_path.as_path()).unwrap();
+
+    let res = setxattr(
+        temp_file_path.as_path(),
+        "user.test_removexattr_ea_exist",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    // The underlying file system does not support EA, skip this test.
+    if let Err(Errno::ENOTSUP) = res {
+        return;
+    }
+
+    // If EA is supported, then no error should occur
+    assert!(res.is_ok());
+
+    assert!(removexattr(
+        temp_file_path.as_path(),
+        "user.test_removexattr_ea_exist",
+    )
+    .is_ok());
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_removexattr_ea_not_exist() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{removexattr, setxattr, SetxattrFlag},
+    };
+    use std::fs::File;
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_removexattr_ea_not_exist");
+    File::create(temp_file_path.as_path()).unwrap();
+
+    // Here, we use `setxattr(path, "user.*", value, flags)` instead of `listxattr`
+    // to test if EA is supported.
+    //
+    // This is necessary as we need to know whether `user` namespace EA is supported
+    // rather than other categories of EA.
+    //
+    // For example, on `tmpfs`, `trusted` and `security` namespace EAs are
+    // supported, but `user` is not.
+    if let Err(Errno::ENOTSUP) = setxattr(
+        temp_file_path.as_path(),
+        "user.ea",
+        "",
+        SetxattrFlag::empty(),
+    ) {
+        // The underlying file system does not support EA, skip this test.
+        return;
+    }
+
+    assert_eq!(
+        Err(Errno::ENODATA),
+        removexattr(
+            temp_file_path.as_path(),
+            "user.test_removexattr_ea_not_exist",
+        )
+    );
+}
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn test_fremovexattr() {
+    use nix::{
+        errno::Errno,
+        sys::xattr::{fremovexattr, fsetxattr, SetxattrFlag},
+    };
+    use std::{fs::File, os::unix::io::AsRawFd};
+
+    let temp_dir = tempfile::tempdir_in("./").unwrap();
+    let temp_file_path = temp_dir.path().join("test_fremovexattr");
+    let temp_file = File::create(temp_file_path.as_path()).unwrap();
+    let temp_file_fd = temp_file.as_raw_fd();
+
+    let res = fsetxattr(
+        temp_file_fd,
+        "user.test_fremovexattr",
+        "",
+        SetxattrFlag::empty(),
+    );
+
+    // The underlying file system does not support EA, skip this test.
+    if let Err(Errno::ENOTSUP) = res {
+        return;
+    }
+
+    // If EA is supported, then no error should occur
+    assert!(res.is_ok());
+
+    assert!(fremovexattr(temp_file_fd, "user.test_fremovexattr").is_ok());
+}

--- a/test/sys/test_xattr.rs
+++ b/test/sys/test_xattr.rs
@@ -20,7 +20,7 @@ fn test_setxattr_file_exist() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => {},
+        Err(Errno::ENOTSUP) => {}
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -70,7 +70,7 @@ fn test_fsetxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => {},
+        Err(Errno::ENOTSUP) => {}
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -90,7 +90,7 @@ fn test_listxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => {},
+        Err(Errno::ENOTSUP) => {}
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }
@@ -111,7 +111,7 @@ fn test_flistxattr() {
 
     match res {
         // The underlying file system does not support EA, skip this test.
-        Err(Errno::ENOTSUP) => {},
+        Err(Errno::ENOTSUP) => {}
         // If EA is supported, then no error should occur
         _ => assert!(res.is_ok()),
     }


### PR DESCRIPTION
#### What this PR does:
This PR adds `listxattr`, `getxattr`, `setxattr`, `removexattr` and their variants on Linux and Android

```rust
pub fn listxattr<P: ?Sized + NixPath>(path: &P) -> Result<Vec<OsString>>
pub fn llistxattr<P: ?Sized + NixPath>(path: &P) -> Result<Vec<OsString>>
pub fn flistxattr(fd: RawFd) -> Result<Vec<OsString>>

pub fn getxattr<P, S>(path: &P, name: S) -> Result<Vec<u8>>
pub fn lgetxattr<P, S>(path: &P, name: S) -> Result<Vec<u8>>
pub fn fgetxattr<S>(fd: RawFd, name: S) -> Result<Vec<u8>>

pub fn setxattr<P, S, B>(
    path: &P,
    name: S,
    value: B,
    flags: SetxattrFlag,
) -> Result<()>
pub fn lsetxattr<P, S, B>(
    path: &P,
    name: S,
    value: B,
    flags: SetxattrFlag,
) -> Result<()>
pub fn fsetxattr<S, B>(
    fd: RawFd,
    name: S,
    value: B,
    flags: SetxattrFlag,
) -> Result<()>

pub fn removexattr<P, S>(path: &P, name: S) -> Result<()>
pub fn lremovexattr<P, S>(path: &P, name: S) -> Result<()>
pub fn fremovexattr<S>(fd: RawFd, name: S) -> Result<()>
```

#### man pages

* [listxattr man page](https://man7.org/linux/man-pages/man2/listxattr.2.html)
* [getxattr man page](https://man7.org/linux/man-pages/man2/getxattr.2.html)
* [setxattr man page](https://man7.org/linux/man-pages/man2/lsetxattr.2.html)
* [removexattr man page](https://man7.org/linux/man-pages/man2/removexattr.2.html)

#### What about other platforms

`NetBSD`  should also be added in this PR, but [their current `libc` bindings are wrong](https://github.com/rust-lang/libc/pull/2961).

Update: I just found that `NetBSD` has another collection of `xattr` APIs, which is compatible with `FreeBSD`, and the `libc` bindings are added in [libc#1114](https://github.com/rust-lang/libc/pull/1114). Then I prefer to put these two BSD OSes together.

#### Module
These APIs are placed in `sys/xattr.rs`

#### Tests

Tests are placed in `test/sys/test-xattr.rs`. Symbolic link versions of APIs are not covered.

> If they should be covered, I will add them.

```rust
pub fn llistxattr<P: ?Sized + NixPath>(path: &P) -> Result<Vec<OsString>>
pub fn lgetxattr<P, S>(path: &P, name: S) -> Result<Vec<u8>>
pub fn lsetxattr<P, S>(
    path: &P,
    name: S,
    value: B,
    flags: SetxattrFlag,
) -> Result<()>
pub fn lremovexattr<P, S>(path: &P, name: S) -> Result<()>
```

In the tests, temporary directory are created in the current working directory instead of under `/tmp`, this is needed because we need to test `user` EA, `tmpfs` does not support this, see [this answer](https://stackoverflow.com/a/46598063/14092446).