### PR TITLE
SockProtocol::Raw = libc::IPPROTO_RAW for raw sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1853](https://github.com/nix-rust/nix/pull/1853))
 - Added `new_unnamed` and `is_unnamed` for `UnixAddr` on Linux and Android.
   ([#1857](https://github.com/nix-rust/nix/pull/1857))
+- Added `SockProtocol::Raw` for raw sockets
+  ([#1848](https://github.com/nix-rust/nix/pull/1848))
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -118,6 +118,8 @@ pub enum SockProtocol {
     Tcp = libc::IPPROTO_TCP,
     /// UDP protocol ([ip(7)](https://man7.org/linux/man-pages/man7/ip.7.html))
     Udp = libc::IPPROTO_UDP,
+    /// Raw sockets ([raw(7)](https://man7.org/linux/man-pages/man7/raw.7.html))
+    Raw = libc::IPPROTO_RAW,
     /// Allows applications and other KEXTs to be notified when certain kernel events occur
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(any(target_os = "ios", target_os = "macos"))]


### PR DESCRIPTION
Hey, I wanna to make call like `socket(af_type, SOCK_RAW, IPPROTO_RAW)` but currently there is no way to do it with rust
https://github.com/rickettm/SendIP/blob/aad12a001157489ab9053c8665e09aec24a2ff6d/sendip.c#L143

Update: Feel free to add `#[cfg]` attribute if I made mistakes that might cause errors on some platforms