### PR TITLE
Add LoongArch64 support on GNU/Linux

### DIFF
--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -42,7 +42,8 @@ mod consts {
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "riscv32",
-    target_arch = "riscv64"
+    target_arch = "riscv64",
+    target_arch = "loongarch64"
 ))]
 mod consts {
     #[doc(hidden)]


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html