### PR TITLE
Convert common syscalls to safe I/O types

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -6,6 +6,7 @@ use crate::sys;
 use crate::{Error, NixPath, Result};
 use cfg_if::cfg_if;
 use std::ffi;
+use std::os::unix::io::AsFd;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::ptr;
 
@@ -39,18 +40,18 @@ impl Dir {
         mode: sys::stat::Mode,
     ) -> Result<Self> {
         let fd = fcntl::open(path, oflag, mode)?;
-        Dir::from_fd(fd)
+        Dir::from_fd(fd.into_raw_fd())
     }
 
     /// Opens the given path as with `fcntl::openat`.
-    pub fn openat<P: ?Sized + NixPath>(
-        dirfd: RawFd,
+    pub fn openat<Fd: AsFd, P: ?Sized + NixPath>(
+        dirfd: &Fd,
         path: &P,
         oflag: OFlag,
         mode: sys::stat::Mode,
     ) -> Result<Self> {
         let fd = fcntl::openat(dirfd, path, oflag, mode)?;
-        Dir::from_fd(fd)
+        Dir::from_fd(fd.into_raw_fd())
     }
 
     /// Converts from a descriptor-based object, closing the descriptor on success or failure.

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -2,11 +2,10 @@
 
 use crate::errno::Errno;
 use crate::fcntl::{self, OFlag};
-use crate::sys;
+use crate::{sys, AsDirFd};
 use crate::{Error, NixPath, Result};
 use cfg_if::cfg_if;
 use std::ffi;
-use std::os::unix::io::AsFd;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::ptr;
 
@@ -44,8 +43,8 @@ impl Dir {
     }
 
     /// Opens the given path as with `fcntl::openat`.
-    pub fn openat<Fd: AsFd, P: ?Sized + NixPath>(
-        dirfd: &Fd,
+    pub fn openat<Fd: AsDirFd, P: ?Sized + NixPath>(
+        dirfd: Fd,
         path: &P,
         oflag: OFlag,
         mode: sys::stat::Mode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,8 @@ pub mod unistd;
 use std::ffi::{CStr, CString, OsStr};
 use std::mem::MaybeUninit;
 use std::os::unix::ffi::OsStrExt;
+#[cfg(not(target_os = "redox"))]
+use std::os::unix::io::BorrowedFd;
 use std::path::{Path, PathBuf};
 use std::{ptr, result, slice};
 
@@ -181,6 +183,17 @@ pub type Result<T> = result::Result<T, Errno>;
 /// * Represents all of the system's errnos, instead of just the most common
 /// ones.
 pub type Error = Errno;
+
+/// A file descriptor representing the current working directory.
+#[cfg(not(target_os = "redox"))]
+pub const AT_FDCWD: &BorrowedFd<'static> = unsafe {
+    &BorrowedFd::borrow_raw(if cfg!(target_os = "haiku") {
+        // Hack to work around BorrowedFd not allowing -1
+        -2
+    } else {
+        libc::AT_FDCWD
+    })
+};
 
 /// Common trait used to represent file system paths by many Nix functions.
 pub trait NixPath {

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -87,7 +87,7 @@ impl EpollEvent {
 /// epoll.add(&eventfd, EpollEvent::new(EpollFlags::EPOLLIN,DATA))?;
 ///
 /// // Arm eventfd & Time wait
-/// write(eventfd.as_raw_fd(), &1u64.to_ne_bytes())?;
+/// write(&eventfd, &1u64.to_ne_bytes())?;
 /// let now = Instant::now();
 ///
 /// // Wait on event

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -143,7 +143,9 @@ impl Inotify {
     pub fn init(flags: InitFlags) -> Result<Inotify> {
         let res = Errno::result(unsafe { libc::inotify_init1(flags.bits()) });
 
-        res.map(|fd| Inotify { fd: unsafe { OwnedFd::from_raw_fd(fd) } })
+        res.map(|fd| Inotify {
+            fd: unsafe { OwnedFd::from_raw_fd(fd) },
+        })
     }
 
     /// Adds a new watch on the target file or directory.
@@ -157,7 +159,11 @@ impl Inotify {
         mask: AddWatchFlags,
     ) -> Result<WatchDescriptor> {
         let res = path.with_nix_path(|cstr| unsafe {
-            libc::inotify_add_watch(self.fd.as_raw_fd(), cstr.as_ptr(), mask.bits())
+            libc::inotify_add_watch(
+                self.fd.as_raw_fd(),
+                cstr.as_ptr(),
+                mask.bits(),
+            )
         })?;
 
         Errno::result(res).map(|wd| WatchDescriptor { wd })
@@ -195,7 +201,7 @@ impl Inotify {
         let mut events = Vec::new();
         let mut offset = 0;
 
-        let nread = read(self.fd.as_raw_fd(), &mut buffer)?;
+        let nread = read(&self.fd, &mut buffer)?;
 
         while (nread - offset) >= header_size {
             let event = unsafe {
@@ -237,6 +243,8 @@ impl Inotify {
 
 impl FromRawFd for Inotify {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Inotify { fd: OwnedFd::from_raw_fd(fd) }
+        Inotify {
+            fd: OwnedFd::from_raw_fd(fd),
+        }
     }
 }

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -304,6 +304,7 @@ mod tests {
     use super::*;
     use crate::sys::time::{TimeVal, TimeValLike};
     use crate::unistd::{pipe, write};
+    use std::os::unix::io::AsRawFd;
     use std::os::unix::io::RawFd;
 
     #[test]
@@ -385,31 +386,31 @@ mod tests {
     #[test]
     fn test_select() {
         let (r1, w1) = pipe().unwrap();
-        write(w1, b"hi!").unwrap();
+        write(&w1, b"hi!").unwrap();
         let (r2, _w2) = pipe().unwrap();
 
         let mut fd_set = FdSet::new();
-        fd_set.insert(r1);
-        fd_set.insert(r2);
+        fd_set.insert(r1.as_raw_fd());
+        fd_set.insert(r2.as_raw_fd());
 
         let mut timeout = TimeVal::seconds(10);
         assert_eq!(
             1,
             select(None, &mut fd_set, None, None, &mut timeout).unwrap()
         );
-        assert!(fd_set.contains(r1));
-        assert!(!fd_set.contains(r2));
+        assert!(fd_set.contains(r1.as_raw_fd()));
+        assert!(!fd_set.contains(r2.as_raw_fd()));
     }
 
     #[test]
     fn test_select_nfds() {
         let (r1, w1) = pipe().unwrap();
-        write(w1, b"hi!").unwrap();
+        write(&w1, b"hi!").unwrap();
         let (r2, _w2) = pipe().unwrap();
 
         let mut fd_set = FdSet::new();
-        fd_set.insert(r1);
-        fd_set.insert(r2);
+        fd_set.insert(r1.as_raw_fd());
+        fd_set.insert(r2.as_raw_fd());
 
         let mut timeout = TimeVal::seconds(10);
         assert_eq!(
@@ -423,25 +424,25 @@ mod tests {
             )
             .unwrap()
         );
-        assert!(fd_set.contains(r1));
-        assert!(!fd_set.contains(r2));
+        assert!(fd_set.contains(r1.as_raw_fd()));
+        assert!(!fd_set.contains(r2.as_raw_fd()));
     }
 
     #[test]
     fn test_select_nfds2() {
         let (r1, w1) = pipe().unwrap();
-        write(w1, b"hi!").unwrap();
+        write(&w1, b"hi!").unwrap();
         let (r2, _w2) = pipe().unwrap();
 
         let mut fd_set = FdSet::new();
-        fd_set.insert(r1);
-        fd_set.insert(r2);
+        fd_set.insert(r1.as_raw_fd());
+        fd_set.insert(r2.as_raw_fd());
 
         let mut timeout = TimeVal::seconds(10);
         assert_eq!(
             1,
             select(
-                ::std::cmp::max(r1, r2) + 1,
+                std::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
                 &mut fd_set,
                 None,
                 None,
@@ -449,7 +450,7 @@ mod tests {
             )
             .unwrap()
         );
-        assert!(fd_set.contains(r1));
-        assert!(!fd_set.contains(r2));
+        assert!(fd_set.contains(r1.as_raw_fd()));
+        assert!(!fd_set.contains(r2.as_raw_fd()));
     }
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1427,13 +1427,15 @@ impl<'a> ControlMessage<'a> {
 /// # use nix::sys::socket::*;
 /// # use nix::unistd::pipe;
 /// # use std::io::IoSlice;
+/// # use std::os::unix::io::AsRawFd;
+///
 /// let (fd1, fd2) = socketpair(AddressFamily::Unix, SockType::Stream, None,
 ///     SockFlag::empty())
 ///     .unwrap();
 /// let (r, w) = pipe().unwrap();
 ///
 /// let iov = [IoSlice::new(b"hello")];
-/// let fds = [r];
+/// let fds = [r.as_raw_fd()];
 /// let cmsg = ControlMessage::ScmRights(&fds);
 /// sendmsg::<()>(fd1, &iov, &[cmsg], MsgFlags::empty(), None).unwrap();
 /// ```
@@ -1442,14 +1444,16 @@ impl<'a> ControlMessage<'a> {
 /// # use nix::sys::socket::*;
 /// # use nix::unistd::pipe;
 /// # use std::io::IoSlice;
+/// # use std::os::unix::io::AsRawFd;
 /// # use std::str::FromStr;
+///
 /// let localhost = SockaddrIn::from_str("1.2.3.4:8080").unwrap();
 /// let fd = socket(AddressFamily::Inet, SockType::Datagram, SockFlag::empty(),
 ///     None).unwrap();
 /// let (r, w) = pipe().unwrap();
 ///
 /// let iov = [IoSlice::new(b"hello")];
-/// let fds = [r];
+/// let fds = [r.as_raw_fd()];
 /// let cmsg = ControlMessage::ScmRights(&fds);
 /// sendmsg(fd, &iov, &[cmsg], MsgFlags::empty(), Some(&localhost)).unwrap();
 /// ```

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -9,10 +9,10 @@ pub use libc::c_ulong;
 pub use libc::stat as FileStat;
 pub use libc::{dev_t, mode_t};
 
-#[cfg(not(target_os = "redox"))]
-use crate::fcntl::AtFlags;
 use crate::sys::time::{TimeSpec, TimeVal};
 use crate::{errno::Errno, NixPath, Result};
+#[cfg(not(target_os = "redox"))]
+use crate::{fcntl::AtFlags, AsDirFd};
 use std::mem;
 use std::os::unix::io::{AsFd, AsRawFd};
 
@@ -191,8 +191,8 @@ pub fn mknod<P: ?Sized + NixPath>(
     target_os = "haiku"
 )))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn mknodat<Fd: AsFd, P: ?Sized + NixPath>(
-    dirfd: &Fd,
+pub fn mknodat<Fd: AsDirFd, P: ?Sized + NixPath>(
+    dirfd: Fd,
     path: &P,
     kind: SFlag,
     perm: Mode,
@@ -200,7 +200,7 @@ pub fn mknodat<Fd: AsFd, P: ?Sized + NixPath>(
 ) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
         libc::mknodat(
-            dirfd.as_fd().as_raw_fd(),
+            dirfd.as_dir_fd(),
             cstr.as_ptr(),
             kind.bits | perm.bits() as mode_t,
             dev,
@@ -258,7 +258,7 @@ pub fn lstat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
     Ok(unsafe { dst.assume_init() })
 }
 
-pub fn fstat<Fd: AsFd>(fd: &Fd) -> Result<FileStat> {
+pub fn fstat<Fd: AsFd>(fd: Fd) -> Result<FileStat> {
     let mut dst = mem::MaybeUninit::uninit();
     let res = unsafe { libc::fstat(fd.as_fd().as_raw_fd(), dst.as_mut_ptr()) };
 
@@ -269,15 +269,15 @@ pub fn fstat<Fd: AsFd>(fd: &Fd) -> Result<FileStat> {
 
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn fstatat<Fd: AsFd, P: ?Sized + NixPath>(
-    dirfd: &Fd,
+pub fn fstatat<Fd: AsDirFd, P: ?Sized + NixPath>(
+    dirfd: Fd,
     pathname: &P,
     f: AtFlags,
 ) -> Result<FileStat> {
     let mut dst = mem::MaybeUninit::uninit();
     let res = pathname.with_nix_path(|cstr| unsafe {
         libc::fstatat(
-            dirfd.as_fd().as_raw_fd(),
+            dirfd.as_dir_fd(),
             cstr.as_ptr(),
             dst.as_mut_ptr(),
             f.bits() as libc::c_int,
@@ -294,7 +294,7 @@ pub fn fstatat<Fd: AsFd, P: ?Sized + NixPath>(
 /// # References
 ///
 /// [fchmod(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmod.html).
-pub fn fchmod<Fd: AsFd>(fd: &Fd, mode: Mode) -> Result<()> {
+pub fn fchmod<Fd: AsFd>(fd: Fd, mode: Mode) -> Result<()> {
     let res =
         unsafe { libc::fchmod(fd.as_fd().as_raw_fd(), mode.bits() as mode_t) };
 
@@ -326,8 +326,8 @@ pub enum FchmodatFlags {
 /// [fchmodat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn fchmodat<Fd: AsFd, P: ?Sized + NixPath>(
-    dirfd: &Fd,
+pub fn fchmodat<Fd: AsDirFd, P: ?Sized + NixPath>(
+    dirfd: Fd,
     path: &P,
     mode: Mode,
     flag: FchmodatFlags,
@@ -338,7 +338,7 @@ pub fn fchmodat<Fd: AsFd, P: ?Sized + NixPath>(
     };
     let res = path.with_nix_path(|cstr| unsafe {
         libc::fchmodat(
-            dirfd.as_fd().as_raw_fd(),
+            dirfd.as_dir_fd(),
             cstr.as_ptr(),
             mode.bits() as mode_t,
             atflag.bits() as libc::c_int,
@@ -410,7 +410,7 @@ pub fn lutimes<P: ?Sized + NixPath>(
 /// [futimens(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html).
 #[inline]
 pub fn futimens<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     atime: &TimeSpec,
     mtime: &TimeSpec,
 ) -> Result<()> {
@@ -446,8 +446,8 @@ pub enum UtimensatFlags {
 /// [utimensat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn utimensat<Fd: AsFd, P: ?Sized + NixPath>(
-    dirfd: &Fd,
+pub fn utimensat<Fd: AsDirFd, P: ?Sized + NixPath>(
+    dirfd: Fd,
     path: &P,
     atime: &TimeSpec,
     mtime: &TimeSpec,
@@ -460,7 +460,7 @@ pub fn utimensat<Fd: AsFd, P: ?Sized + NixPath>(
     let times: [libc::timespec; 2] = [*atime.as_ref(), *mtime.as_ref()];
     let res = path.with_nix_path(|cstr| unsafe {
         libc::utimensat(
-            dirfd.as_fd().as_raw_fd(),
+            dirfd.as_dir_fd(),
             cstr.as_ptr(),
             &times[0],
             atflag.bits() as libc::c_int,
@@ -472,17 +472,13 @@ pub fn utimensat<Fd: AsFd, P: ?Sized + NixPath>(
 
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
-pub fn mkdirat<Fd: AsFd, P: ?Sized + NixPath>(
-    fd: &Fd,
+pub fn mkdirat<Fd: AsDirFd, P: ?Sized + NixPath>(
+    fd: Fd,
     path: &P,
     mode: Mode,
 ) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
-        libc::mkdirat(
-            fd.as_fd().as_raw_fd(),
-            cstr.as_ptr(),
-            mode.bits() as mode_t,
-        )
+        libc::mkdirat(fd.as_dir_fd(), cstr.as_ptr(), mode.bits() as mode_t)
     })?;
 
     Errno::result(res).map(drop)

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -201,7 +201,7 @@ impl TimerFd {
     ///
     /// Note: If the alarm is unset, then you will wait forever.
     pub fn wait(&self) -> Result<()> {
-        while let Err(e) = read(self.fd.as_fd().as_raw_fd(), &mut [0u8; 8]) {
+        while let Err(e) = read(&self.fd, &mut [0u8; 8]) {
             if e != Errno::EINTR {
                 return Err(e);
             }

--- a/test/sys/test_select.rs
+++ b/test/sys/test_select.rs
@@ -2,18 +2,19 @@ use nix::sys::select::*;
 use nix::sys::signal::SigSet;
 use nix::sys::time::{TimeSpec, TimeValLike};
 use nix::unistd::{pipe, write};
+use std::os::unix::io::AsRawFd;
 
 #[test]
 pub fn test_pselect() {
     let _mtx = crate::SIGNAL_MTX.lock();
 
     let (r1, w1) = pipe().unwrap();
-    write(w1, b"hi!").unwrap();
+    write(&w1, b"hi!").unwrap();
     let (r2, _w2) = pipe().unwrap();
 
     let mut fd_set = FdSet::new();
-    fd_set.insert(r1);
-    fd_set.insert(r2);
+    fd_set.insert(r1.as_raw_fd());
+    fd_set.insert(r2.as_raw_fd());
 
     let timeout = TimeSpec::seconds(10);
     let sigmask = SigSet::empty();
@@ -21,25 +22,25 @@ pub fn test_pselect() {
         1,
         pselect(None, &mut fd_set, None, None, &timeout, &sigmask).unwrap()
     );
-    assert!(fd_set.contains(r1));
-    assert!(!fd_set.contains(r2));
+    assert!(fd_set.contains(r1.as_raw_fd()));
+    assert!(!fd_set.contains(r2.as_raw_fd()));
 }
 
 #[test]
 pub fn test_pselect_nfds2() {
     let (r1, w1) = pipe().unwrap();
-    write(w1, b"hi!").unwrap();
+    write(&w1, b"hi!").unwrap();
     let (r2, _w2) = pipe().unwrap();
 
     let mut fd_set = FdSet::new();
-    fd_set.insert(r1);
-    fd_set.insert(r2);
+    fd_set.insert(r1.as_raw_fd());
+    fd_set.insert(r2.as_raw_fd());
 
     let timeout = TimeSpec::seconds(10);
     assert_eq!(
         1,
         pselect(
-            ::std::cmp::max(r1, r2) + 1,
+            ::std::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
             &mut fd_set,
             None,
             None,
@@ -48,8 +49,8 @@ pub fn test_pselect_nfds2() {
         )
         .unwrap()
     );
-    assert!(fd_set.contains(r1));
-    assert!(!fd_set.contains(r2));
+    assert!(fd_set.contains(r1.as_raw_fd()));
+    assert!(!fd_set.contains(r2.as_raw_fd()));
 }
 
 macro_rules! generate_fdset_bad_fd_tests {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -197,9 +197,9 @@ pub fn test_socketpair() {
         SockFlag::empty(),
     )
     .unwrap();
-    write(unsafe { &BorrowedFd::borrow_raw(fd1) }, b"hello").unwrap();
+    write(unsafe { BorrowedFd::borrow_raw(fd1) }, b"hello").unwrap();
     let mut buf = [0; 5];
-    read(unsafe { &BorrowedFd::borrow_raw(fd2) }, &mut buf).unwrap();
+    read(unsafe { BorrowedFd::borrow_raw(fd2) }, &mut buf).unwrap();
 
     assert_eq!(&buf[..], b"hello");
 }
@@ -736,7 +736,7 @@ pub fn test_scm_rights() {
     // Ensure that the received file descriptor works
     write(&w, b"world").unwrap();
     let mut buf = [0u8; 5];
-    read(unsafe { &BorrowedFd::borrow_raw(received_r) }, &mut buf).unwrap();
+    read(unsafe { BorrowedFd::borrow_raw(received_r) }, &mut buf).unwrap();
     assert_eq!(&buf[..], b"world");
     close(received_r).unwrap();
 }
@@ -798,7 +798,7 @@ pub fn test_af_alg_cipher() {
     // allocate buffer for encrypted data
     let mut encrypted = vec![0u8; payload_len];
     let num_bytes = read(
-        unsafe { &BorrowedFd::borrow_raw(session_socket) },
+        unsafe { BorrowedFd::borrow_raw(session_socket) },
         &mut encrypted,
     )
     .expect("read encrypt");
@@ -818,7 +818,7 @@ pub fn test_af_alg_cipher() {
     // allocate buffer for decrypted data
     let mut decrypted = vec![0u8; payload_len];
     let num_bytes = read(
-        unsafe { &BorrowedFd::borrow_raw(session_socket) },
+        unsafe { BorrowedFd::borrow_raw(session_socket) },
         &mut decrypted,
     )
     .expect("read decrypt");
@@ -903,7 +903,7 @@ pub fn test_af_alg_aead() {
     let mut encrypted =
         vec![0u8; (assoc_size as usize) + payload_len + auth_size];
     let num_bytes = read(
-        unsafe { &BorrowedFd::borrow_raw(session_socket) },
+        unsafe { BorrowedFd::borrow_raw(session_socket) },
         &mut encrypted,
     )
     .expect("read encrypt");
@@ -938,7 +938,7 @@ pub fn test_af_alg_aead() {
     fcntl(session_socket, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
         .expect("fcntl non_blocking");
     let num_bytes = read(
-        unsafe { &BorrowedFd::borrow_raw(session_socket) },
+        unsafe { BorrowedFd::borrow_raw(session_socket) },
         &mut decrypted,
     )
     .expect("read decrypt");
@@ -1413,7 +1413,7 @@ fn test_impl_scm_credentials_and_rights(mut space: Vec<u8>) {
     // Ensure that the received file descriptor works
     write(&w, b"world").unwrap();
     let mut buf = [0u8; 5];
-    read(unsafe { &BorrowedFd::borrow_raw(received_r) }, &mut buf).unwrap();
+    read(unsafe { BorrowedFd::borrow_raw(received_r) }, &mut buf).unwrap();
     assert_eq!(&buf[..], b"world");
     close(received_r).unwrap();
 }
@@ -1448,7 +1448,7 @@ pub fn test_named_unixdomain() {
         )
         .expect("socket failed");
         connect(s2, &sockaddr).expect("connect failed");
-        write(unsafe { &BorrowedFd::borrow_raw(s2) }, b"hello")
+        write(unsafe { BorrowedFd::borrow_raw(s2) }, b"hello")
             .expect("write failed");
         close(s2).unwrap();
     });
@@ -1456,7 +1456,7 @@ pub fn test_named_unixdomain() {
     let s3 = accept(s1).expect("accept failed");
 
     let mut buf = [0; 5];
-    read(unsafe { &BorrowedFd::borrow_raw(s3) }, &mut buf).unwrap();
+    read(unsafe { BorrowedFd::borrow_raw(s3) }, &mut buf).unwrap();
     close(s3).unwrap();
     close(s1).unwrap();
     thr.join().unwrap();

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -135,7 +135,7 @@ fn test_so_tcp_maxseg() {
     .unwrap();
     connect(ssock, &sock_addr).unwrap();
     let rsess = accept(rsock).unwrap();
-    write(unsafe { &BorrowedFd::borrow_raw(rsess) }, b"hello").unwrap();
+    write(unsafe { BorrowedFd::borrow_raw(rsess) }, b"hello").unwrap();
     let actual = getsockopt(ssock, sockopt::TcpMaxSeg).unwrap();
     // Actual max segment size takes header lengths into account, max IPv4 options (60 bytes) + max
     // TCP options (40 bytes) are subtracted from the requested maximum as a lower boundary.

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -96,6 +96,7 @@ fn test_so_tcp_maxseg() {
     use nix::sys::socket::{accept, bind, connect, listen, SockaddrIn};
     use nix::unistd::{close, write};
     use std::net::SocketAddrV4;
+    use std::os::unix::io::BorrowedFd;
     use std::str::FromStr;
 
     let std_sa = SocketAddrV4::from_str("127.0.0.1:4001").unwrap();
@@ -134,7 +135,7 @@ fn test_so_tcp_maxseg() {
     .unwrap();
     connect(ssock, &sock_addr).unwrap();
     let rsess = accept(rsock).unwrap();
-    write(rsess, b"hello").unwrap();
+    write(unsafe { &BorrowedFd::borrow_raw(rsess) }, b"hello").unwrap();
     let actual = getsockopt(ssock, sockopt::TcpMaxSeg).unwrap();
     // Actual max segment size takes header lengths into account, max IPv4 options (60 bytes) + max
     // TCP options (40 bytes) are subtracted from the requested maximum as a lower boundary.

--- a/test/sys/test_stat.rs
+++ b/test/sys/test_stat.rs
@@ -7,13 +7,12 @@ fn test_chflags() {
         sys::stat::{fstat, FileFlag},
         unistd::chflags,
     };
-    use std::os::unix::io::AsRawFd;
     use tempfile::NamedTempFile;
 
     let f = NamedTempFile::new().unwrap();
 
     let initial = FileFlag::from_bits_truncate(
-        fstat(f.as_raw_fd()).unwrap().st_flags.into(),
+        fstat(f.as_file()).unwrap().st_flags.into(),
     );
     // UF_OFFLINE is preserved by all FreeBSD file systems, but not interpreted
     // in any way, so it's handy for testing.
@@ -22,7 +21,7 @@ fn test_chflags() {
     chflags(f.path(), commanded).unwrap();
 
     let changed = FileFlag::from_bits_truncate(
-        fstat(f.as_raw_fd()).unwrap().st_flags.into(),
+        fstat(f.as_file()).unwrap().st_flags.into(),
     );
 
     assert_eq!(commanded, changed);

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -4,7 +4,6 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::fs::OpenOptions;
 use std::io::IoSlice;
-use std::os::unix::io::{FromRawFd, OwnedFd};
 use std::{cmp, iter};
 
 #[cfg(not(target_os = "redox"))]
@@ -43,23 +42,17 @@ fn test_writev() {
     let (reader, writer) = pipe().expect("Couldn't create pipe");
     // FileDesc will close its filedesc (reader).
     let mut read_buf: Vec<u8> = iter::repeat(0u8).take(128 * 16).collect();
-
-    // Temporary workaround to cope with the existing RawFd pipe(2), should be
-    // removed when pipe(2) becomes I/O-safe.
-    let writer = unsafe { OwnedFd::from_raw_fd(writer) };
-
     // Blocking io, should write all data.
     let write_res = writev(&writer, &iovecs);
     let written = write_res.expect("couldn't write");
     // Check whether we written all data
     assert_eq!(to_write.len(), written);
-    let read_res = read(reader, &mut read_buf[..]);
+    let read_res = read(&reader, &mut read_buf[..]);
     let read = read_res.expect("couldn't read");
     // Check we have read as much as we written
     assert_eq!(read, written);
     // Check equality of written and read data
     assert_eq!(&to_write, &read_buf);
-    close(reader).expect("closed reader");
 }
 
 #[test]
@@ -90,12 +83,7 @@ fn test_readv() {
     }
     let (reader, writer) = pipe().expect("couldn't create pipe");
     // Blocking io, should write all data.
-    write(writer, &to_write).expect("write failed");
-
-    // Temporary workaround to cope with the existing RawFd pipe(2), should be
-    // removed when pipe(2) becomes I/O-safe.
-    let reader = unsafe { OwnedFd::from_raw_fd(reader) };
-
+    write(&writer, &to_write).expect("write failed");
     let read = readv(&reader, &mut iovecs[..]).expect("read failed");
     // Check whether we've read all data
     assert_eq!(to_write.len(), read);
@@ -108,7 +96,6 @@ fn test_readv() {
     assert_eq!(read_buf.len(), to_write.len());
     // Check equality of written and read data
     assert_eq!(&read_buf, &to_write);
-    close(writer).expect("couldn't close writer");
 }
 
 #[test]
@@ -243,8 +230,8 @@ fn test_process_vm_readv() {
         Parent { child } => {
             close(w).unwrap();
             // wait for child
-            read(r, &mut [0u8]).unwrap();
-            close(r).unwrap();
+            read(&r, &mut [0u8]).unwrap();
+            drop(r);
 
             let ptr = vector.as_ptr() as usize;
             let remote_iov = RemoteIoVec { base: ptr, len: 5 };
@@ -267,8 +254,8 @@ fn test_process_vm_readv() {
             for i in &mut vector {
                 *i += 1;
             }
-            let _ = write(w, b"\0");
-            let _ = close(w);
+            let _ = write(&w, b"\0");
+            drop(w);
             loop {
                 pause();
             }

--- a/test/test.rs
+++ b/test/test.rs
@@ -66,7 +66,7 @@ mod test_unistd;
 
 use nix::unistd::{chdir, getcwd, read};
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
-use std::os::unix::io::{AsFd, AsRawFd};
+use std::os::unix::io::AsFd;
 use std::path::PathBuf;
 
 /// Helper function analogous to `std::io::Read::read_exact`, but for `Fd`s
@@ -75,7 +75,7 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     while len < buf.len() {
         // get_mut would be better than split_at_mut, but it requires nightly
         let (_, remaining) = buf.split_at_mut(len);
-        len += read(f.as_fd().as_raw_fd(), remaining).unwrap();
+        len += read(&f, remaining).unwrap();
     }
 }
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -340,7 +340,7 @@ mod linux_android {
 
         let tmp = NamedTempFile::new().unwrap();
 
-        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must
@@ -380,7 +380,7 @@ mod linux_android {
 
         let tmp = NamedTempFile::new().unwrap();
 
-        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -18,7 +18,7 @@ use nix::fcntl::{renameat2, RenameFlags};
 #[cfg(not(target_os = "redox"))]
 use nix::sys::stat::Mode;
 #[cfg(not(target_os = "redox"))]
-use nix::unistd::{close, read};
+use nix::unistd::read;
 #[cfg(not(target_os = "redox"))]
 use std::fs::File;
 #[cfg(not(target_os = "redox"))]
@@ -42,7 +42,7 @@ fn test_openat() {
         open(tmp.path().parent().unwrap(), OFlag::empty(), Mode::empty())
             .unwrap();
     let fd = openat(
-        dirfd,
+        &dirfd,
         tmp.path().file_name().unwrap(),
         OFlag::O_RDONLY,
         Mode::empty(),
@@ -50,11 +50,8 @@ fn test_openat() {
     .unwrap();
 
     let mut buf = [0u8; 1024];
-    assert_eq!(4, read(fd, &mut buf).unwrap());
+    assert_eq!(4, read(&fd, &mut buf).unwrap());
     assert_eq!(CONTENTS, &buf[0..4]);
-
-    close(fd).unwrap();
-    close(dirfd).unwrap();
 }
 
 #[test]
@@ -68,13 +65,11 @@ fn test_renameat() {
     let new_dir = tempfile::tempdir().unwrap();
     let new_dirfd =
         open(new_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
-    renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap();
+    renameat(&old_dirfd, "old", &new_dirfd, "new").unwrap();
     assert_eq!(
-        renameat(Some(old_dirfd), "old", Some(new_dirfd), "new").unwrap_err(),
+        renameat(&old_dirfd, "old", &new_dirfd, "new").unwrap_err(),
         Errno::ENOENT
     );
-    close(old_dirfd).unwrap();
-    close(new_dirfd).unwrap();
     assert!(new_dir.path().join("new").exists());
 }
 
@@ -98,27 +93,13 @@ fn test_renameat2_behaves_like_renameat_with_no_flags() {
     let new_dir = tempfile::tempdir().unwrap();
     let new_dirfd =
         open(new_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
-    renameat2(
-        Some(old_dirfd),
-        "old",
-        Some(new_dirfd),
-        "new",
-        RenameFlags::empty(),
-    )
-    .unwrap();
+    renameat2(&old_dirfd, "old", &new_dirfd, "new", RenameFlags::empty())
+        .unwrap();
     assert_eq!(
-        renameat2(
-            Some(old_dirfd),
-            "old",
-            Some(new_dirfd),
-            "new",
-            RenameFlags::empty()
-        )
-        .unwrap_err(),
+        renameat2(&old_dirfd, "old", &new_dirfd, "new", RenameFlags::empty())
+            .unwrap_err(),
         Errno::ENOENT
     );
-    close(old_dirfd).unwrap();
-    close(new_dirfd).unwrap();
     assert!(new_dir.path().join("new").exists());
 }
 
@@ -151,9 +132,9 @@ fn test_renameat2_exchange() {
         new_f.write_all(b"new").unwrap();
     }
     renameat2(
-        Some(old_dirfd),
+        &old_dirfd,
         "old",
-        Some(new_dirfd),
+        &new_dirfd,
         "new",
         RenameFlags::RENAME_EXCHANGE,
     )
@@ -166,8 +147,6 @@ fn test_renameat2_exchange() {
     let mut old_f = File::open(&old_path).unwrap();
     old_f.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, "new");
-    close(old_dirfd).unwrap();
-    close(new_dirfd).unwrap();
 }
 
 #[test]
@@ -194,17 +173,15 @@ fn test_renameat2_noreplace() {
     File::create(new_path).unwrap();
     assert_eq!(
         renameat2(
-            Some(old_dirfd),
+            &old_dirfd,
             "old",
-            Some(new_dirfd),
+            &new_dirfd,
             "new",
             RenameFlags::RENAME_NOREPLACE
         )
         .unwrap_err(),
         Errno::EEXIST
     );
-    close(old_dirfd).unwrap();
-    close(new_dirfd).unwrap();
     assert!(new_dir.path().join("new").exists());
     assert!(old_dir.path().join("old").exists());
 }
@@ -222,7 +199,7 @@ fn test_readlink() {
 
     assert_eq!(readlink(&dst).unwrap().to_str().unwrap(), expected_dir);
     assert_eq!(
-        readlinkat(dirfd, "b").unwrap().to_str().unwrap(),
+        readlinkat(&dirfd, "b").unwrap().to_str().unwrap(),
         expected_dir
     );
 }
@@ -232,10 +209,9 @@ mod linux_android {
     use libc::loff_t;
     use std::io::prelude::*;
     use std::io::IoSlice;
-    use std::os::unix::prelude::*;
 
     use nix::fcntl::*;
-    use nix::unistd::{close, pipe, read, write};
+    use nix::unistd::{pipe, read, write};
 
     use tempfile::tempfile;
     #[cfg(any(target_os = "linux"))]
@@ -262,14 +238,7 @@ mod linux_android {
         tmp1.flush().unwrap();
 
         let mut from_offset: i64 = 3;
-        copy_file_range(
-            tmp1.as_raw_fd(),
-            Some(&mut from_offset),
-            tmp2.as_raw_fd(),
-            None,
-            3,
-        )
-        .unwrap();
+        copy_file_range(&tmp1, Some(&mut from_offset), &tmp2, None, 3).unwrap();
 
         let mut res: String = String::new();
         tmp2.rewind().unwrap();
@@ -288,9 +257,9 @@ mod linux_android {
         let (rd, wr) = pipe().unwrap();
         let mut offset: loff_t = 5;
         let res = splice(
-            tmp.as_raw_fd(),
+            &tmp,
             Some(&mut offset),
-            wr,
+            &wr,
             None,
             2,
             SpliceFFlags::empty(),
@@ -300,12 +269,9 @@ mod linux_android {
         assert_eq!(2, res);
 
         let mut buf = [0u8; 1024];
-        assert_eq!(2, read(rd, &mut buf).unwrap());
+        assert_eq!(2, read(&rd, &mut buf).unwrap());
         assert_eq!(b"f1", &buf[0..2]);
         assert_eq!(7, offset);
-
-        close(rd).unwrap();
-        close(wr).unwrap();
     }
 
     #[test]
@@ -313,25 +279,20 @@ mod linux_android {
         let (rd1, wr1) = pipe().unwrap();
         let (rd2, wr2) = pipe().unwrap();
 
-        write(wr1, b"abc").unwrap();
-        let res = tee(rd1, wr2, 2, SpliceFFlags::empty()).unwrap();
+        write(&wr1, b"abc").unwrap();
+        let res = tee(&rd1, &wr2, 2, SpliceFFlags::empty()).unwrap();
 
         assert_eq!(2, res);
 
         let mut buf = [0u8; 1024];
 
         // Check the tee'd bytes are at rd2.
-        assert_eq!(2, read(rd2, &mut buf).unwrap());
+        assert_eq!(2, read(&rd2, &mut buf).unwrap());
         assert_eq!(b"ab", &buf[0..2]);
 
         // Check all the bytes are still at rd1.
-        assert_eq!(3, read(rd1, &mut buf).unwrap());
+        assert_eq!(3, read(&rd1, &mut buf).unwrap());
         assert_eq!(b"abc", &buf[0..3]);
-
-        close(rd1).unwrap();
-        close(wr1).unwrap();
-        close(rd2).unwrap();
-        close(wr2).unwrap();
     }
 
     #[test]
@@ -342,17 +303,14 @@ mod linux_android {
         let buf2 = b"defghi";
         let iovecs = vec![IoSlice::new(&buf1[0..3]), IoSlice::new(&buf2[0..3])];
 
-        let res = vmsplice(wr, &iovecs[..], SpliceFFlags::empty()).unwrap();
+        let res = vmsplice(&wr, &iovecs[..], SpliceFFlags::empty()).unwrap();
 
         assert_eq!(6, res);
 
         // Check the bytes can be read at rd.
         let mut buf = [0u8; 32];
-        assert_eq!(6, read(rd, &mut buf).unwrap());
+        assert_eq!(6, read(&rd, &mut buf).unwrap());
         assert_eq!(b"abcdef", &buf[0..6]);
-
-        close(rd).unwrap();
-        close(wr).unwrap();
     }
 
     #[cfg(any(target_os = "linux"))]
@@ -360,12 +318,11 @@ mod linux_android {
     fn test_fallocate() {
         let tmp = NamedTempFile::new().unwrap();
 
-        let fd = tmp.as_raw_fd();
-        fallocate(fd, FallocateFlags::empty(), 0, 100).unwrap();
+        fallocate(tmp.as_file(), FallocateFlags::empty(), 0, 100).unwrap();
 
         // Check if we read exactly 100 bytes
         let mut buf = [0u8; 200];
-        assert_eq!(100, read(fd, &mut buf).unwrap());
+        assert_eq!(100, read(tmp.as_file(), &mut buf).unwrap());
     }
 
     // The tests below are disabled for the listed targets
@@ -379,18 +336,18 @@ mod linux_android {
     fn test_ofd_write_lock() {
         use nix::sys::stat::fstat;
         use std::mem;
+        use std::os::unix::prelude::*;
 
         let tmp = NamedTempFile::new().unwrap();
 
-        let fd = tmp.as_raw_fd();
-        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(fd).expect("fstat failed").st_ino as usize;
+        let inode = fstat(tmp.as_file()).expect("fstat failed").st_ino as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips
@@ -400,14 +357,16 @@ mod linux_android {
         flock.l_start = 0;
         flock.l_len = 0;
         flock.l_pid = 0;
-        fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).expect("write lock failed");
+        fcntl(tmp.as_raw_fd(), F_OFD_SETLKW(&flock))
+            .expect("write lock failed");
         assert_eq!(
             Some(("OFDLCK".to_string(), "WRITE".to_string())),
             lock_info(inode)
         );
 
         flock.l_type = libc::F_UNLCK as libc::c_short;
-        fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).expect("write unlock failed");
+        fcntl(tmp.as_raw_fd(), F_OFD_SETLKW(&flock))
+            .expect("write unlock failed");
         assert_eq!(None, lock_info(inode));
     }
 
@@ -417,18 +376,18 @@ mod linux_android {
     fn test_ofd_read_lock() {
         use nix::sys::stat::fstat;
         use std::mem;
+        use std::os::unix::prelude::*;
 
         let tmp = NamedTempFile::new().unwrap();
 
-        let fd = tmp.as_raw_fd();
-        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(fd).expect("fstat failed").st_ino as usize;
+        let inode = fstat(tmp.as_file()).expect("fstat failed").st_ino as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips
@@ -438,14 +397,15 @@ mod linux_android {
         flock.l_start = 0;
         flock.l_len = 0;
         flock.l_pid = 0;
-        fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).expect("read lock failed");
+        fcntl(tmp.as_raw_fd(), F_OFD_SETLKW(&flock)).expect("read lock failed");
         assert_eq!(
             Some(("OFDLCK".to_string(), "READ".to_string())),
             lock_info(inode)
         );
 
         flock.l_type = libc::F_UNLCK as libc::c_short;
-        fcntl(fd, FcntlArg::F_OFD_SETLKW(&flock)).expect("read unlock failed");
+        fcntl(tmp.as_raw_fd(), F_OFD_SETLKW(&flock))
+            .expect("read unlock failed");
         assert_eq!(None, lock_info(inode));
     }
 
@@ -481,30 +441,28 @@ mod linux_android {
     target_os = "freebsd"
 ))]
 mod test_posix_fadvise {
-
     use nix::errno::Errno;
     use nix::fcntl::*;
     use nix::unistd::pipe;
-    use std::os::unix::io::{AsRawFd, RawFd};
     use tempfile::NamedTempFile;
 
     #[test]
     fn test_success() {
         let tmp = NamedTempFile::new().unwrap();
-        let fd = tmp.as_raw_fd();
-        posix_fadvise(fd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED)
-            .expect("posix_fadvise failed");
+        posix_fadvise(
+            tmp.as_file(),
+            0,
+            100,
+            PosixFadviseAdvice::POSIX_FADV_WILLNEED,
+        )
+        .expect("posix_fadvise failed");
     }
 
     #[test]
     fn test_errno() {
         let (rd, _wr) = pipe().unwrap();
-        let res = posix_fadvise(
-            rd as RawFd,
-            0,
-            100,
-            PosixFadviseAdvice::POSIX_FADV_WILLNEED,
-        );
+        let res =
+            posix_fadvise(&rd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED);
         assert_eq!(res, Err(Errno::ESPIPE));
     }
 }
@@ -523,18 +481,14 @@ mod test_posix_fallocate {
     use nix::errno::Errno;
     use nix::fcntl::*;
     use nix::unistd::pipe;
-    use std::{
-        io::Read,
-        os::unix::io::{AsRawFd, RawFd},
-    };
+    use std::io::Read;
     use tempfile::NamedTempFile;
 
     #[test]
     fn success() {
         const LEN: usize = 100;
         let mut tmp = NamedTempFile::new().unwrap();
-        let fd = tmp.as_raw_fd();
-        let res = posix_fallocate(fd, 0, LEN as libc::off_t);
+        let res = posix_fallocate(tmp.as_file(), 0, LEN as libc::off_t);
         match res {
             Ok(_) => {
                 let mut data = [1u8; LEN];
@@ -556,7 +510,7 @@ mod test_posix_fallocate {
     #[test]
     fn errno() {
         let (rd, _wr) = pipe().unwrap();
-        let err = posix_fallocate(rd as RawFd, 0, 100).unwrap_err();
+        let err = posix_fallocate(&rd, 0, 100).unwrap_err();
         match err {
             Errno::EINVAL | Errno::ENODEV | Errno::ESPIPE | Errno::EBADF => (),
             errno => panic!("unexpected errno {errno}",),

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -260,7 +260,7 @@ fn test_forkpty() {
     match pty.fork_result {
         Child => {
             write(
-                unsafe { &BorrowedFd::borrow_raw(STDOUT_FILENO) },
+                unsafe { BorrowedFd::borrow_raw(STDOUT_FILENO) },
                 string.as_bytes(),
             )
             .unwrap();

--- a/test/test_sendfile.rs
+++ b/test/test_sendfile.rs
@@ -1,6 +1,4 @@
 use std::io::prelude::*;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-use std::os::unix::io::{FromRawFd, OwnedFd};
 
 use libc::off_t;
 use nix::sys::sendfile::*;
@@ -8,7 +6,7 @@ use tempfile::tempfile;
 
 cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
-        use nix::unistd::{close, pipe, read};
+        use nix::unistd::{pipe, read};
     } else if #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos"))] {
         use std::net::Shutdown;
         use std::os::unix::net::UnixStream;
@@ -24,21 +22,14 @@ fn test_sendfile_linux() {
 
     let (rd, wr) = pipe().unwrap();
     let mut offset: off_t = 5;
-    // The construct of this `OwnedFd` is a temporary workaround, when `pipe(2)`
-    // becomes I/O-safe:
-    // pub fn pipe() -> std::result::Result<(OwnedFd, OwnedFd), Error>
-    // then it is no longer needed.
-    let wr = unsafe { OwnedFd::from_raw_fd(wr) };
     let res = sendfile(&wr, &tmp, Some(&mut offset), 2).unwrap();
 
     assert_eq!(2, res);
 
     let mut buf = [0u8; 1024];
-    assert_eq!(2, read(rd, &mut buf).unwrap());
+    assert_eq!(2, read(&rd, &mut buf).unwrap());
     assert_eq!(b"f1", &buf[0..2]);
     assert_eq!(7, offset);
-
-    close(rd).unwrap();
 }
 
 #[cfg(target_os = "linux")]
@@ -50,21 +41,14 @@ fn test_sendfile64_linux() {
 
     let (rd, wr) = pipe().unwrap();
     let mut offset: libc::off64_t = 5;
-    // The construct of this `OwnedFd` is a temporary workaround, when `pipe(2)`
-    // becomes I/O-safe:
-    // pub fn pipe() -> std::result::Result<(OwnedFd, OwnedFd), Error>
-    // then it is no longer needed.
-    let wr = unsafe { OwnedFd::from_raw_fd(wr) };
     let res = sendfile64(&wr, &tmp, Some(&mut offset), 2).unwrap();
 
     assert_eq!(2, res);
 
     let mut buf = [0u8; 1024];
-    assert_eq!(2, read(rd, &mut buf).unwrap());
+    assert_eq!(2, read(&rd, &mut buf).unwrap());
     assert_eq!(b"f1", &buf[0..2]);
     assert_eq!(7, offset);
-
-    close(rd).unwrap();
 }
 
 #[cfg(target_os = "freebsd")]

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -14,7 +14,7 @@ use libc::mode_t;
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 use libc::{S_IFLNK, S_IFMT};
 #[cfg(not(target_os = "redox"))]
-use nix::AT_FDCWD;
+use nix::Cwd;
 
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
@@ -194,7 +194,7 @@ fn test_fchmodat() {
 
     let mut mode2 = Mode::empty();
     mode2.insert(Mode::S_IROTH);
-    fchmodat(AT_FDCWD, filename, mode2, FchmodatFlags::FollowSymlink).unwrap();
+    fchmodat(Cwd, filename, mode2, FchmodatFlags::FollowSymlink).unwrap();
 
     let file_stat2 = stat(&fullpath).unwrap();
     assert_eq!(file_stat2.st_mode as mode_t & 0o7777, mode2.bits());
@@ -305,7 +305,7 @@ fn test_utimensat() {
     chdir(tempdir.path()).unwrap();
 
     utimensat(
-        AT_FDCWD,
+        Cwd,
         filename,
         &TimeSpec::seconds(500),
         &TimeSpec::seconds(800),
@@ -403,7 +403,7 @@ fn test_mknodat() {
     let target_dir =
         Dir::open(tempdir.path(), OFlag::O_DIRECTORY, Mode::S_IRWXU).unwrap();
     mknodat(
-        unsafe { &BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
+        unsafe { BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
         file_name,
         SFlag::S_IFREG,
         Mode::S_IRWXU,
@@ -411,7 +411,7 @@ fn test_mknodat() {
     )
     .unwrap();
     let mode = fstatat(
-        unsafe { &BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
+        unsafe { BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
         file_name,
         AtFlags::AT_SYMLINK_NOFOLLOW,
     )

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -5,7 +5,6 @@ use std::fs::File;
 use std::os::unix::fs::symlink;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::prelude::AsRawFd;
 #[cfg(not(target_os = "redox"))]
 use std::path::Path;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
@@ -14,6 +13,8 @@ use std::time::{Duration, UNIX_EPOCH};
 use libc::mode_t;
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 use libc::{S_IFLNK, S_IFMT};
+#[cfg(not(target_os = "redox"))]
+use nix::AT_FDCWD;
 
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
@@ -103,7 +104,7 @@ fn test_stat_and_fstat() {
     let stat_result = stat(&filename);
     assert_stat_results(stat_result);
 
-    let fstat_result = fstat(file.as_raw_fd());
+    let fstat_result = fstat(&file);
     assert_stat_results(fstat_result);
 }
 
@@ -114,10 +115,10 @@ fn test_fstatat() {
     let filename = tempdir.path().join("foo.txt");
     File::create(&filename).unwrap();
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty());
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), Mode::empty())
+            .unwrap();
 
-    let result =
-        stat::fstatat(dirfd.unwrap(), &filename, fcntl::AtFlags::empty());
+    let result = stat::fstatat(&dirfd, &filename, fcntl::AtFlags::empty());
     assert_stat_results(result);
 }
 
@@ -142,7 +143,7 @@ fn test_stat_fstat_lstat() {
     let lstat_result = lstat(&linkname);
     assert_lstat_results(lstat_result);
 
-    let fstat_result = fstat(link.as_raw_fd());
+    let fstat_result = fstat(&link);
     assert_stat_results(fstat_result);
 }
 
@@ -155,14 +156,14 @@ fn test_fchmod() {
     let mut mode1 = Mode::empty();
     mode1.insert(Mode::S_IRUSR);
     mode1.insert(Mode::S_IWUSR);
-    fchmod(file.as_raw_fd(), mode1).unwrap();
+    fchmod(&file, mode1).unwrap();
 
     let file_stat1 = stat(&filename).unwrap();
     assert_eq!(file_stat1.st_mode as mode_t & 0o7777, mode1.bits());
 
     let mut mode2 = Mode::empty();
     mode2.insert(Mode::S_IROTH);
-    fchmod(file.as_raw_fd(), mode2).unwrap();
+    fchmod(&file, mode2).unwrap();
 
     let file_stat2 = stat(&filename).unwrap();
     assert_eq!(file_stat2.st_mode as mode_t & 0o7777, mode2.bits());
@@ -178,14 +179,13 @@ fn test_fchmodat() {
     File::create(&fullpath).unwrap();
 
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), Mode::empty())
             .unwrap();
 
     let mut mode1 = Mode::empty();
     mode1.insert(Mode::S_IRUSR);
     mode1.insert(Mode::S_IWUSR);
-    fchmodat(Some(dirfd), filename, mode1, FchmodatFlags::FollowSymlink)
-        .unwrap();
+    fchmodat(&dirfd, filename, mode1, FchmodatFlags::FollowSymlink).unwrap();
 
     let file_stat1 = stat(&fullpath).unwrap();
     assert_eq!(file_stat1.st_mode as mode_t & 0o7777, mode1.bits());
@@ -194,7 +194,7 @@ fn test_fchmodat() {
 
     let mut mode2 = Mode::empty();
     mode2.insert(Mode::S_IROTH);
-    fchmodat(None, filename, mode2, FchmodatFlags::FollowSymlink).unwrap();
+    fchmodat(AT_FDCWD, filename, mode2, FchmodatFlags::FollowSymlink).unwrap();
 
     let file_stat2 = stat(&fullpath).unwrap();
     assert_eq!(file_stat2.st_mode as mode_t & 0o7777, mode2.bits());
@@ -272,10 +272,10 @@ fn test_futimens() {
     let fullpath = tempdir.path().join("file");
     drop(File::create(&fullpath).unwrap());
 
-    let fd = fcntl::open(&fullpath, fcntl::OFlag::empty(), stat::Mode::empty())
-        .unwrap();
+    let fd =
+        fcntl::open(&fullpath, fcntl::OFlag::empty(), Mode::empty()).unwrap();
 
-    futimens(fd, &TimeSpec::seconds(10), &TimeSpec::seconds(20)).unwrap();
+    futimens(&fd, &TimeSpec::seconds(10), &TimeSpec::seconds(20)).unwrap();
     assert_times_eq(10, 20, &fs::metadata(&fullpath).unwrap());
 }
 
@@ -289,11 +289,11 @@ fn test_utimensat() {
     drop(File::create(&fullpath).unwrap());
 
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), Mode::empty())
             .unwrap();
 
     utimensat(
-        Some(dirfd),
+        &dirfd,
         filename,
         &TimeSpec::seconds(12345),
         &TimeSpec::seconds(678),
@@ -305,7 +305,7 @@ fn test_utimensat() {
     chdir(tempdir.path()).unwrap();
 
     utimensat(
-        None,
+        AT_FDCWD,
         filename,
         &TimeSpec::seconds(500),
         &TimeSpec::seconds(800),
@@ -321,23 +321,22 @@ fn test_mkdirat_success_path() {
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "example_subdir";
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), Mode::empty())
             .unwrap();
-    mkdirat(dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(&dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
     assert!(Path::exists(&tempdir.path().join(filename)));
 }
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_mkdirat_success_mode() {
-    let expected_bits =
-        stat::SFlag::S_IFDIR.bits() | stat::Mode::S_IRWXU.bits();
+    let expected_bits = stat::SFlag::S_IFDIR.bits() | Mode::S_IRWXU.bits();
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "example_subdir";
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), Mode::empty())
             .unwrap();
-    mkdirat(dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(&dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
     let permissions = fs::metadata(tempdir.path().join(filename))
         .unwrap()
         .permissions();
@@ -354,10 +353,10 @@ fn test_mkdirat_fail() {
     let dirfd = fcntl::open(
         &tempdir.path().join(not_dir_filename),
         fcntl::OFlag::O_CREAT,
-        stat::Mode::empty(),
+        Mode::empty(),
     )
     .unwrap();
-    let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
+    let result = mkdirat(&dirfd, filename, Mode::S_IRWXU).unwrap_err();
     assert_eq!(result, Errno::ENOTDIR);
 }
 
@@ -396,13 +395,15 @@ fn test_mknodat() {
     use fcntl::{AtFlags, OFlag};
     use nix::dir::Dir;
     use stat::{fstatat, mknodat, SFlag};
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::io::BorrowedFd;
 
     let file_name = "test_file";
     let tempdir = tempfile::tempdir().unwrap();
     let target_dir =
         Dir::open(tempdir.path(), OFlag::O_DIRECTORY, Mode::S_IRWXU).unwrap();
     mknodat(
-        target_dir.as_raw_fd(),
+        unsafe { &BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
         file_name,
         SFlag::S_IFREG,
         Mode::S_IRWXU,
@@ -410,7 +411,7 @@ fn test_mknodat() {
     )
     .unwrap();
     let mode = fstatat(
-        target_dir.as_raw_fd(),
+        unsafe { &BorrowedFd::borrow_raw(target_dir.as_raw_fd()) },
         file_name,
         AtFlags::AT_SYMLINK_NOFOLLOW,
     )

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1,10 +1,10 @@
 use libc::{_exit, mode_t, off_t};
 use nix::errno::Errno;
+#[cfg(not(target_os = "redox"))]
+use nix::fcntl::open;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use nix::fcntl::readlink;
 use nix::fcntl::OFlag;
-#[cfg(not(target_os = "redox"))]
-use nix::fcntl::{self, open};
 #[cfg(not(any(
     target_os = "redox",
     target_os = "fuchsia",
@@ -19,6 +19,8 @@ use nix::sys::stat::{self, Mode, SFlag};
 use nix::sys::wait::*;
 use nix::unistd::ForkResult::*;
 use nix::unistd::*;
+#[cfg(not(target_os = "redox"))]
+use nix::AT_FDCWD;
 use std::env;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
 use std::ffi::CString;
@@ -47,7 +49,7 @@ fn test_fork_and_waitpid() {
         Child => unsafe { _exit(0) },
         Parent { child } => {
             // assert that child was created and pid > 0
-            let child_raw: ::libc::pid_t = child.into();
+            let child_raw: libc::pid_t = child.into();
             assert!(child_raw > 0);
             let wait_status = waitpid(child, None);
             match wait_status {
@@ -113,7 +115,7 @@ fn test_mkfifo() {
     mkfifo(&mkfifo_fifo, Mode::S_IRUSR).unwrap();
 
     let stats = stat::stat(&mkfifo_fifo).unwrap();
-    let typ = stat::SFlag::from_bits_truncate(stats.st_mode as mode_t);
+    let typ = SFlag::from_bits_truncate(stats.st_mode as mode_t);
     assert_eq!(typ, SFlag::S_IFIFO);
 }
 
@@ -138,10 +140,10 @@ fn test_mkfifoat_none() {
     let tempdir = tempdir().unwrap();
     let mkfifoat_fifo = tempdir.path().join("mkfifoat_fifo");
 
-    mkfifoat(None, &mkfifoat_fifo, Mode::S_IRUSR).unwrap();
+    mkfifoat(AT_FDCWD, &mkfifoat_fifo, Mode::S_IRUSR).unwrap();
 
     let stats = stat::stat(&mkfifoat_fifo).unwrap();
-    let typ = stat::SFlag::from_bits_truncate(stats.st_mode);
+    let typ = SFlag::from_bits_truncate(stats.st_mode);
     assert_eq!(typ, SFlag::S_IFIFO);
 }
 
@@ -154,17 +156,16 @@ fn test_mkfifoat_none() {
     target_os = "haiku"
 )))]
 fn test_mkfifoat() {
-    use nix::fcntl;
+    use nix::fcntl::AtFlags;
 
     let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let mkfifoat_name = "mkfifoat_name";
 
-    mkfifoat(Some(dirfd), mkfifoat_name, Mode::S_IRUSR).unwrap();
+    mkfifoat(&dirfd, mkfifoat_name, Mode::S_IRUSR).unwrap();
 
-    let stats =
-        stat::fstatat(dirfd, mkfifoat_name, fcntl::AtFlags::empty()).unwrap();
-    let typ = stat::SFlag::from_bits_truncate(stats.st_mode);
+    let stats = stat::fstatat(&dirfd, mkfifoat_name, AtFlags::empty()).unwrap();
+    let typ = SFlag::from_bits_truncate(stats.st_mode);
     assert_eq!(typ, SFlag::S_IFIFO);
 }
 
@@ -180,7 +181,7 @@ fn test_mkfifoat_directory_none() {
     let _m = crate::CWD_LOCK.read();
 
     // mkfifoat should fail if a directory is given
-    mkfifoat(None, &env::temp_dir(), Mode::S_IRUSR)
+    mkfifoat(AT_FDCWD, &env::temp_dir(), Mode::S_IRUSR)
         .expect_err("assertion failed");
 }
 
@@ -197,16 +198,16 @@ fn test_mkfifoat_directory() {
     let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let mkfifoat_dir = "mkfifoat_dir";
-    stat::mkdirat(dirfd, mkfifoat_dir, Mode::S_IRUSR).unwrap();
+    stat::mkdirat(&dirfd, mkfifoat_dir, Mode::S_IRUSR).unwrap();
 
-    mkfifoat(Some(dirfd), mkfifoat_dir, Mode::S_IRUSR)
+    mkfifoat(&dirfd, mkfifoat_dir, Mode::S_IRUSR)
         .expect_err("assertion failed");
 }
 
 #[test]
 fn test_getpid() {
-    let pid: ::libc::pid_t = getpid().into();
-    let ppid: ::libc::pid_t = getppid().into();
+    let pid: libc::pid_t = getpid().into();
+    let ppid: libc::pid_t = getppid().into();
     assert!(pid > 0);
     assert!(ppid > 0);
 }
@@ -214,8 +215,8 @@ fn test_getpid() {
 #[test]
 #[cfg(not(target_os = "redox"))]
 fn test_getsid() {
-    let none_sid: ::libc::pid_t = getsid(None).unwrap().into();
-    let pid_sid: ::libc::pid_t = getsid(Some(getpid())).unwrap().into();
+    let none_sid: libc::pid_t = getsid(None).unwrap().into();
+    let pid_sid: libc::pid_t = getsid(Some(getpid())).unwrap().into();
     assert!(none_sid > 0);
     assert_eq!(none_sid, pid_sid);
 }
@@ -226,7 +227,7 @@ mod linux_android {
 
     #[test]
     fn test_gettid() {
-        let tid: ::libc::pid_t = gettid().into();
+        let tid: libc::pid_t = gettid().into();
         assert!(tid > 0);
     }
 }
@@ -315,8 +316,9 @@ macro_rules! execve_test_factory (
     const BAZ: &'static [u8] = b"baz=quux\0";
 
     fn syscall_cstr_ref() -> Result<std::convert::Infallible, nix::Error> {
+        let exe = $exe;
         $syscall(
-            $exe,
+            &exe,
             $(CString::new($pathname).unwrap().as_c_str(), )*
             &[CStr::from_bytes_with_nul(EMPTY).unwrap(),
               CStr::from_bytes_with_nul(DASH_C).unwrap(),
@@ -327,8 +329,9 @@ macro_rules! execve_test_factory (
     }
 
     fn syscall_cstring() -> Result<std::convert::Infallible, nix::Error> {
+        let exe = $exe;
         $syscall(
-            $exe,
+            &exe,
             $(CString::new($pathname).unwrap().as_c_str(), )*
             &[CString::from(CStr::from_bytes_with_nul(EMPTY).unwrap()),
               CString::from(CStr::from_bytes_with_nul(DASH_C).unwrap()),
@@ -356,7 +359,8 @@ macro_rules! execve_test_factory (
         match unsafe{fork()}.unwrap() {
             Child => {
                 // Make `writer` be the stdout of the new process.
-                dup2(writer, 1).unwrap();
+                let mut stdout = std::mem::ManuallyDrop::new(unsafe { OwnedFd::from_raw_fd(libc::STDOUT_FILENO) });
+                dup2(&writer, &mut stdout).unwrap();
                 let r = syscall();
                 let _ = std::io::stderr()
                     .write_all(format!("{:?}", r).as_bytes());
@@ -370,7 +374,7 @@ macro_rules! execve_test_factory (
                 assert_eq!(ws, Ok(WaitStatus::Exited(child, 0)));
                 // Read 1024 bytes.
                 let mut buf = [0u8; 1024];
-                read(reader, &mut buf).unwrap();
+                read(&reader, &mut buf).unwrap();
                 // It should contain the things we printed using `/bin/sh`.
                 let string = String::from_utf8_lossy(&buf);
                 assert!(string.contains("nix!!!"));
@@ -402,48 +406,48 @@ macro_rules! execve_test_factory (
 
 cfg_if! {
     if #[cfg(target_os = "android")] {
-        execve_test_factory!(test_execve, execve, CString::new("/system/bin/sh").unwrap().as_c_str());
-        execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
+        execve_test_factory!(test_execve, execve, CString::new("/system/bin/sh").unwrap());
+        execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap());
     } else if #[cfg(any(target_os = "dragonfly",
                         target_os = "freebsd",
                         target_os = "linux"))] {
         // These tests frequently fail on musl, probably due to
         // https://github.com/nix-rust/nix/issues/555
-        execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap().as_c_str());
-        execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap().into_raw_fd());
+        execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap());
+        execve_test_factory!(test_fexecve, fexecve, File::open("/bin/sh").unwrap());
     } else if #[cfg(any(target_os = "illumos",
                         target_os = "ios",
                         target_os = "macos",
                         target_os = "netbsd",
                         target_os = "openbsd",
                         target_os = "solaris"))] {
-        execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap().as_c_str());
+        execve_test_factory!(test_execve, execve, CString::new("/bin/sh").unwrap());
         // No fexecve() on ios, macos, NetBSD, OpenBSD.
     }
 }
 
 #[cfg(any(target_os = "haiku", target_os = "linux", target_os = "openbsd"))]
-execve_test_factory!(test_execvpe, execvpe, &CString::new("sh").unwrap());
+execve_test_factory!(test_execvpe, execvpe, CString::new("sh").unwrap());
 
 cfg_if! {
     if #[cfg(target_os = "android")] {
         use nix::fcntl::AtFlags;
         execve_test_factory!(test_execveat_empty, execveat,
-                             File::open("/system/bin/sh").unwrap().into_raw_fd(),
+                             File::open("/system/bin/sh").unwrap(),
                              "", AtFlags::AT_EMPTY_PATH);
         execve_test_factory!(test_execveat_relative, execveat,
-                             File::open("/system/bin/").unwrap().into_raw_fd(),
+                             File::open("/system/bin/").unwrap(),
                              "./sh", AtFlags::empty());
         execve_test_factory!(test_execveat_absolute, execveat,
-                             File::open("/").unwrap().into_raw_fd(),
+                             File::open("/").unwrap(),
                              "/system/bin/sh", AtFlags::empty());
     } else if #[cfg(all(target_os = "linux", any(target_arch ="x86_64", target_arch ="x86")))] {
         use nix::fcntl::AtFlags;
-        execve_test_factory!(test_execveat_empty, execveat, File::open("/bin/sh").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_empty, execveat, File::open("/bin/sh").unwrap(),
                              "", AtFlags::AT_EMPTY_PATH);
-        execve_test_factory!(test_execveat_relative, execveat, File::open("/bin/").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_relative, execveat, File::open("/bin/").unwrap(),
                              "./sh", AtFlags::empty());
-        execve_test_factory!(test_execveat_absolute, execveat, File::open("/").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_absolute, execveat, File::open("/").unwrap(),
                              "/bin/sh", AtFlags::empty());
     }
 }
@@ -452,22 +456,20 @@ cfg_if! {
 #[cfg(not(target_os = "fuchsia"))]
 fn test_fchdir() {
     // fchdir changes the process's cwd
-    let _dr = crate::DirRestore::new();
+    let _dr = DirRestore::new();
 
     let tmpdir = tempdir().unwrap();
     let tmpdir_path = tmpdir.path().canonicalize().unwrap();
-    let tmpdir_fd = File::open(&tmpdir_path).unwrap().into_raw_fd();
+    let tmpdir_fd = File::open(&tmpdir_path).unwrap();
 
-    fchdir(tmpdir_fd).expect("assertion failed");
+    fchdir(&tmpdir_fd).expect("assertion failed");
     assert_eq!(getcwd().unwrap(), tmpdir_path);
-
-    close(tmpdir_fd).expect("assertion failed");
 }
 
 #[test]
 fn test_getcwd() {
     // chdir changes the process's cwd
-    let _dr = crate::DirRestore::new();
+    let _dr = DirRestore::new();
 
     let tmpdir = tempdir().unwrap();
     let tmpdir_path = tmpdir.path().canonicalize().unwrap();
@@ -516,18 +518,18 @@ fn test_fchown() {
     let gid = Some(getgid());
 
     let path = tempfile().unwrap();
-    let fd = path.as_raw_fd();
 
-    fchown(fd, uid, gid).unwrap();
-    fchown(fd, uid, None).unwrap();
-    fchown(fd, None, gid).unwrap();
-    fchown(999999999, uid, gid).unwrap_err();
+    fchown(&path, uid, gid).unwrap();
+    fchown(&path, uid, None).unwrap();
+    fchown(&path, None, gid).unwrap();
+    fchown(unsafe { &BorrowedFd::borrow_raw(999999999) }, uid, gid)
+        .unwrap_err();
 }
 
 #[test]
 #[cfg(not(target_os = "redox"))]
 fn test_fchownat() {
-    let _dr = crate::DirRestore::new();
+    let _dr = DirRestore::new();
     // Testing for anything other than our own UID/GID is hard.
     let uid = Some(getuid());
     let gid = Some(getgid());
@@ -540,14 +542,14 @@ fn test_fchownat() {
 
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
-    fchownat(Some(dirfd), "file", uid, gid, FchownatFlags::FollowSymlink)
-        .unwrap();
+    fchownat(&dirfd, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap();
 
     chdir(tempdir.path()).unwrap();
-    fchownat(None, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap();
+    fchownat(AT_FDCWD, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap();
 
     fs::remove_file(&path).unwrap();
-    fchownat(None, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap_err();
+    fchownat(AT_FDCWD, "file", uid, gid, FchownatFlags::FollowSymlink)
+        .unwrap_err();
 }
 
 #[test]
@@ -557,7 +559,7 @@ fn test_lseek() {
     tmp.write_all(CONTENTS).unwrap();
 
     let offset: off_t = 5;
-    lseek(tmp.as_raw_fd(), offset, Whence::SeekSet).unwrap();
+    lseek(&tmp, offset, Whence::SeekSet).unwrap();
 
     let mut buf = [0u8; 7];
     crate::read_exact(&tmp, &mut buf);
@@ -571,7 +573,7 @@ fn test_lseek64() {
     let mut tmp = tempfile().unwrap();
     tmp.write_all(CONTENTS).unwrap();
 
-    lseek64(tmp.as_raw_fd(), 5, Whence::SeekSet).unwrap();
+    lseek64(&tmp, 5, Whence::SeekSet).unwrap();
 
     let mut buf = [0u8; 7];
     crate::read_exact(&tmp, &mut buf);
@@ -713,14 +715,12 @@ fn test_getresgid() {
 #[test]
 fn test_pipe() {
     let (fd0, fd1) = pipe().unwrap();
-    let m0 = stat::SFlag::from_bits_truncate(
-        stat::fstat(fd0).unwrap().st_mode as mode_t,
-    );
+    let m0 =
+        SFlag::from_bits_truncate(stat::fstat(&fd0).unwrap().st_mode as mode_t);
     // S_IFIFO means it's a pipe
     assert_eq!(m0, SFlag::S_IFIFO);
-    let m1 = stat::SFlag::from_bits_truncate(
-        stat::fstat(fd1).unwrap().st_mode as mode_t,
-    );
+    let m1 =
+        SFlag::from_bits_truncate(stat::fstat(&fd1).unwrap().st_mode as mode_t);
     assert_eq!(m1, SFlag::S_IFIFO);
 }
 
@@ -743,9 +743,13 @@ fn test_pipe2() {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag};
 
     let (fd0, fd1) = pipe2(OFlag::O_CLOEXEC).unwrap();
-    let f0 = FdFlag::from_bits_truncate(fcntl(fd0, FcntlArg::F_GETFD).unwrap());
+    let f0 = FdFlag::from_bits_truncate(
+        fcntl(fd0.as_raw_fd(), FcntlArg::F_GETFD).unwrap(),
+    );
     assert!(f0.contains(FdFlag::FD_CLOEXEC));
-    let f1 = FdFlag::from_bits_truncate(fcntl(fd1, FcntlArg::F_GETFD).unwrap());
+    let f1 = FdFlag::from_bits_truncate(
+        fcntl(fd1.as_raw_fd(), FcntlArg::F_GETFD).unwrap(),
+    );
     assert!(f1.contains(FdFlag::FD_CLOEXEC));
 }
 
@@ -772,15 +776,11 @@ fn test_ftruncate() {
     let tempdir = tempdir().unwrap();
     let path = tempdir.path().join("file");
 
-    let tmpfd = {
-        let mut tmp = File::create(&path).unwrap();
-        const CONTENTS: &[u8] = b"12345678";
-        tmp.write_all(CONTENTS).unwrap();
-        tmp.into_raw_fd()
-    };
+    let mut tmp = File::create(&path).unwrap();
+    const CONTENTS: &[u8] = b"12345678";
+    tmp.write_all(CONTENTS).unwrap();
 
-    ftruncate(tmpfd, 2).unwrap();
-    close(tmpfd).unwrap();
+    ftruncate(&tmp, 2).unwrap();
 
     let metadata = fs::metadata(&path).unwrap();
     assert_eq!(2, metadata.len());
@@ -862,7 +862,7 @@ fn test_symlinkat() {
 
     let target = tempdir.path().join("a");
     let linkpath = tempdir.path().join("b");
-    symlinkat(&target, None, &linkpath).unwrap();
+    symlinkat(&target, AT_FDCWD, &linkpath).unwrap();
     assert_eq!(
         readlink(&linkpath).unwrap().to_str().unwrap(),
         target.to_str().unwrap()
@@ -871,7 +871,7 @@ fn test_symlinkat() {
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let target = "c";
     let linkpath = "d";
-    symlinkat(target, Some(dirfd), linkpath).unwrap();
+    symlinkat(target, &dirfd, linkpath).unwrap();
     assert_eq!(
         readlink(&tempdir.path().join(linkpath))
             .unwrap()
@@ -895,15 +895,13 @@ fn test_linkat_file() {
     File::create(oldfilepath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt hard link file at relative path
     linkat(
-        Some(dirfd),
+        &dirfd,
         oldfilename,
-        Some(dirfd),
+        &dirfd,
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
@@ -914,7 +912,7 @@ fn test_linkat_file() {
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_olddirfd_none() {
-    let _dr = crate::DirRestore::new();
+    let _dr = DirRestore::new();
 
     let tempdir_oldfile = tempdir().unwrap();
     let oldfilename = "foo.txt";
@@ -928,19 +926,15 @@ fn test_linkat_olddirfd_none() {
     File::create(oldfilepath).unwrap();
 
     // Get file descriptor for base directory of new file
-    let dirfd = fcntl::open(
-        tempdir_newfile.path(),
-        fcntl::OFlag::empty(),
-        stat::Mode::empty(),
-    )
-    .unwrap();
+    let dirfd =
+        open(tempdir_newfile.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt hard link file using curent working directory as relative path for old file path
     chdir(tempdir_oldfile.path()).unwrap();
     linkat(
-        None,
+        AT_FDCWD,
         oldfilename,
-        Some(dirfd),
+        &dirfd,
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
@@ -951,7 +945,7 @@ fn test_linkat_olddirfd_none() {
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_newdirfd_none() {
-    let _dr = crate::DirRestore::new();
+    let _dr = DirRestore::new();
 
     let tempdir_oldfile = tempdir().unwrap();
     let oldfilename = "foo.txt";
@@ -965,19 +959,15 @@ fn test_linkat_newdirfd_none() {
     File::create(oldfilepath).unwrap();
 
     // Get file descriptor for base directory of old file
-    let dirfd = fcntl::open(
-        tempdir_oldfile.path(),
-        fcntl::OFlag::empty(),
-        stat::Mode::empty(),
-    )
-    .unwrap();
+    let dirfd =
+        open(tempdir_oldfile.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt hard link file using current working directory as relative path for new file path
     chdir(tempdir_newfile.path()).unwrap();
     linkat(
-        Some(dirfd),
+        &dirfd,
         oldfilename,
-        None,
+        AT_FDCWD,
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
@@ -1009,18 +999,16 @@ fn test_linkat_no_follow_symlink() {
     File::create(&oldfilepath).unwrap();
 
     // Create symlink to file
-    symlinkat(&oldfilepath, None, &symoldfilepath).unwrap();
+    symlinkat(&oldfilepath, AT_FDCWD, &symoldfilepath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt link symlink of file at relative path
     linkat(
-        Some(dirfd),
+        &dirfd,
         symoldfilename,
-        Some(dirfd),
+        &dirfd,
         newfilename,
         LinkatFlags::NoSymlinkFollow,
     )
@@ -1052,18 +1040,16 @@ fn test_linkat_follow_symlink() {
     File::create(&oldfilepath).unwrap();
 
     // Create symlink to file
-    symlinkat(&oldfilepath, None, &symoldfilepath).unwrap();
+    symlinkat(&oldfilepath, AT_FDCWD, &symoldfilepath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt link target of symlink of file at relative path
     linkat(
-        Some(dirfd),
+        &dirfd,
         symoldfilename,
-        Some(dirfd),
+        &dirfd,
         newfilename,
         LinkatFlags::SymlinkFollow,
     )
@@ -1073,7 +1059,7 @@ fn test_linkat_follow_symlink() {
 
     // Check the file type of the new link
     assert_eq!(
-        (stat::SFlag::from_bits_truncate(newfilestat.st_mode as mode_t)
+        (SFlag::from_bits_truncate(newfilestat.st_mode as mode_t)
             & SFlag::S_IFMT),
         SFlag::S_IFREG
     );
@@ -1093,13 +1079,11 @@ fn test_unlinkat_dir_noremovedir() {
     DirBuilder::new().recursive(true).create(dirpath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt unlink dir at relative path without proper flag
     let err_result =
-        unlinkat(Some(dirfd), dirname, UnlinkatFlags::NoRemoveDir).unwrap_err();
+        unlinkat(&dirfd, dirname, UnlinkatFlags::NoRemoveDir).unwrap_err();
     assert!(err_result == Errno::EISDIR || err_result == Errno::EPERM);
 }
 
@@ -1114,12 +1098,10 @@ fn test_unlinkat_dir_removedir() {
     DirBuilder::new().recursive(true).create(&dirpath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt unlink dir at relative path with proper flag
-    unlinkat(Some(dirfd), dirname, UnlinkatFlags::RemoveDir).unwrap();
+    unlinkat(&dirfd, dirname, UnlinkatFlags::RemoveDir).unwrap();
     assert!(!dirpath.exists());
 }
 
@@ -1134,12 +1116,10 @@ fn test_unlinkat_file() {
     File::create(&filepath).unwrap();
 
     // Get file descriptor for base directory
-    let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
-            .unwrap();
+    let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
     // Attempt unlink file at relative path
-    unlinkat(Some(dirfd), filename, UnlinkatFlags::NoRemoveDir).unwrap();
+    unlinkat(&dirfd, filename, UnlinkatFlags::NoRemoveDir).unwrap();
     assert!(!filepath.exists());
 }
 
@@ -1202,7 +1182,7 @@ fn test_setfsuid() {
         // set filesystem UID
         let fuid = setfsuid(nobody.uid);
         // trying to open the temporary file should fail with EACCES
-        let res = fs::File::open(&temp_path);
+        let res = File::open(&temp_path);
         let err = res.expect_err("assertion failed");
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
 
@@ -1214,7 +1194,7 @@ fn test_setfsuid() {
     .unwrap();
 
     // open the temporary file with the current thread filesystem UID
-    fs::File::open(temp_path_2).unwrap();
+    File::open(temp_path_2).unwrap();
 }
 
 #[test]
@@ -1225,7 +1205,7 @@ fn test_setfsuid() {
 )))]
 fn test_ttyname() {
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
-    assert!(fd.as_raw_fd() > 0);
+    assert!(fd.as_fd().as_raw_fd() > 0);
 
     // on linux, we can just call ttyname on the pty master directly, but
     // apparently osx requires that ttyname is called on a slave pty (can't
@@ -1233,11 +1213,11 @@ fn test_ttyname() {
     grantpt(&fd).expect("grantpt failed");
     unlockpt(&fd).expect("unlockpt failed");
     let sname = unsafe { ptsname(&fd) }.expect("ptsname failed");
-    let fds = open(Path::new(&sname), OFlag::O_RDWR, stat::Mode::empty())
+    let fds = open(Path::new(&sname), OFlag::O_RDWR, Mode::empty())
         .expect("open failed");
-    assert!(fds > 0);
+    assert!(fds.as_raw_fd() > 0);
 
-    let name = ttyname(fds).expect("ttyname failed");
+    let name = ttyname(fds.as_raw_fd()).expect("ttyname failed");
     assert!(name.starts_with("/dev"));
 }
 
@@ -1302,10 +1282,10 @@ fn test_getpeereid_invalid_fd() {
 #[cfg(not(target_os = "redox"))]
 fn test_faccessat_none_not_existing() {
     use nix::fcntl::AtFlags;
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir().unwrap();
     let dir = tempdir.path().join("does_not_exist.txt");
     assert_eq!(
-        faccessat(None, &dir, AccessFlags::F_OK, AtFlags::empty())
+        faccessat(AT_FDCWD, &dir, AccessFlags::F_OK, AtFlags::empty())
             .err()
             .unwrap(),
         Errno::ENOENT
@@ -1316,18 +1296,13 @@ fn test_faccessat_none_not_existing() {
 #[cfg(not(target_os = "redox"))]
 fn test_faccessat_not_existing() {
     use nix::fcntl::AtFlags;
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let not_exist_file = "does_not_exist.txt";
     assert_eq!(
-        faccessat(
-            Some(dirfd),
-            not_exist_file,
-            AccessFlags::F_OK,
-            AtFlags::empty(),
-        )
-        .err()
-        .unwrap(),
+        faccessat(&dirfd, not_exist_file, AccessFlags::F_OK, AtFlags::empty())
+            .err()
+            .unwrap(),
         Errno::ENOENT
     );
 }
@@ -1336,11 +1311,11 @@ fn test_faccessat_not_existing() {
 #[cfg(not(target_os = "redox"))]
 fn test_faccessat_none_file_exists() {
     use nix::fcntl::AtFlags;
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir().unwrap();
     let path = tempdir.path().join("does_exist.txt");
     let _file = File::create(path.clone()).unwrap();
     assert!(faccessat(
-        None,
+        AT_FDCWD,
         &path,
         AccessFlags::R_OK | AccessFlags::W_OK,
         AtFlags::empty(),
@@ -1352,13 +1327,13 @@ fn test_faccessat_none_file_exists() {
 #[cfg(not(target_os = "redox"))]
 fn test_faccessat_file_exists() {
     use nix::fcntl::AtFlags;
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let exist_file = "does_exist.txt";
     let path = tempdir.path().join(exist_file);
     let _file = File::create(path.clone()).unwrap();
     assert!(faccessat(
-        Some(dirfd),
+        &dirfd,
         &path,
         AccessFlags::R_OK | AccessFlags::W_OK,
         AtFlags::empty(),


### PR DESCRIPTION
Works towards https://github.com/nix-rust/nix/issues/1750. Fixes https://github.com/nix-rust/nix/issues/1850.

I went the lazy route and pulled the plug... trying to feature gate everything seemed way too complicated.