### PR TITLE
Add routing socket type on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Add `PF_ROUTE` to `SockType` on macOS, iOS, all of the BSDs, Fuchsia, Haiku, Illumos.
+  ([#1867](https://github.com/nix-rust/nix/pull/1867))
+
 ### Changed
 ### Fixed
 ### Removed

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -80,6 +80,9 @@ pub enum AddressFamily {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     Netlink = libc::AF_NETLINK,
+    /// Kernel interface for interacting with the routing table
+    #[cfg(not(any(target_os = "redox", target_os = "linux", target_os = "android")))]
+    Route = libc::PF_ROUTE,
     /// Low level packet interface (see [`packet(7)`](https://man7.org/linux/man-pages/man7/packet.7.html))
     #[cfg(any(
         target_os = "android",
@@ -421,6 +424,8 @@ impl AddressFamily {
             libc::AF_NETLINK => Some(AddressFamily::Netlink),
             #[cfg(any(target_os = "macos", target_os = "macos"))]
             libc::AF_SYSTEM => Some(AddressFamily::System),
+            #[cfg(not(any(target_os = "redox", target_os = "linux", target_os = "android")))]
+            libc::PF_ROUTE => Some(AddressFamily::Route),
             #[cfg(any(target_os = "android", target_os = "linux"))]
             libc::AF_PACKET => Some(AddressFamily::Packet),
             #[cfg(any(

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -2484,4 +2484,16 @@ mod tests {
     fn can_use_cmsg_space() {
         let _ = cmsg_space!(u8);
     }
+
+    #[cfg(not(any(target_os = "redox", target_os = "linux", target_os = "android")))]
+    #[test]
+    fn can_open_routing_socket() {
+        let _ = super::socket(
+            super::AddressFamily::Route,
+            super::SockType::Raw,
+            super::SockFlag::empty(),
+            None,
+        )
+        .expect("Failed to open routing socket");
+    }
 }


### PR DESCRIPTION
This is a small change to add the routing socket type to the list of socket types one can open with `nix`. I've added a smoke test to see that a socket of such type can actually be opened, but I'm not sure if such a test belongs in the codebase here.