### PR TITLE
mmap addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - The MSRV is now 1.56.1
   ([#1792](https://github.com/nix-rust/nix/pull/1792))
+- The `addr` argument of `sys::mman::mmap` is now of type `Option<NonZeroUsize>`.
+  ([#1870](https://github.com/nix-rust/nix/pull/1870))
 
 ### Fixed
 

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -4,7 +4,7 @@ use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 fn test_mmap_anonymous() {
     unsafe {
         let ptr = mmap(
-            std::ptr::null_mut(),
+            None,
             1,
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS,
@@ -27,7 +27,7 @@ fn test_mremap_grow() {
     const ONE_K: size_t = 1024;
     let slice: &mut [u8] = unsafe {
         let mem = mmap(
-            std::ptr::null_mut(),
+            None,
             ONE_K,
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
@@ -83,7 +83,7 @@ fn test_mremap_shrink() {
     const ONE_K: size_t = 1024;
     let slice: &mut [u8] = unsafe {
         let mem = mmap(
-            std::ptr::null_mut(),
+            None,
             10 * ONE_K,
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,


### PR DESCRIPTION
Uses `Some<size_t>` instead of `*mut c_void` for the `addr` passed to [`sys::mman::mmap`](https://docs.rs/nix/latest/nix/sys/mman/fn.mmap.html).

In this instance we are not usefully passing a pointer, it will never be dereferenced. We are passing a location which represents where to attach the shared memory to.

In this case `size_t` better represents an address and not a pointer, and `Option<size_t>` better represents an optional argument than `NULLPTR`.

In C since there is no optional type this is a pointer as this allows it be null which is an alias here for `None`.