### PR TITLE
mmap non-zero length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1792](https://github.com/nix-rust/nix/pull/1792))
 - The `addr` argument of `sys::mman::mmap` is now of type `Option<NonZeroUsize>`.
   ([#1870](https://github.com/nix-rust/nix/pull/1870))
+- The `length` argument of `sys::mman::mmap` is now of type `NonZeroUsize`.
+  ([#1873](https://github.com/nix-rust/nix/pull/1873))
 
 ### Fixed
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -418,7 +418,7 @@ pub fn munlockall() -> Result<()> {
 /// [`mmap(2)`]: https://man7.org/linux/man-pages/man2/mmap.2.html
 pub unsafe fn mmap(
     addr: Option<NonZeroUsize>,
-    length: size_t,
+    length: NonZeroUsize,
     prot: ProtFlags,
     flags: MapFlags,
     fd: RawFd,
@@ -428,8 +428,8 @@ pub unsafe fn mmap(
         std::ptr::null_mut(),
         |a| usize::from(a) as *mut c_void
     );
-
-    let ret = libc::mmap(ptr, length, prot.bits(), flags.bits(), fd, offset);
+    
+    let ret = libc::mmap(ptr, length.into(), prot.bits(), flags.bits(), fd, offset);
 
     if ret == libc::MAP_FAILED {
         Err(Errno::last())
@@ -520,8 +520,9 @@ pub unsafe fn madvise(
 /// # use nix::sys::mman::{mmap, mprotect, MapFlags, ProtFlags};
 /// # use std::ptr;
 /// const ONE_K: size_t = 1024;
+/// let one_k_non_zero = std::num::NonZeroUsize::new(ONE_K).unwrap();
 /// let mut slice: &mut [u8] = unsafe {
-///     let mem = mmap(None, ONE_K, ProtFlags::PROT_NONE,
+///     let mem = mmap(None, one_k_non_zero, ProtFlags::PROT_NONE,
 ///                    MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE, -1, 0).unwrap();
 ///     mprotect(mem, ONE_K, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE).unwrap();
 ///     std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,11 +1,12 @@
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
+use std::num::NonZeroUsize;
 
 #[test]
 fn test_mmap_anonymous() {
     unsafe {
         let ptr = mmap(
             None,
-            1,
+            NonZeroUsize::new(1).unwrap(),
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS,
             -1,
@@ -25,10 +26,12 @@ fn test_mremap_grow() {
     use nix::sys::mman::{mremap, MRemapFlags};
 
     const ONE_K: size_t = 1024;
+    let one_k_non_zero = NonZeroUsize::new(ONE_K).unwrap();
+
     let slice: &mut [u8] = unsafe {
         let mem = mmap(
             None,
-            ONE_K,
+            one_k_non_zero,
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
             -1,
@@ -79,12 +82,14 @@ fn test_mremap_grow() {
 fn test_mremap_shrink() {
     use nix::libc::{c_void, size_t};
     use nix::sys::mman::{mremap, MRemapFlags};
+    use std::num::NonZeroUsize;
 
     const ONE_K: size_t = 1024;
+    let ten_one_k = NonZeroUsize::new(10 * ONE_K).unwrap();
     let slice: &mut [u8] = unsafe {
         let mem = mmap(
             None,
-            10 * ONE_K,
+            ten_one_k,
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
             -1,
@@ -100,7 +105,7 @@ fn test_mremap_shrink() {
     let slice: &mut [u8] = unsafe {
         let mem = mremap(
             slice.as_mut_ptr() as *mut c_void,
-            10 * ONE_K,
+            ten_one_k.into(),
             ONE_K,
             MRemapFlags::empty(),
             None,


### PR DESCRIPTION
When calling [`mmap`](https://man7.org/linux/man-pages/man2/mmap.2.html) the passed length needs to be greater than zero, else an  error is returned:

> EINVAL (since Linux 2.6.12) length was 0.

By specifying the argument as `std::num::NonZeroUsize` we eliminate this error case.