### PR TITLE
Safer poll timeout

### DIFF
--- a/changelog/1876.changed.md
+++ b/changelog/1876.changed.md
@@ -1,0 +1,1 @@
+`poll` now takes `PollTimeout` replacing `libc::c_int`.

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,6 +1,6 @@
 use nix::{
     errno::Errno,
-    poll::{poll, PollFd, PollFlags},
+    poll::{poll, PollFd, PollFlags, PollTimeout},
     unistd::{pipe, write},
 };
 use std::os::unix::io::{AsFd, BorrowedFd};
@@ -23,14 +23,14 @@ fn test_poll() {
     let mut fds = [PollFd::new(r.as_fd(), PollFlags::POLLIN)];
 
     // Poll an idle pipe.  Should timeout
-    let nfds = loop_while_eintr!(poll(&mut fds, 100));
+    let nfds = loop_while_eintr!(poll(&mut fds, PollTimeout::from(100u8)));
     assert_eq!(nfds, 0);
     assert!(!fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 
     write(&w, b".").unwrap();
 
     // Poll a readable pipe.  Should return an event.
-    let nfds = poll(&mut fds, 100).unwrap();
+    let nfds = poll(&mut fds, PollTimeout::from(100u8)).unwrap();
     assert_eq!(nfds, 1);
     assert!(fds[0].revents().unwrap().contains(PollFlags::POLLIN));
 }


### PR DESCRIPTION
Implements a wrapper around `i32` for the `timeout` argument in [`poll::poll`](https://docs.rs/nix/latest/nix/poll/fn.poll.html).

This prevents the error case:

> EINVAL (ppoll()) The timeout value expressed in *ip is invalid
              (negative).

Most of the code additions are simple conversions to/from integer primitives.

An alternative approach to implement the same safety with less code would require something like https://internals.rust-lang.org/t/non-negative-integer-types/17796 and would offer less usability like converting to/from `std::time::Duration`s.