### PR TITLE
PollFd utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added `SockaddrStorage::{as_unix_addr, as_unix_addr_mut}`
   ([#1871](https://github.com/nix-rust/nix/pull/1871))
 - Added `MntFlags` and `unmount` on all of the BSDs.
+- Added `any()` and `all()` to `poll::PollFd`.
+  ([#1877](https://github.com/nix-rust/nix/pull/1877))
+- Add `MntFlags` and `unmount` on all of the BSDs.
   ([#1849](https://github.com/nix-rust/nix/pull/1849))
 - Added a 'Statfs::flags' method.
   ([#1849](https://github.com/nix-rust/nix/pull/1849))

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -37,6 +37,26 @@ impl PollFd {
         PollFlags::from_bits(self.pollfd.revents)
     }
 
+    /// Returns if any of the events of interest occured in the last call to `poll` or `ppoll`. Will
+    /// only return `None` if the kernel provides status flags that Nix does not know about.
+    ///
+    /// Equivalent to `x.revents()? != PollFlags::empty()`.
+    ///
+    /// This is marginally more efficient than [`PollFd::all`].
+    pub fn any(self) -> Option<bool> {
+        Some(self.revents()? != PollFlags::empty())
+    }
+
+    /// Returns if all the events of interest occured in the last call to `poll` or `ppoll`. Will
+    /// only return `None` if the kernel provides status flags that Nix does not know about.
+    ///
+    /// Equivalent to `x.revents()? & x.events() == x.events()`.
+    ///
+    /// This is marginally less efficient than [`PollFd::any`].
+    pub fn all(self) -> Option<bool> {
+        Some(self.revents()? & self.events() == self.events())
+    }
+
     /// The events of interest for this `PollFd`.
     pub fn events(self) -> PollFlags {
         PollFlags::from_bits(self.pollfd.events).unwrap()


### PR DESCRIPTION
Adds `poll::PollFd::any()` and `poll::PollFd::all()` functions which returns if any/all of the events of interest occurred in the last call to `poll` or `ppoll`.

Consider the case:
```rust
let (first_fd, second_fd) = /* ... */;
let mut poll_fds = [
    poll::PollFd::new(interrupt_fd, poll::PollFlags::POLLIN),
    poll::PollFd::new(transfer_fd, poll::PollFlags::POLLIN),
];
let _ = poll::poll(&mut poll_fds, -1)?;

let first = poll_fds[0].revents()? != poll::PollFlags::empty();
let second = poll_fds[1].revents()? != poll::PollFlags::empty();;

if first { /* ... */ }
if second { /* ... */ }
```
which can now be reduced:
```rust
let (first_fd, second_fd) = /* ... */;
let mut poll_fds = [
    poll::PollFd::new(interrupt_fd, poll::PollFlags::POLLIN),
    poll::PollFd::new(transfer_fd, poll::PollFlags::POLLIN),
];
let _ = poll::poll(&mut poll_fds, -1)?;

let first = poll_fds[0].any()?;
let second = poll_fds[1].any()?;

if first { /* ... */ }
if second { /* ... */ }
```