### PR TITLE
EPOLL_CLOEXEC bool

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -35,12 +35,6 @@ pub enum EpollOp {
     EpollCtlMod = libc::EPOLL_CTL_MOD,
 }
 
-libc_bitflags! {
-    pub struct EpollCreateFlags: c_int {
-        EPOLL_CLOEXEC;
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct EpollEvent {
@@ -78,8 +72,9 @@ pub fn epoll_create() -> Result<RawFd> {
 }
 
 #[inline]
-pub fn epoll_create1(flags: EpollCreateFlags) -> Result<RawFd> {
-    let res = unsafe { libc::epoll_create1(flags.bits()) };
+pub fn epoll_create1(close_on_exec: bool) -> Result<RawFd> {
+    let flags = if close_on_exec { libc::EPOLL_CLOEXEC } else { 0 };
+    let res = unsafe { libc::epoll_create1(flags) };
 
     Errno::result(res)
 }

--- a/test/sys/test_epoll.rs
+++ b/test/sys/test_epoll.rs
@@ -1,10 +1,10 @@
 use nix::errno::Errno;
 use nix::sys::epoll::{epoll_create1, epoll_ctl};
-use nix::sys::epoll::{EpollCreateFlags, EpollEvent, EpollFlags, EpollOp};
+use nix::sys::epoll::{EpollEvent, EpollFlags, EpollOp};
 
 #[test]
 pub fn test_epoll_errno() {
-    let efd = epoll_create1(EpollCreateFlags::empty()).unwrap();
+    let efd = epoll_create1(false).unwrap();
     let result = epoll_ctl(efd, EpollOp::EpollCtlDel, 1, None);
     result.expect_err("assertion failed");
     assert_eq!(result.unwrap_err(), Errno::ENOENT);
@@ -16,7 +16,7 @@ pub fn test_epoll_errno() {
 
 #[test]
 pub fn test_epoll_ctl() {
-    let efd = epoll_create1(EpollCreateFlags::empty()).unwrap();
+    let efd = epoll_create1(false).unwrap();
     let mut event =
         EpollEvent::new(EpollFlags::EPOLLIN | EpollFlags::EPOLLERR, 1);
     epoll_ctl(efd, EpollOp::EpollCtlAdd, 1, &mut event).unwrap();


### PR DESCRIPTION
Replaces `EpollCreateFlags` with a simple bool argument. Bitflags with 1 option should just be a boolean.