### PR TITLE
Use the new UnixAddr::new_unnamed in the unit tests

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -3197,8 +3197,7 @@ mod tests {
         #[cfg(any(target_os = "android", target_os = "linux"))]
         #[test]
         fn from_sockaddr_un_abstract_unnamed() {
-            let empty = String::new();
-            let ua = UnixAddr::new_abstract(empty.as_bytes()).unwrap();
+            let ua = UnixAddr::new_unnamed();
             let ptr = ua.as_ptr() as *const libc::sockaddr;
             let ss = unsafe {
                 SockaddrStorage::from_raw(ptr, Some(ua.len()))


### PR DESCRIPTION
Use it in the from_sockaddr_un_abstract_unnamed test.  That test and this method were introduced by PRs #1871 and #1857, which crossed each other.