### PR TITLE
Fix network byte order of ETH_P_ALL socket protocol

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -226,7 +226,7 @@ pub enum SockProtocol {
     // The protocol number is fed into the socket syscall in network byte order.
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
-    EthAll = libc::ETH_P_ALL.to_be(),
+    EthAll = (libc::ETH_P_ALL as i16).to_be() as c_int,
 }
 
 #[cfg(any(target_os = "linux"))]


### PR DESCRIPTION
I was wondering why I couldn't read from my nix socket and it turns out there's a bug in the attempt to pass the protocol number into the socket syscall in network byte order. Here's a minimal example:

_nix/examples/socket.rs_
```
use nix::sys::socket::*;
fn main() {
    let _fd = socket(
        AddressFamily::Packet,
        SockType::Raw,
        SockFlag::empty(),
        SockProtocol::EthAll,
    ).unwrap();
}
```

Trace the actual values passed into the `socket` syscall:
```
nix$ cargo b --example socket
nix$ sudo strace ./target/debug/examples/socket  // before
socket(AF_PACKET, SOCK_RAW, htons(0 /* ETH_P_??? */)) = 3
nix$ sudo strace ./target/debug/examples/socket  // after
socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL)) = 3
```