### PR TITLE
Update use of libc::timespec to prepare for future libc version (0.23 backport)

### DIFF
--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -28,7 +28,7 @@
 //! // We wait for the timer to expire.
 //! timer.wait().unwrap();
 //! ```
-use crate::sys::time::TimeSpec;
+use crate::sys::time::{TIMESPEC_ZERO, TimeSpec};
 use crate::unistd::read;
 use crate::{errno::Errno, Result};
 use bitflags::bitflags;
@@ -90,14 +90,8 @@ struct TimerSpec(libc::itimerspec);
 impl TimerSpec {
     pub const fn none() -> Self {
         Self(libc::itimerspec {
-            it_interval: libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-            it_value: libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
+            it_interval: TIMESPEC_ZERO,
+            it_value: TIMESPEC_ZERO,
         })
     }
 }
@@ -112,10 +106,7 @@ impl From<Expiration> for TimerSpec {
     fn from(expiration: Expiration) -> TimerSpec {
         match expiration {
             Expiration::OneShot(t) => TimerSpec(libc::itimerspec {
-                it_interval: libc::timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                },
+                it_interval: TIMESPEC_ZERO,
                 it_value: *t.as_ref(),
             }),
             Expiration::IntervalDelayed(start, interval) => TimerSpec(libc::itimerspec {
@@ -138,6 +129,7 @@ impl From<TimerSpec> for Expiration {
                     libc::timespec {
                         tv_sec: 0,
                         tv_nsec: 0,
+                        ..
                     },
                 it_value: ts,
             }) => Expiration::OneShot(ts.into()),


### PR DESCRIPTION
This is a backport of 006fc6f7975b3a6b64329847b780622aab392109. The original commit message follows:

In a future release of the `libc` crate, `libc::timespec` will contain private padding fields on `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initialization syntax.

Update places where `libc::timespec` is created to first zero initialize the value and then update the `tv_sec` and `tv_nsec` fields manually. Many of these places are in `const fn`s so a helper function `zero_init_timespec()` is introduced to help with this as `std::mem::MaybeUninit::zeroed()` is not a `const` function.

Some matches on `libc::timespec` are also updated to include a trailing `..` pattern which works when `libc::timespec` has additional, private fields as well as when it does not (like for
`x86_64-unknown-linux-gnu`).