### PR TITLE
Enable ucontext module on aarch64-unknown-linux-gnu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Add `PF_ROUTE` to `SockType` on macOS, iOS, all of the BSDs, Fuchsia, Haiku, Illumos.
   ([#1867](https://github.com/nix-rust/nix/pull/1867))
+- Added `nix::ucontext` module on `aarch64-unknown-linux-gnu`.
+  (#[1662](https://github.com/nix-rust/nix/pull/1662))
 
 ### Changed
 ### Fixed
@@ -213,7 +215,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1563](https://github.com/nix-rust/nix/pull/1563))
 - Added `process_vm_readv` and `process_vm_writev` on Android.
   (#[1557](https://github.com/nix-rust/nix/pull/1557))
-- Added `nix::uncontext` module on s390x.
+- Added `nix::ucontext` module on s390x.
   (#[1662](https://github.com/nix-rust/nix/pull/1662))
 - Implemented `Extend`, `FromIterator`, and `IntoIterator` for `SigSet` and
   added `SigSet::iter` and `SigSetIter`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.137", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "15d27952bfa93e5e4f419c603f275486f15a050c", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,12 @@ feature! {
 // provides bindings for them.
 #[cfg(all(
     target_os = "linux",
-    any(target_arch = "s390x", target_arch = "x86", target_arch = "x86_64")
+    any(
+        target_arch = "aarch64",
+        target_arch = "s390x",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    )
 ))]
 feature! {
     #![feature = "ucontext"]


### PR DESCRIPTION
Untested, but I saw https://github.com/rust-lang/libc/commit/fd32da6e7dfa2afcae86e176904244cf45a90c06 and figured we should uptake it.