### PR TITLE
Drop x86_64-unknown-darwin to Tier 2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,13 +67,13 @@ task:
     - if [ -z "$NOHACK" ]; then cargo hack check --each-feature --target i686-unknown-freebsd; fi
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-# Test macOS x86_64 in a full VM
+# Test macOS aarch64 in a full VM
 task:
-  name: macOS x86_64
+  name: macOS aarch64
   env:
-    TARGET: x86_64-apple-darwin
-  osx_instance:
-    image: big-sur-xcode
+    TARGET: aarch64-apple-darwin
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   setup_script:
     - curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
@@ -235,9 +235,9 @@ task:
     - name: Linux x32
       env:
         TARGET: x86_64-unknown-linux-gnux32
-    - name: macOS aarch64
+    - name: macOS x86_64
       env:
-        TARGET: aarch64-apple-darwin
+        TARGET: x86_64-apple-darwin
     - name: NetBSD x86_64
       env:
         TARGET: x86_64-unknown-netbsd

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ limitations. Support for platforms is split into three tiers:
 The following targets are supported by `nix`:
 
 Tier 1:
+  * aarch64-apple-darwin
   * aarch64-unknown-linux-gnu
   * arm-unknown-linux-gnueabi
   * armv7-unknown-linux-gnueabihf
@@ -58,13 +59,11 @@ Tier 1:
   * mips64el-unknown-linux-gnuabi64
   * mipsel-unknown-linux-gnu
   * powerpc64le-unknown-linux-gnu
-  * x86_64-apple-darwin
   * x86_64-unknown-freebsd
   * x86_64-unknown-linux-gnu
   * x86_64-unknown-linux-musl
 
 Tier 2:
-  * aarch64-apple-darwin
   * aarch64-apple-ios
   * aarch64-linux-android
   * arm-linux-androideabi
@@ -75,6 +74,7 @@ Tier 2:
   * s390x-unknown-linux-gnu
   * x86_64-apple-ios
   * x86_64-linux-android
+  * x86_64-apple-darwin
   * x86_64-unknown-illumos
   * x86_64-unknown-netbsd
 


### PR DESCRIPTION
And promote aarch64-unknown-darwin to Tier 1.  Because that's what Cirrus CI is doing.

Fixes #1904