### PR TITLE
feat: I/O safety for 'sys/inotify'

### DIFF
--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -32,7 +32,7 @@ use libc::{c_char, c_int};
 use std::ffi::{CStr, OsStr, OsString};
 use std::mem::{size_of, MaybeUninit};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::ptr;
 
 libc_bitflags! {
@@ -101,9 +101,9 @@ libc_bitflags! {
 
 /// An inotify instance. This is also a file descriptor, you can feed it to
 /// other interfaces consuming file descriptors, epoll for example.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct Inotify {
-    fd: RawFd,
+    fd: OwnedFd,
 }
 
 /// This object is returned when you create a new watch on an inotify instance.
@@ -143,7 +143,7 @@ impl Inotify {
     pub fn init(flags: InitFlags) -> Result<Inotify> {
         let res = Errno::result(unsafe { libc::inotify_init1(flags.bits()) });
 
-        res.map(|fd| Inotify { fd })
+        res.map(|fd| Inotify { fd: unsafe { OwnedFd::from_raw_fd(fd) } })
     }
 
     /// Adds a new watch on the target file or directory.
@@ -152,12 +152,12 @@ impl Inotify {
     ///
     /// For more information see, [inotify_add_watch(2)](https://man7.org/linux/man-pages/man2/inotify_add_watch.2.html).
     pub fn add_watch<P: ?Sized + NixPath>(
-        self,
+        &self,
         path: &P,
         mask: AddWatchFlags,
     ) -> Result<WatchDescriptor> {
         let res = path.with_nix_path(|cstr| unsafe {
-            libc::inotify_add_watch(self.fd, cstr.as_ptr(), mask.bits())
+            libc::inotify_add_watch(self.fd.as_raw_fd(), cstr.as_ptr(), mask.bits())
         })?;
 
         Errno::result(res).map(|wd| WatchDescriptor { wd })
@@ -169,7 +169,7 @@ impl Inotify {
     /// Returns an EINVAL error if the watch descriptor is invalid.
     ///
     /// For more information see, [inotify_rm_watch(2)](https://man7.org/linux/man-pages/man2/inotify_rm_watch.2.html).
-    pub fn rm_watch(self, wd: WatchDescriptor) -> Result<()> {
+    pub fn rm_watch(&self, wd: WatchDescriptor) -> Result<()> {
         cfg_if! {
             if #[cfg(target_os = "linux")] {
                 let arg = wd.wd;
@@ -177,7 +177,7 @@ impl Inotify {
                 let arg = wd.wd as u32;
             }
         }
-        let res = unsafe { libc::inotify_rm_watch(self.fd, arg) };
+        let res = unsafe { libc::inotify_rm_watch(self.fd.as_raw_fd(), arg) };
 
         Errno::result(res).map(drop)
     }
@@ -188,14 +188,14 @@ impl Inotify {
     ///
     /// Returns as many events as available. If the call was non blocking and no
     /// events could be read then the EAGAIN error is returned.
-    pub fn read_events(self) -> Result<Vec<InotifyEvent>> {
+    pub fn read_events(&self) -> Result<Vec<InotifyEvent>> {
         let header_size = size_of::<libc::inotify_event>();
         const BUFSIZ: usize = 4096;
         let mut buffer = [0u8; BUFSIZ];
         let mut events = Vec::new();
         let mut offset = 0;
 
-        let nread = read(self.fd, &mut buffer)?;
+        let nread = read(self.fd.as_raw_fd(), &mut buffer)?;
 
         while (nread - offset) >= header_size {
             let event = unsafe {
@@ -235,14 +235,8 @@ impl Inotify {
     }
 }
 
-impl AsRawFd for Inotify {
-    fn as_raw_fd(&self) -> RawFd {
-        self.fd
-    }
-}
-
 impl FromRawFd for Inotify {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Inotify { fd }
+        Inotify { fd: OwnedFd::from_raw_fd(fd) }
     }
 }


### PR DESCRIPTION
#### What this PR does:

1. Changes the `fd` field of `struct Inotify` from `RawFd` to `OwnedFd`
2. Changes the interfaces of functions in the `impl Inotify {}`
   
    > The type of `self` changes from `Self` to `&mut Self`. 
    
    From:

   ```rust
   pub fn add_watch<P: ?Sized + NixPath>(
         self,
         path: &P,
         mask: AddWatchFlags,
   ) -> Result<WatchDescriptor> 

   pub fn rm_watch(self, wd: WatchDescriptor) -> Result<()>

   pub fn read_events(self) -> Result<Vec<InotifyEvent>>
   ```

   To:

   ```rust
   pub fn add_watch<P: ?Sized + NixPath>(
        &mut self,
        path: &P,
        mask: AddWatchFlags,
    ) -> Result<WatchDescriptor>

   pub fn rm_watch(&mut self, wd: WatchDescriptor) -> Result<()>

   pub fn read_events(&mut self) -> Result<Vec<InotifyEvent>>
   ```
  

   In the previous implementation, these functions can take `self` by value as `struct Inotify` [was `Copy`](https://docs.rs/nix/latest/nix/sys/inotify/struct.Inotify.html#impl-Copy-for-Inotify). With the changes in `1` applied, `struct Inotify` is no longer `Copy`, so we have to take `self` by reference.

-------

Blocks until the merge of #1863 as this PR needs `read(2)` to be I/O-safe.
