### PR TITLE
Added CanAddr for binding sockets for CANbus access

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -54,6 +54,8 @@ pub use self::addr::{SockaddrIn, SockaddrIn6};
 pub use crate::sys::socket::addr::alg::AlgAddr;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use crate::sys::socket::addr::netlink::NetlinkAddr;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use crate::sys::socket::addr::can::CanAddr;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 #[cfg(feature = "ioctl")]
 pub use crate::sys::socket::addr::sys_control::SysControlAddr;


### PR DESCRIPTION
This adds a `CanAddr` type for CANbus access. It would allow an application to `bind()` a SocketCAN socket.

I have no idea if I did this properly; I just tried some copy-pasta from the `NetlinkAddr`. But it does appear to wok and I can use it to successfully bind to a can interface.