### PR TITLE
feat: I/O safety for 'sys/statfs'

### DIFF
--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -5,7 +5,7 @@
 use std::ffi::CStr;
 use std::fmt::{self, Debug};
 use std::mem;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsFd, AsRawFd};
 
 use cfg_if::cfg_if;
 
@@ -740,10 +740,10 @@ pub fn statfs<P: ?Sized + NixPath>(path: &P) -> Result<Statfs> {
 /// # Arguments
 ///
 /// `fd` - File descriptor of any open file within the file system to describe
-pub fn fstatfs<T: AsRawFd>(fd: &T) -> Result<Statfs> {
+pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> Result<Statfs> {
     unsafe {
         let mut stat = mem::MaybeUninit::<type_of_statfs>::uninit();
-        Errno::result(LIBC_FSTATFS(fd.as_raw_fd(), stat.as_mut_ptr()))
+        Errno::result(LIBC_FSTATFS(fd.as_fd().as_raw_fd(), stat.as_mut_ptr()))
             .map(|_| Statfs(stat.assume_init()))
     }
 }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -383,7 +383,7 @@ mod linux_android {
         let tmp = NamedTempFile::new().unwrap();
 
         let fd = tmp.as_raw_fd();
-        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must
@@ -421,7 +421,7 @@ mod linux_android {
         let tmp = NamedTempFile::new().unwrap();
 
         let fd = tmp.as_raw_fd();
-        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
+        let statfs = nix::sys::statfs::fstatfs(tmp.as_file()).unwrap();
         if statfs.filesystem_type() == nix::sys::statfs::OVERLAYFS_SUPER_MAGIC {
             // OverlayFS is a union file system.  It returns one inode value in
             // stat(2), but a different one shows up in /proc/locks.  So we must


### PR DESCRIPTION
### What this PR does:

1. Adds I/O safety for module `sys/statfs`. 

This PR is pretty small as all we need to do is to change the interface of `fstatfs(2)`:

from:

```rust
pub fn fstatfs<T: AsRawFd>(fd: &T) -> Result<Statfs> 
```

to:
```rust
pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> Result<Statfs>
```

------

~Besides from the changes in module `sys/statfs`, there are two extra places where care needs to be taken:~

```shell
$ cd nix

# Search for the usage of `fstatfs(2)` in `nix`
$ rg "fstatfs\("
test/test_fcntl.rs
386:        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
424:        let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();

CHANGELOG.md
849:- Now functions `statfs()` and `fstatfs()` return result with `Statfs` wrapper

src/sys/statfs.rs
769:        check_fstatfs("/tmp");
770:        check_fstatfs("/dev");
771:        check_fstatfs("/run");
772:        check_fstatfs("/");
775:    fn check_fstatfs(path: &str) {
781:        let fs = fstatfs(&file).unwrap();
830:        let fs = fstatfs(&file);
```

~As you can see, `fstatfs(2)` is used in the tests in `test/test_fcntl.rs`:~

```rust
// Test code that involves `fstatfs(2)`

 let tmp: NamedTempFile = NamedTempFile::new().unwrap();

 let fd = tmp.as_raw_fd();
 let statfs = nix::sys::statfs::fstatfs(&tmp).unwrap();
```
~`tmp` is of type [`NamedTempFile`](https://docs.rs/tempfile/latest/tempfile/struct.NamedTempFile.html), which does not implement `AsFd` in the current implementation of `tempfile`, but the implementation should be easy as it contains `std::fs::File` internally:~

```rust
pub struct NamedTempFile {
    path: TempPath,
    file: File,
}
```

~So I am thinking about making a PR to `tempfile` to make `NamedTempFile` `AsFd`, any thoughts on this?~
