### PR TITLE
Fix tests with --no-default-features.

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -1122,7 +1122,7 @@ mod sigevent {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test,any(feature = "signal")))]
 mod tests {
     use super::*;
     #[cfg(not(target_os = "redox"))]

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2317,6 +2317,7 @@ pub mod vsock {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "net")]
     mod types {
         use super::*;
 
@@ -2385,6 +2386,7 @@ mod tests {
             target_endian = "little"
         ))]
         #[test]
+        #[cfg(feature = "net")]
         fn linux_loopback() {
             #[repr(align(2))]
             struct Raw([u8; 20]);
@@ -2465,6 +2467,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(feature = "net")]
         fn size() {
             #[cfg(any(
                 target_os = "dragonfly",
@@ -2487,6 +2490,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "net")]
     mod sockaddr_in {
         use super::*;
         use std::str::FromStr;
@@ -2507,6 +2511,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "net")]
     mod sockaddr_in6 {
         use super::*;
         use std::str::FromStr;

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1801,6 +1801,7 @@ mod test {
     use std::str::FromStr;
 
     #[cfg_attr(qemu, ignore)]
+    #[cfg(all(feature = "net",feature = "time"))]
     #[test]
     fn test_recvmm2() -> crate::Result<()> {
         use crate::sys::socket::{
@@ -2380,6 +2381,7 @@ pub fn shutdown(df: RawFd, how: Shutdown) -> Result<()> {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg(feature = "uio")]
     fn can_use_cmsg_space() {
         let _ = cmsg_space!(u8);
     }

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -78,11 +78,15 @@ macro_rules! skip_if_jailed {
 #[macro_export]
 macro_rules! skip_if_not_root {
     ($name:expr) => {
+        #[cfg(feature = "user")]
         use nix::unistd::Uid;
 
+        #[cfg(feature = "user")]
         if !Uid::current().is_root() {
             skip!("{} requires root privileges. Skipping test.", $name);
         }
+        #[cfg(not(feature = "user"))]
+        skip!("{} requires root privileges and 'user' feature is disabled so the current user cannot be determined. Skipping test.", $name);
     };
 }
 

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "aio",feature = "signal"))]
 use std::{
     io::{Read, Seek, Write},
     ops::Deref,

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -4,6 +4,7 @@
 #[test]
 #[should_panic(expected = "Dropped an in-progress AioCb")]
 #[cfg(all(
+    feature = "aio",
     not(target_env = "musl"),
     not(target_env = "uclibc"),
     any(

--- a/test/sys/test_epoll.rs
+++ b/test/sys/test_epoll.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "event")]
 #![allow(deprecated)]
 
 use nix::errno::Errno;

--- a/test/sys/test_inotify.rs
+++ b/test/sys/test_inotify.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "inotify")]
 use nix::errno::Errno;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::ffi::OsString;

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "ioctl")]
 #![allow(dead_code)]
 
 // Simple tests to ensure macro generated fns compile

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "mman")]
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
 use std::{num::NonZeroUsize, os::unix::io::BorrowedFd};
 

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "pthread")]
 use nix::sys::pthread::*;
 
 #[cfg(any(target_env = "musl", target_os = "redox"))]
@@ -16,6 +17,7 @@ fn test_pthread_self() {
 
 #[test]
 #[cfg(not(target_os = "redox"))]
+#[cfg(feature = "signal")]
 fn test_pthread_kill_none() {
     pthread_kill(pthread_self(), None)
         .expect("Should be able to send signal to my thread.");

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -1,8 +1,10 @@
+#![cfg(feature = "ptrace")]
 #[cfg(all(
     target_os = "linux",
     any(target_arch = "x86_64", target_arch = "x86"),
     target_env = "gnu"
 ))]
+#[cfg(feature = "memoffset")]
 use memoffset::offset_of;
 use nix::errno::Errno;
 use nix::sys::ptrace;
@@ -67,6 +69,7 @@ fn test_ptrace_setsiginfo() {
 }
 
 #[test]
+#[cfg(feature = "signal")]
 fn test_ptrace_cont() {
     use nix::sys::ptrace;
     use nix::sys::signal::{raise, Signal};
@@ -183,6 +186,7 @@ fn test_ptrace_interrupt() {
     target_env = "gnu"
 ))]
 #[test]
+#[cfg(all(feature = "signal",feature = "memoffset"))]
 fn test_ptrace_syscall() {
     use nix::sys::ptrace;
     use nix::sys::signal::kill;

--- a/test/sys/test_select.rs
+++ b/test/sys/test_select.rs
@@ -1,9 +1,12 @@
+#![cfg(feature = "poll")]
 use nix::sys::select::*;
+#[cfg(feature = "signal")]
 use nix::sys::signal::SigSet;
 use nix::sys::time::{TimeSpec, TimeValLike};
 use nix::unistd::{pipe, write};
 
 #[test]
+#[cfg(feature = "signal")]
 pub fn test_pselect() {
     let _mtx = crate::SIGNAL_MTX.lock();
 
@@ -26,6 +29,7 @@ pub fn test_pselect() {
 }
 
 #[test]
+#[cfg(feature = "signal")]
 pub fn test_pselect_nfds2() {
     let (r1, w1) = pipe().unwrap();
     write(w1, b"hi!").unwrap();

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "signal")]
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
 use nix::sys::signal::*;

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "signal")]
 use std::convert::TryFrom;
 
 #[test]

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "socket")]
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::*;
 use libc::c_char;
@@ -12,6 +13,7 @@ use std::str::FromStr;
 
 #[cfg(any(target_os = "linux"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "uio",feature = "net",feature = "time"))]
 #[test]
 pub fn test_timestamping() {
     use nix::sys::socket::{
@@ -203,6 +205,7 @@ pub fn test_socketpair() {
 }
 
 #[test]
+#[cfg(feature = "net")]
 pub fn test_std_conversions() {
     use nix::sys::socket::*;
 
@@ -269,6 +272,7 @@ mod recvfrom {
     }
 
     #[test]
+    #[cfg(feature = "net")]
     pub fn udp() {
         let std_sa = SocketAddrV4::from_str("127.0.0.1:6789").unwrap();
         let sock_addr = SockaddrIn::from(std_sa);
@@ -298,6 +302,7 @@ mod recvfrom {
     }
 
     #[cfg(target_os = "linux")]
+    #[cfg(feature = "net")]
     mod udp_offload {
         use super::*;
         use nix::sys::socket::sockopt::{UdpGroSegment, UdpGsoSegment};
@@ -307,6 +312,7 @@ mod recvfrom {
         // Disable the test under emulation because it fails in Cirrus-CI.  Lack
         // of QEMU support is suspected.
         #[cfg_attr(qemu, ignore)]
+        #[cfg(all(feature = "process",feature = "feature"))]
         pub fn gso() {
             require_kernel_version!(udp_offload::gso, ">= 4.18");
 
@@ -367,6 +373,7 @@ mod recvfrom {
         // Disable the test on emulated platforms because it fails in Cirrus-CI.
         // Lack of QEMU support is suspected.
         #[cfg_attr(qemu, ignore)]
+        #[cfg(all(feature = "process",feature = "feature"))]
         pub fn gro() {
             require_kernel_version!(udp_offload::gro, ">= 5.3");
 
@@ -392,6 +399,7 @@ mod recvfrom {
         target_os = "freebsd",
         target_os = "netbsd",
     ))]
+    #[cfg(all(feature = "uio",feature = "net"))]
     #[test]
     pub fn udp_sendmmsg() {
         use std::io::IoSlice;
@@ -459,6 +467,7 @@ mod recvfrom {
         target_os = "freebsd",
         target_os = "netbsd",
     ))]
+    #[cfg(all(feature = "uio",feature = "net"))]
     #[test]
     pub fn udp_recvmmsg() {
         use nix::sys::socket::{recvmmsg, MsgFlags};
@@ -531,6 +540,7 @@ mod recvfrom {
         target_os = "netbsd",
     ))]
     #[test]
+    #[cfg(all(feature = "uio", feature = "net"))]
     pub fn udp_recvmmsg_dontwait_short_read() {
         use nix::sys::socket::{recvmmsg, MsgFlags};
         use std::io::IoSliceMut;
@@ -606,6 +616,7 @@ mod recvfrom {
     }
 
     #[test]
+    #[cfg(feature = "net")]
     pub fn udp_inet6() {
         let addr = std::net::Ipv6Addr::from_str("::1").unwrap();
         let rport = 6789;
@@ -653,6 +664,7 @@ mod recvfrom {
 
 // Test error handling of our recvmsg wrapper
 #[test]
+#[cfg(feature = "uio")]
 pub fn test_recvmsg_ebadf() {
     use nix::errno::Errno;
     use nix::sys::socket::{recvmsg, MsgFlags};
@@ -670,6 +682,7 @@ pub fn test_recvmsg_ebadf() {
 // Disable the test on emulated platforms due to a bug in QEMU versions <
 // 2.12.0.  https://bugs.launchpad.net/qemu/+bug/1701808
 #[cfg_attr(qemu, ignore)]
+#[cfg(feature = "uio")]
 #[test]
 pub fn test_scm_rights() {
     use nix::sys::socket::{
@@ -743,6 +756,7 @@ pub fn test_scm_rights() {
 // Disable the test on emulated platforms due to not enabled support of AF_ALG in QEMU from rust cross
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(feature = "uio")]
 #[test]
 pub fn test_af_alg_cipher() {
     use nix::sys::socket::sockopt::AlgSetKey;
@@ -822,6 +836,7 @@ pub fn test_af_alg_cipher() {
 // in QEMU from rust cross
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "uio",feature = "fs"))]
 #[test]
 pub fn test_af_alg_aead() {
     use libc::{ALG_OP_DECRYPT, ALG_OP_ENCRYPT};
@@ -941,6 +956,7 @@ pub fn test_af_alg_aead() {
 // has more than one IP address (since we could select a different address to
 // test from).
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "netbsd"))]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 pub fn test_sendmsg_ipv4packetinfo() {
     use cfg_if::cfg_if;
@@ -1000,6 +1016,7 @@ pub fn test_sendmsg_ipv4packetinfo() {
     target_os = "netbsd",
     target_os = "freebsd"
 ))]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 pub fn test_sendmsg_ipv6packetinfo() {
     use nix::errno::Errno;
@@ -1059,6 +1076,7 @@ pub fn test_sendmsg_ipv6packetinfo() {
     target_os = "openbsd",
     target_os = "dragonfly",
 ))]
+#[cfg(feature = "uio")]
 #[test]
 pub fn test_sendmsg_ipv4sendsrcaddr() {
     use nix::sys::socket::{
@@ -1101,6 +1119,7 @@ pub fn test_sendmsg_ipv4sendsrcaddr() {
 // Disable the test on emulated platforms due to a bug in QEMU versions <
 // 2.12.0.  https://bugs.launchpad.net/qemu/+bug/1701808
 #[cfg_attr(qemu, ignore)]
+#[cfg(feature = "uio")]
 #[test]
 fn test_scm_rights_single_cmsg_multiple_fds() {
     use nix::sys::socket::{
@@ -1160,6 +1179,7 @@ fn test_scm_rights_single_cmsg_multiple_fds() {
 // msg_control field and a msg_controllen of 0 when calling into the
 // raw `sendmsg`.
 #[test]
+#[cfg(feature = "uio")]
 pub fn test_sendmsg_empty_cmsgs() {
     use nix::sys::socket::{
         recvmsg, sendmsg, socketpair, AddressFamily, MsgFlags, SockFlag,
@@ -1215,6 +1235,7 @@ pub fn test_sendmsg_empty_cmsgs() {
     target_os = "freebsd",
     target_os = "dragonfly",
 ))]
+#[cfg(all(feature = "uio",feature = "user",feature = "process"))]
 #[test]
 fn test_scm_credentials() {
     use nix::sys::socket::{
@@ -1295,6 +1316,7 @@ fn test_scm_credentials() {
 // qemu's handling of multiple cmsgs is bugged, ignore tests under emulation
 // see https://bugs.launchpad.net/qemu/+bug/1781280
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "user",feature = "uio",feature = "process"))]
 #[test]
 fn test_scm_credentials_and_rights() {
     let space = cmsg_space!(libc::ucred, RawFd);
@@ -1307,6 +1329,7 @@ fn test_scm_credentials_and_rights() {
 // qemu's handling of multiple cmsgs is bugged, ignore tests under emulation
 // see https://bugs.launchpad.net/qemu/+bug/1781280
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "user",feature = "uio",feature = "process"))]
 #[test]
 fn test_too_large_cmsgspace() {
     let space = vec![0u8; 1024];
@@ -1314,6 +1337,7 @@ fn test_too_large_cmsgspace() {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(all(feature = "user",feature = "uio",feature = "process"))]
 fn test_impl_scm_credentials_and_rights(mut space: Vec<u8>) {
     use libc::ucred;
     use nix::sys::socket::sockopt::PassCred;
@@ -1321,7 +1345,7 @@ fn test_impl_scm_credentials_and_rights(mut space: Vec<u8>) {
         recvmsg, sendmsg, setsockopt, socketpair, ControlMessage,
         ControlMessageOwned, MsgFlags, SockFlag, SockType,
     };
-    use nix::unistd::{close, getgid, getpid, getuid, pipe, write};
+    use nix::unistd::{close, getgid, getpid, getuid, pipe, read, write};
     use std::io::{IoSlice, IoSliceMut};
 
     let (send, recv) = socketpair(
@@ -1536,6 +1560,7 @@ pub fn test_syscontrol() {
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
+#[cfg(feature = "net")]
 fn loopback_address(
     family: AddressFamily,
 ) -> Option<nix::ifaddrs::InterfaceAddress> {
@@ -1581,6 +1606,7 @@ fn loopback_address(
     ),
     ignore
 )]
+#[cfg(all(feature = "uio", feature = "net"))]
 #[test]
 pub fn test_recv_ipv4pktinfo() {
     use nix::net::if_::*;
@@ -1675,6 +1701,7 @@ pub fn test_recv_ipv4pktinfo() {
     ),
     ignore
 )]
+#[cfg(feature = "uio")]
 #[test]
 pub fn test_recvif() {
     use nix::net::if_::*;
@@ -1775,6 +1802,7 @@ pub fn test_recvif() {
 
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 pub fn test_recvif_ipv4() {
     use nix::sys::socket::sockopt::Ipv4OrigDstAddr;
@@ -1860,6 +1888,7 @@ pub fn test_recvif_ipv4() {
 
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 pub fn test_recvif_ipv6() {
     use nix::sys::socket::sockopt::Ipv6OrigDstAddr;
@@ -1964,6 +1993,7 @@ pub fn test_recvif_ipv6() {
     ),
     ignore
 )]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 pub fn test_recv_ipv6pktinfo() {
     use nix::net::if_::*;
@@ -2097,6 +2127,7 @@ pub fn test_vsock() {
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
 #[cfg(all(target_os = "linux"))]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 fn test_recvmsg_timestampns() {
     use nix::sys::socket::*;
@@ -2152,6 +2183,7 @@ fn test_recvmsg_timestampns() {
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
 #[cfg(all(target_os = "linux"))]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 fn test_recvmmsg_timestampns() {
     use nix::sys::socket::*;
@@ -2209,6 +2241,7 @@ fn test_recvmmsg_timestampns() {
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg(all(feature = "uio",feature = "net"))]
 #[test]
 fn test_recvmsg_rxq_ovfl() {
     use nix::sys::socket::sockopt::{RcvBuf, RxqOvfl};
@@ -2301,6 +2334,7 @@ fn test_recvmsg_rxq_ovfl() {
 }
 
 #[cfg(any(target_os = "linux", target_os = "android",))]
+#[cfg(all(feature = "uio",feature = "net"))]
 mod linux_errqueue {
     use super::FromStr;
     use nix::sys::socket::*;
@@ -2479,6 +2513,7 @@ mod linux_errqueue {
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
 #[cfg(target_os = "linux")]
+#[cfg(all(feature = "uio",feature = "process",feature = "net",feature = "feature",feature = "time"))]
 #[test]
 pub fn test_txtime() {
     use nix::sys::socket::{

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1345,7 +1345,12 @@ fn test_impl_scm_credentials_and_rights(mut space: Vec<u8>) {
         recvmsg, sendmsg, setsockopt, socketpair, ControlMessage,
         ControlMessageOwned, MsgFlags, SockFlag, SockType,
     };
-    use nix::unistd::{close, getgid, getpid, getuid, pipe, read, write};
+    // read exists in the unistd submodule without the fs feature,
+    // but with the fs feature it also exists at the top level
+    // and this causes an redundant import warning
+    #[cfg(not(feature = "fs"))]
+    use nix::unistd::read;
+    use nix::unistd::{close, getgid, getpid, getuid, pipe, write};
     use std::io::{IoSlice, IoSliceMut};
 
     let (send, recv) = socketpair(

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "socket")]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::*;
 use nix::sys::socket::{
@@ -92,6 +93,7 @@ fn test_so_buf() {
 }
 
 #[test]
+#[cfg(feature = "net")]
 fn test_so_tcp_maxseg() {
     use nix::sys::socket::{accept, bind, connect, listen, SockaddrIn};
     use nix::unistd::{close, write};
@@ -187,6 +189,7 @@ fn test_so_type_unknown() {
     any(target_arch = "x86", target_arch = "x86_64"),
     any(target_os = "freebsd", target_os = "linux")
 ))]
+#[cfg(feature = "net")]
 fn test_tcp_congestion() {
     use std::ffi::OsString;
 
@@ -231,6 +234,7 @@ fn test_bindtodevice() {
 }
 
 #[test]
+#[cfg(feature = "net")]
 fn test_so_tcp_keepalive() {
     let fd = socket(
         AddressFamily::Inet,
@@ -266,6 +270,7 @@ fn test_so_tcp_keepalive() {
 #[test]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[cfg_attr(qemu, ignore)]
+#[cfg(feature = "net")]
 fn test_get_mtu() {
     use nix::sys::socket::{bind, connect, SockaddrIn};
     use std::net::SocketAddrV4;
@@ -384,6 +389,7 @@ fn test_v6dontfrag_opts() {
 
 #[test]
 #[cfg(target_os = "linux")]
+#[cfg(feature = "net")]
 fn test_so_priority() {
     let fd = socket(
         AddressFamily::Inet,
@@ -399,6 +405,7 @@ fn test_so_priority() {
 
 #[test]
 #[cfg(target_os = "linux")]
+#[cfg(feature = "net")]
 fn test_ip_tos() {
     let fd = socket(
         AddressFamily::Inet,
@@ -416,6 +423,7 @@ fn test_ip_tos() {
 #[cfg(target_os = "linux")]
 // Disable the test under emulation because it fails in Cirrus-CI.  Lack
 // of QEMU support is suspected.
+#[cfg(feature = "net")]
 #[cfg_attr(qemu, ignore)]
 fn test_ipv6_tclass() {
     let fd = socket(

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "term")]
 use std::os::unix::prelude::*;
 use tempfile::tempfile;
 
@@ -91,6 +92,7 @@ fn test_output_flags() {
 
 // Test modifying local flags
 #[test]
+#[cfg(feature = "fs")]
 fn test_local_flags() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();

--- a/test/sys/test_timerfd.rs
+++ b/test/sys/test_timerfd.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "time")]
 use nix::sys::time::{TimeSpec, TimeValLike};
 use nix::sys::timerfd::{
     ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags,

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "uio")]
 use nix::sys::uio::*;
 use nix::unistd::*;
 use rand::distributions::Alphanumeric;
@@ -218,6 +219,7 @@ fn test_preadv() {
 // uclibc doesn't implement process_vm_readv
 // qemu-user doesn't implement process_vm_readv/writev on most arches
 #[cfg_attr(qemu, ignore)]
+#[cfg(all(feature = "process",feature = "signal"))]
 fn test_process_vm_readv() {
     use crate::*;
     use nix::sys::signal::*;

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "process")]
 use libc::_exit;
 use nix::errno::Errno;
 use nix::sys::signal::*;
@@ -7,6 +8,7 @@ use nix::unistd::*;
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+#[cfg(feature = "signal")]
 fn test_wait_signal() {
     let _m = crate::FORK_MTX.lock();
 
@@ -34,6 +36,7 @@ fn test_wait_signal() {
     all(target_os = "linux", not(target_env = "uclibc")),
 ))]
 #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+#[cfg(feature = "signal")]
 fn test_waitid_signal() {
     let _m = crate::FORK_MTX.lock();
 
@@ -143,6 +146,7 @@ fn test_waitid_pid() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 // FIXME: qemu-user doesn't implement ptrace on most arches
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(feature = "ptrace",feature = "signal"))]
 mod ptrace {
     use crate::*;
     use libc::_exit;

--- a/test/test_clearenv.rs
+++ b/test/test_clearenv.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "env")]
 use std::env;
 
 #[test]

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "dir")]
 use nix::dir::{Dir, Type};
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "fs")]
 #[cfg(not(target_os = "redox"))]
 use nix::errno::*;
 #[cfg(not(target_os = "redox"))]
@@ -252,6 +253,7 @@ mod linux_android {
     #[test]
     // QEMU does not support copy_file_range. Skip under qemu
     #[cfg_attr(qemu, ignore)]
+    #[cfg(feature = "zerocopy")]
     fn test_copy_file_range() {
         const CONTENTS: &[u8] = b"foobarbaz";
 
@@ -280,6 +282,7 @@ mod linux_android {
     }
 
     #[test]
+    #[cfg(feature = "zerocopy")]
     fn test_splice() {
         const CONTENTS: &[u8] = b"abcdef123456";
         let mut tmp = tempfile().unwrap();
@@ -309,6 +312,7 @@ mod linux_android {
     }
 
     #[test]
+    #[cfg(feature = "zerocopy")]
     fn test_tee() {
         let (rd1, wr1) = pipe().unwrap();
         let (rd2, wr2) = pipe().unwrap();
@@ -335,6 +339,7 @@ mod linux_android {
     }
 
     #[test]
+    #[cfg(feature = "zerocopy")]
     fn test_vmsplice() {
         let (rd, wr) = pipe().unwrap();
 

--- a/test/test_kmod/mod.rs
+++ b/test/test_kmod/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "kmod")]
 use crate::*;
 use std::fs::copy;
 use std::path::PathBuf;

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -1,3 +1,4 @@
+#![cfg(feature="mqueue")]
 use cfg_if::cfg_if;
 use std::ffi::CString;
 use std::str;

--- a/test/test_net.rs
+++ b/test/test_net.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "net")]
 use nix::net::if_::*;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "poll")]
 use nix::{
     errno::Errno,
     poll::{poll, PollFd, PollFlags},
@@ -43,6 +44,7 @@ fn test_poll() {
     target_os = "freebsd",
     target_os = "linux"
 ))]
+#[cfg(feature = "signal")]
 #[test]
 fn test_ppoll() {
     use nix::poll::ppoll;

--- a/test/test_ptymaster_drop.rs
+++ b/test/test_ptymaster_drop.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+#[cfg(all(not(any(target_os = "redox", target_os = "fuchsia")), feature = "term"))]
 mod t {
     use nix::fcntl::OFlag;
     use nix::pty::*;

--- a/test/test_resource.rs
+++ b/test/test_resource.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "resource")]
 #[cfg(not(any(
     target_os = "redox",
     target_os = "fuchsia",

--- a/test/test_sched.rs
+++ b/test/test_sched.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "sched")]
 use nix::sched::{sched_getaffinity, sched_getcpu, sched_setaffinity, CpuSet};
 use nix::unistd::Pid;
 

--- a/test/test_sendfile.rs
+++ b/test/test_sendfile.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "zerocopy")]
 use std::io::prelude::*;
 use std::os::unix::prelude::*;
 

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "fs")]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 use std::fs;
 use std::fs::File;
@@ -392,6 +393,7 @@ fn test_mknod() {
     target_os = "haiku",
     target_os = "redox"
 )))]
+#[cfg(feature = "dir")]
 fn test_mknodat() {
     use fcntl::{AtFlags, OFlag};
     use nix::dir::Dir;

--- a/test/test_time.rs
+++ b/test/test_time.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "time")]
 #[cfg(any(
     target_os = "freebsd",
     target_os = "dragonfly",
@@ -5,6 +6,7 @@
     target_os = "android",
     target_os = "emscripten",
 ))]
+#[cfg(feature = "process")]
 use nix::time::clock_getcpuclockid;
 use nix::time::{clock_gettime, ClockId};
 
@@ -26,6 +28,7 @@ pub fn test_clock_gettime() {
     target_os = "android",
     target_os = "emscripten",
 ))]
+#[cfg(feature = "process")]
 #[test]
 pub fn test_clock_getcpuclockid() {
     let clock_id = clock_getcpuclockid(nix::unistd::Pid::this()).unwrap();
@@ -50,6 +53,7 @@ pub fn test_clock_id_now() {
     target_os = "android",
     target_os = "emscripten",
 ))]
+#[cfg(feature = "process")]
 #[test]
 pub fn test_clock_id_pid_cpu_clock_id() {
     ClockId::pid_cpu_clock_id(nix::unistd::Pid::this())


### PR DESCRIPTION
While updating nix in Debian, I noticed that the tests fail when run with --no-default-features because the tests are not marked with the features they require, this patch adds those feature markers.

I have tested it with each feature individually, and also with the following feature combinations.

aio,signal
process,ptrace
process,fs
fs,user
fs,zerocopy
mount,sched
mount,fs,sched
mount,sched,user
mount,fs,sched,user
uio,process                 
socket,uio                  
socket,uio,fs               
socket,uio,term             
net,uio                     
net,uio,time
socket,user
socket,user,uio
socket,user,uio,process
socket,process
socket,uio,process
net,uio,process
net,uio,process,feature
net,uio,process,feature,time
poll,signal
process,signal
pthread,signal
ptrace,memoffset
ptrace,signal
ptrace,signal,memoffset
term,fs
term,signal
term,process
term,process,signal
time,process
uio,process,signal