### PR TITLE
feat: I/O safety for 'sys/memfd' & 'sys/event' & 'sys/eventfd'

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -83,7 +83,7 @@ impl EpollEvent {
 /// let epoll = Epoll::new(EpollCreateFlags::empty())?;
 ///
 /// // Create eventfd & Add event
-/// let eventfd = unsafe { OwnedFd::from_raw_fd(eventfd(0, EfdFlags::empty())?) };
+/// let eventfd = eventfd(0, EfdFlags::empty())?;
 /// epoll.add(&eventfd, EpollEvent::new(EpollFlags::EPOLLIN,DATA))?;
 ///
 /// // Arm eventfd & Time wait

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -1,6 +1,6 @@
 use crate::errno::Errno;
 use crate::Result;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{FromRawFd, OwnedFd};
 
 libc_bitflags! {
     pub struct EfdFlags: libc::c_int {
@@ -10,8 +10,8 @@ libc_bitflags! {
     }
 }
 
-pub fn eventfd(initval: libc::c_uint, flags: EfdFlags) -> Result<RawFd> {
+pub fn eventfd(initval: libc::c_uint, flags: EfdFlags) -> Result<OwnedFd> {
     let res = unsafe { libc::eventfd(initval, flags.bits()) };
 
-    Errno::result(res).map(|r| r as RawFd)
+    Errno::result(res).map(|r| unsafe { OwnedFd::from_raw_fd(r) })
 }

--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -1,7 +1,7 @@
 //! Interfaces for managing memory-backed files.
 
 use cfg_if::cfg_if;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
 
 use crate::errno::Errno;
 use crate::Result;
@@ -40,7 +40,7 @@ libc_bitflags!(
 /// For more information, see [`memfd_create(2)`].
 ///
 /// [`memfd_create(2)`]: https://man7.org/linux/man-pages/man2/memfd_create.2.html
-pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<RawFd> {
+pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<OwnedFd> {
     let res = unsafe {
         cfg_if! {
             if #[cfg(all(
@@ -60,5 +60,5 @@ pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<RawFd> {
         }
     };
 
-    Errno::result(res).map(|r| r as RawFd)
+    Errno::result(res).map(|r| unsafe { OwnedFd::from_raw_fd(r as RawFd) })
 }


### PR DESCRIPTION
#### What this PR does:

Adds I/O safety for moduels:
1. `sys/memfd`
2. `sys/event`
3. `sys/eventfd`

-----

BYW, I called `rustfmt` on these 4 files, which introduces some noise, sorry about this.