### PR TITLE
refactor: take `AsFd` by value

### DIFF
--- a/src/kmod.rs
+++ b/src/kmod.rs
@@ -80,7 +80,7 @@ libc_bitflags!(
 ///
 /// See [`man init_module(2)`](https://man7.org/linux/man-pages/man2/init_module.2.html) for more information.
 pub fn finit_module<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     param_values: &CStr,
     flags: ModuleInitFlags,
 ) -> Result<()> {

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -421,7 +421,7 @@ pub unsafe fn mmap<F: AsFd>(
     length: NonZeroUsize,
     prot: ProtFlags,
     flags: MapFlags,
-    f: Option<&F>,
+    f: Option<F>,
     offset: off_t,
 ) -> Result<*mut c_void> {
     let ptr =

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -740,7 +740,7 @@ pub fn statfs<P: ?Sized + NixPath>(path: &P) -> Result<Statfs> {
 /// # Arguments
 ///
 /// `fd` - File descriptor of any open file within the file system to describe
-pub fn fstatfs<Fd: AsFd>(fd: &Fd) -> Result<Statfs> {
+pub fn fstatfs<Fd: AsFd>(fd: Fd) -> Result<Statfs> {
     unsafe {
         let mut stat = mem::MaybeUninit::<type_of_statfs>::uninit();
         Errno::result(LIBC_FSTATFS(fd.as_fd().as_raw_fd(), stat.as_mut_ptr()))

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -1143,7 +1143,7 @@ pub fn cfmakesane(termios: &mut Termios) {
 /// `tcgetattr()` returns a `Termios` structure with the current configuration for a port. Modifying
 /// this structure *will not* reconfigure the port, instead the modifications should be done to
 /// the `Termios` structure and then the port should be reconfigured using `tcsetattr()`.
-pub fn tcgetattr<Fd: AsFd>(fd: &Fd) -> Result<Termios> {
+pub fn tcgetattr<Fd: AsFd>(fd: Fd) -> Result<Termios> {
     let mut termios = mem::MaybeUninit::uninit();
 
     let res = unsafe {
@@ -1162,7 +1162,7 @@ pub fn tcgetattr<Fd: AsFd>(fd: &Fd) -> Result<Termios> {
 /// takes affect at a time specified by `actions`. Note that this function may return success if
 /// *any* of the parameters were successfully set, not only if all were set successfully.
 pub fn tcsetattr<Fd: AsFd>(
-    fd: &Fd,
+    fd: Fd,
     actions: SetArg,
     termios: &Termios,
 ) -> Result<()> {
@@ -1179,7 +1179,7 @@ pub fn tcsetattr<Fd: AsFd>(
 
 /// Block until all output data is written (see
 /// [tcdrain(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcdrain.html)).
-pub fn tcdrain<Fd: AsFd>(fd: &Fd) -> Result<()> {
+pub fn tcdrain<Fd: AsFd>(fd: Fd) -> Result<()> {
     Errno::result(unsafe { libc::tcdrain(fd.as_fd().as_raw_fd()) }).map(drop)
 }
 
@@ -1188,7 +1188,7 @@ pub fn tcdrain<Fd: AsFd>(fd: &Fd) -> Result<()> {
 ///
 /// `tcflow()` suspends of resumes the transmission or reception of data for the given port
 /// depending on the value of `action`.
-pub fn tcflow<Fd: AsFd>(fd: &Fd, action: FlowArg) -> Result<()> {
+pub fn tcflow<Fd: AsFd>(fd: Fd, action: FlowArg) -> Result<()> {
     Errno::result(unsafe {
         libc::tcflow(fd.as_fd().as_raw_fd(), action as c_int)
     })
@@ -1200,7 +1200,7 @@ pub fn tcflow<Fd: AsFd>(fd: &Fd, action: FlowArg) -> Result<()> {
 ///
 /// `tcflush()` will discard data for a terminal port in the input queue, output queue, or both
 /// depending on the value of `action`.
-pub fn tcflush<Fd: AsFd>(fd: &Fd, action: FlushArg) -> Result<()> {
+pub fn tcflush<Fd: AsFd>(fd: Fd, action: FlushArg) -> Result<()> {
     Errno::result(unsafe {
         libc::tcflush(fd.as_fd().as_raw_fd(), action as c_int)
     })
@@ -1212,7 +1212,7 @@ pub fn tcflush<Fd: AsFd>(fd: &Fd, action: FlushArg) -> Result<()> {
 ///
 /// When using asynchronous data transmission `tcsendbreak()` will transmit a continuous stream
 /// of zero-valued bits for an implementation-defined duration.
-pub fn tcsendbreak<Fd: AsFd>(fd: &Fd, duration: c_int) -> Result<()> {
+pub fn tcsendbreak<Fd: AsFd>(fd: Fd, duration: c_int) -> Result<()> {
     Errno::result(unsafe {
         libc::tcsendbreak(fd.as_fd().as_raw_fd(), duration)
     })
@@ -1223,7 +1223,7 @@ feature! {
 #![feature = "process"]
 /// Get the session controlled by the given terminal (see
 /// [tcgetsid(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetsid.html)).
-pub fn tcgetsid<Fd: AsFd>(fd: &Fd) -> Result<Pid> {
+pub fn tcgetsid<Fd: AsFd>(fd: Fd) -> Result<Pid> {
     let res = unsafe { libc::tcgetsid(fd.as_fd().as_raw_fd()) };
 
     Errno::result(res).map(Pid::from_raw)

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -8,7 +8,7 @@ use nix::sys::termios::{self, tcgetattr, LocalFlags, OutputFlags};
 use nix::unistd::{read, write};
 
 /// Helper function analogous to `std::io::Write::write_all`, but for `Fd`s
-fn write_all<Fd: AsFd>(f: &Fd, buf: &[u8]) {
+fn write_all<Fd: AsFd>(f: Fd, buf: &[u8]) {
     let mut len = 0;
     while len < buf.len() {
         len += write(f.as_fd().as_raw_fd(), &buf[len..]).unwrap();

--- a/test/test.rs
+++ b/test/test.rs
@@ -70,7 +70,7 @@ use std::os::unix::io::{AsFd, AsRawFd};
 use std::path::PathBuf;
 
 /// Helper function analogous to `std::io::Read::read_exact`, but for `Fd`s
-fn read_exact<Fd: AsFd>(f: &Fd, buf: &mut [u8]) {
+fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     let mut len = 0;
     while len < buf.len() {
         // get_mut would be better than split_at_mut, but it requires nightly

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -136,9 +136,9 @@ fn test_open_ptty_pair() {
 
 /// Put the terminal in raw mode.
 fn make_raw<Fd: AsFd>(fd: Fd) {
-    let mut termios = tcgetattr(fd).unwrap();
+    let mut termios = tcgetattr(&fd).unwrap();
     cfmakeraw(&mut termios);
-    tcsetattr(fd, SetArg::TCSANOW, &termios).unwrap();
+    tcsetattr(&fd, SetArg::TCSANOW, &termios).unwrap();
 }
 
 /// Test `io::Read` on the PTTY master

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -135,7 +135,7 @@ fn test_open_ptty_pair() {
 }
 
 /// Put the terminal in raw mode.
-fn make_raw<Fd: AsFd>(fd: &Fd) {
+fn make_raw<Fd: AsFd>(fd: Fd) {
     let mut termios = tcgetattr(fd).unwrap();
     cfmakeraw(&mut termios);
     tcsetattr(fd, SetArg::TCSANOW, &termios).unwrap();


### PR DESCRIPTION
#### What this PR does

1. Changes the `fd` type to take `AsFd` by value for the I/O safety PRs that are merged.
    * #1916 
    * #1919 
    * #1921 
    * #1922 