### PR TITLE
feat: I/O safety for 'sys/signal'

### DIFF
--- a/changelog/1936.changed.md
+++ b/changelog/1936.changed.md
@@ -1,0 +1,1 @@
+Module sys/signal now adopts I/O safety

--- a/changelog/1936.removed.md
+++ b/changelog/1936.removed.md
@@ -1,0 +1,1 @@
+Type `SigevNotify` is no longer `PartialEq`, `Eq` and `Hash` due to the use of `BorrowedFd`


### PR DESCRIPTION
## What does this PR do

1. Adds I/O safety for `sys/signal`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API