### PR TITLE
Rework vsock test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,7 +142,6 @@ task:
       arm_container:
         image: rust:1.63.0
       env:
-        RUSTFLAGS: --cfg graviton -D warnings
         TARGET: aarch64-unknown-linux-gnu
     - name: Linux x86_64
       container:

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -2040,57 +2040,43 @@ pub fn test_recv_ipv6pktinfo() {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(graviton, ignore = "Not supported by the CI environment")]
 #[test]
 pub fn test_vsock() {
-    use nix::errno::Errno;
-    use nix::sys::socket::{
-        bind, connect, listen, socket, AddressFamily, SockFlag, SockType,
-        VsockAddr,
-    };
-    use nix::unistd::close;
-    use std::thread;
+    use nix::sys::socket::SockaddrLike;
+    use nix::sys::socket::{AddressFamily, VsockAddr};
+    use std::mem;
 
     let port: u32 = 3000;
 
-    let s1 = socket(
-        AddressFamily::Vsock,
-        SockType::Stream,
-        SockFlag::empty(),
-        None,
-    )
-    .expect("socket failed");
+    let addr_local = VsockAddr::new(libc::VMADDR_CID_LOCAL, port);
+    assert_eq!(addr_local.cid(), libc::VMADDR_CID_LOCAL);
+    assert_eq!(addr_local.port(), port);
 
-    // VMADDR_CID_HYPERVISOR is reserved, so we expect an EADDRNOTAVAIL error.
-    let sockaddr_hv = VsockAddr::new(libc::VMADDR_CID_HYPERVISOR, port);
-    assert_eq!(bind(s1, &sockaddr_hv).err(), Some(Errno::EADDRNOTAVAIL));
+    let addr_any = VsockAddr::new(libc::VMADDR_CID_ANY, libc::VMADDR_PORT_ANY);
+    assert_eq!(addr_any.cid(), libc::VMADDR_CID_ANY);
+    assert_eq!(addr_any.port(), libc::VMADDR_PORT_ANY);
 
-    let sockaddr_any = VsockAddr::new(libc::VMADDR_CID_ANY, port);
-    assert_eq!(bind(s1, &sockaddr_any), Ok(()));
-    listen(s1, 10).expect("listen failed");
+    assert_ne!(addr_local, addr_any);
+    assert_ne!(calculate_hash(&addr_local), calculate_hash(&addr_any));
 
-    let thr = thread::spawn(move || {
-        let cid: u32 = libc::VMADDR_CID_HOST;
+    let addr1 = VsockAddr::new(libc::VMADDR_CID_HOST, port);
+    let addr2 = VsockAddr::new(libc::VMADDR_CID_HOST, port);
+    assert_eq!(addr1, addr2);
+    assert_eq!(calculate_hash(&addr1), calculate_hash(&addr2));
 
-        let s2 = socket(
-            AddressFamily::Vsock,
-            SockType::Stream,
-            SockFlag::empty(),
-            None,
+    let addr3 = unsafe {
+        VsockAddr::from_raw(
+            addr2.as_ref() as *const libc::sockaddr_vm as *const libc::sockaddr,
+            Some(mem::size_of::<libc::sockaddr_vm>().try_into().unwrap()),
         )
-        .expect("socket failed");
-
-        let sockaddr_host = VsockAddr::new(cid, port);
-
-        // The current implementation does not support loopback devices, so,
-        // for now, we expect a failure on the connect.
-        assert_ne!(connect(s2, &sockaddr_host), Ok(()));
-
-        close(s2).unwrap();
-    });
-
-    close(s1).unwrap();
-    thr.join().unwrap();
+    }
+    .unwrap();
+    assert_eq!(
+        addr3.as_ref().svm_family,
+        AddressFamily::Vsock as libc::sa_family_t
+    );
+    assert_eq!(addr3.as_ref().svm_cid, addr1.cid());
+    assert_eq!(addr3.as_ref().svm_port, addr1.port());
 }
 
 // Disable the test on emulated platforms because it fails in Cirrus-CI.  Lack


### PR DESCRIPTION
We mainly provide VsockAddr, so let's try to test well that VsockAddr mapping to libc::sockaddr_vm is correct.

Let's remove all interactions with the socket, since vsock may or may not be available in the environment.
Testing socket(), bind(), listen(), connect(), etc. caused unexpected failures, and it's out of scope of this crate.

So let's simplify the vsock test focussing on VsockAddr. This should work also on graviton, so let's try to re-enable it.

Fixes #1934

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>