### PR TITLE
SigSet: Fix incorrect implementation of Eq, PartialEq and Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+- Fix `SigSet` incorrect implementation of `Eq`, `PartialEq` and `Hash`
+  ([#1946](https://github.com/nix-rust/nix/pull/1946))
+
 ### Changed
 
 - The following APIs now take an implementation of `AsFd` rather than a


### PR DESCRIPTION
`signal::SigSet` derives `Eq`, `PartialEq` and `Hash`, but on linux, `sigfillset(3)` only initializes the first 64 bits, leaving the rest uninitialized. So two `signal::SigSets` can be different even though both have the same set of signals.

closes #1749