### PR TITLE
Sigset conveniance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1959](https://github.com/nix-rust/nix/pull/1959))
 - Added `impl std::ops::BitOr for SigSet`.
   ([#1959](https://github.com/nix-rust/nix/pull/1959))
+- Added `impl std::ops::BitOr for Signal`.
+  ([#1959](https://github.com/nix-rust/nix/pull/1959))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1959](https://github.com/nix-rust/nix/pull/1959))
 - Added `impl std::ops::BitOr for Signal`.
   ([#1959](https://github.com/nix-rust/nix/pull/1959))
+- Added `impl std::ops::BitOr<Signal> for SigSet`
+  ([#1959](https://github.com/nix-rust/nix/pull/1959))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `impl From<Signal> for SigSet`.
   ([#1959](https://github.com/nix-rust/nix/pull/1959))
+- Added `impl std::ops::BitOr for SigSet`.
+  ([#1959](https://github.com/nix-rust/nix/pull/1959))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fixed the function signature of `recvmmsg`, potentially causing UB
   ([#2119](https://github.com/nix-rust/nix/issues/2119))
+### Added
+
+- Added `impl From<Signal> for SigSet`.
+  ([#1959](https://github.com/nix-rust/nix/pull/1959))
 
 ### Changed
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -9,6 +9,7 @@ use cfg_if::cfg_if;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::mem;
+use std::ops::BitOr;
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 use std::os::unix::io::RawFd;
 use std::ptr;
@@ -612,11 +613,9 @@ impl From<Signal> for SigSet {
     }
 }
 
-
-impl std::ops::BitOr for Signal {
+impl BitOr for Signal {
     type Output = SigSet;
 
-    // rhs is the "right-hand side" of the expression `a | b`
     fn bitor(self, rhs: Self) -> Self::Output {
         let mut sigset = SigSet::empty();
         sigset.add(self);
@@ -625,7 +624,16 @@ impl std::ops::BitOr for Signal {
     }
 }
 
-impl std::ops::BitOr for SigSet {
+impl BitOr<Signal> for SigSet {
+    type Output = SigSet;
+
+    fn bitor(mut self, rhs: Signal) -> Self::Output {
+        self.add(rhs);
+        self
+    }
+}
+
+impl BitOr for SigSet {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -612,6 +612,19 @@ impl From<Signal> for SigSet {
     }
 }
 
+
+impl std::ops::BitOr for Signal {
+    type Output = SigSet;
+
+    // rhs is the "right-hand side" of the expression `a | b`
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let mut sigset = SigSet::empty();
+        sigset.add(self);
+        sigset.add(rhs);
+        sigset
+    }
+}
+
 impl std::ops::BitOr for SigSet {
     type Output = Self;
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -604,6 +604,14 @@ impl SigSet {
     }
 }
 
+impl From<Signal> for SigSet {
+    fn from(signal: Signal) -> SigSet {
+        let mut sigset = SigSet::empty();
+        sigset.add(signal);
+        sigset
+    }
+}
+
 impl AsRef<libc::sigset_t> for SigSet {
     fn as_ref(&self) -> &libc::sigset_t {
         &self.sigset

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -612,6 +612,14 @@ impl From<Signal> for SigSet {
     }
 }
 
+impl std::ops::BitOr for SigSet {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.iter().chain(rhs.iter()).collect()
+    }
+}
+
 impl AsRef<libc::sigset_t> for SigSet {
     fn as_ref(&self) -> &libc::sigset_t {
         &self.sigset


### PR DESCRIPTION
Adds convenience functions for dealing with `SigSet`.

```rust
let mut sigset = SigSet::empty();
sigset.add(SIGINT);
pthread_sigmask(SigmaskHow::SIG_SETMASK, Some(&sigset), None)
```
becomes
```rust
let sigset = SigSet::from(SIGINT);
pthread_sigmask(SigmaskHow::SIG_SETMASK, Some(&sigset), None)
```

---

```rust
let mut sigset = SigSet::empty();
sigset.add(SIGINT);
sigset.add(SIGUSR1);
sigset.wait();
```
becomes
```rust
(SIGINT | SIGUSR1).wait();
```
