### PR TITLE
feat: I/O safety `ftruncate`

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -35,6 +35,7 @@ use std::ffi::{CString, OsStr};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsFd, AsRawFd};
 use std::path::PathBuf;
 use std::{fmt, mem, ptr};
 
@@ -1255,8 +1256,8 @@ pub fn truncate<P: ?Sized + NixPath>(path: &P, len: off_t) -> Result<()> {
 ///
 /// See also
 /// [ftruncate(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html)
-pub fn ftruncate(fd: RawFd, len: off_t) -> Result<()> {
-    Errno::result(unsafe { libc::ftruncate(fd, len) }).map(drop)
+pub fn ftruncate<Fd: AsFd>(fd: Fd, len: off_t) -> Result<()> {
+    Errno::result(unsafe { libc::ftruncate(fd.as_fd().as_raw_fd(), len) }).map(drop)
 }
 
 pub fn isatty(fd: RawFd) -> Result<bool> {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -772,15 +772,12 @@ fn test_ftruncate() {
     let tempdir = tempdir().unwrap();
     let path = tempdir.path().join("file");
 
-    let tmpfd = {
-        let mut tmp = File::create(&path).unwrap();
-        const CONTENTS: &[u8] = b"12345678";
-        tmp.write_all(CONTENTS).unwrap();
-        tmp.into_raw_fd()
-    };
+    let mut file = File::create(&path).unwrap();
+    const CONTENTS: &[u8] = b"12345678";
+    file.write_all(CONTENTS).unwrap();
 
-    ftruncate(tmpfd, 2).unwrap();
-    close(tmpfd).unwrap();
+    ftruncate(&file, 2).unwrap();
+    drop(file);
 
     let metadata = fs::metadata(&path).unwrap();
     assert_eq!(2, metadata.len());


### PR DESCRIPTION
Uses `AsFd` for `unistd::ftruncate`.