### PR TITLE
fix: Update libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "15d27952bfa93e5e4f419c603f275486f15a050c", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "44cc30c6b68427d3628926868758d35fe561bbe6", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }


### PR DESCRIPTION
To include fix https://github.com/rust-lang/libc/commit/44cc30c6b68427d3628926868758d35fe561bbe6.

This is needed to unblock https://github.com/nix-rust/nix/pull/1868.