### PR TITLE
Added `mq_timedreceive` to `::nix::mqueue`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1662](https://github.com/nix-rust/nix/pull/1662))
 - Added `CanRaw` to `SockProtocol` and `CanBcm` as a separate `SocProtocol` constant.
   ([#1912](https://github.com/nix-rust/nix/pull/1912))
+- Added `mq_timedreceive` to `::nix::mqueue`.
+  ([#1966])(https://github.com/nix-rust/nix/pull/1966)
 
 ### Changed
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -197,6 +197,32 @@ pub fn mq_receive(
     Errno::result(res).map(|r| r as usize)
 }
 
+feature! {
+    #![feature = "time"]
+    use crate::sys::time::TimeSpec;
+    /// Receive a message from a message queue with a timeout
+    ///
+    /// See also ['mq_timedreceive(2)'](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_receive.html)
+    pub fn mq_timedreceive(
+        mqdes: &MqdT,
+        message: &mut [u8],
+        msg_prio: &mut u32,
+        abstime: &TimeSpec,
+    ) -> Result<usize> {
+        let len = message.len() as size_t;
+        let res = unsafe {
+            libc::mq_timedreceive(
+                mqdes.0,
+                message.as_mut_ptr() as *mut c_char,
+                len,
+                msg_prio as *mut u32,
+                abstime.as_ref(),
+            )
+        };
+        Errno::result(res).map(|r| r as usize)
+    }
+}
+
 /// Send a message to a message queue
 ///
 /// See also [`mq_send(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_send.html)


### PR DESCRIPTION
Noticed when working on a project that `mq_timedreceive` is missing from the `mqueue` module.

Not entirely familiar with best practices around feature gating in tests - I feel like I might have messed up by not including a `#[cfg(feature = "time")]`. Would like a little guidance there.