### PR TITLE
Added LOCAL_PEERPID/LocalPeerPid sockopt for macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1912](https://github.com/nix-rust/nix/pull/1912))
 - Added `mq_timedreceive` to `::nix::mqueue`.
   ([#1966])(https://github.com/nix-rust/nix/pull/1966)
+- Added `LocalPeerPid` to `nix::sys::socket::sockopt` for macOS. ([#1967](https://github.com/nix-rust/nix/pull/1967))
 
 ### Changed
 

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -492,7 +492,7 @@ sockopt_impl!(
     libc::LOCAL_PEERCRED,
     super::XuCred
 );
-#[cfg(any(target_os = "macos"))]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 sockopt_impl!(
     /// Get the PID of the peer process of a connected unix domain socket.
     LocalPeerPid,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -492,6 +492,15 @@ sockopt_impl!(
     libc::LOCAL_PEERCRED,
     super::XuCred
 );
+#[cfg(any(target_os = "macos"))]
+sockopt_impl!(
+    /// Get the PID of the peer process of a connected unix domain socket.
+    LocalPeerPid,
+    GetOnly,
+    0,
+    libc::LOCAL_PEERPID,
+    libc::c_int
+);
 #[cfg(any(target_os = "android", target_os = "linux"))]
 sockopt_impl!(
     /// Return the credentials of the foreign process connected to this socket.

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -54,6 +54,22 @@ pub fn test_local_peercred_stream() {
     assert_eq!(Gid::from_raw(xucred.groups()[0]), Gid::current());
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+pub fn test_local_peer_pid() {
+    use nix::sys::socket::socketpair;
+
+    let (fd1, _fd2) = socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .unwrap();
+    let pid = getsockopt(fd1, sockopt::LocalPeerPid).unwrap();
+    assert_eq!(pid, std::process::id() as _);
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn is_so_mark_functional() {

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -54,7 +54,7 @@ pub fn test_local_peercred_stream() {
     assert_eq!(Gid::from_raw(xucred.groups()[0]), Gid::current());
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "ios", target_os = "macos"))]
 #[test]
 pub fn test_local_peer_pid() {
     use nix::sys::socket::socketpair;


### PR DESCRIPTION
macOS has a badly documented `LOCAL_PEERPID` sockopt that can be used to retrieve the PID of the connected peer.

I intentionally only added this for macOS because I know it exists there, and I'm not sure about ios yet even if it exists there, it's doubtful that the PID information gets any use there.