### PR TITLE
Fix byte-swapped flowinfo and scope_id

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1180,10 +1180,10 @@ impl From<net::SocketAddrV6> for SockaddrIn6 {
 impl From<SockaddrIn6> for net::SocketAddrV6 {
     fn from(addr: SockaddrIn6) -> Self {
         net::SocketAddrV6::new(
-            net::Ipv6Addr::from(addr.0.sin6_addr.s6_addr),
-            u16::from_be(addr.0.sin6_port),
-            u32::from_be(addr.0.sin6_flowinfo),
-            u32::from_be(addr.0.sin6_scope_id),
+            addr.ip(),
+            addr.port(),
+            addr.flowinfo(),
+            addr.scope_id(),
         )
     }
 }
@@ -2489,7 +2489,15 @@ mod tests {
 
     mod sockaddr_in {
         use super::*;
+        use std::net::SocketAddrV4;
         use std::str::FromStr;
+
+        #[test]
+        fn roundtrip_std_socketaddrv4() {
+            let addr = SocketAddrV4::new("1.2.3.4".parse().unwrap(), 0x0102);
+            let s = SockaddrIn::from(addr);
+            assert_eq!(SocketAddrV4::from(s), addr);
+        }
 
         #[test]
         fn display() {
@@ -2509,7 +2517,20 @@ mod tests {
 
     mod sockaddr_in6 {
         use super::*;
+        use std::net::SocketAddrV6;
         use std::str::FromStr;
+
+        #[test]
+        fn roundtrip_std_socketaddrv6() {
+            let addr = SocketAddrV6::new(
+                "1234:5678:90ab:cdef::1111:2222".parse().unwrap(),
+                0x0102,
+                0x01020304,
+                0x01020304,
+            );
+            let s = SockaddrIn6::from(addr);
+            assert_eq!(SocketAddrV6::from(s), addr);
+        }
 
         #[test]
         fn display() {


### PR DESCRIPTION
The `From<SockaddrIn6> for net::SocketAddrV6` implementation used `from_be()` on each of the port/flowinfo/scope_id fields, but the flowinfo and scope_id are not stored in big endian, causing the conversion to produce a `SocketAddrV6` with byte-swapped flowinfo and scope_id. I noticed this when running `getifaddrs()` on my machine and then converting to a standard `SocketAddrV6` created an address with a scope ID of `33554432` (hex `0x02000000`) for an interface that should have been scope id 2.

I added a basic test to round-trip between a standard `SocketAddrV6` and a `SockaddrIn6`; prior to the change to the `From` impl, this test failed with

```
thread 'sys::socket::addr::tests::sockaddr_in6::roundtrip_std_socketaddrv6' panicked at 'assertion failed: `(left == right)`
  left: `[1234:5678:90ab:cdef::1111:2222%67305985]:258`,
 right: `[1234:5678:90ab:cdef::1111:2222%16909060]:258`
```

where `67305985 == 0x4030201` is the byte-swapped value of `16909060 == 0x1020304`, the expected value.