### PR TITLE
if_nameindex: add `target_os = illumos`

### DIFF
--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -334,6 +334,7 @@ libc_bitflags!(
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "illumos",
 ))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 mod if_nameindex {
@@ -465,5 +466,6 @@ mod if_nameindex {
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "illumos",
 ))]
 pub use if_nameindex::*;


### PR DESCRIPTION
illumos [also has if_nameindex()](https://illumos.org/man/3XNET/if_nameindex); this change allows calling nix's wrappers when building for it.