### PR TITLE
feat: `readv` `iov` as immutable slice .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - With I/O-safe type applied in `pty::OpenptyResult` and `pty::ForkptyResult`,
   users no longer need to manually close the file descriptors in these types.
   ([#1921](https://github.com/nix-rust/nix/pull/1921))
+- The `iov` parameter for `readv` that was previously a mutable slice is now an immutable slice.
+  ([#1982](https://github.com/nix-rust/nix/pull/1982))
 
 ### Fixed
 - Fix `SockaddrIn6` bug that was swapping flowinfo and scope_id byte ordering.

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -27,7 +27,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, iov: &[IoSlice<'_>]) -> Result<usize> {
 /// Low-level vectored read from a raw file descriptor
 ///
 /// See also [readv(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/readv.html)
-pub fn readv<Fd: AsFd>(fd: Fd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
+pub fn readv<Fd: AsFd>(fd: Fd, iov: &[IoSliceMut<'_>]) -> Result<usize> {
     // SAFETY: same as in writev(), IoSliceMut is ABI-compatible with iovec
     let res = unsafe {
         libc::readv(fd.as_fd().as_raw_fd(), iov.as_ptr() as *const libc::iovec, iov.len() as c_int)

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -96,7 +96,7 @@ fn test_readv() {
     // removed when pipe(2) becomes I/O-safe.
     let reader = unsafe { OwnedFd::from_raw_fd(reader) };
 
-    let read = readv(&reader, &mut iovecs[..]).expect("read failed");
+    let read = readv(&reader, &iovecs[..]).expect("read failed");
     // Check whether we've read all data
     assert_eq!(to_write.len(), read);
     // Cccumulate data from iovecs


### PR DESCRIPTION
The `iov` parameter for `readv` does not need to be a mutable slice, I have changed it to an immutable slice.

The `iov` parameter for `readv` that was previously a mutable slice is now an immutable slice.