### PR TITLE
Add System V shared memory APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1912](https://github.com/nix-rust/nix/pull/1912))
 - Added `mq_timedreceive` to `::nix::mqueue`.
   ([#1966])(https://github.com/nix-rust/nix/pull/1966)
+- Added System V shared memory APIs `shmget`, `shmat`, `shmdt` and `shmctl`.
+  ([#1989])(https://github.com/nix-rust/nix/pull/1989)
 
 ### Changed
 


### PR DESCRIPTION
First draft to add System V shared memory APIs.
I would like some help with these questions:
1. How to decide if an exported function should be `unsafe` or not? For now, I've marked functions taking in any pointer arguments as unsafe.
2. Should we have `libc_bitflags` for `shmflg` or `cmd`? There aren't a set of constants with a fixed prefix as described in the [CONVENTIONS.md](https://github.com/nix-rust/nix/blob/master/CONVENTIONS.md#bitflags) file. There are a few `IPC_*` and `SHM_*` constants for them

Partially addresses #1718.