### PR TITLE
Don't deref uninit addrs in `pack_mhdr_to_receive`

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -910,6 +910,10 @@ impl private::SockaddrLikePriv for () {
     fn as_mut_ptr(&mut self) -> *mut libc::sockaddr {
         ptr::null_mut()
     }
+
+    fn as_mut_ptr_raw(_: *mut Self) -> *mut libc::sockaddr {
+        ptr::null_mut()
+    }
 }
 
 /// `()` can be used in place of a real Sockaddr when no address is expected,
@@ -1682,7 +1686,14 @@ mod private {
         /// It is best to use this method only with foreign functions that do
         /// not change the sockaddr type.
         fn as_mut_ptr(&mut self) -> *mut libc::sockaddr {
-            self as *mut Self as *mut libc::sockaddr
+            (self as *mut Self).cast::<libc::sockaddr>()
+        }
+
+        fn as_mut_ptr_raw(this: *mut Self) -> *mut libc::sockaddr
+        where
+            Self: Sized,
+        {
+            this as *mut libc::sockaddr
         }
     }
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1946,6 +1946,9 @@ unsafe fn read_mhdr<'a, 'i, S>(
 /// headers are not used
 ///
 /// Buffers must remain valid for the whole lifetime of msghdr
+///
+/// `address` must be non-null, properly-aligned, and point to a space suitable
+/// for an `S`. It does not have to be initialized.
 unsafe fn pack_mhdr_to_receive<S>(
     iov_buffer: *const IoSliceMut,
     iov_buffer_len: usize,
@@ -1960,7 +1963,7 @@ unsafe fn pack_mhdr_to_receive<S>(
     // initialize it.
     let mut mhdr = mem::MaybeUninit::<msghdr>::zeroed();
     let p = mhdr.as_mut_ptr();
-    (*p).msg_name = (*address).as_mut_ptr() as *mut c_void;
+    (*p).msg_name = S::as_mut_ptr_raw(address) as *mut c_void;
     (*p).msg_namelen = S::size();
     (*p).msg_iov = iov_buffer as *mut iovec;
     (*p).msg_iovlen = iov_buffer_len as _;


### PR DESCRIPTION
This adds a new method to `SockaddrLikePriv` to get a pointer to some underlying `libc::sockaddr` from a pointer to some type. This avoids dereferencing uninitialized values during `pack_mhdr_to_receive`, which is called from `MultiHeaders::preallocate` and `recvmsg`.

Because this is a private trait, this is not a semver-breaking change.

Fixes #1990 