### PR TITLE
Add `AT_EACCESS` to `AtFlags` on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added `AT_EACCESS` to `AtFlags` on all platforms but android
+  ([#1995](https://github.com/nix-rust/nix/pull/1995))
 - Add `PF_ROUTE` to `SockType` on macOS, iOS, all of the BSDs, Fuchsia, Haiku, Illumos.
   ([#1867](https://github.com/nix-rust/nix/pull/1867))
 - Added `nix::ucontext` module on `aarch64-unknown-linux-gnu`.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -35,7 +35,7 @@ libc_bitflags! {
         AT_NO_AUTOMOUNT;
         #[cfg(any(target_os = "android", target_os = "linux"))]
         AT_EMPTY_PATH;
-        #[cfg(any(target_os = "illumos", target_os = "solaris"))]
+        #[cfg(not(target_os = "android"))]
         AT_EACCESS;
     }
 }


### PR DESCRIPTION
On Linux, I need the `AT_EACCESS` flag for `faccessat`:
```
AT_EACCESS
       Perform access checks using the effective user and group IDs.  By default, faccessat() uses the real IDs (like access()).
```

~~This commit is enabling it for all platforms but redox. I'm not really sure if this is correct of I should have just added a target_os = "linux". A did quick git grep -e AT_EACCESS -e 'AT_REMOVEDIR' on libc and it showed they're available on the same targets, so for consistence I just removed the cfg limitation.~~ CI was helpful and showed me I was wrong: it's undefined on android.
