### PR TITLE
Add `suspend` to `sys::signal::SigSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1912](https://github.com/nix-rust/nix/pull/1912))
 - Added `mq_timedreceive` to `::nix::mqueue`.
   ([#1966])(https://github.com/nix-rust/nix/pull/1966)
+- Added `libc::sigsuspend` wrapper `suspend` to `nix::sys::signal::SigSet`.
 
 ### Changed
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -571,6 +571,18 @@ impl SigSet {
         })
     }
 
+    /// Replaces the signal mask of the calling thread with this signal mask,
+    /// suspends execution until delivery of a signal whose action is either
+    /// execution of a signal-catching handler or termination of the process.
+    /// In the first case it returns after the handler returned and the signal
+    /// mask is restored to the set that existed prior to the call.
+    /// In the second case, suspend does not return.
+    #[cfg(not(target_os = "redox"))] // Redox does not yet support sigsuspend
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    pub fn suspend(&self) {
+        unsafe { libc::sigsuspend(&self.sigset as *const libc::sigset_t) };
+    }
+
     /// Converts a `libc::sigset_t` object to a [`SigSet`] without checking  whether the
     /// `libc::sigset_t` is already initialized.
     ///


### PR DESCRIPTION
This adds a simple wrapper for libc::sigsuspend.  `sigsuspend` either doesn't return (if the sighandler terminates the process) or returns -1 and sets errno to EITR.  So if this function returns, the return value must be -1 and does not need to be explicitly returned by `SigSet::suspend`.

In issue #1994 I asked for hints. This is what I got.

I want to add a test, but have difficulties with kill and making sure the test never blocks.