### PR TITLE
inotify: Add AsFd to allow using with epoll (issue #1998)

### DIFF
--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -32,7 +32,7 @@ use libc::{c_char, c_int};
 use std::ffi::{CStr, OsStr, OsString};
 use std::mem::{size_of, MaybeUninit};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::ptr;
 
 libc_bitflags! {
@@ -238,5 +238,11 @@ impl Inotify {
 impl FromRawFd for Inotify {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Inotify { fd: OwnedFd::from_raw_fd(fd) }
+    }
+}
+
+impl AsFd for Inotify {
+    fn as_fd(&'_ self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
     }
 }


### PR DESCRIPTION
This resolves issue #1998 and allows `Inotify` to be used by `Epoll` by adding AsFd.

I'm not entirely sure about the unit test. Maybe it would be possible to do a more comperhensive check by contructing inotify using `from_raw_fd` and checking that I get the same value back. However, that would basically mean duplicating  `Inotify::new` and that feels a bit pointless.

Another option would be to create an integration test to combine `Inotify` and `Epoll`.

Fixes #1998