### PR TITLE
feat: mman `NonNull`

### DIFF
--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise` and `msync` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync` and `mprotect` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous` and `munmap` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap` and `mremap` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync`, `mprotect` and `munlock` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync`, `mprotect`, `munlock` and `mlock` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous`, `munmap`, `mremap` and `madvise` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise` and `msync` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,0 +1,1 @@
+`mmap` and `mmap_anonymous` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous`, `munmap` and `mremap` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap`, `mremap` and `madvise` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync` and `mprotect` updated to use `NonNull`.
+`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync`, `mprotect` and `munlock` updated to use `NonNull`.

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,1 @@
-`mmap` and `mmap_anonymous` updated to use `NonNull`.
+`mmap`, `mmap_anonymous` and `munmap` updated to use `NonNull`.

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -537,11 +537,11 @@ pub unsafe fn munmap(addr: NonNull<c_void>, len: size_t) -> Result<()> {
 ///
 /// [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html
 pub unsafe fn madvise(
-    addr: *mut c_void,
+    addr: NonNull<c_void>,
     length: size_t,
     advise: MmapAdvise,
 ) -> Result<()> {
-    Errno::result(libc::madvise(addr, length, advise as i32)).map(drop)
+    Errno::result(libc::madvise(addr.as_ptr(), length, advise as i32)).map(drop)
 }
 
 /// Set protection of memory mapping.

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -375,8 +375,8 @@ libc_bitflags! {
 /// `addr` must meet all the requirements described in the [`mlock(2)`] man page.
 ///
 /// [`mlock(2)`]: https://man7.org/linux/man-pages/man2/mlock.2.html
-pub unsafe fn mlock(addr: *const c_void, length: size_t) -> Result<()> {
-    Errno::result(libc::mlock(addr, length)).map(drop)
+pub unsafe fn mlock(addr: NonNull<c_void>, length: size_t) -> Result<()> {
+    Errno::result(libc::mlock(addr.as_ptr(), length)).map(drop)
 }
 
 /// Unlocks all memory pages that contain part of the address range with

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -388,8 +388,8 @@ pub unsafe fn mlock(addr: *const c_void, length: size_t) -> Result<()> {
 /// page.
 ///
 /// [`munlock(2)`]: https://man7.org/linux/man-pages/man2/munlock.2.html
-pub unsafe fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
-    Errno::result(libc::munlock(addr, length)).map(drop)
+pub unsafe fn munlock(addr: NonNull<c_void>, length: size_t) -> Result<()> {
+    Errno::result(libc::munlock(addr.as_ptr(), length)).map(drop)
 }
 
 /// Locks all memory pages mapped into this process' address space.

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -522,8 +522,8 @@ pub unsafe fn mremap(
 /// page.
 ///
 /// [`munmap(2)`]: https://man7.org/linux/man-pages/man2/munmap.2.html
-pub unsafe fn munmap(addr: *mut c_void, len: size_t) -> Result<()> {
-    Errno::result(libc::munmap(addr, len)).map(drop)
+pub unsafe fn munmap(addr: NonNull<c_void>, len: size_t) -> Result<()> {
+    Errno::result(libc::munmap(addr.as_ptr(), len)).map(drop)
 }
 
 /// give advice about use of memory

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -588,11 +588,11 @@ pub unsafe fn mprotect(
 ///
 /// [`msync(2)`]: https://man7.org/linux/man-pages/man2/msync.2.html
 pub unsafe fn msync(
-    addr: *mut c_void,
+    addr: NonNull<c_void>,
     length: size_t,
     flags: MsFlags,
 ) -> Result<()> {
-    Errno::result(libc::msync(addr, length, flags.bits())).map(drop)
+    Errno::result(libc::msync(addr.as_ptr(), length, flags.bits())).map(drop)
 }
 
 #[cfg(not(target_os = "android"))]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -564,7 +564,7 @@ pub unsafe fn madvise(
 /// let mut slice: &mut [u8] = unsafe {
 ///     let mem = mmap_anonymous(None, one_k_non_zero, ProtFlags::PROT_NONE, MapFlags::MAP_PRIVATE)
 ///         .unwrap();
-///     mprotect(mem.as_ptr(), ONE_K, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE).unwrap();
+///     mprotect(mem, ONE_K, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE).unwrap();
 ///     std::slice::from_raw_parts_mut(mem.as_ptr().cast(), ONE_K)
 /// };
 /// assert_eq!(slice[0], 0x00);
@@ -572,11 +572,11 @@ pub unsafe fn madvise(
 /// assert_eq!(slice[0], 0xFF);
 /// ```
 pub unsafe fn mprotect(
-    addr: *mut c_void,
+    addr: NonNull<c_void>,
     length: size_t,
     prot: ProtFlags,
 ) -> Result<()> {
-    Errno::result(libc::mprotect(addr, length, prot.bits())).map(drop)
+    Errno::result(libc::mprotect(addr.as_ptr(), length, prot.bits())).map(drop)
 }
 
 /// synchronize a mapped region

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -4,16 +4,17 @@ use std::num::NonZeroUsize;
 #[test]
 fn test_mmap_anonymous() {
     unsafe {
-        let ptr = mmap_anonymous(
+        let mut ptr = mmap_anonymous(
             None,
             NonZeroUsize::new(1).unwrap(),
             ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
             MapFlags::MAP_PRIVATE,
         )
-        .unwrap() as *mut u8;
-        assert_eq!(*ptr, 0x00u8);
-        *ptr = 0xffu8;
-        assert_eq!(*ptr, 0xffu8);
+        .unwrap()
+        .cast::<u8>();
+        assert_eq!(*ptr.as_ref(), 0x00u8);
+        *ptr.as_mut() = 0xffu8;
+        assert_eq!(*ptr.as_ref(), 0xffu8);
     }
 }
 
@@ -34,7 +35,7 @@ fn test_mremap_grow() {
             MapFlags::MAP_PRIVATE,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        std::slice::from_raw_parts_mut(mem.as_ptr().cast(), ONE_K)
     };
     assert_eq!(slice[ONE_K - 1], 0x00);
     slice[ONE_K - 1] = 0xFF;
@@ -90,7 +91,7 @@ fn test_mremap_shrink() {
             MapFlags::MAP_PRIVATE,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        std::slice::from_raw_parts_mut(mem.as_ptr().cast(), ONE_K)
     };
     assert_eq!(slice[ONE_K - 1], 0x00);
     slice[ONE_K - 1] = 0xFF;

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_slicing)]
+
 use nix::sys::mman::{mmap_anonymous, MapFlags, ProtFlags};
 use std::num::NonZeroUsize;
 
@@ -23,6 +25,7 @@ fn test_mmap_anonymous() {
 fn test_mremap_grow() {
     use nix::libc::size_t;
     use nix::sys::mman::{mremap, MRemapFlags};
+    use std::ptr::NonNull;
 
     const ONE_K: size_t = 1024;
     let one_k_non_zero = NonZeroUsize::new(ONE_K).unwrap();
@@ -44,7 +47,7 @@ fn test_mremap_grow() {
     let slice: &mut [u8] = unsafe {
         #[cfg(target_os = "linux")]
         let mem = mremap(
-            slice.as_mut_ptr().cast(),
+            NonNull::from(&mut slice[..]).cast(),
             ONE_K,
             10 * ONE_K,
             MRemapFlags::MREMAP_MAYMOVE,
@@ -53,14 +56,14 @@ fn test_mremap_grow() {
         .unwrap();
         #[cfg(target_os = "netbsd")]
         let mem = mremap(
-            slice.as_mut_ptr().cast(),
+            NonNull::from(&mut slice[..]).cast(),
             ONE_K,
             10 * ONE_K,
             MRemapFlags::MAP_REMAPDUP,
             None,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, 10 * ONE_K)
+        std::slice::from_raw_parts_mut(mem.cast().as_ptr(), 10 * ONE_K)
     };
 
     // The first KB should still have the old data in it.
@@ -80,6 +83,7 @@ fn test_mremap_shrink() {
     use nix::libc::size_t;
     use nix::sys::mman::{mremap, MRemapFlags};
     use std::num::NonZeroUsize;
+    use std::ptr::NonNull;
 
     const ONE_K: size_t = 1024;
     let ten_one_k = NonZeroUsize::new(10 * ONE_K).unwrap();
@@ -99,7 +103,7 @@ fn test_mremap_shrink() {
 
     let slice: &mut [u8] = unsafe {
         let mem = mremap(
-            slice.as_mut_ptr().cast(),
+            NonNull::from(&mut slice[..]).cast(),
             ten_one_k.into(),
             ONE_K,
             MRemapFlags::empty(),
@@ -108,8 +112,8 @@ fn test_mremap_shrink() {
         .unwrap();
         // Since we didn't supply MREMAP_MAYMOVE, the address should be the
         // same.
-        assert_eq!(mem, slice.as_mut_ptr().cast());
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        assert_eq!(mem.as_ptr(), NonNull::from(&mut slice[..]).cast().as_ptr());
+        std::slice::from_raw_parts_mut(mem.as_ptr().cast(), ONE_K)
     };
 
     // The first KB should still be accessible and have the old data in it.


### PR DESCRIPTION
Updates functions in  `nix::sys::mman` to use `NonNull`.

The case where the returned pointer is null is the error case, therefore in the `Ok` case we can return `NonNull`.