### PR TITLE
Add TCP_FASTOPEN sockopts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added `mq_timedreceive` to `::nix::mqueue`.
   ([#1966])(https://github.com/nix-rust/nix/pull/1966)
 - Added `LocalPeerPid` to `nix::sys::socket::sockopt` for macOS. ([#1967](https://github.com/nix-rust/nix/pull/1967))
+- Added `TcpFastOpen` to `nix::sys::socket::sockopt` for Linux, Android, macOS,
+  iOS and FreeBSD.
+  ([#1995](https://github.com/nix-rust/nix/pull/2002))
+- Added `TcpFastOpenConnect`, `TcpFastOpenKey` and `TcpFastOpenNoCookie` to
+  `nix::sys::socket::sockopt` for Linux and Android.
+  ([#1995](https://github.com/nix-rust/nix/pull/2002))
 
 ### Changed
 

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1000,6 +1000,74 @@ sockopt_impl!(
     libc::IPV6_DONTFRAG,
     bool
 );
+#[cfg(any(target_os = "linux",
+          target_os = "l4re",
+          target_os = "android",
+          target_os = "emscripten"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// This option enables Fast Open (RFC7413) on a listener socket.
+    /// The value specifies the maximum length of pending SYNs.
+    TcpFastOpen,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FASTOPEN,
+    libc::c_int
+);
+#[cfg(any(target_os = "macos",
+          target_os = "ios",
+          target_os = "tvos",
+          target_os = "watchos",
+          target_os = "freebsd"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// This option enables Fast Open (RFC7413) on a listener socket.
+    TcpFastOpen,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FASTOPEN,
+    bool
+);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// This boolean option enables an alternative way to perform Fast Open
+    /// (RFC7413) on a client socket. It modifies the behaviour of `connect(2)`
+    /// depending on if a Fast Open cookie is available for the destination.
+    TcpFastOpenConnect,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FASTOPEN_CONNECT,
+    bool
+);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Sets or retrieves a key used for generating and validating TCP Fast
+    /// Open cookies.
+    TcpFastOpenKey,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FASTOPEN_KEY,
+    OsString<[u8; 16]>
+
+);
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// This boolean option enables Fast Open (RFC7413) without requiring a
+    /// previously-stored cookie.
+    TcpFastOpenNoCookie,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FASTOPEN_NO_COOKIE,
+    bool
+);
 
 #[allow(missing_docs)]
 // Not documented by Linux!


### PR DESCRIPTION
Adds TCP_FASTOPEN for Darwin/FreeBSD (boolean) and Linux-like (integer backlog), plus Linux settings for controlling TCP Fast Open behaviour and cookie generation.