### PR TITLE
Revert libc::memfd_create for gnu and musl

### DIFF
--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -48,9 +48,6 @@ pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<OwnedFd> {
                 not(target_os = "android"),
                 any(
                     target_os = "freebsd",
-                    // If the OS is Linux, gnu and musl expose a memfd_create symbol but not uclibc
-                    target_env = "gnu",
-                    target_env = "musl",
                 )))]
             {
                 libc::memfd_create(name.as_ptr(), flags.bits())


### PR DESCRIPTION
Closes #1972 

https://github.com/nix-rust/nix/commit/cf15c2bb5505231bc3128ef61522336e315e2169 introduced changes to force a hard dependency on `libc::memfd_create`. This symbol doesn't exist in Ubuntu 16.04 or CentOS 7 and thus it [breaks our builds](https://github.com/vectordotdev/vector/actions/runs/4252121295/jobs/7395320611). [Neither](https://ubuntu.com/about/release-cycle) of [these](https://wiki.centos.org/About/Product) are EOL for a few more years.

```
 = note: /target/x86_64-unknown-linux-gnu/debug/deps/libnix-0e1e3ef93965abb0.rlib(nix-0e1e3ef93965abb0.nix.194bd3d9-cgu.7.rcgu.o): In function `nix::sys::memfd::memfd_create::h8f53f62aa4e9fe80':
          /cargo/registry/src/github.com-1ecc6299db9ec823/nix-0.26.2/src/sys/memfd.rs:56: undefined reference to `memfd_create'
          collect2: error: ld returned 1 exit status
```

This change pulls out using `libc::memfd_create` for gnu and musl. I believe the original commit was intended just for freebsd, so the original intent of that commit remains unchanged.