### PR TITLE
add IP_ADD/DROP_SOURCE_MEMBERSHIP sockopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,6 +606,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2097](https://github.com/nix-rust/nix/pull/2097))
 - Add the ability to set `kevent_flags` on `SigEvent`.
   ([#1731](https://github.com/nix-rust/nix/pull/1731))
+- Added `IpAddSourceMembership`, `IpDropSourceMembership` to `nix::sys::socket::sockopt` on all platforms except Fuchsia, Haiku, NetBSD, OpenBSD.
+  ([#2008])(https://github.com/nix-rust/nix/pull/2008)
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -627,10 +627,22 @@ impl IpMembershipRequest {
 /// Request for source-specific multicast socket operations
 ///
 /// This is a wrapper type around `ip_mreq_source`.
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IpSourceMembershipRequest(libc::ip_mreq_source);
 
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
 impl IpSourceMembershipRequest {
     /// Instantiate a new `IpSourceMembershipRequest`
     ///

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -624,6 +624,29 @@ impl IpMembershipRequest {
     }
 }
 
+/// Request for source-specific multicast socket operations
+///
+/// This is a wrapper type around `ip_mreq_source`.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IpSourceMembershipRequest(libc::ip_mreq_source);
+
+impl IpSourceMembershipRequest {
+    /// Instantiate a new `IpSourceMembershipRequest`
+    ///
+    /// If `interface` is `None`, then `Ipv4Addr::any()` will be used for the interface.
+    pub fn new(group: net::Ipv4Addr, source: net::Ipv4Addr, interface: Option<net::Ipv4Addr>)
+        -> Self
+    {
+        let imr_addr = interface.unwrap_or(net::Ipv4Addr::UNSPECIFIED);
+        IpSourceMembershipRequest(libc::ip_mreq_source {
+            imr_multiaddr: ipv4addr_to_libc(group),
+            imr_sourceaddr: ipv4addr_to_libc(source),
+            imr_interface: ipv4addr_to_libc(imr_addr)
+        })
+    }
+}
+
 /// Request for ipv6 multicast socket operations
 ///
 /// This is a wrapper type around `ipv6_mreq`.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -420,6 +420,12 @@ sockopt_impl!(
     super::IpMembershipRequest
 );
 #[cfg(feature = "net")]
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Join a multicast group and allow receiving data only from specified source
@@ -430,6 +436,12 @@ sockopt_impl!(
     super::IpSourceMembershipRequest
 );
 #[cfg(feature = "net")]
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Leave a source-specific group

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -419,6 +419,26 @@ sockopt_impl!(
     libc::IP_DROP_MEMBERSHIP,
     super::IpMembershipRequest
 );
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Join a multicast group and allow receiving data only from specified source
+    IpAddSourceMembership,
+    SetOnly,
+    libc::IPPROTO_IP,
+    libc::IP_ADD_SOURCE_MEMBERSHIP,
+    super::IpSourceMembershipRequest
+);
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Leave a source-specific group
+    IpDropSourceMembership,
+    SetOnly,
+    libc::IPPROTO_IP,
+    libc::IP_DROP_SOURCE_MEMBERSHIP,
+    super::IpSourceMembershipRequest
+);
 cfg_if! {
     if #[cfg(linux_android)] {
         #[cfg(feature = "net")]

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1270,3 +1270,34 @@ pub fn test_so_attach_reuseport_cbpf() {
         assert_eq!(e, nix::errno::Errno::ENOPROTOOPT);
     });
 }
+
+#[test]
+#[cfg(not(any(
+    target_os = "fuchsia",
+    target_os = "haiku",
+    target_os = "netbsd",
+    target_os = "openbsd"
+)))]
+fn test_source_membership_opts() {
+    let fd = socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty(),
+        SockProtocol::Udp,
+    )
+    .unwrap();
+    let request = nix::sys::socket::IpSourceMembershipRequest::new(
+        "224.0.0.0".parse().unwrap(),
+        "127.0.0.1".parse().unwrap(),
+        None,
+    );
+
+    setsockopt(fd, sockopt::IpDropSourceMembership, &request)
+        .expect_err("drop not exist multicast membership sould fail");
+
+    setsockopt(fd, sockopt::IpAddSourceMembership, &request)
+        .expect("add source specific multicast membership sould succeed");
+
+    setsockopt(fd, sockopt::IpDropSourceMembership, &request)
+        .expect("drop source specific multicast membership sould succeed");
+}

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1293,11 +1293,11 @@ fn test_source_membership_opts() {
     );
 
     setsockopt(fd, sockopt::IpDropSourceMembership, &request)
-        .expect_err("drop not exist multicast membership sould fail");
+        .expect_err("drop not exist multicast membership should fail");
 
     setsockopt(fd, sockopt::IpAddSourceMembership, &request)
-        .expect("add source specific multicast membership sould succeed");
+        .expect("add source specific multicast membership should succeed");
 
     setsockopt(fd, sockopt::IpDropSourceMembership, &request)
-        .expect("drop source specific multicast membership sould succeed");
+        .expect("drop source specific multicast membership should succeed");
 }


### PR DESCRIPTION
Socket options  IP_ADD_SOURCE_MEMBERSHIP / IP_DROP_SOURCE_MEMBERSHIP is used to manage source-specific multicast group; related constant and struct  is defined in libc crate, but not in nix.