### PR TITLE
Initial wasi/wasm support for fs, uio, zerocopy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.cargo.target": "wasm32-wasi",
+  "rust-analyzer.cargo.noDefaultFeatures": true,
+  "rust-analyzer.check.allTargets": false,
+  "rust-analyzer.cargo.features": ["fs", "uio", "zerocopy"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "rust-analyzer.cargo.target": "wasm32-wasi",
-  "rust-analyzer.cargo.noDefaultFeatures": true,
-  "rust-analyzer.check.allTargets": false,
-  "rust-analyzer.cargo.features": ["fs", "uio", "zerocopy"]
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { path = "../libc", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "34e9a5e37856ba122791ce6d5f04cec9c7c24f2b", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "44cc30c6b68427d3628926868758d35fe561bbe6", features = [ "extra_traits" ] }
+libc = { path = "../libc", features = [ "extra_traits" ] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -22,7 +22,8 @@ cfg_if! {
     } else if #[cfg(any(target_os = "linux",
                         target_os = "redox",
                         target_os = "dragonfly",
-                        target_os = "fuchsia"))] {
+                        target_os = "fuchsia",
+                        target_os = "wasi"))] {
         unsafe fn errno_location() -> *mut c_int {
             libc::__errno_location()
         }
@@ -109,6 +110,7 @@ impl ErrnoSentinel for *mut c_void {
     }
 }
 
+#[cfg(not(target_os = "wasi"))]
 impl ErrnoSentinel for libc::sighandler_t {
     fn sentinel() -> Self {
         libc::SIG_ERR
@@ -160,6 +162,7 @@ fn desc(errno: Errno) -> &'static str {
         EACCES => "Permission denied",
         EFAULT => "Bad address",
         #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(target_os = "wasi"))]
         ENOTBLK => "Block device required",
         EBUSY => "Device or resource busy",
         EEXIST => "File exists",
@@ -197,8 +200,10 @@ fn desc(errno: Errno) -> &'static str {
         ENOPROTOOPT => "Protocol not available",
         EPROTONOSUPPORT => "Protocol not supported",
         #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(target_os = "wasi"))]
         ESOCKTNOSUPPORT => "Socket type not supported",
         #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(target_os = "wasi"))]
         EPFNOSUPPORT => "Protocol family not supported",
         #[cfg(not(target_os = "haiku"))]
         EAFNOSUPPORT => "Address family not supported by protocol",
@@ -212,11 +217,14 @@ fn desc(errno: Errno) -> &'static str {
         ENOBUFS => "No buffer space available",
         EISCONN => "Transport endpoint is already connected",
         ENOTCONN => "Transport endpoint is not connected",
+        #[cfg(not(target_os = "wasi"))]
         ESHUTDOWN => "Cannot send after transport endpoint shutdown",
         #[cfg(not(target_os = "haiku"))]
+        #[cfg(not(target_os = "wasi"))]
         ETOOMANYREFS => "Too many references: cannot splice",
         ETIMEDOUT => "Connection timed out",
         ECONNREFUSED => "Connection refused",
+        #[cfg(not(target_os = "wasi"))]
         EHOSTDOWN => "Host is down",
         EHOSTUNREACH => "No route to host",
 
@@ -459,7 +467,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "android",
             target_os = "illumos",
             target_os = "solaris",
-            target_os = "fuchsia"
+            target_os = "fuchsia",
+            target_os = "wasi"
         ))]
         EPROTO => "Protocol error",
 
@@ -482,7 +491,8 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(
             target_os = "linux",
             target_os = "android",
-            target_os = "fuchsia"
+            target_os = "fuchsia",
+            target_os = "wasi"
         ))]
         EBADMSG => "Not a data message",
 
@@ -660,7 +670,8 @@ fn desc(errno: Errno) -> &'static str {
         #[cfg(any(
             target_os = "linux",
             target_os = "android",
-            target_os = "fuchsia"
+            target_os = "fuchsia",
+            target_os = "wasi"
         ))]
         EDQUOT => "Quota exceeded",
 
@@ -687,7 +698,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "illumos",
             target_os = "solaris",
             target_os = "fuchsia",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         ECANCELED => "Operation canceled",
 
@@ -768,7 +780,7 @@ fn desc(errno: Errno) -> &'static str {
         ))]
         ENOLINK => "Link has been severed",
 
-        #[cfg(target_os = "freebsd")]
+        #[cfg(any(target_os = "freebsd", target_os = "wasi"))]
         ENOTCAPABLE => "Capabilities insufficient",
 
         #[cfg(target_os = "freebsd")]
@@ -793,7 +805,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "netbsd",
             target_os = "redox",
             target_os = "illumos",
-            target_os = "solaris"
+            target_os = "solaris",
+            target_os = "wasi"
         ))]
         EOVERFLOW => "Value too large to be stored in data type",
 
@@ -804,7 +817,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "ios",
             target_os = "netbsd",
             target_os = "redox",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         EILSEQ => "Illegal byte sequence",
 
@@ -848,7 +862,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "freebsd",
             target_os = "dragonfly",
             target_os = "ios",
-            target_os = "openbsd"
+            target_os = "openbsd",
+            target_os = "wasi"
         ))]
         ENOTRECOVERABLE => "State not recoverable",
 
@@ -857,7 +872,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "freebsd",
             target_os = "dragonfly",
             target_os = "ios",
-            target_os = "openbsd"
+            target_os = "openbsd",
+            target_os = "wasi"
         ))]
         EOWNERDEAD => "Previous owner died",
 
@@ -870,7 +886,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "netbsd",
             target_os = "illumos",
             target_os = "solaris",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         ENOTSUP => "Operation not supported",
 
@@ -919,7 +936,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "redox",
             target_os = "illumos",
             target_os = "solaris",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         ESTALE => "Stale NFS file handle",
 
@@ -1037,7 +1055,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "macos",
             target_os = "ios",
             target_os = "netbsd",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         EMULTIHOP => "Reserved",
 
@@ -1053,7 +1072,8 @@ fn desc(errno: Errno) -> &'static str {
             target_os = "macos",
             target_os = "ios",
             target_os = "netbsd",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi"
         ))]
         ENOLINK => "Reserved",
 
@@ -1400,6 +1420,181 @@ mod consts {
             libc::ERFKILL => ERFKILL,
             #[cfg(not(any(target_os = "android", target_arch = "mips")))]
             libc::EHWPOISON => EHWPOISON,
+            _ => UnknownErrno,
+        }
+    }
+}
+
+#[cfg(target_os = "wasi")]
+mod consts {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[repr(i32)]
+    #[non_exhaustive]
+    pub enum Errno {
+        UnknownErrno = 0,
+        E2BIG = libc::E2BIG,
+        EACCES = libc::EACCES,
+        EADDRINUSE = libc::EADDRINUSE,
+        EADDRNOTAVAIL = libc::EADDRNOTAVAIL,
+        EAFNOSUPPORT = libc::EAFNOSUPPORT,
+        EAGAIN = libc::EAGAIN,
+        EALREADY = libc::EALREADY,
+        EBADF = libc::EBADF,
+        EBADMSG = libc::EBADMSG,
+        EBUSY = libc::EBUSY,
+        ECANCELED = libc::ECANCELED,
+        ECHILD = libc::ECHILD,
+        ECONNABORTED = libc::ECONNABORTED,
+        ECONNREFUSED = libc::ECONNREFUSED,
+        ECONNRESET = libc::ECONNRESET,
+        EDEADLK = libc::EDEADLK,
+        EDESTADDRREQ = libc::EDESTADDRREQ,
+        EDOM = libc::EDOM,
+        EDQUOT = libc::EDQUOT,
+        EEXIST = libc::EEXIST,
+        EFAULT = libc::EFAULT,
+        EFBIG = libc::EFBIG,
+        EHOSTUNREACH = libc::EHOSTUNREACH,
+        EIDRM = libc::EIDRM,
+        EILSEQ = libc::EILSEQ,
+        EINPROGRESS = libc::EINPROGRESS,
+        EINTR = libc::EINTR,
+        EINVAL = libc::EINVAL,
+        EIO = libc::EIO,
+        EISCONN = libc::EISCONN,
+        EISDIR = libc::EISDIR,
+        ELOOP = libc::ELOOP,
+        EMFILE = libc::EMFILE,
+        EMLINK = libc::EMLINK,
+        EMSGSIZE = libc::EMSGSIZE,
+        EMULTIHOP = libc::EMULTIHOP,
+        ENAMETOOLONG = libc::ENAMETOOLONG,
+        ENETDOWN = libc::ENETDOWN,
+        ENETRESET = libc::ENETRESET,
+        ENETUNREACH = libc::ENETUNREACH,
+        ENFILE = libc::ENFILE,
+        ENOBUFS = libc::ENOBUFS,
+        ENODEV = libc::ENODEV,
+        ENOENT = libc::ENOENT,
+        ENOEXEC = libc::ENOEXEC,
+        ENOLCK = libc::ENOLCK,
+        ENOLINK = libc::ENOLINK,
+        ENOMEM = libc::ENOMEM,
+        ENOMSG = libc::ENOMSG,
+        ENOPROTOOPT = libc::ENOPROTOOPT,
+        ENOSPC = libc::ENOSPC,
+        ENOSYS = libc::ENOSYS,
+        ENOTCONN = libc::ENOTCONN,
+        ENOTDIR = libc::ENOTDIR,
+        ENOTEMPTY = libc::ENOTEMPTY,
+        ENOTRECOVERABLE = libc::ENOTRECOVERABLE,
+        ENOTSOCK = libc::ENOTSOCK,
+        ENOTSUP = libc::ENOTSUP,
+        ENOTTY = libc::ENOTTY,
+        ENXIO = libc::ENXIO,
+        EOVERFLOW = libc::EOVERFLOW,
+        EOWNERDEAD = libc::EOWNERDEAD,
+        EPERM = libc::EPERM,
+        EPIPE = libc::EPIPE,
+        EPROTO = libc::EPROTO,
+        EPROTONOSUPPORT = libc::EPROTONOSUPPORT,
+        EPROTOTYPE = libc::EPROTOTYPE,
+        ERANGE = libc::ERANGE,
+        EROFS = libc::EROFS,
+        ESPIPE = libc::ESPIPE,
+        ESRCH = libc::ESRCH,
+        ESTALE = libc::ESTALE,
+        ETIMEDOUT = libc::ETIMEDOUT,
+        ETXTBSY = libc::ETXTBSY,
+        EXDEV = libc::EXDEV,
+        ENOTCAPABLE = libc::ENOTCAPABLE,
+    }
+
+    impl Errno {
+        pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
+        pub const ENOTSUP: Errno = Errno::ENOTSUP;
+    }
+
+    pub const fn from_i32(e: i32) -> Errno {
+        use self::Errno::*;
+
+        match e {
+            libc::E2BIG => E2BIG,
+            libc::EACCES => EACCES,
+            libc::EADDRINUSE => EADDRINUSE,
+            libc::EADDRNOTAVAIL => EADDRNOTAVAIL,
+            libc::EAFNOSUPPORT => EAFNOSUPPORT,
+            libc::EAGAIN => EAGAIN,
+            libc::EALREADY => EALREADY,
+            libc::EBADF => EBADF,
+            libc::EBADMSG => EBADMSG,
+            libc::EBUSY => EBUSY,
+            libc::ECANCELED => ECANCELED,
+            libc::ECHILD => ECHILD,
+            libc::ECONNABORTED => ECONNABORTED,
+            libc::ECONNREFUSED => ECONNREFUSED,
+            libc::ECONNRESET => ECONNRESET,
+            libc::EDEADLK => EDEADLK,
+            libc::EDESTADDRREQ => EDESTADDRREQ,
+            libc::EDOM => EDOM,
+            libc::EDQUOT => EDQUOT,
+            libc::EEXIST => EEXIST,
+            libc::EFAULT => EFAULT,
+            libc::EFBIG => EFBIG,
+            libc::EHOSTUNREACH => EHOSTUNREACH,
+            libc::EIDRM => EIDRM,
+            libc::EILSEQ => EILSEQ,
+            libc::EINPROGRESS => EINPROGRESS,
+            libc::EINTR => EINTR,
+            libc::EINVAL => EINVAL,
+            libc::EIO => EIO,
+            libc::EISCONN => EISCONN,
+            libc::EISDIR => EISDIR,
+            libc::ELOOP => ELOOP,
+            libc::EMFILE => EMFILE,
+            libc::EMLINK => EMLINK,
+            libc::EMSGSIZE => EMSGSIZE,
+            libc::EMULTIHOP => EMULTIHOP,
+            libc::ENAMETOOLONG => ENAMETOOLONG,
+            libc::ENETDOWN => ENETDOWN,
+            libc::ENETRESET => ENETRESET,
+            libc::ENETUNREACH => ENETUNREACH,
+            libc::ENFILE => ENFILE,
+            libc::ENOBUFS => ENOBUFS,
+            libc::ENODEV => ENODEV,
+            libc::ENOENT => ENOENT,
+            libc::ENOEXEC => ENOEXEC,
+            libc::ENOLCK => ENOLCK,
+            libc::ENOLINK => ENOLINK,
+            libc::ENOMEM => ENOMEM,
+            libc::ENOMSG => ENOMSG,
+            libc::ENOPROTOOPT => ENOPROTOOPT,
+            libc::ENOSPC => ENOSPC,
+            libc::ENOSYS => ENOSYS,
+            libc::ENOTCONN => ENOTCONN,
+            libc::ENOTDIR => ENOTDIR,
+            libc::ENOTEMPTY => ENOTEMPTY,
+            libc::ENOTRECOVERABLE => ENOTRECOVERABLE,
+            libc::ENOTSOCK => ENOTSOCK,
+            libc::ENOTSUP => ENOTSUP,
+            libc::ENOTTY => ENOTTY,
+            libc::ENXIO => ENXIO,
+            libc::EOVERFLOW => EOVERFLOW,
+            libc::EOWNERDEAD => EOWNERDEAD,
+            libc::EPERM => EPERM,
+            libc::EPIPE => EPIPE,
+            libc::EPROTO => EPROTO,
+            libc::EPROTONOSUPPORT => EPROTONOSUPPORT,
+            libc::EPROTOTYPE => EPROTOTYPE,
+            libc::ERANGE => ERANGE,
+            libc::EROFS => EROFS,
+            libc::ESPIPE => ESPIPE,
+            libc::ESRCH => ESRCH,
+            libc::ESTALE => ESTALE,
+            libc::ETIMEDOUT => ETIMEDOUT,
+            libc::ETXTBSY => ETXTBSY,
+            libc::EXDEV => EXDEV,
+            libc::ENOTCAPABLE => ENOTCAPABLE,
             _ => UnknownErrno,
         }
     }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -193,7 +193,7 @@ feature! {
 #![feature = "fs"]
 
 #[cfg(unix)]
-pub const PATH_MAX: usize = libc::PATH_MAX;
+pub const PATH_MAX: usize = libc::PATH_MAX as usize;
 
 #[cfg(target_os = "wasi")]
 pub const PATH_MAX: usize = 4096; // max is whatever the host system is... so guess posix?
@@ -318,7 +318,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
 ) -> Result<OsString> {
-    let mut v = Vec::with_capacity(libc::PATH_MAX as usize);
+    let mut v = Vec::with_capacity(PATH_MAX as usize);
 
     {
         // simple case: result is strictly less than `PATH_MAX`
@@ -371,7 +371,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
         } else {
             // If lstat doesn't cooperate, or reports an error, be a little less
             // precise.
-            (libc::PATH_MAX as usize).max(128) << 1
+            (PATH_MAX as usize).max(128) << 1
         }
     };
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -189,14 +189,14 @@ libc_bitflags!(
     }
 );
 
-feature! {
-#![feature = "fs"]
-
 #[cfg(unix)]
 pub const PATH_MAX: usize = libc::PATH_MAX as usize;
 
 #[cfg(target_os = "wasi")]
 pub const PATH_MAX: usize = 4096; // max is whatever the host system is... so guess posix?
+
+feature! {
+#![feature = "fs"]
 
 // The conversion is not identical on all operating systems.
 #[allow(clippy::useless_conversion)]
@@ -318,7 +318,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
 ) -> Result<OsString> {
-    let mut v = Vec::with_capacity(PATH_MAX as usize);
+    let mut v = Vec::with_capacity(PATH_MAX);
 
     {
         // simple case: result is strictly less than `PATH_MAX`
@@ -371,7 +371,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
         } else {
             // If lstat doesn't cooperate, or reports an error, be a little less
             // precise.
-            (PATH_MAX as usize).max(128) << 1
+            PATH_MAX.max(128) << 1
         }
     };
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,4 +1,6 @@
 use crate::{errno::Errno, RawFd};
+#[cfg(feature = "fs")]
+use crate::{sys::stat::Mode, NixPath, Result};
 use libc::{self, c_char, c_int, c_uint, size_t, ssize_t};
 use std::ffi::OsString;
 #[cfg(not(target_os = "redox"))]
@@ -7,8 +9,6 @@ use std::os::raw;
 use std::os::unix::ffi::OsStringExt;
 #[cfg(target_os = "wasi")]
 use std::os::wasi::ffi::OsStringExt;
-#[cfg(feature = "fs")]
-use crate::{sys::stat::Mode, NixPath, Result};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use std::ptr; // For splice and copy_file_range
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! * `user` - Stuff relating to users and groups
 //! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
-#![cfg(unix)]
+#![cfg(any(unix, target_os = "wasi"))]
 #![cfg_attr(docsrs, doc(cfg(all())))]
 #![allow(non_camel_case_types)]
 #![cfg_attr(test, deny(warnings))]
@@ -161,7 +161,10 @@ pub mod unistd;
 
 use std::ffi::{CStr, CString, OsStr};
 use std::mem::MaybeUninit;
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::{ptr, result, slice};
 
@@ -336,3 +339,12 @@ impl NixPath for PathBuf {
         self.as_os_str().with_nix_path(f)
     }
 }
+
+
+/// Raw file descriptors.
+#[cfg(unix)]
+pub type RawFd = std::os::unix::io::RawFd;
+
+/// Raw file descriptors.
+#[cfg(target_os = "wasi")]
+pub type RawFd = std::os::wasi::io::RawFd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,6 @@ impl NixPath for PathBuf {
     }
 }
 
-
 /// Raw file descriptors.
 #[cfg(unix)]
 pub type RawFd = std::os::unix::io::RawFd;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -165,6 +165,7 @@ feature! {
     pub mod statfs;
 }
 
+#[cfg(unix)]
 feature! {
     #![feature = "fs"]
     pub mod statvfs;

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -12,7 +12,7 @@ pub use libc::{dev_t, mode_t};
 #[cfg(not(target_os = "redox"))]
 use crate::fcntl::{at_rawfd, AtFlags};
 use crate::sys::time::{TimeSpec, TimeVal};
-use crate::{errno::Errno, NixPath, Result, RawFd};
+use crate::{errno::Errno, NixPath, RawFd, Result};
 use std::mem;
 
 libc_bitflags!(
@@ -32,7 +32,6 @@ libc_bitflags!(
 libc_bitflags! {
     /// "File mode / permissions" flags.
     pub struct Mode: mode_t {
-        #[cfg(not(target_os = "redox"))]
         /// Read, write and execute for owner.
         S_IRWXU;
         /// Read for owner.
@@ -367,12 +366,12 @@ pub fn utimes<P: ?Sized + NixPath>(
     atime: &TimeVal,
     mtime: &TimeVal,
 ) -> Result<()> {
-        let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
-        let res = path.with_nix_path(|cstr| unsafe {
-            libc::utimes(cstr.as_ptr(), &times[0])
-        })?;
+    let times: [libc::timeval; 2] = [*atime.as_ref(), *mtime.as_ref()];
+    let res = path.with_nix_path(|cstr| unsafe {
+        libc::utimes(cstr.as_ptr(), &times[0])
+    })?;
 
-        Errno::result(res).map(drop)
+    Errno::result(res).map(drop)
 }
 
 /// Change the access and modification times of a file without following symlinks.

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -4,7 +4,10 @@ use crate::errno::Errno;
 use crate::{Result, RawFd};
 use libc::{self, c_int, c_void, off_t, size_t};
 use std::io::{IoSlice, IoSliceMut};
-use std::os::fd::{AsFd, AsRawFd};
+#[cfg(unix)]
+use std::os::unix::prelude::{AsFd, AsRawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::prelude::{AsFd, AsRawFd};
 
 /// Low-level vectored write to a raw file descriptor
 ///

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -1,10 +1,10 @@
 //! Vectored I/O
 
 use crate::errno::Errno;
-use crate::Result;
+use crate::{Result, RawFd};
 use libc::{self, c_int, c_void, off_t, size_t};
 use std::io::{IoSlice, IoSliceMut};
-use std::os::unix::io::{AsFd, AsRawFd};
+use std::os::fd::{AsFd, AsRawFd};
 
 /// Low-level vectored write to a raw file descriptor
 ///

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -1,7 +1,7 @@
 //! Vectored I/O
 
 use crate::errno::Errno;
-use crate::{Result, RawFd};
+use crate::Result;
 use libc::{self, c_int, c_void, off_t, size_t};
 use std::io::{IoSlice, IoSliceMut};
 #[cfg(unix)]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,12 +1,12 @@
 //! Safe wrappers around functions found in libc "unistd.h" header
 
 use crate::errno::{self, Errno};
-#[cfg(not(target_os = "wasi"))]
-#[cfg(feature = "fs")]
-use crate::fcntl::{fcntl, FcntlArg::F_SETFD};
 #[cfg(not(target_os = "redox"))]
 #[cfg(feature = "fs")]
 use crate::fcntl::{at_rawfd, AtFlags};
+#[cfg(not(target_os = "wasi"))]
+#[cfg(feature = "fs")]
+use crate::fcntl::{fcntl, FcntlArg::F_SETFD};
 #[cfg(feature = "fs")]
 use crate::fcntl::{FdFlag, OFlag, PATH_MAX};
 #[cfg(all(
@@ -23,12 +23,12 @@ use crate::fcntl::{FdFlag, OFlag, PATH_MAX};
 use crate::sys::stat::FileFlag;
 #[cfg(feature = "fs")]
 use crate::sys::stat::Mode;
-use crate::{Error, NixPath, Result, RawFd};
+use crate::{Error, NixPath, RawFd, Result};
 #[cfg(not(target_os = "redox"))]
 use cfg_if::cfg_if;
 use libc::{
     self, c_char, c_int, c_long, c_uint, c_void, gid_t, mode_t, off_t, pid_t,
-    size_t, uid_t
+    size_t, uid_t,
 };
 use std::convert::Infallible;
 use std::ffi::{CStr, OsString};
@@ -38,12 +38,12 @@ use std::ffi::{CString, OsStr};
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
+#[cfg(unix)]
+use std::os::unix::io::{AsFd, AsRawFd};
 #[cfg(target_os = "wasi")]
 use std::os::wasi::ffi::{OsStrExt, OsStringExt};
 #[cfg(target_os = "wasi")]
 use std::os::wasi::io::{AsFd, AsRawFd};
-#[cfg(unix)]
-use std::os::unix::io::{AsFd, AsRawFd};
 use std::path::PathBuf;
 use std::{fmt, mem, ptr};
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,14 +1,15 @@
 //! Safe wrappers around functions found in libc "unistd.h" header
 
 use crate::errno::{self, Errno};
+#[cfg(any(feature = "fs", feature = "term"))]
+use crate::fcntl::PATH_MAX;
 #[cfg(not(target_os = "redox"))]
 #[cfg(feature = "fs")]
 use crate::fcntl::{at_rawfd, AtFlags};
 #[cfg(not(target_os = "wasi"))]
 #[cfg(feature = "fs")]
-use crate::fcntl::{fcntl, FcntlArg::F_SETFD};
+use crate::fcntl::{fcntl, FcntlArg::F_SETFD, FdFlag, OFlag};
 #[cfg(feature = "fs")]
-use crate::fcntl::{FdFlag, OFlag, PATH_MAX};
 #[cfg(all(
     feature = "fs",
     any(

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3917,7 +3917,6 @@ feature! {
 /// (see [`ttyname(3)`](https://man7.org/linux/man-pages/man3/ttyname.3.html)).
 #[cfg(not(target_os = "fuchsia"))]
 pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
-    const PATH_MAX: usize = libc::PATH_MAX as usize;
     let mut buf = vec![0_u8; PATH_MAX];
     let c_buf = buf.as_mut_ptr() as *mut libc::c_char;
 


### PR DESCRIPTION
References https://github.com/nix-rust/nix/issues/786 
~~Depends on https://github.com/rust-lang/libc/pull/3143, hence marking as a draft.~~ Done

This implements WASI support sufficient to build the fs, uio, and zerocopy features (enough to build [coreutils](https://github.com/uutils/coreutils) 🙂)

Lots of stuff is flagged out since file permissions aren't present in [`wasi_snapshot_preview1`](https://github.com/WebAssembly/wasi-http-proxy/blob/main/phases/snapshot/witx/wasi_snapshot_preview1.witx) which is what rust supports out of the box for `wasm32-wasi`.

One kind of weird thing is dealing with `PATH_MAX`. WASI doesn't define one, it's whatever the host system is, but afaik there's not an API to get this. So for WASI I defaulted to libc's "linux_like" value of 4096. Let me know what you think.