### PR TITLE
Add `getaddrinfo` from POSIX <netdb.h>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added a `netdb` module which initially includes `getaddrinfo` and `AddrInfo`. 
+  ([#????](https://github.com/nix-rust/nix/pull/????))
 - Added `AT_EACCESS` to `AtFlags` on all platforms but android
   ([#1995](https://github.com/nix-rust/nix/pull/1995))
 - Add `PF_ROUTE` to `SockType` on macOS, iOS, all of the BSDs, Fuchsia, Haiku, Illumos.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ memoffset = { version = "0.8", optional = true }
 default = [
   "acct", "aio", "dir", "env", "event", "feature", "fs",
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
-  "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
-  "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
+  "netdb", "net", "personality", "poll", "process", "pthread", "ptrace",
+  "quota", "reboot", "resource", "sched", "signal", "socket", "term",
+  "time", "ucontext", "uio", "user", "zerocopy",
 ]
 
 acct = []
@@ -59,6 +59,7 @@ kmod = []
 mman = []
 mount = ["uio"]
 mqueue = ["fs"]
+netdb = []
 net = ["socket"]
 personality = []
 poll = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! * `mman` - Stuff relating to memory management
 //! * `mount` - Mount and unmount file systems
 //! * `mqueue` - POSIX message queues
+//! * `netdb` - POSIX definitions for network database operations
 //! * `net` - Networking-related functionality
 //! * `personality` - Set the process execution domain
 //! * `poll` - APIs like `poll` and `select`
@@ -119,6 +120,10 @@ feature! {
 feature! {
     #![feature = "mqueue"]
     pub mod mqueue;
+}
+feature! {
+    #![feature = "netdb"]
+    pub mod netdb;
 }
 feature! {
     #![feature = "poll"]

--- a/src/netdb.rs
+++ b/src/netdb.rs
@@ -95,7 +95,8 @@ libc_bitflags!{
 #[repr(i32)]
 #[non_exhaustive]
 pub enum AddressInfoError {
-    // UnknownErrno = 0,
+    /// An error which is unmapped by this enum
+    Unknown = 0,
     /// The name could not be resolved at this time. Future attempts may succeed.
     EAI_AGAIN = libc::EAI_AGAIN,
     /// The flags had an invalid value.
@@ -117,5 +118,27 @@ pub enum AddressInfoError {
     EAI_SYSTEM(Errno) = libc::EAI_SYSTEM,
     /// An argument buffer overflowed.
     EAI_OVERFLOW = libc::EAI_OVERFLOW,
+}
+impl AddressInfoError {
+    /// interprets the error code and requests extra info from `errno` if nessesary
+    pub fn from_i32_and_errno(e: i32) -> Self {
+        use AddressInfoError::*;
+
+        match e {
+            libc::EAI_AGAIN => EAI_AGAIN,
+            libc::EAI_BADFLAGS => EAI_BADFLAGS,
+            libc::EAI_FAIL => EAI_FAIL,
+            libc::EAI_FAMILY => EAI_FAMILY,
+            libc::EAI_MEMORY => EAI_MEMORY,
+            libc::EAI_NONAME => EAI_NONAME,
+            libc::EAI_SERVICE => EAI_SERVICE,
+            libc::EAI_SOCKTYPE => EAI_SOCKTYPE,
+            libc::EAI_SYSTEM => {
+                EAI_SYSTEM(Errno::last())
+            },
+            libc::EAI_OVERFLOW => EAI_OVERFLOW,
+            _ => Unknown,
+        }
+    }
 }
 pub use libc::socklen_t;

--- a/src/netdb.rs
+++ b/src/netdb.rs
@@ -1,8 +1,78 @@
 //! Safe wrappers around functions found in POSIX <netdb.h> header
 //! 
 //! https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netdb.h.html
+use crate::errno::Errno;
 
 // The <netdb.h> header may define the in_port_t type and the in_addr_t type as described in <netinet/in.h>.
 // Simple integer type aliases, so we rexport
 pub use libc::{in_port_t, in_addr_t};
+
+libc_bitflags!{
+    ///  the flags field of the addrinfo structure
+    pub struct AiFlags: libc::c_int {
+        /// Socket address is intended for bind().
+        AI_PASSIVE;
+        /// Request for canonical name.
+        AI_CANONNAME;
+        /// Return numeric host address as name.
+        AI_NUMERICHOST;
+        /// Inhibit service name resolution.
+        AI_NUMERICSERV;
+        /// If no IPv6 addresses are found,
+        /// query for IPv4 addresses and return them to the caller as IPv4-mapped IPv6 addresses.
+        AI_V4MAPPED;
+        /// Query for both IPv4 and IPv6 addresses.
+        AI_ALL;
+        /// Query for IPv4 addresses only when an IPv4 address is configured;
+        /// Query for IPv6 addresses only when an IPv6 address is configured.
+        AI_ADDRCONFIG;
+    }
+}
+
+libc_bitflags!{
+    ///  the flags argument to getnameinfo():
+    pub struct NiFlags: libc::c_int {
+        /// Only the nodename portion of the FQDN is returned for local hosts.
+        NI_NOFQDN;
+        /// The numeric form of the node's address is returned instead of its name.
+        NI_NUMERICHOST;
+        /// Return an error if the node's name cannot be located in the database.
+        NI_NAMEREQD;
+        /// The numeric form of the service address is returned instead of its name.
+        NI_NUMERICSERV;
+        /// For IPv6 addresses, the numeric form of the scope identifier is returned instead of its name.
+        NI_NUMERICSCOPE;
+        /// Indicates that the service is a datagram service (SOCK_DGRAM).
+        NI_DGRAM;
+    }
+}
+
+/// error values for getaddrinfo() and getnameinfo().
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i32)]
+#[non_exhaustive]
+pub enum AddressInfoError {
+    // UnknownErrno = 0,
+    /// The name could not be resolved at this time. Future attempts may succeed.
+    EAI_AGAIN = libc::EAI_AGAIN,
+    /// The flags had an invalid value.
+    EAI_BADFLAGS = libc::EAI_BADFLAGS,
+    /// A non-recoverable error occurred.
+    EAI_FAIL = libc::EAI_FAIL,
+    /// The address family was not recognized or the address length was invalid for the specified family.
+    EAI_FAMILY = libc::EAI_FAMILY,
+    /// There was a memory allocation failure.
+    EAI_MEMORY = libc::EAI_MEMORY,
+    /// The name does not resolve for the supplied parameters.
+    /// NI_NAMEREQD is set and the host's name cannot be located, or both nodename and servname were null.
+    EAI_NONAME = libc::EAI_NONAME,
+    /// The service passed was not recognized for the specified socket type.
+    EAI_SERVICE = libc::EAI_SERVICE,
+    /// The intended socket type was not recognized.
+    EAI_SOCKTYPE = libc::EAI_SOCKTYPE,
+    /// A system error occurred. The error code can be found in errno.
+    EAI_SYSTEM(Errno) = libc::EAI_SYSTEM,
+    /// An argument buffer overflowed.
+    EAI_OVERFLOW = libc::EAI_OVERFLOW,
+}
 pub use libc::socklen_t;

--- a/src/netdb.rs
+++ b/src/netdb.rs
@@ -51,6 +51,23 @@ impl AddrInfo {
         unsafe { self.0.ai_next.cast::<Self>().as_mut() }
     } 
 }
+impl Default for AddrInfo {
+    /// POSIX requires AddrInfo be default constructable.
+    fn default() -> Self {
+        // Rust-C interop assumes C default contruction be equivalent to zeroing all fields
+        Self(libc::addrinfo {
+            ai_flags: 0,
+            ai_family: 0,
+            ai_socktype: 0,
+            ai_protocol: 0,
+            ai_addrlen: 0,
+            ai_canonname: core::ptr::null_mut(),
+            ai_addr: core::ptr::null_mut(),
+            ai_next: core::ptr::null_mut(),
+        })
+    }
+}
+
 /// Corresponds to a list of `AddrInfo` returned by `getaddrinfo`.
 /// Deliberately is not Clone because we want to own indirect data.
 #[repr(transparent)]

--- a/src/netdb.rs
+++ b/src/netdb.rs
@@ -1,0 +1,4 @@
+//! Safe wrappers around functions found in POSIX <netdb.h> header
+//! 
+//! https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netdb.h.html
+

--- a/src/netdb.rs
+++ b/src/netdb.rs
@@ -2,3 +2,7 @@
 //! 
 //! https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netdb.h.html
 
+// The <netdb.h> header may define the in_port_t type and the in_addr_t type as described in <netinet/in.h>.
+// Simple integer type aliases, so we rexport
+pub use libc::{in_port_t, in_addr_t};
+pub use libc::socklen_t;

--- a/test/test.rs
+++ b/test/test.rs
@@ -22,6 +22,7 @@ mod test_kmod;
 mod test_mq;
 #[cfg(not(target_os = "redox"))]
 mod test_net;
+mod test_netdb;
 mod test_nix_path;
 #[cfg(target_os = "freebsd")]
 mod test_nmount;

--- a/test/test_netdb.rs
+++ b/test/test_netdb.rs
@@ -1,0 +1,9 @@
+use nix::netdb::{getaddrinfo, AddressInfoError};
+
+#[test]
+fn test_getaddrinfo_all_null() {
+    assert_eq!(
+        getaddrinfo(None, None, None),
+        Err(AddressInfoError::EAI_NONAME)
+    )
+}


### PR DESCRIPTION
I found myself implementing this and felt I should make a PR.
Most of the doc comments are quotes from the posix documentation.
I am uncertain how the remaining `AddrInfo` fields should be converted to stronger types so I just left comments. 
I also added the name info bit flags struct, but left it unused.
