### PR TITLE
Add `MSG_WAITFORONE` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Removed `flock` from `::nix::fcntl` on Solaris. ([#2082](https://github.com/nix-rust/nix/pull/2082))
 - Use I/O safety with `copy_file_range`, and expose it on FreeBSD.
   (#[1906](https://github.com/nix-rust/nix/pull/1906))
+- Added `MSG_WAITFORONE` to `MsgFlags` on Android, Fuchsia, Linux, NetBSD,
+  FreeBSD, OpenBSD, and Solaris.
+  ([#2014](https://github.com/nix-rust/nix/pull/2014))
 
 ### Changed
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -374,6 +374,17 @@ libc_bitflags! {
                   target_os = "solaris"))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_NOSIGNAL;
+        /// Turns on [`MSG_DONTWAIT`] after the first message has been received (only for
+        /// `recvmmsg()`).
+        #[cfg(any(target_os = "android",
+                  target_os = "fuchsia",
+                  target_os = "linux",
+                  target_os = "netbsd",
+                  target_os = "freebsd",
+                  target_os = "openbsd",
+                  target_os = "solaris"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
+        MSG_WAITFORONE;
     }
 }
 


### PR DESCRIPTION
I'm not sure what platforms this is defined on, so I listed the ones that I think it's defined on. Below I've listed why I think it's defined on each platform.

- android - android src: https://android.googlesource.com/platform/bionic/+/c7ca8f3/libc/include/sys/socket.h#233
- freebsd - man page: https://man.freebsd.org/cgi/man.cgi?query=recvmmsg&apropos=0&sektion=2&manpath=FreeBSD+11-current&format=html
- fuchsia - defined in rust libc: https://github.com/rust-lang/libc/blob/60bf6d7fa9d561820ea562751ee455ccf67d3015/src/fuchsia/mod.rs#L1768
- illumos - I think this is the illumos src?: https://github.com/TritonDataCenter/illumos-joyent/blob/master/usr/src/uts/common/brand/lx/syscall/lx_socket.c
- linux - man page: https://man7.org/linux/man-pages/man2/recvmmsg.2.html
- netbsd - man page: https://man.netbsd.org/recvfrom.2
- openbsd - man page: https://man.openbsd.org/recvmsg.2
- solaris - man page: https://docs.oracle.com/cd/E88353_01/html/E37843/recvmmsg-3c.html

**Edit:** Removed the flag for freebsd, illumos, and openbsd since it isn't defined in the rust libc library for those platforms. The linux musl failure seems to be unrelated.

**Edit 2:** Added a changelog entry.