### PR TITLE
Make accept() return a (fd, SockaddrLike) tuple

### DIFF
--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -784,7 +784,7 @@ pub fn test_af_alg_cipher() {
     assert_eq!(sockaddr.alg_type().to_string_lossy(), alg_type);
 
     setsockopt(sock, AlgSetKey::default(), &key).expect("setsockopt");
-    let session_socket = accept(sock).expect("accept failed");
+    let (session_socket, ()) = accept(sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&libc::ALG_OP_ENCRYPT),
@@ -878,7 +878,7 @@ pub fn test_af_alg_aead() {
     setsockopt(sock, AlgSetAeadAuthSize, &auth_size)
         .expect("setsockopt AlgSetAeadAuthSize");
     setsockopt(sock, AlgSetKey::default(), &key).expect("setsockopt AlgSetKey");
-    let session_socket = accept(sock).expect("accept failed");
+    let (session_socket, ()) = accept(sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&ALG_OP_ENCRYPT),
@@ -905,7 +905,7 @@ pub fn test_af_alg_aead() {
 
     let iv = vec![1u8; iv_len];
 
-    let session_socket = accept(sock).expect("accept failed");
+    let (session_socket, ()) = accept(sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&ALG_OP_DECRYPT),
@@ -1436,7 +1436,7 @@ pub fn test_named_unixdomain() {
         close(s2).unwrap();
     });
 
-    let s3 = accept(s1).expect("accept failed");
+    let (s3, ()) = accept(s1).expect("accept failed");
 
     let mut buf = [0; 5];
     read(s3, &mut buf).unwrap();

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -149,7 +149,7 @@ fn test_so_tcp_maxseg() {
     )
     .unwrap();
     connect(ssock, &sock_addr).unwrap();
-    let rsess = accept(rsock).unwrap();
+    let (rsess, ()) = accept(rsock).unwrap();
     write(rsess, b"hello").unwrap();
     let actual = getsockopt(ssock, sockopt::TcpMaxSeg).unwrap();
     // Actual max segment size takes header lengths into account, max IPv4 options (60 bytes) + max


### PR DESCRIPTION
This PR addresses #1298.

On my machine 4 tests are failing, I don't understand what's the exact cause. Any suggestions how to fix them would be appreciated.