### PR TITLE
Remove 'static mut' usage in features::os::kernel_version.

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -6,6 +6,7 @@ mod os {
     use crate::sys::utsname::uname;
     use crate::Result;
     use std::os::unix::ffi::OsStrExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     // Features:
     // * atomic cloexec on socket: 2.6.27
@@ -72,15 +73,15 @@ mod os {
     }
 
     fn kernel_version() -> Result<usize> {
-        static mut KERNEL_VERS: usize = 0;
+        static KERNEL_VERS: AtomicUsize = AtomicUsize::new(0);
+        let mut kernel_vers = KERNEL_VERS.load(Ordering::Relaxed);
 
-        unsafe {
-            if KERNEL_VERS == 0 {
-                KERNEL_VERS = parse_kernel_version()?;
-            }
-
-            Ok(KERNEL_VERS)
+        if kernel_vers == 0 {
+            kernel_vers = parse_kernel_version()?;
+            KERNEL_VERS.store(kernel_vers, Ordering::Relaxed);
         }
+
+        Ok(kernel_vers)
     }
 
     /// Check if the OS supports atomic close-on-exec for sockets


### PR DESCRIPTION
Resolves #2028 

Note that this is (AFAICT) the first use of `Atomic*` types in `nix` (other than tests). However, this shouldn't be a portability issue, since `nix` is not `#![no_std]`, and (IIUC) [`std` requires](https://doc.rust-lang.org/std/sync/atomic/#portability) at least loads and stores of pointer-sized atomics (i.e. `AtomicUsize`), which is all this PR uses.