### PR TITLE
sockopt: add netlink options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2097](https://github.com/nix-rust/nix/pull/2097))
 - Add the ability to set `kevent_flags` on `SigEvent`.
   ([#1731](https://github.com/nix-rust/nix/pull/1731))
+- Added Netlink socket options for Android and Linux.
+  ([#2036](https://github.com/nix-rust/nix/pull/2036))
 
 ### Changed
 


### PR DESCRIPTION
Add all of the netlink socket options for Linux.
Documentation for them is very succinct on purpose as `man 7 netlink` does a much better job.