### PR TITLE
timerfd: Add TFD_TIMER_CANCEL_ON_SET flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added `mq_timedreceive` to `::nix::mqueue`.
   ([#1966])(https://github.com/nix-rust/nix/pull/1966)
 - Added `LocalPeerPid` to `nix::sys::socket::sockopt` for macOS. ([#1967](https://github.com/nix-rust/nix/pull/1967))
+- Added `TFD_TIMER_CANCEL_ON_SET` to `::nix::sys::time::TimerSetTimeFlags` on Linux and Android.
+  ([#2040](https://github.com/nix-rust/nix/pull/2040))
 
 ### Changed
 

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -93,6 +93,7 @@ pub(crate) mod timer {
         /// Flags that are used for arming the timer.
         pub struct TimerSetTimeFlags: libc::c_int {
             const TFD_TIMER_ABSTIME = libc::TFD_TIMER_ABSTIME;
+            const TFD_TIMER_CANCEL_ON_SET = libc::TFD_TIMER_CANCEL_ON_SET;
         }
     }
     #[cfg(any(


### PR DESCRIPTION
Hi.
This PR adds an TFD_TIMER_CANCEL_ON_SET flag to use with `timerfd` on Linux and Android