### PR TITLE
README: Remove Gitter channel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ changed in the future without bumping the major or minor version.
 Contributions are very welcome.  Please See [CONTRIBUTING](CONTRIBUTING.md) for
 additional details.
 
-Feel free to join us in [the nix-rust/nix](https://gitter.im/nix-rust/nix) channel on Gitter to
-discuss `nix` development.
-
 ## License
 
 Nix is licensed under the MIT license.  See [LICENSE](LICENSE) for more details.


### PR DESCRIPTION
This channel is not really helping anyone. Nobody is there to help out folks for many months now. Best not to give false hope.