### PR TITLE
Remove unnecessary static assertion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ libc = { version = "0.2.141", features = ["extra_traits"] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
-static_assertions = "1"
 memoffset = { version = "0.9", optional = true }
 
 [features]

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -39,16 +39,13 @@ use std::{fmt, mem, net, ptr, slice};
 /// Convert a std::net::Ipv4Addr into the libc form.
 #[cfg(feature = "net")]
 pub(crate) const fn ipv4addr_to_libc(addr: net::Ipv4Addr) -> libc::in_addr {
-    static_assertions::assert_eq_size!(net::Ipv4Addr, libc::in_addr);
-    // Safe because both types have the same memory layout, and no fancy Drop
-    // impls.
+    // Safe because neither has a fancy Drop impl.
     unsafe { mem::transmute(addr) }
 }
 
 /// Convert a std::net::Ipv6Addr into the libc form.
 #[cfg(feature = "net")]
 pub(crate) const fn ipv6addr_to_libc(addr: &net::Ipv6Addr) -> libc::in6_addr {
-    static_assertions::assert_eq_size!(net::Ipv6Addr, libc::in6_addr);
     // Safe because both are Newtype wrappers around the same libc type
     unsafe { mem::transmute(*addr) }
 }


### PR DESCRIPTION
This assertion is not required. The docs for std::mem::transmute read:

    Both types must have the same size. Compilation will fail if this is
    not guaranteed.

I have confirmed this to be the case by trying to transmute two different variables of different length:

    error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
      --> src/sys/socket/addr.rs:44:14
       |
    44 |     unsafe { mem::transmute("asdfasd") }
       |              ^^^^^^^^^^^^^^
       |
       = note: source type: `&str` (128 bits)
       = note: target type: `in_addr` (32 bits)

Given that this is the only usage of the `static_assertions` crates, this allows dropping an unnecessary dependency.