### PR TITLE
Add #[inline] to memfd_create to delay codegen and prevent undefined symbols in dylibs

### DIFF
--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -40,6 +40,7 @@ libc_bitflags!(
 /// For more information, see [`memfd_create(2)`].
 ///
 /// [`memfd_create(2)`]: https://man7.org/linux/man-pages/man2/memfd_create.2.html
+#[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
 pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<OwnedFd> {
     let res = unsafe {
         cfg_if! {


### PR DESCRIPTION
I think this is related to https://github.com/nix-rust/nix/issues/1972

I want this because I'm trying to use `ctrlc` in the compiler (https://github.com/rust-lang/rust/pull/111769), which uses this crate, and the feature set that `ctrlc` uses pulls in this function.

The compiler is primarily built as a shared object, and it is linked against an old version of glibc (2.17) so there is no `memfd_create` symbol available when it is built. Adding `#[inline]` causes this function to be codegenned differently; it is kept as MIR then since it is in fact dead, we never actually codegen it. Without `#[inline]` this function is eagerly codegenned then since dylibs have poor/no dead code elimination, we end up with an undefined symbol.