### PR TITLE
Clippy cleanup:

### DIFF
--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -86,7 +86,7 @@ impl Kqueue {
     target_os = "openbsd"
 ))]
 type type_of_udata = *mut libc::c_void;
-#[cfg(any(target_os = "netbsd"))]
+#[cfg(target_os = "netbsd")]
 type type_of_udata = intptr_t;
 
 #[cfg(target_os = "netbsd")]
@@ -171,7 +171,7 @@ libc_enum! {
 ))]
 #[doc(hidden)]
 pub type type_of_event_flag = u16;
-#[cfg(any(target_os = "netbsd"))]
+#[cfg(target_os = "netbsd")]
 #[doc(hidden)]
 pub type type_of_event_flag = u32;
 libc_bitflags! {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::slice;
 use std::str::FromStr;
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 #[cfg_attr(qemu, ignore)]
 #[test]
 pub fn test_timestamping() {
@@ -2082,7 +2082,7 @@ pub fn test_vsock() {
 // Disable the test on emulated platforms because it fails in Cirrus-CI.  Lack
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
-#[cfg(all(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_recvmsg_timestampns() {
     use nix::sys::socket::*;
@@ -2137,7 +2137,7 @@ fn test_recvmsg_timestampns() {
 // Disable the test on emulated platforms because it fails in Cirrus-CI.  Lack
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]
-#[cfg(all(target_os = "linux"))]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_recvmmsg_timestampns() {
     use nix::sys::socket::*;


### PR DESCRIPTION
fix the new clippy::non-minimal-cfg lint