### PR TITLE
Haiku: `speed_t` is defined as `u8` for 32 and 64 bit systems

### DIFF
--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -355,9 +355,9 @@ libc_enum! {
     /// enum.
     ///
     /// B0 is special and will disable the port.
-    #[cfg_attr(all(any(target_os = "haiku"), target_pointer_width = "64"), repr(u8))]
+    #[cfg_attr(target_os = "haiku", repr(u8))]
     #[cfg_attr(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64"), repr(u64))]
-    #[cfg_attr(not(all(any(target_os = "ios", target_os = "macos", target_os = "haiku"), target_pointer_width = "64")), repr(u32))]
+    #[cfg_attr(all(not(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64")), not(target_os = "haiku")), repr(u32))]
     #[non_exhaustive]
     pub enum BaudRate {
         B0,


### PR DESCRIPTION
This fixes the build on 32 bit Haiku systems.