### PR TITLE
For invalid IP address conversions with future Rust versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1964](https://github.com/nix-rust/nix/pull/1964))
 - Fix: send ETH_P_ALL in htons format 
   ([#1925](https://github.com/nix-rust/nix/pull/1925))
+- Fix potentially invalid conversions in
+  `SockaddrIn::from<std::net::SocketAddrV4>`,
+  `SockaddrIn6::from<std::net::SockaddrV6>`, `IpMembershipRequest::new`, and
+  `Ipv6MembershipRequest::new` with future Rust versions.
+  ([#2061](https://github.com/nix-rust/nix/pull/2061))
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ libc = { version = "0.2.141", features = ["extra_traits"] }
 bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
-static_assertions = "1"
 memoffset = { version = "0.9", optional = true }
 
 [features]


### PR DESCRIPTION
Rust's standard library no longer guarantees that Ipv4Addr and Ipv6Addr are wrappers around the C types (though for now at least, they are identical on all platforms I'm aware of).  So do the conversions explicitly instead of transmuting.

Fixes #2053