### PR TITLE
Parse SOL_TLS control message, closes #2064

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.147", features = ["extra_traits"] }
+libc = { version = "0.2.148", features = ["extra_traits"] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2065.added.md
+++ b/changelog/2065.added.md
@@ -1,0 +1,1 @@
+Added `TlsGetRecordType` control message type and corresponding enum for linux

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -894,6 +894,7 @@ pub struct Timestamps {
 #[cfg(all(target_os = "linux"))]
 const TLS_GET_RECORD_TYPE: c_int = 2;
 
+#[cfg(all(target_os = "linux"))]
 const SOL_TLS: c_int = 282;
 
 impl ControlMessageOwned {

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1032,7 +1032,7 @@ impl ControlMessageOwned {
                 let dl = ptr::read_unaligned(p as *const libc::sockaddr_in6);
                 ControlMessageOwned::Ipv6OrigDstAddr(dl)
             },
-            #[cfg(all(target_os = "linux"))]
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             (libc::SOL_TLS, libc::TLS_GET_RECORD_TYPE) => {
                 let content_type = ptr::read_unaligned(p as *const u8);
                 ControlMessageOwned::TlsGetRecordType(content_type)

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -890,13 +890,6 @@ pub struct Timestamps {
     pub hw_raw: TimeSpec,
 }
 
-// Defined in `linux/tls.h`
-#[cfg(all(target_os = "linux"))]
-const TLS_GET_RECORD_TYPE: c_int = 2;
-
-#[cfg(all(target_os = "linux"))]
-const SOL_TLS: c_int = 282;
-
 impl ControlMessageOwned {
     /// Decodes a `ControlMessageOwned` from raw bytes.
     ///
@@ -1040,7 +1033,7 @@ impl ControlMessageOwned {
                 ControlMessageOwned::Ipv6OrigDstAddr(dl)
             },
             #[cfg(all(target_os = "linux"))]
-            (SOL_TLS, TLS_GET_RECORD_TYPE) => {
+            (libc::SOL_TLS, libc::TLS_GET_RECORD_TYPE) => {
                 let content_type = ptr::read_unaligned(p as *const u8);
                 ControlMessageOwned::TlsGetRecordType(content_type)
             },

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -869,7 +869,7 @@ pub enum ControlMessageOwned {
     Ipv6RecvErr(libc::sock_extended_err, Option<sockaddr_in6>),
 
     /// `SOL_TLS` messages of type `TLS_GET_RECORD_TYPE`
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(any(target_os = "linux"))]
     TlsGetRecordType(TlsGetRecordType),
 
     /// Catch-all variant for unimplemented cmsg types.
@@ -891,7 +891,7 @@ pub struct Timestamps {
 
 /// These constants correspond to TLS 1.2 message types, as defined in
 /// RFC 5246, Appendix A.1
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "linux"))]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 #[non_exhaustive]
@@ -903,7 +903,7 @@ pub enum TlsGetRecordType {
     Unknown(u8),
 }
 
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "linux"))]
 impl From<u8> for TlsGetRecordType {
     fn from(x: u8) -> Self {
         match x {
@@ -1058,7 +1058,7 @@ impl ControlMessageOwned {
                 let dl = ptr::read_unaligned(p as *const libc::sockaddr_in6);
                 ControlMessageOwned::Ipv6OrigDstAddr(dl)
             },
-            #[cfg(any(target_os = "android", target_os = "linux"))]
+            #[cfg(any(target_os = "linux"))]
             (libc::SOL_TLS, libc::TLS_GET_RECORD_TYPE) => {
                 let content_type = ptr::read_unaligned(p as *const u8);
                 ControlMessageOwned::TlsGetRecordType(content_type.into())

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -869,6 +869,7 @@ pub enum ControlMessageOwned {
     Ipv6RecvErr(libc::sock_extended_err, Option<sockaddr_in6>),
 
     /// `SOL_TLS` messages of type `TLS_GET_RECORD_TYPE`
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     TlsGetRecordType(TlsGetRecordType),
 
     /// Catch-all variant for unimplemented cmsg types.


### PR DESCRIPTION
cf. #2064 - I've added the absolute minimum I need. We could swap that u8 with something more strongly-typed, but since I'm clearly the first person using ktls & the nix crate together, I'm treading lightly in terms of added lines.