### PR TITLE
Fix setting sockopt::IpMulticastTtl

### DIFF
--- a/changelog/2072.fixed.md
+++ b/changelog/2072.fixed.md
@@ -1,1 +1,1 @@
-Fixed `::sys::socket::sockopt::IpMulticastTtl` by fixing the value of optlen passed to `libc::setsockopt`.
+Fixed `::sys::socket::sockopt::IpMulticastTtl` by fixing the value of optlen passed to `libc::setsockopt` and added tests.

--- a/changelog/2072.fixed.md
+++ b/changelog/2072.fixed.md
@@ -1,0 +1,1 @@
+Fixed `::sys::socket::sockopt::IpMulticastTtl` by fixing the value of optlen passed to `libc::setsockopt`.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1247,7 +1247,7 @@ impl<'a> Set<'a, bool> for SetBool {
     }
 
     fn ffi_len(&self) -> socklen_t {
-        mem::size_of::<c_int>() as socklen_t
+        mem::size_of_val(&self.val) as socklen_t
     }
 }
 
@@ -1298,7 +1298,7 @@ impl<'a> Set<'a, u8> for SetU8 {
     }
 
     fn ffi_len(&self) -> socklen_t {
-        mem::size_of::<c_int>() as socklen_t
+        mem::size_of_val(&self.val) as socklen_t
     }
 }
 
@@ -1349,7 +1349,7 @@ impl<'a> Set<'a, usize> for SetUsize {
     }
 
     fn ffi_len(&self) -> socklen_t {
-        mem::size_of::<c_int>() as socklen_t
+        mem::size_of_val(&self.val) as socklen_t
     }
 }
 

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -303,7 +303,7 @@ fn test_get_mtu() {
 }
 
 #[test]
-#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 fn test_ttl_opts() {
     let fd4 = socket(
         AddressFamily::Inet,
@@ -323,6 +323,34 @@ fn test_ttl_opts() {
     .unwrap();
     setsockopt(&fd6, sockopt::Ipv6Ttl, &1)
         .expect("setting ipv6ttl on an inet6 socket should succeed");
+}
+
+#[test]
+#[cfg(any(linux_android, target_os = "freebsd"))]
+fn test_multicast_ttl_opts_ipv4() {
+    let fd4 = socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    setsockopt(&fd4, sockopt::IpMulticastTtl, &2)
+        .expect("setting ipmulticastttl on an inet socket should succeed");
+}
+
+#[test]
+#[cfg(linux_android)]
+fn test_multicast_ttl_opts_ipv6() {
+    let fd6 = socket(
+        AddressFamily::Inet6,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    setsockopt(&fd6, sockopt::IpMulticastTtl, &2)
+        .expect("setting ipmulticastttl on an inet6 socket should succeed");
 }
 
 #[test]


### PR DESCRIPTION
The socket option `IpMulticastTtl` was implemented with `u8` as type however `i32` seems to be the correct type.