### PR TITLE
Don't build flock on Solaris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2085](https://github.com/nix-rust/nix/pull/2085))
 - Added `SO_RTABLE` for OpenBSD and `SO_ACCEPTFILTER` for FreeBSD/NetBSD to `nix::sys::socket::sockopt`.
   ([#2085](https://github.com/nix-rust/nix/pull/2085))
+- Removed `flock` from `::nix::fcntl` on Solaris. ([#2082](https://github.com/nix-rust/nix/pull/2082))
 
 ### Changed
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -559,7 +559,7 @@ pub enum FlockArg {
     UnlockNonblock,
 }
 
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 pub fn flock(fd: RawFd, arg: FlockArg) -> Result<()> {
     use self::FlockArg::*;
 


### PR DESCRIPTION
Solaris hasn't included flock(2) for a long while now, and building this wrapper creates issues with undefined symbols.  However, OpenSolaris derivatives like Illumos do include flock(2) so they should not be excluded here.