### PR TITLE
Do not enable any features by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,9 +18,9 @@ build: &BUILD
     - . $HOME/.cargo/env || true
     - $TOOL -Vv
     - rustc -Vv
-    - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets
-    - $TOOL doc $ZFLAGS --no-deps --target $TARGET
-    - $TOOL clippy $ZFLAGS --target $TARGET --all-targets -- $CLIPPYFLAGS
+    - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets --all-features
+    - $TOOL doc $ZFLAGS --no-deps --target $TARGET --all-features
+    - $TOOL clippy $ZFLAGS --target $TARGET --all-targets --all-features -- $CLIPPYFLAGS
     - if [ -z "$NOHACK" ]; then mkdir -p $HOME/.cargo/bin; export PATH=$HOME/.cargo/bin:$PATH; fi
     - if [ -z "$NOHACK" ]; then curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-${HOST:-$TARGET}.tar.gz | tar xzf - -C ~/.cargo/bin; fi
     - if [ -z "$NOHACK" ]; then $TOOL hack $ZFLAGS check --target $TARGET --each-feature; fi
@@ -30,7 +30,7 @@ test: &TEST
   << : *BUILD
   test_script:
     - . $HOME/.cargo/env || true
-    - $TOOL test --target $TARGET
+    - $TOOL test --target $TARGET --all-features
 
 # Test FreeBSD in a full VM.  Test the i686 target too, in the
 # same VM.  The binary will be built in 32-bit mode, but will execute on a
@@ -59,9 +59,9 @@ task:
   << : *TEST
   i386_test_script:
     - . $HOME/.cargo/env
-    - cargo build --target i686-unknown-freebsd
-    - cargo doc --no-deps --target i686-unknown-freebsd
-    - cargo test --target i686-unknown-freebsd
+    - cargo build --target i686-unknown-freebsd --all-features
+    - cargo doc --no-deps --target i686-unknown-freebsd --all-features
+    - cargo test --target i686-unknown-freebsd --all-features
   i386_feature_script:
     - . $HOME/.cargo/env
     - if [ -z "$NOHACK" ]; then cargo hack check --each-feature --target i686-unknown-freebsd; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1943](https://github.com/nix-rust/nix/pull/1943))
 - `nix::socket` and `nix::select` are now available on Redox.
   ([#2012](https://github.com/nix-rust/nix/pull/2012))
+- All features have been removed from the default set. Users will need to specify
+  which features they depend on in their Cargo.toml.
+  ([#2091](https://github.com/nix-rust/nix/pull/2091))
 
 ### Fixed
 - Fix: send `ETH_P_ALL` in htons format 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,7 @@ pin-utils = { version = "0.1.0", optional = true }
 memoffset = { version = "0.9", optional = true }
 
 [features]
-default = [
-  "acct", "aio", "dir", "env", "event", "feature", "fs",
-  "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
-  "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
-  "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
-]
+default = []
 
 acct = []
 aio = ["pin-utils"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,43 @@
 #![recursion_limit = "500"]
 #![deny(unused)]
 #![allow(unused_macros)]
-#![cfg_attr(not(feature = "default"), allow(unused_imports))]
+#![cfg_attr(
+    not(all(
+        feature = "acct",
+        feature = "aio",
+        feature = "dir",
+        feature = "env",
+        feature = "event",
+        feature = "feature",
+        feature = "fs",
+        feature = "hostname",
+        feature = "inotify",
+        feature = "ioctl",
+        feature = "kmod",
+        feature = "mman",
+        feature = "mount",
+        feature = "mqueue",
+        feature = "net",
+        feature = "personality",
+        feature = "poll",
+        feature = "process",
+        feature = "pthread",
+        feature = "ptrace",
+        feature = "quota",
+        feature = "reboot",
+        feature = "resource",
+        feature = "sched",
+        feature = "socket",
+        feature = "signal",
+        feature = "term",
+        feature = "time",
+        feature = "ucontext",
+        feature = "uio",
+        feature = "user",
+        feature = "zerocopy",
+    )),
+    allow(unused_imports)
+)]
 #![deny(unstable_features)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
The original intention behind https://github.com/nix-rust/nix/pull/1498 was to allow repositories to slim down what amount of nix they consume, saving on compile time. However, with all these features enabled by default, it only takes one crate in your entire dependency tree that doesn't set `default-features = false` and suddenly you're back to square one. The better solution IMHO would be to always require crates to opt in to the functionality they need, ensuring that this footgun can't fire.

This is a breaking change, and would need a new version number before release.