### PR TITLE
feat: I/O safety `pipe` & `pipe2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
 - impl `From<uid_t>` for `Uid` and `From<gid_t>` for `Gid`
   (#[1727](https://github.com/nix-rust/nix/pull/1727))
-- impl `From<SockaddrIn>` for `std::net::SocketAddrV4` and
-  impl `From<SockaddrIn6>` for `std::net::SocketAddrV6`.
+- impl `From<SockaddrIn>` for `core::net::SocketAddrV4` and
+  impl `From<SockaddrIn6>` for `core::net::SocketAddrV6`.
   (#[1711](https://github.com/nix-rust/nix/pull/1711))
 - Added support for the `x86_64-unknown-haiku` target.
   (#[1703](https://github.com/nix-rust/nix/pull/1703))
@@ -177,7 +177,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1713](https://github.com/nix-rust/nix/pull/1713))
 - `nix::poll::ppoll`: `sigmask` parameter is now optional.
   (#[1739](https://github.com/nix-rust/nix/pull/1739))
-- Changed `gethostname` to return an owned `OsString`.
+- Changed `gethostname` to return an owned `CString`.
   (#[1745](https://github.com/nix-rust/nix/pull/1745))
 - `signal:SigSet` is now marked as `repr(transparent)`.
   (#[1741](https://github.com/nix-rust/nix/pull/1741))
@@ -275,7 +275,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   Accessors take this type by reference, not by value.
   (#[1639](https://github.com/nix-rust/nix/pull/1639))
 - Removed `SigSet::extend` in favor of `<SigSet as Extend<Signal>>::extend`.
-  Because of this change, you now need `use std::iter::Extend` to call `extend`
+  Because of this change, you now need `use core::iter::Extend` to call `extend`
   on a `SigSet`.
   (#[1553](https://github.com/nix-rust/nix/pull/1553))
 - Removed the the `PATH_MAX` restriction from APIs accepting paths. Paths
@@ -293,10 +293,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1685](https://github.com/nix-rust/nix/pull/1685))
 - `uname` now returns a `Result<UtsName>` instead of just a `UtsName` and
   ignoring failures from libc.  And getters on the `UtsName` struct now return
-  an `&OsStr` instead of `&str`.
+  an `&CStr` instead of `&str`.
   (#[1672](https://github.com/nix-rust/nix/pull/1672))
-- Replaced `IoVec` with `IoSlice` and `IoSliceMut`, and replaced `IoVec::from_slice` with
-  `IoSlice::new`. (#[1643](https://github.com/nix-rust/nix/pull/1643))
+- Replaced `IoVec` with `libc::iovec` and `libc::iovec`, and replaced `IoVec::from_slice` with
+  `libc::iovec::new`. (#[1643](https://github.com/nix-rust/nix/pull/1643))
 
 ### Fixed
 
@@ -481,7 +481,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   just like `ptsname`.
   ([#1446](https://github.com/nix-rust/nix/pull/1446))
 - Nix's error type is now a simple wrapper around the platform's Errno.  This
-  means it is now `Into<std::io::Error>`.  It's also `Clone`, `Copy`, `Eq`, and
+  means it is now `Into<core::io::Error>`.  It's also `Clone`, `Copy`, `Eq`, and
   has a small fixed size.  It also requires less typing.  For example, the old
   enum variant `nix::Error::Sys(nix::errno::Errno::EINVAL)` is now simply
   `nix::Error::EINVAL`.
@@ -520,7 +520,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1429](https://github.com/nix-rust/nix/pull/1429))
 - `AioCb` is now always pinned.  Once a `libc::aiocb` gets sent to the kernel,
   its address in memory must not change.  Nix now enforces that by using
-  `std::pin`.  Most users won't need to change anything, except when using
+  `core::pin`.  Most users won't need to change anything, except when using
   `aio_suspend`.  See that method's documentation for the new usage.
   (#[1440](https://github.com/nix-rust/nix/pull/1440))
 - `LioCb` is now constructed using a distinct `LioCbBuilder` struct.  This
@@ -643,7 +643,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   (#[1195](https://github.com/nix-rust/nix/pull/1195))
 - Added `env::clearenv()`: calls `libc::clearenv` on platforms
   where it's available, and clears the environment of all variables
-  via `std::env::vars` and `std::env::remove_var` on others.
+  via `core::env::vars` and `core::env::remove_var` on others.
   (#[1185](https://github.com/nix-rust/nix/pull/1185))
 - `FsType` inner value made public.
   (#[1187](https://github.com/nix-rust/nix/pull/1187))
@@ -809,21 +809,21 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `Signal::from_c_int` has been replaced by `Signal::try_from`
   ([#1113](https://github.com/nix-rust/nix/pull/1113))
 
-- Changed `readlink` and `readlinkat` to return `OsString`
+- Changed `readlink` and `readlinkat` to return `CString`
   ([#1109](https://github.com/nix-rust/nix/pull/1109))
 
   ```rust
   # use nix::fcntl::{readlink, readlinkat};
   // the buffer argument of `readlink` and `readlinkat` has been removed,
-  // and the return value is now an owned type (`OsString`).
+  // and the return value is now an owned type (`CString`).
   // Existing code can be updated by removing the buffer argument
   // and removing any clone or similar operation on the output
 
   // old code `readlink(&path, &mut buf)` can be replaced with the following
-  let _: OsString = readlink(&path);
+  let _: CString = readlink(&path);
 
   // old code `readlinkat(dirfd, &path, &mut buf)` can be replaced with the following
-  let _: OsString = readlinkat(dirfd, &path);
+  let _: CString = readlinkat(dirfd, &path);
   ```
 
 - Minimum supported Rust version is now 1.36.0.
@@ -1621,7 +1621,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#357](https://github.com/nix-rust/nix/pull/357))
 
 ### Fixed
-- Improved the conversion from `std::net::SocketAddr` to `InetAddr` in
+- Improved the conversion from `core::net::SocketAddr` to `InetAddr` in
   `::nix::sys::socket::addr`.
   ([#335](https://github.com/nix-rust/nix/pull/335))
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -76,7 +76,7 @@ to parameters of functions by [enumerations][enum].
 
 Whenever we need to use a [libc][libc] function to properly initialize a
 variable and said function allows us to use uninitialized memory, we use
-[`std::mem::MaybeUninit`][std_MaybeUninit] when defining the variable. This
+[`core::mem::MaybeUninit`][std_MaybeUninit] when defining the variable. This
 allows us to avoid the overhead incurred by zeroing or otherwise initializing
 the variable.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,10 @@ default = [
   "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
   "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
   "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
+  "ucontext", "uio", "user", "zerocopy", "no_std","uio"
 ]
 
+no_std = []
 acct = []
 aio = ["pin-utils"]
 dir = ["fs"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ call:
 // libc api (unsafe, requires handling return code/errno)
 pub unsafe extern fn gethostname(name: *mut c_char, len: size_t) -> c_int;
 
-// nix api (returns a nix::Result<OsString>)
-pub fn gethostname() -> Result<OsString>;
+// nix api (returns a nix::Result<CString>)
+pub fn gethostname() -> Result<CString>;
 ```
 
 ## Supported Platforms

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,6 @@
 //! Environment variables
 use cfg_if::cfg_if;
-use std::fmt;
+use core::fmt;
 
 /// Indicates that [`clearenv`] failed for some unknown reason
 #[derive(Clone, Copy, Debug)]
@@ -12,7 +12,7 @@ impl fmt::Display for ClearEnvError {
     }
 }
 
-impl std::error::Error for ClearEnvError {}
+impl core::error::Error for ClearEnvError {}
 
 /// Clear the environment of all name-value pairs.
 ///
@@ -28,17 +28,17 @@ impl std::error::Error for ClearEnvError {}
 /// # Safety
 ///
 /// This function is not threadsafe and can cause undefined behavior in
-/// combination with `std::env` or other program components that access the
-/// environment. See, for example, the discussion on `std::env::remove_var`; this
+/// combination with `core::env` or other program components that access the
+/// environment. See, for example, the discussion on `core::env::remove_var`; this
 /// function is a case of an "inherently unsafe non-threadsafe API" dealing with
 /// the environment.
 ///
 ///  The caller must ensure no other threads access the process environment while
 ///  this function executes and that no raw pointers to an element of libc's
 ///  `environ` is currently held. The latter is not an issue if the only other
-///  environment access in the program is via `std::env`, but the requirement on
+///  environment access in the program is via `core::env`, but the requirement on
 ///  thread safety must still be upheld.
-pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
+pub unsafe fn clearenv() -> core::result::Result<(), ClearEnvError> {
     cfg_if! {
         if #[cfg(any(target_os = "fuchsia",
                      target_os = "wasi",
@@ -48,7 +48,7 @@ pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
                      target_os = "emscripten"))] {
             let ret = libc::clearenv();
         } else {
-            use std::env;
+            use core::env;
             for (name, _) in env::vars_os() {
                 env::remove_var(name);
             }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,8 +1,8 @@
 use crate::Result;
 use cfg_if::cfg_if;
+use core::convert::TryFrom;
+use core::{error, fmt, io};
 use libc::{c_int, c_void};
-use std::convert::TryFrom;
-use std::{error, fmt, io};
 
 pub use self::consts::*;
 
@@ -132,7 +132,7 @@ impl From<Errno> for io::Error {
 impl TryFrom<io::Error> for Errno {
     type Error = io::Error;
 
-    fn try_from(ioerror: io::Error) -> std::result::Result<Self, io::Error> {
+    fn try_from(ioerror: io::Error) -> core::result::Result<Self, io::Error> {
         ioerror.raw_os_error().map(Errno::from_i32).ok_or(ioerror)
     }
 }

--- a/src/features.rs
+++ b/src/features.rs
@@ -5,8 +5,8 @@ pub use self::os::*;
 mod os {
     use crate::sys::utsname::uname;
     use crate::Result;
-    use std::os::unix::ffi::OsStrExt;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use core::os::unix::ffi::CStrExt;
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     // Features:
     // * atomic cloexec on socket: 2.6.27

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -5,11 +5,12 @@
 
 use cfg_if::cfg_if;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
-use std::convert::TryFrom;
-use std::ffi;
-use std::iter::Iterator;
-use std::mem;
-use std::option::Option;
+use core::convert::TryFrom;
+use core::ffi;
+use core::iter::Iterator;
+use core::mem;
+use core::option::Option;
+use alloc::string::String;
 
 use crate::net::if_::*;
 use crate::sys::socket::{SockaddrLike, SockaddrStorage};
@@ -63,7 +64,7 @@ unsafe fn workaround_xnu_bug(info: &libc::ifaddrs) -> Option<SockaddrStorage> {
     let mut dst_sock = mem::MaybeUninit::<libc::sockaddr_storage>::zeroed();
 
     // memcpy only sa_len bytes, assume the rest is zero
-    std::ptr::copy_nonoverlapping(
+    core::ptr::copy_nonoverlapping(
         src_sock as *const u8,
         dst_sock.as_mut_ptr() as *mut u8,
         (*src_sock).sa_len.into(),

--- a/src/kmod.rs
+++ b/src/kmod.rs
@@ -2,8 +2,8 @@
 //!
 //! For more details see
 
-use std::ffi::CStr;
-use std::os::unix::io::{AsFd, AsRawFd};
+use core::ffi::CStr;
+use crate::os::fd::{AsFd, AsRawFd};
 
 use crate::errno::Errno;
 use crate::Result;
@@ -30,9 +30,9 @@ use crate::Result;
 /// # Example
 ///
 /// ```no_run
-/// use std::fs::File;
-/// use std::io::Read;
-/// use std::ffi::CString;
+/// use core::fs::File;
+/// use core::io::Read;
+/// use core::ffi::CString;
 /// use nix::kmod::init_module;
 ///
 /// let mut f = File::open("mykernel.ko").unwrap();
@@ -70,8 +70,8 @@ libc_bitflags!(
 /// # Example
 ///
 /// ```no_run
-/// use std::fs::File;
-/// use std::ffi::CString;
+/// use core::fs::File;
+/// use core::ffi::CString;
 /// use nix::kmod::{finit_module, ModuleInitFlags};
 ///
 /// let f = File::open("mymod.ko").unwrap();
@@ -112,7 +112,7 @@ libc_bitflags!(
 /// # Example
 ///
 /// ```no_run
-/// use std::ffi::CString;
+/// use core::ffi::CString;
 /// use nix::kmod::{delete_module, DeleteModuleFlags};
 ///
 /// delete_module(&CString::new("mymod").unwrap(), DeleteModuleFlags::O_NONBLOCK).unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -129,7 +129,7 @@ macro_rules! libc_enum {
         $v enum $BitFlags {
             $($entries)*
         }
-        impl ::std::convert::TryFrom<$repr> for $BitFlags {
+        impl ::core::convert::TryFrom<$repr> for $BitFlags {
             type Error = $crate::Error;
             #[allow(unused_doc_comments)]
             #[allow(deprecated)]

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -5,7 +5,7 @@ use libc::c_int;
 #[cfg(target_os = "freebsd")]
 use libc::{c_char, c_uint, c_void};
 #[cfg(target_os = "freebsd")]
-use std::{
+use core::{
     borrow::Cow,
     ffi::{CStr, CString},
     fmt, io,
@@ -135,7 +135,7 @@ impl NmountError {
 }
 
 #[cfg(target_os = "freebsd")]
-impl std::error::Error for NmountError {}
+impl core::error::Error for NmountError {}
 
 #[cfg(target_os = "freebsd")]
 impl fmt::Display for NmountError {
@@ -157,7 +157,7 @@ impl From<NmountError> for io::Error {
 
 /// Result type of [`Nmount::nmount`].
 #[cfg(target_os = "freebsd")]
-pub type NmountResult = std::result::Result<(), NmountError>;
+pub type NmountResult = core::result::Result<(), NmountError>;
 
 /// Mount a FreeBSD file system.
 ///
@@ -177,7 +177,7 @@ pub type NmountResult = std::result::Result<(), NmountError>;
 /// #     return;
 /// # };
 /// use nix::mount::{MntFlags, Nmount, unmount};
-/// use std::ffi::CString;
+/// use core::ffi::CString;
 /// use tempfile::tempdir;
 ///
 /// let mountpoint = tempdir().unwrap();
@@ -262,8 +262,8 @@ impl<'a> Nmount<'a> {
     /// ```
     /// use libc::c_void;
     /// use nix::mount::Nmount;
-    /// use std::ffi::CString;
-    /// use std::mem;
+    /// use core::ffi::CString;
+    /// use core::mem;
     ///
     /// // Note that flags outlives name
     /// let mut flags: u32 = 0xdeadbeef;
@@ -289,7 +289,7 @@ impl<'a> Nmount<'a> {
     /// # Examples
     /// ```
     /// use nix::mount::Nmount;
-    /// use std::ffi::CString;
+    /// use core::ffi::CString;
     ///
     /// let read_only = CString::new("ro").unwrap();
     /// Nmount::new()
@@ -331,7 +331,7 @@ impl<'a> Nmount<'a> {
     /// # Examples
     /// ```
     /// use nix::mount::Nmount;
-    /// use std::ffi::CString;
+    /// use core::ffi::CString;
     ///
     /// let fstype = CString::new("fstype").unwrap();
     /// let nullfs = CString::new("nullfs").unwrap();
@@ -353,7 +353,7 @@ impl<'a> Nmount<'a> {
     /// # Examples
     /// ```
     /// use nix::mount::Nmount;
-    /// use std::path::Path;
+    /// use core::path::Path;
     ///
     /// let mountpoint = Path::new("/mnt");
     /// Nmount::new()

--- a/src/mount/linux.rs
+++ b/src/mount/linux.rs
@@ -120,7 +120,7 @@ pub fn mount<
     {
         match p {
             Some(path) => path.with_nix_path(|p_str| f(p_str.as_ptr())),
-            None => Ok(f(std::ptr::null())),
+            None => Ok(f(core::ptr::null())),
         }
     }
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -4,7 +4,7 @@
 //!
 // no_run because a kernel module may be required.
 //! ```no_run
-//! # use std::ffi::CString;
+//! # use core::ffi::CString;
 //! # use nix::mqueue::*;
 //! use nix::sys::stat::Mode;
 //!
@@ -35,8 +35,8 @@ use crate::Result;
 
 use crate::sys::stat::Mode;
 use libc::{self, c_char, mqd_t, size_t};
-use std::ffi::CStr;
-use std::mem;
+use core::ffi::CStr;
+use core::mem;
 
 libc_bitflags! {
     /// Used with [`mq_open`].

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -340,10 +340,10 @@ libc_bitflags!(
 mod if_nameindex {
     use super::*;
 
-    use std::ffi::CStr;
-    use std::fmt;
-    use std::marker::PhantomData;
-    use std::ptr::NonNull;
+    use core::ffi::CStr;
+    use core::fmt;
+    use core::marker::PhantomData;
+    use core::ptr::NonNull;
 
     /// A network interface. Has a name like "eth0" or "wlp4s0" or "wlan0", as well as an index
     /// (1, 2, 3, etc) that identifies it in the OS's networking stack.
@@ -390,7 +390,7 @@ mod if_nameindex {
         pub fn to_slice(&self) -> &[Interface] {
             let ifs = self.ptr.as_ptr() as *const Interface;
             let len = self.iter().count();
-            unsafe { std::slice::from_raw_parts(ifs, len) }
+            unsafe { core::slice::from_raw_parts(ifs, len) }
         }
     }
 

--- a/src/os/fd/mod.rs
+++ b/src/os/fd/mod.rs
@@ -1,0 +1,46 @@
+pub trait AsRawFd {
+    fn as_raw_fd(&self) -> RawFd;
+}
+
+pub trait FromRawFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> OwnedFd;
+}
+
+pub trait IntoRawFd {
+    fn into_raw_fd(self) -> RawFd;
+}
+
+pub trait AsFd {
+    fn as_fd(&self) -> BorrowedFd<'_>;
+}
+
+#[repr(transparent)]
+pub struct OwnedFd {
+    fd: RawFd,
+}
+
+impl Drop for OwnedFd {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            // Note that errors are ignored when closing a file descriptor. The
+            // reason for this is that if an error occurs we don't actually know if
+            // the file descriptor was closed or not, and if we retried (for
+            // something like EINTR), we might close another valid file descriptor
+            // opened after we closed ours.
+            #[cfg(not(target_os = "hermit"))]
+            let _ = libc::close(self.fd);
+            #[cfg(target_os = "hermit")]
+            let _ = hermit_abi::close(self.fd);
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct BorrowedFd<'fd> {
+    fd: RawFd,
+    _phantom: core::marker::PhantomData<&'fd OwnedFd>,
+}
+
+pub type RawFd = core::ffi::c_int;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,0 +1,1 @@
+pub mod fd;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,5 @@
 //! Wait for events to trigger on specific file descriptors
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
+use crate::os::fd::{AsFd, AsRawFd, BorrowedFd};
 
 use crate::errno::Errno;
 use crate::Result;
@@ -16,7 +16,7 @@ use crate::Result;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct PollFd<'fd> {
     pollfd: libc::pollfd,
-    _fd: std::marker::PhantomData<BorrowedFd<'fd>>,
+    _fd: core::marker::PhantomData<BorrowedFd<'fd>>,
 }
 
 impl<'fd> PollFd<'fd> {
@@ -43,7 +43,7 @@ impl<'fd> PollFd<'fd> {
                 events: events.bits(),
                 revents: PollFlags::empty().bits(),
             },
-            _fd: std::marker::PhantomData,
+            _fd: core::marker::PhantomData,
         }
     }
 

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -14,9 +14,10 @@ mod sched_linux_like {
     use crate::unistd::Pid;
     use crate::Result;
     use libc::{self, c_int, c_void};
-    use std::mem;
-    use std::option::Option;
-    use std::os::unix::io::{AsFd, AsRawFd};
+    use core::mem;
+    use core::option::Option;
+    use crate::os::fd::{AsFd, AsRawFd};
+    use alloc::boxed::Box;
 
     // For some functions taking with a parameter of type CloneFlags,
     // only a subset of these flags have an effect.
@@ -161,7 +162,7 @@ mod sched_affinity {
     use crate::errno::Errno;
     use crate::unistd::Pid;
     use crate::Result;
-    use std::mem;
+    use core::mem;
 
     /// CpuSet represent a bit-mask of CPUs.
     /// CpuSets are used by sched_setaffinity and

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,8 +1,8 @@
 use crate::errno::Errno;
 use crate::Result;
 use libc::{self, c_int};
-use std::mem;
-use std::os::unix::io::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
+use core::mem;
+use crate::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 libc_bitflags!(
     pub struct EpollFlags: c_int {
@@ -73,8 +73,8 @@ impl EpollEvent {
 /// ```
 /// # use nix::sys::{epoll::{Epoll, EpollEvent, EpollFlags, EpollCreateFlags}, eventfd::{eventfd, EfdFlags}};
 /// # use nix::unistd::write;
-/// # use std::os::unix::io::{OwnedFd, FromRawFd, AsRawFd, AsFd};
-/// # use std::time::{Instant, Duration};
+/// # use crate::os::fd::{OwnedFd, FromRawFd, AsRawFd, AsFd};
+/// # use core::time::{Instant, Duration};
 /// # fn main() -> nix::Result<()> {
 /// const DATA: u64 = 17;
 /// const MILLIS: u64 = 100;
@@ -175,7 +175,7 @@ impl Epoll {
         let event: Option<&mut EpollEvent> = event.into();
         let ptr = event
             .map(|x| &mut x.event as *mut libc::epoll_event)
-            .unwrap_or(std::ptr::null_mut());
+            .unwrap_or(core::ptr::null_mut());
         unsafe {
             Errno::result(libc::epoll_ctl(
                 self.0.as_raw_fd(),
@@ -223,7 +223,7 @@ where
             if let Some(ref mut event) = event {
                 libc::epoll_ctl(epfd, op as c_int, fd, &mut event.event)
             } else {
-                libc::epoll_ctl(epfd, op as c_int, fd, std::ptr::null_mut())
+                libc::epoll_ctl(epfd, op as c_int, fd, core::ptr::null_mut())
             }
         };
         Errno::result(res).map(drop)

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -8,10 +8,10 @@ use crate::{Errno, Result};
 use libc::{c_int, c_long, intptr_t, time_t, timespec, uintptr_t};
 #[cfg(target_os = "netbsd")]
 use libc::{c_long, intptr_t, size_t, time_t, timespec, uintptr_t};
-use std::convert::TryInto;
-use std::mem;
-use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
-use std::ptr;
+use core::convert::TryInto;
+use core::mem;
+use crate::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use core::ptr;
 
 /// A kernel event queue.  Used to notify a process of various asynchronous
 /// events.
@@ -487,7 +487,7 @@ pub fn ev_set(
 
 #[test]
 fn test_struct_kevent() {
-    use std::mem;
+    use core::mem;
 
     let udata: intptr_t = 12345;
 

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -1,6 +1,6 @@
 use crate::errno::Errno;
 use crate::Result;
-use std::os::unix::io::{FromRawFd, OwnedFd};
+use crate::os::fd::{FromRawFd, OwnedFd};
 
 libc_bitflags! {
     pub struct EfdFlags: libc::c_int {

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -29,11 +29,13 @@ use crate::NixPath;
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{c_char, c_int};
-use std::ffi::{CStr, OsStr, OsString};
-use std::mem::{size_of, MaybeUninit};
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
-use std::ptr;
+use alloc::ffi::CString;
+use core::ffi::CStr;
+use core::mem::{size_of, MaybeUninit};
+use core::os::unix::ffi::CStrExt;
+use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use core::ptr;
+use alloc::vec::Vec;
 
 libc_bitflags! {
     /// Configuration options for [`inotify_add_watch`](fn.inotify_add_watch.html).
@@ -131,7 +133,7 @@ pub struct InotifyEvent {
     pub cookie: u32,
     /// Filename. This field exists only if the event was triggered for a file
     /// inside the watched directory.
-    pub name: Option<OsString>,
+    pub name: Option<CString>,
 }
 
 impl Inotify {
@@ -217,7 +219,7 @@ impl Inotify {
                     };
                     let cstr = unsafe { CStr::from_ptr(ptr) };
 
-                    Some(OsStr::from_bytes(cstr.to_bytes()).to_owned())
+                    Some(CStr::from_bytes(cstr.to_bytes()).to_owned())
                 }
             };
 

--- a/src/sys/ioctl/bsd.rs
+++ b/src/sys/ioctl/bsd.rs
@@ -76,7 +76,7 @@ macro_rules! request_code_write_int {
             $crate::sys::ioctl::VOID,
             $g,
             $n,
-            ::std::mem::size_of::<$crate::libc::c_int>()
+            ::core::mem::size_of::<$crate::libc::c_int>()
         )
     };
 }

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -65,7 +65,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate nix;
-//! # use std::mem;
+//! # use core::mem;
 //! # use nix::{libc, Result};
 //! # use nix::errno::Errno;
 //! # use nix::libc::c_int as c_int;
@@ -171,7 +171,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate nix;
-//! # use std::mem;
+//! # use core::mem;
 //! # use nix::{libc, Result};
 //! # use nix::errno::Errno;
 //! # use nix::libc::c_int as c_int;
@@ -330,8 +330,8 @@ macro_rules! ioctl_none {
 /// ```no_run
 /// # #[macro_use] extern crate nix;
 /// # use libc::TIOCNXCL;
-/// # use std::fs::File;
-/// # use std::os::unix::io::AsRawFd;
+/// # use core::fs::File;
+/// # use crate::os::fd::AsRawFd;
 /// ioctl_none_bad!(tiocnxcl, TIOCNXCL);
 /// fn main() {
 ///     let file = File::open("/dev/ttyUSB0").unwrap();
@@ -383,7 +383,7 @@ macro_rules! ioctl_read {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::core::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }
@@ -456,7 +456,7 @@ macro_rules! ioctl_write_ptr {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *const $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::core::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }
@@ -574,7 +574,7 @@ cfg_if! {
                 pub unsafe fn $name(fd: $crate::libc::c_int,
                                     data: $crate::sys::ioctl::ioctl_param_type)
                                     -> $crate::Result<$crate::libc::c_int> {
-                    convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$crate::libc::c_int>()) as $crate::sys::ioctl::ioctl_num_type, data))
+                    convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::core::mem::size_of::<$crate::libc::c_int>()) as $crate::sys::ioctl::ioctl_num_type, data))
                 }
             )
         }
@@ -655,7 +655,7 @@ macro_rules! ioctl_readwrite {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::core::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }
@@ -712,7 +712,7 @@ macro_rules! ioctl_read_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &mut [$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::core::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }
@@ -751,7 +751,7 @@ macro_rules! ioctl_write_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &[$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::core::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }
@@ -780,7 +780,7 @@ macro_rules! ioctl_readwrite_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &mut [$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
+            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::core::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data))
         }
     )
 }

--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -1,11 +1,11 @@
 //! Interfaces for managing memory-backed files.
 
 use cfg_if::cfg_if;
-use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
+use crate::os::fd::{FromRawFd, OwnedFd, RawFd};
 
 use crate::errno::Errno;
 use crate::Result;
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 libc_bitflags!(
     /// Options that change the behavior of [`memfd_create`].

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -8,7 +8,7 @@ use crate::Result;
 #[cfg(feature = "fs")]
 use crate::{fcntl::OFlag, sys::stat::Mode};
 use libc::{self, c_int, c_void, off_t, size_t};
-use std::{num::NonZeroUsize, os::unix::io::{AsRawFd, AsFd}};
+use core::{num::NonZeroUsize, os::unix::io::{AsRawFd, AsFd}};
 
 libc_bitflags! {
     /// Desired memory protection of a memory mapping.
@@ -425,7 +425,7 @@ pub unsafe fn mmap<F: AsFd>(
     offset: off_t,
 ) -> Result<*mut c_void> {
     let ptr =
-        addr.map_or(std::ptr::null_mut(), |a| usize::from(a) as *mut c_void);
+        addr.map_or(core::ptr::null_mut(), |a| usize::from(a) as *mut c_void);
 
     let fd = f.map(|f| f.as_fd().as_raw_fd()).unwrap_or(-1);
     let ret =
@@ -459,13 +459,13 @@ pub unsafe fn mremap(
         old_size,
         new_size,
         flags.bits(),
-        new_address.unwrap_or(std::ptr::null_mut()),
+        new_address.unwrap_or(core::ptr::null_mut()),
     );
     #[cfg(target_os = "netbsd")]
     let ret = libc::mremap(
         addr,
         old_size,
-        new_address.unwrap_or(std::ptr::null_mut()),
+        new_address.unwrap_or(core::ptr::null_mut()),
         new_size,
         flags.bits(),
     );
@@ -518,15 +518,15 @@ pub unsafe fn madvise(
 /// ```
 /// # use nix::libc::size_t;
 /// # use nix::sys::mman::{mmap, mprotect, MapFlags, ProtFlags};
-/// # use std::ptr;
-/// # use std::os::unix::io::BorrowedFd;
+/// # use core::ptr;
+/// # use crate::os::fd::BorrowedFd;
 /// const ONE_K: size_t = 1024;
-/// let one_k_non_zero = std::num::NonZeroUsize::new(ONE_K).unwrap();
+/// let one_k_non_zero = core::num::NonZeroUsize::new(ONE_K).unwrap();
 /// let mut slice: &mut [u8] = unsafe {
 ///     let mem = mmap::<BorrowedFd>(None, one_k_non_zero, ProtFlags::PROT_NONE,
 ///                    MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE, None, 0).unwrap();
 ///     mprotect(mem, ONE_K, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE).unwrap();
-///     std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+///     core::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
 /// };
 /// assert_eq!(slice[0], 0x00);
 /// slice[0] = 0xFF;
@@ -568,10 +568,10 @@ pub fn shm_open<P>(
     name: &P,
     flag: OFlag,
     mode: Mode
-    ) -> Result<std::os::unix::io::OwnedFd>
+    ) -> Result<crate::os::fd::OwnedFd>
     where P: ?Sized + NixPath
 {
-    use std::os::unix::io::{FromRawFd, OwnedFd};
+    use crate::os::fd::{FromRawFd, OwnedFd};
 
     let ret = name.with_nix_path(|cstr| {
         #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -4,7 +4,7 @@ use crate::unistd::Pid;
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{self, c_int};
-use std::ptr;
+use core::ptr;
 
 pub type RequestType = c_int;
 

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -6,7 +6,7 @@ use crate::unistd::Pid;
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{self, c_long, c_void, siginfo_t};
-use std::{mem, ptr};
+use core::{mem, ptr};
 
 pub type AddressType = *mut ::libc::c_void;
 

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -15,8 +15,8 @@
 use crate::errno::Errno;
 use crate::{NixPath, Result};
 use libc::{self, c_char, c_int};
-use std::default::Default;
-use std::{mem, ptr};
+use core::default::Default;
+use core::{mem, ptr};
 
 struct QuotaCmd(QuotaSubCmd, QuotaType);
 

--- a/src/sys/reboot.rs
+++ b/src/sys/reboot.rs
@@ -2,8 +2,8 @@
 
 use crate::errno::Errno;
 use crate::Result;
-use std::convert::Infallible;
-use std::mem::drop;
+use core::convert::Infallible;
+use core::mem::drop;
 
 libc_enum! {
     /// How exactly should the system be rebooted.

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -7,7 +7,7 @@ use crate::sys::time::TimeVal;
 use crate::Result;
 pub use libc::rlim_t;
 pub use libc::RLIM_INFINITY;
-use std::mem;
+use core::mem;
 
 cfg_if! {
     if #[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "uclibc")))]{

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -3,12 +3,12 @@ use crate::errno::Errno;
 use crate::sys::time::{TimeSpec, TimeVal};
 use crate::Result;
 use libc::{self, c_int};
-use std::convert::TryFrom;
-use std::iter::FusedIterator;
-use std::mem;
-use std::ops::Range;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
-use std::ptr::{null, null_mut};
+use core::convert::TryFrom;
+use core::iter::FusedIterator;
+use core::mem;
+use core::ops::Range;
+use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use core::ptr::{null, null_mut};
 
 pub use libc::FD_SETSIZE;
 
@@ -17,7 +17,7 @@ pub use libc::FD_SETSIZE;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FdSet<'fd> {
     set: libc::fd_set,
-    _fd: std::marker::PhantomData<BorrowedFd<'fd>>,
+    _fd: core::marker::PhantomData<BorrowedFd<'fd>>,
 }
 
 fn assert_fd_valid(fd: RawFd) {
@@ -35,7 +35,7 @@ impl<'fd> FdSet<'fd> {
             libc::FD_ZERO(fdset.as_mut_ptr());
             Self {
                 set: fdset.assume_init(),
-                _fd: std::marker::PhantomData,
+                _fd: core::marker::PhantomData,
             }
         }
     }
@@ -72,7 +72,7 @@ impl<'fd> FdSet<'fd> {
     /// # Example
     ///
     /// ```
-    /// # use std::os::unix::io::{AsRawFd, BorrowedFd};
+    /// # use crate::os::fd::{AsRawFd, BorrowedFd};
     /// # use nix::sys::select::FdSet;
     /// let fd_four = unsafe {BorrowedFd::borrow_raw(4)};
     /// let fd_nine = unsafe {BorrowedFd::borrow_raw(9)};
@@ -97,7 +97,7 @@ impl<'fd> FdSet<'fd> {
     ///
     /// ```
     /// # use nix::sys::select::FdSet;
-    /// # use std::os::unix::io::{AsRawFd, BorrowedFd, RawFd};
+    /// # use crate::os::fd::{AsRawFd, BorrowedFd, RawFd};
     /// let mut set = FdSet::new();
     /// let fd_four = unsafe {BorrowedFd::borrow_raw(4)};
     /// let fd_nine = unsafe {BorrowedFd::borrow_raw(9)};
@@ -323,7 +323,7 @@ mod tests {
     use super::*;
     use crate::sys::time::{TimeVal, TimeValLike};
     use crate::unistd::{close, pipe, write};
-    use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
+    use crate::os::fd::{FromRawFd, OwnedFd, RawFd};
 
     #[test]
     fn fdset_insert() {
@@ -539,7 +539,7 @@ mod tests {
         assert_eq!(
             1,
             select(
-                std::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
+                core::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
                 &mut fd_set,
                 None,
                 None,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -4,14 +4,14 @@
 //! Operating system signals.
 
 use crate::errno::Errno;
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+use crate::os::fd::RawFd;
 use crate::{Error, Result};
 use cfg_if::cfg_if;
-use std::fmt;
-use std::mem;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-use std::os::unix::io::RawFd;
-use std::ptr;
-use std::str::FromStr;
+use core::fmt;
+use core::mem;
+use core::ptr;
+use core::str::FromStr;
 
 #[cfg(not(any(target_os = "openbsd", target_os = "redox")))]
 #[cfg(any(feature = "aio", feature = "signal"))]
@@ -460,9 +460,9 @@ feature! {
 #![feature = "signal"]
 
 use crate::unistd::Pid;
-use std::iter::Extend;
-use std::iter::FromIterator;
-use std::iter::IntoIterator;
+use core::iter::Extend;
+use core::iter::FromIterator;
+use core::iter::IntoIterator;
 
 /// Specifies a set of [`Signal`]s that may be blocked, waited for, etc.
 // We are using `transparent` here to be super sure that `SigSet`
@@ -561,7 +561,7 @@ impl SigSet {
     #[cfg(not(target_os = "redox"))] // RedoxFS does not yet support sigwait
     #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn wait(&self) -> Result<Signal> {
-        use std::convert::TryFrom;
+        use core::convert::TryFrom;
 
         let mut signum = mem::MaybeUninit::uninit();
         let res = unsafe { libc::sigwait(&self.sigset as *const libc::sigset_t, signum.as_mut_ptr()) };
@@ -792,8 +792,8 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 ///
 /// ```no_run
 /// # #[macro_use] extern crate lazy_static;
-/// # use std::convert::TryFrom;
-/// # use std::sync::atomic::{AtomicBool, Ordering};
+/// # use core::convert::TryFrom;
+/// # use core::sync::atomic::{AtomicBool, Ordering};
 /// # use nix::sys::signal::{self, Signal, SigHandler};
 /// lazy_static! {
 ///    static ref SIGNALED: AtomicBool = AtomicBool::new(false);
@@ -1024,8 +1024,8 @@ mod sigevent {
     feature! {
     #![any(feature = "aio", feature = "signal")]
 
-    use std::mem;
-    use std::ptr;
+    use core::mem;
+    use core::ptr;
     use super::SigevNotify;
     #[cfg(any(target_os = "freebsd", target_os = "linux"))]
     use super::type_of_thread_id;
@@ -1126,7 +1126,7 @@ mod sigevent {
 mod tests {
     use super::*;
     #[cfg(not(target_os = "redox"))]
-    use std::thread;
+    use core::thread;
 
     #[test]
     fn test_contains() {

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -20,8 +20,8 @@ pub use crate::sys::signal::{self, SigSet};
 use crate::Result;
 pub use libc::signalfd_siginfo as siginfo;
 
-use std::mem;
-use std::os::unix::io::{AsRawFd, RawFd, FromRawFd, OwnedFd, AsFd, BorrowedFd};
+use core::mem;
+use crate::os::fd::{AsRawFd, RawFd, FromRawFd, OwnedFd, AsFd, BorrowedFd};
 
 libc_bitflags! {
     pub struct SfdFlags: libc::c_int {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -13,8 +13,8 @@ pub use libc::{dev_t, mode_t};
 use crate::fcntl::{at_rawfd, AtFlags};
 use crate::sys::time::{TimeSpec, TimeVal};
 use crate::{errno::Errno, NixPath, Result};
-use std::mem;
-use std::os::unix::io::RawFd;
+use core::mem;
+use crate::os::fd::RawFd;
 
 libc_bitflags!(
     /// "File type" flags for `mknod` and related functions.

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -2,10 +2,10 @@
 //!
 //! See [`statvfs`](crate::sys::statvfs) for a portable alternative.
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-use std::ffi::CStr;
-use std::fmt::{self, Debug};
-use std::mem;
-use std::os::unix::io::{AsFd, AsRawFd};
+use core::ffi::CStr;
+use core::fmt::{self, Debug};
+use core::mem;
+use crate::os::fd::{AsFd, AsRawFd};
 
 use cfg_if::cfg_if;
 
@@ -750,11 +750,11 @@ pub fn fstatfs<Fd: AsFd>(fd: Fd) -> Result<Statfs> {
 
 #[cfg(test)]
 mod test {
-    use std::fs::File;
+    use core::fs::File;
 
     use crate::sys::statfs::*;
     use crate::sys::statvfs::*;
-    use std::path::Path;
+    use core::path::Path;
 
     #[test]
     fn statfs_call() {

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -2,8 +2,8 @@
 //!
 //! See [the man pages](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatvfs.html)
 //! for more details.
-use std::mem;
-use std::os::unix::io::{AsFd, AsRawFd};
+use core::mem;
+use crate::os::fd::{AsFd, AsRawFd};
 
 use libc::{self, c_ulong};
 
@@ -158,7 +158,7 @@ pub fn fstatvfs<Fd: AsFd>(fd: Fd) -> Result<Statvfs> {
 #[cfg(test)]
 mod test {
     use crate::sys::statvfs::*;
-    use std::fs::File;
+    use core::fs::File;
 
     #[test]
     fn statvfs_call() {

--- a/src/sys/sysinfo.rs
+++ b/src/sys/sysinfo.rs
@@ -1,6 +1,6 @@
+use core::time::Duration;
+use core::{cmp, mem};
 use libc::{self, SI_LOAD_SHIFT};
-use std::time::Duration;
-use std::{cmp, mem};
 
 use crate::errno::Errno;
 use crate::Result;

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -25,7 +25,7 @@
 //! ```
 //! # use self::nix::sys::termios::SpecialCharacterIndices::VEOF;
 //! # use self::nix::sys::termios::{_POSIX_VDISABLE, Termios};
-//! # let mut termios: Termios = unsafe { std::mem::zeroed() };
+//! # let mut termios: Termios = unsafe { core::mem::zeroed() };
 //! termios.control_chars[VEOF as usize] = _POSIX_VDISABLE;
 //! ```
 //!
@@ -38,7 +38,7 @@
 //!
 //! ```
 //! # use self::nix::sys::termios::{ControlFlags, Termios};
-//! # let mut termios: Termios = unsafe { std::mem::zeroed() };
+//! # let mut termios: Termios = unsafe { core::mem::zeroed() };
 //! termios.control_flags & ControlFlags::CSIZE == ControlFlags::CS5;
 //! termios.control_flags |= ControlFlags::CS5;
 //! ```
@@ -63,7 +63,7 @@
 //! ```rust
 //! # use nix::sys::termios::{BaudRate, cfsetispeed, cfsetospeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! cfsetispeed(&mut t, BaudRate::B9600).unwrap();
 //! cfsetospeed(&mut t, BaudRate::B9600).unwrap();
 //! cfsetspeed(&mut t, BaudRate::B9600).unwrap();
@@ -75,7 +75,7 @@
 //! ```rust
 //! # use nix::sys::termios::{BaudRate, cfgetispeed, cfgetospeed, cfsetispeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! # cfsetspeed(&mut t, BaudRate::B9600).unwrap();
 //! let speed = cfgetispeed(&t);
 //! assert_eq!(speed, cfgetospeed(&t));
@@ -109,7 +109,7 @@
 )]
 //! # use nix::sys::termios::{BaudRate, cfgetispeed, cfgetospeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! # cfsetspeed(&mut t, BaudRate::B9600);
 //! assert_eq!(cfgetispeed(&t), BaudRate::B9600);
 //! assert_eq!(cfgetospeed(&t), BaudRate::B9600);
@@ -142,7 +142,7 @@
 )]
 //! # use nix::sys::termios::{BaudRate, cfgetispeed, cfgetospeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! # cfsetspeed(&mut t, 9600u32);
 //! assert_eq!(cfgetispeed(&t), 9600u32);
 //! assert_eq!(cfgetospeed(&t), 9600u32);
@@ -175,7 +175,7 @@
 )]
 //! # use nix::sys::termios::{BaudRate, cfgetispeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! # cfsetspeed(&mut t, 9600u32);
 //! assert_eq!(cfgetispeed(&t), BaudRate::B9600.into());
 //! assert_eq!(u32::from(BaudRate::B9600), 9600u32);
@@ -209,7 +209,7 @@
 )]
 //! # use nix::sys::termios::{cfsetispeed, cfsetospeed, cfsetspeed, Termios};
 //! # fn main() {
-//! # let mut t: Termios = unsafe { std::mem::zeroed() };
+//! # let mut t: Termios = unsafe { core::mem::zeroed() };
 //! cfsetispeed(&mut t, 9600u32);
 //! cfsetospeed(&mut t, 9600u32);
 //! cfsetspeed(&mut t, 9600u32);
@@ -219,10 +219,10 @@ use crate::errno::Errno;
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{self, c_int, tcflag_t};
-use std::cell::{Ref, RefCell};
-use std::convert::From;
-use std::mem;
-use std::os::unix::io::{AsFd, AsRawFd};
+use core::cell::{Ref, RefCell};
+use core::convert::From;
+use core::mem;
+use crate::os::fd::{AsFd, AsRawFd};
 
 #[cfg(feature = "process")]
 use crate::unistd::Pid;
@@ -1052,7 +1052,7 @@ cfg_if! {
             Errno::result(res).map(drop)
         }
     } else {
-        use std::convert::TryInto;
+        use core::convert::TryInto;
 
         /// Get input baud rate (see
         /// [cfgetispeed(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/cfgetispeed.html)).
@@ -1233,7 +1233,7 @@ pub fn tcgetsid<Fd: AsFd>(fd: Fd) -> Result<Pid> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn try_from() {

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -1,16 +1,16 @@
+use core::convert::From;
+use core::time::Duration;
+use core::{cmp, fmt, ops};
 #[cfg_attr(target_env = "musl", allow(deprecated))]
 // https://github.com/rust-lang/libc/issues/1848
 pub use libc::{suseconds_t, time_t};
 use libc::{timespec, timeval};
-use std::convert::From;
-use std::time::Duration;
-use std::{cmp, fmt, ops};
 
 const fn zero_init_timespec() -> timespec {
-    // `std::mem::MaybeUninit::zeroed()` is not yet a const fn
+    // `core::mem::MaybeUninit::zeroed()` is not yet a const fn
     // (https://github.com/rust-lang/rust/issues/91850) so we will instead initialize an array of
     // the appropriate size to zero and then transmute it to a timespec value.
-    unsafe { std::mem::transmute([0u8; std::mem::size_of::<timespec>()]) }
+    unsafe { core::mem::transmute([0u8; core::mem::size_of::<timespec>()]) }
 }
 
 #[cfg(any(
@@ -714,7 +714,7 @@ fn div_rem_64(this: i64, other: i64) -> (i64, i64) {
 #[cfg(test)]
 mod test {
     use super::{TimeSpec, TimeVal, TimeValLike};
-    use std::time::Duration;
+    use core::time::Duration;
 
     #[test]
     pub fn test_timespec() {

--- a/src/sys/timer.rs
+++ b/src/sys/timer.rs
@@ -15,10 +15,10 @@
 //! use nix::sys::signal::{self, SigEvent, SigHandler, SigevNotify, Signal};
 //! use nix::sys::timer::{Expiration, Timer, TimerSetTimeFlags};
 //! use nix::time::ClockId;
-//! use std::convert::TryFrom;
-//! use std::sync::atomic::{AtomicU64, Ordering};
-//! use std::thread::yield_now;
-//! use std::time::Duration;
+//! use core::convert::TryFrom;
+//! use core::sync::atomic::{AtomicU64, Ordering};
+//! use core::thread::yield_now;
+//! use core::time::Duration;
 //!
 //! const SIG: Signal = Signal::SIGALRM;
 //! static ALARMS: AtomicU64 = AtomicU64::new(0);
@@ -177,11 +177,9 @@ impl Timer {
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        if !std::thread::panicking() {
-            let result = Errno::result(unsafe { libc::timer_delete(self.0) });
-            if let Err(Errno::EINVAL) = result {
-                panic!("close of Timer encountered EINVAL");
-            }
+        let result = Errno::result(unsafe { libc::timer_delete(self.0) });
+        if let Err(Errno::EINVAL) = result {
+            panic!("close of Timer encountered EINVAL");
         }
     }
 }

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -9,7 +9,7 @@
 //!
 //! Create a new one-shot timer that expires after 1 second.
 //! ```
-//! # use std::os::unix::io::AsRawFd;
+//! # use crate::os::fd::AsRawFd;
 //! # use nix::sys::timerfd::{TimerFd, ClockId, TimerFlags, TimerSetTimeFlags,
 //! #    Expiration};
 //! # use nix::sys::time::{TimeSpec, TimeValLike};
@@ -33,7 +33,7 @@ pub use crate::sys::time::timer::{Expiration, TimerSetTimeFlags};
 use crate::unistd::read;
 use crate::{errno::Errno, Result};
 use libc::c_int;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 
 /// A timerfd instance. This is also a file descriptor, you can feed it to
 /// other interfaces taking file descriptors as arguments, [`epoll`] for example.
@@ -161,7 +161,7 @@ impl TimerFd {
                 self.fd.as_fd().as_raw_fd(),
                 flags.bits(),
                 timerspec.as_ref(),
-                std::ptr::null_mut(),
+                core::ptr::null_mut(),
             )
         })
         .map(drop)
@@ -198,7 +198,7 @@ impl TimerFd {
                 self.fd.as_fd().as_raw_fd(),
                 TimerSetTimeFlags::empty().bits(),
                 TimerSpec::none().as_ref(),
-                std::ptr::null_mut(),
+                core::ptr::null_mut(),
             )
         })
         .map(drop)

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -1,9 +1,9 @@
 //! Get system identification
 use crate::{Errno, Result};
 use libc::c_char;
-use std::ffi::OsStr;
-use std::mem;
-use std::os::unix::ffi::OsStrExt;
+use core::ffi::CStr;
+use core::mem;
+use core::os::unix::ffi::CStrExt;
 
 /// Describes the running system.  Return type of [`uname`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -12,33 +12,33 @@ pub struct UtsName(libc::utsname);
 
 impl UtsName {
     /// Name of the operating system implementation.
-    pub fn sysname(&self) -> &OsStr {
+    pub fn sysname(&self) -> &CStr {
         cast_and_trim(&self.0.sysname)
     }
 
     /// Network name of this machine.
-    pub fn nodename(&self) -> &OsStr {
+    pub fn nodename(&self) -> &CStr {
         cast_and_trim(&self.0.nodename)
     }
 
     /// Release level of the operating system.
-    pub fn release(&self) -> &OsStr {
+    pub fn release(&self) -> &CStr {
         cast_and_trim(&self.0.release)
     }
 
     /// Version level of the operating system.
-    pub fn version(&self) -> &OsStr {
+    pub fn version(&self) -> &CStr {
         cast_and_trim(&self.0.version)
     }
 
     /// Machine hardware platform.
-    pub fn machine(&self) -> &OsStr {
+    pub fn machine(&self) -> &CStr {
         cast_and_trim(&self.0.machine)
     }
 
     /// NIS or YP domain name of this machine.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    pub fn domainname(&self) -> &OsStr {
+    pub fn domainname(&self) -> &CStr {
         cast_and_trim(&self.0.domainname)
     }
 }
@@ -52,15 +52,15 @@ pub fn uname() -> Result<UtsName> {
     }
 }
 
-fn cast_and_trim(slice: &[c_char]) -> &OsStr {
+fn cast_and_trim(slice: &[c_char]) -> &CStr {
     let length = slice
         .iter()
         .position(|&byte| byte == 0)
         .unwrap_or(slice.len());
     let bytes =
-        unsafe { std::slice::from_raw_parts(slice.as_ptr().cast(), length) };
+        unsafe { core::slice::from_raw_parts(slice.as_ptr().cast(), length) };
 
-    OsStr::from_bytes(bytes)
+    CStr::from_bytes(bytes)
 }
 
 #[cfg(test)]

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -5,12 +5,12 @@ use crate::unistd::Pid;
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{self, c_int};
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 #[cfg(any(
     target_os = "android",
     all(target_os = "linux", not(target_env = "uclibc")),
 ))]
-use std::os::unix::io::{AsRawFd, BorrowedFd};
+use crate::os::fd::{AsRawFd, BorrowedFd};
 
 libc_bitflags!(
     /// Controls the behavior of [`waitpid`].
@@ -359,7 +359,7 @@ pub enum Id<'fd> {
     /// A helper variant to resolve the unused parameter (`'fd`) problem on platforms
     /// other than Linux and Android.
     #[doc(hidden)]
-    _Unreachable(std::marker::PhantomData<&'fd std::convert::Infallible>),
+    _Unreachable(core::marker::PhantomData<&'fd core::convert::Infallible>),
 }
 
 /// Wait for a process to change status
@@ -384,7 +384,7 @@ pub fn waitid(id: Id, flags: WaitPidFlag) -> Result<WaitStatus> {
     let siginfo = unsafe {
         // Memory is zeroed rather than uninitialized, as not all platforms
         // initialize the memory in the StillAlive case
-        let mut siginfo: libc::siginfo_t = std::mem::zeroed();
+        let mut siginfo: libc::siginfo_t = core::mem::zeroed();
         Errno::result(libc::waitid(idtype, idval, &mut siginfo, flags.bits()))?;
         siginfo
     };

--- a/src/time.rs
+++ b/src/time.rs
@@ -10,7 +10,7 @@ use crate::sys::time::TimeSpec;
 use crate::unistd::Pid;
 use crate::{Errno, Result};
 use libc::{self, clockid_t};
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Clock identifier
 ///
@@ -214,9 +214,9 @@ impl From<clockid_t> for ClockId {
     }
 }
 
-impl std::fmt::Display for ClockId {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
+impl core::fmt::Display for ClockId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.0, f)
     }
 }
 

--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -4,7 +4,7 @@ use crate::sys::signal::SigSet;
 #[cfg(not(target_env = "musl"))]
 use crate::Result;
 #[cfg(not(target_env = "musl"))]
-use std::mem;
+use core::mem;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UContext {

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 #[macro_export]
 macro_rules! skip {
     ($($reason: expr),+) => {
-        use ::std::io::{self, Write};
+        use ::core::io::{self, Write};
 
         let stderr = io::stderr();
         let mut handle = stderr.lock();
@@ -55,7 +55,7 @@ macro_rules! require_mount {
 #[macro_export]
 macro_rules! skip_if_cirrus {
     ($reason:expr) => {
-        if std::env::var_os("CIRRUS_CI").is_some() {
+        if core::env::var_os("CIRRUS_CI").is_some() {
             skip!("{}", $reason);
         }
     };
@@ -90,7 +90,7 @@ cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
         #[macro_export] macro_rules! skip_if_seccomp {
             ($name:expr) => {
-                if let Ok(s) = std::fs::read_to_string("/proc/self/status") {
+                if let Ok(s) = core::fs::read_to_string("/proc/self/status") {
                     for l in s.lines() {
                         let mut fields = l.split_whitespace();
                         if fields.next() == Some("Seccomp:") &&

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     io::{Read, Seek, Write},
     ops::Deref,
     os::unix::io::AsRawFd,
@@ -71,7 +71,7 @@ mod aio_fsync {
     #[test]
     #[cfg(any(target_os = "freebsd", target_os = "macos"))]
     fn error() {
-        use std::mem;
+        use core::mem;
 
         const INITIAL: &[u8] = b"abcdef123456";
         // Create an invalid AioFsyncMode
@@ -230,7 +230,7 @@ mod aio_read {
 #[cfg(target_os = "freebsd")]
 #[cfg(fbsd14)]
 mod aio_readv {
-    use std::io::IoSliceMut;
+    use core::io::libc::iovec;
 
     use super::*;
 
@@ -239,7 +239,7 @@ mod aio_readv {
         let mut rbuf0 = vec![0; 4];
         let mut rbuf1 = vec![0; 8];
         let mut rbufs =
-            [IoSliceMut::new(&mut rbuf0), IoSliceMut::new(&mut rbuf1)];
+            [libc::iovec::new(&mut rbuf0), libc::iovec::new(&mut rbuf1)];
         let aiocb = AioReadv::new(
             1001,
             2, //offset
@@ -266,7 +266,7 @@ mod aio_readv {
         let mut rbuf0 = vec![0; 4];
         let mut rbuf1 = vec![0; 2];
         let mut rbufs =
-            [IoSliceMut::new(&mut rbuf0), IoSliceMut::new(&mut rbuf1)];
+            [libc::iovec::new(&mut rbuf0), libc::iovec::new(&mut rbuf1)];
         const EXPECT0: &[u8] = b"cdef";
         const EXPECT1: &[u8] = b"12";
         let mut f = tempfile().unwrap();
@@ -431,7 +431,7 @@ mod aio_write {
 #[cfg(target_os = "freebsd")]
 #[cfg(fbsd14)]
 mod aio_writev {
-    use std::io::IoSlice;
+    use core::io::libc::iovec;
 
     use super::*;
 
@@ -439,7 +439,7 @@ mod aio_writev {
     fn test_accessors() {
         let wbuf0 = vec![0; 4];
         let wbuf1 = vec![0; 8];
-        let wbufs = [IoSlice::new(&wbuf0), IoSlice::new(&wbuf1)];
+        let wbufs = [libc::iovec::new(&wbuf0), libc::iovec::new(&wbuf1)];
         let aiocb = AioWritev::new(
             1001,
             2, //offset
@@ -467,7 +467,7 @@ mod aio_writev {
         const INITIAL: &[u8] = b"abcdef123456";
         let wbuf0 = b"BC";
         let wbuf1 = b"DEF";
-        let wbufs = [IoSlice::new(wbuf0), IoSlice::new(wbuf1)];
+        let wbufs = [libc::iovec::new(wbuf0), libc::iovec::new(wbuf1)];
         let wlen = wbuf0.len() + wbuf1.len();
         let mut rbuf = Vec::new();
         const EXPECT: &[u8] = b"aBCDEF123456";

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -15,9 +15,9 @@
     )
 ))]
 fn test_drop() {
+    use crate::os::fd::AsRawFd;
     use nix::sys::aio::*;
     use nix::sys::signal::*;
-    use std::os::unix::io::AsRawFd;
     use tempfile::tempfile;
 
     const WBUF: &[u8] = b"CDEF";

--- a/test/sys/test_inotify.rs
+++ b/test/sys/test_inotify.rs
@@ -1,7 +1,7 @@
+use core::ffi::CString;
+use core::fs::{rename, File};
 use nix::errno::Errno;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use std::ffi::OsString;
-use std::fs::{rename, File};
 
 #[test]
 pub fn test_inotify() {
@@ -18,7 +18,7 @@ pub fn test_inotify() {
     File::create(tempdir.path().join("test")).unwrap();
 
     let events = instance.read_events().unwrap();
-    assert_eq!(events[0].name, Some(OsString::from("test")));
+    assert_eq!(events[0].name, Some(CString::from("test")));
 }
 
 #[test]
@@ -47,19 +47,19 @@ pub fn test_inotify_multi_events() {
     assert_eq!(events.len(), 5);
 
     assert_eq!(events[0].mask, AddWatchFlags::IN_CREATE);
-    assert_eq!(events[0].name, Some(OsString::from("test")));
+    assert_eq!(events[0].name, Some(CString::from("test")));
 
     assert_eq!(events[1].mask, AddWatchFlags::IN_OPEN);
-    assert_eq!(events[1].name, Some(OsString::from("test")));
+    assert_eq!(events[1].name, Some(CString::from("test")));
 
     assert_eq!(events[2].mask, AddWatchFlags::IN_CLOSE_WRITE);
-    assert_eq!(events[2].name, Some(OsString::from("test")));
+    assert_eq!(events[2].name, Some(CString::from("test")));
 
     assert_eq!(events[3].mask, AddWatchFlags::IN_MOVED_FROM);
-    assert_eq!(events[3].name, Some(OsString::from("test")));
+    assert_eq!(events[3].name, Some(CString::from("test")));
 
     assert_eq!(events[4].mask, AddWatchFlags::IN_MOVED_TO);
-    assert_eq!(events[4].name, Some(OsString::from("test2")));
+    assert_eq!(events[4].name, Some(CString::from("test2")));
 
     assert_eq!(events[3].cookie, events[4].cookie);
 }

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -195,8 +195,8 @@ mod bsd {
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux_ioctls {
-    use std::mem;
-    use std::os::unix::io::AsRawFd;
+    use crate::os::fd::AsRawFd;
+    use core::mem;
 
     use libc::{termios, TCGETS, TCSBRK, TCSETS, TIOCNXCL};
     use tempfile::tempfile;
@@ -334,8 +334,8 @@ mod linux_ioctls {
 
 #[cfg(target_os = "freebsd")]
 mod freebsd_ioctls {
-    use std::mem;
-    use std::os::unix::io::AsRawFd;
+    use crate::os::fd::AsRawFd;
+    use core::mem;
 
     use libc::termios;
     use tempfile::tempfile;

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -1,5 +1,5 @@
+use core::{num::NonZeroUsize, os::unix::io::BorrowedFd};
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
-use std::{num::NonZeroUsize, os::unix::io::BorrowedFd};
 
 #[test]
 fn test_mmap_anonymous() {
@@ -38,7 +38,7 @@ fn test_mremap_grow() {
             0,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        core::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
     };
     assert_eq!(slice[ONE_K - 1], 0x00);
     slice[ONE_K - 1] = 0xFF;
@@ -63,7 +63,7 @@ fn test_mremap_grow() {
             None,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, 10 * ONE_K)
+        core::slice::from_raw_parts_mut(mem as *mut u8, 10 * ONE_K)
     };
 
     // The first KB should still have the old data in it.
@@ -80,9 +80,9 @@ fn test_mremap_grow() {
 // Segfaults for unknown reasons under QEMU for 32-bit targets
 #[cfg_attr(all(target_pointer_width = "32", qemu), ignore)]
 fn test_mremap_shrink() {
+    use core::num::NonZeroUsize;
     use nix::libc::{c_void, size_t};
     use nix::sys::mman::{mremap, MRemapFlags};
-    use std::num::NonZeroUsize;
 
     const ONE_K: size_t = 1024;
     let ten_one_k = NonZeroUsize::new(10 * ONE_K).unwrap();
@@ -96,7 +96,7 @@ fn test_mremap_shrink() {
             0,
         )
         .unwrap();
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        core::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
     };
     assert_eq!(slice[ONE_K - 1], 0x00);
     slice[ONE_K - 1] = 0xFF;
@@ -114,7 +114,7 @@ fn test_mremap_shrink() {
         // Since we didn't supply MREMAP_MAYMOVE, the address should be the
         // same.
         assert_eq!(mem, slice.as_mut_ptr() as *mut c_void);
-        std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
+        core::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
     };
 
     // The first KB should still be accessible and have the old data in it.

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -11,7 +11,7 @@ use nix::sys::ptrace::Options;
 use nix::unistd::getpid;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use std::mem;
+use core::mem;
 
 use crate::*;
 
@@ -131,13 +131,13 @@ fn test_ptrace_cont() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_ptrace_interrupt() {
+    use core::thread::sleep;
+    use core::time::Duration;
     use nix::sys::ptrace;
     use nix::sys::signal::Signal;
     use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
     use nix::unistd::fork;
     use nix::unistd::ForkResult::*;
-    use std::thread::sleep;
-    use std::time::Duration;
 
     require_capability!("test_ptrace_interrupt", CAP_SYS_PTRACE);
 

--- a/test/sys/test_select.rs
+++ b/test/sys/test_select.rs
@@ -1,8 +1,8 @@
+use crate::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use nix::sys::select::*;
 use nix::sys::signal::SigSet;
 use nix::sys::time::{TimeSpec, TimeValLike};
 use nix::unistd::{pipe, write};
-use std::os::unix::io::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 
 #[test]
 pub fn test_pselect() {
@@ -44,7 +44,7 @@ pub fn test_pselect_nfds2() {
     assert_eq!(
         1,
         pselect(
-            std::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
+            core::cmp::max(r1.as_raw_fd(), r2.as_raw_fd()) + 1,
             &mut fd_set,
             None,
             None,
@@ -72,7 +72,7 @@ macro_rules! generate_fdset_bad_fd_tests {
 
 mod test_fdset_too_large_fd {
     use super::*;
-    use std::convert::TryInto;
+    use core::convert::TryInto;
     generate_fdset_bad_fd_tests!(
         FD_SETSIZE.try_into().unwrap(),
         insert,

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,9 +1,9 @@
+use core::convert::TryFrom;
+use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_os = "redox"))]
 use nix::errno::Errno;
 use nix::sys::signal::*;
 use nix::unistd::*;
-use std::convert::TryFrom;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 #[test]
 fn test_kill_none() {

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 #[test]
 fn test_signalfd() {

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -67,7 +67,7 @@ pub fn test_local_peer_pid() {
     )
     .unwrap();
     let pid = getsockopt(fd1, sockopt::LocalPeerPid).unwrap();
-    assert_eq!(pid, std::process::id() as _);
+    assert_eq!(pid, core::process::id() as _);
 }
 
 #[cfg(target_os = "linux")]
@@ -109,10 +109,10 @@ fn test_so_buf() {
 
 #[test]
 fn test_so_tcp_maxseg() {
+    use core::net::SocketAddrV4;
+    use core::str::FromStr;
     use nix::sys::socket::{accept, bind, connect, listen, SockaddrIn};
     use nix::unistd::{close, write};
-    use std::net::SocketAddrV4;
-    use std::str::FromStr;
 
     let std_sa = SocketAddrV4::from_str("127.0.0.1:4001").unwrap();
     let sock_addr = SockaddrIn::from(std_sa);
@@ -204,7 +204,7 @@ fn test_so_type_unknown() {
     any(target_os = "freebsd", target_os = "linux")
 ))]
 fn test_tcp_congestion() {
-    use std::ffi::OsString;
+    use core::ffi::CString;
 
     let fd = socket(
         AddressFamily::Inet,
@@ -220,7 +220,7 @@ fn test_tcp_congestion() {
     setsockopt(
         fd,
         sockopt::TcpCongestion,
-        &OsString::from("tcp_congestion_does_not_exist"),
+        &CString::from("tcp_congestion_does_not_exist"),
     )
     .unwrap_err();
 
@@ -283,9 +283,9 @@ fn test_so_tcp_keepalive() {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[cfg_attr(qemu, ignore)]
 fn test_get_mtu() {
+    use core::net::SocketAddrV4;
+    use core::str::FromStr;
     use nix::sys::socket::{bind, connect, SockaddrIn};
-    use std::net::SocketAddrV4;
-    use std::str::FromStr;
 
     let std_sa = SocketAddrV4::from_str("127.0.0.1:4001").unwrap();
     let std_sb = SocketAddrV4::from_str("127.0.0.1:4002").unwrap();

--- a/test/sys/test_stat.rs
+++ b/test/sys/test_stat.rs
@@ -3,11 +3,11 @@
 #[cfg(target_os = "freebsd")]
 #[test]
 fn test_chflags() {
+    use crate::os::fd::AsRawFd;
     use nix::{
         sys::stat::{fstat, FileFlag},
         unistd::chflags,
     };
-    use std::os::unix::io::AsRawFd;
     use tempfile::NamedTempFile;
 
     let f = NamedTempFile::new().unwrap();

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,4 +1,4 @@
-use std::os::unix::io::{AsFd, AsRawFd};
+use crate::os::fd::{AsFd, AsRawFd};
 use tempfile::tempfile;
 
 use nix::errno::Errno;
@@ -7,7 +7,7 @@ use nix::pty::openpty;
 use nix::sys::termios::{self, tcgetattr, LocalFlags, OutputFlags};
 use nix::unistd::{read, write};
 
-/// Helper function analogous to `std::io::Write::write_all`, but for `Fd`s
+/// Helper function analogous to `core::io::Write::write_all`, but for `Fd`s
 fn write_all<Fd: AsFd>(f: Fd, buf: &[u8]) {
     let mut len = 0;
     while len < buf.len() {

--- a/test/sys/test_timerfd.rs
+++ b/test/sys/test_timerfd.rs
@@ -1,8 +1,8 @@
+use core::time::Instant;
 use nix::sys::time::{TimeSpec, TimeValLike};
 use nix::sys::timerfd::{
     ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags,
 };
-use std::time::Instant;
 
 #[test]
 pub fn test_timerfd_oneshot() {

--- a/test/test.rs
+++ b/test/test.rs
@@ -64,12 +64,12 @@ mod test_time;
 mod test_timer;
 mod test_unistd;
 
+use crate::os::fd::{AsFd, AsRawFd};
+use core::path::PathBuf;
 use nix::unistd::{chdir, getcwd, read};
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
-use std::os::unix::io::{AsFd, AsRawFd};
-use std::path::PathBuf;
 
-/// Helper function analogous to `std::io::Read::read_exact`, but for `Fd`s
+/// Helper function analogous to `core::io::Read::read_exact`, but for `Fd`s
 fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     let mut len = 0;
     while len < buf.len() {
@@ -117,7 +117,7 @@ impl<'a> DirRestore<'a> {
 impl<'a> Drop for DirRestore<'a> {
     fn drop(&mut self) {
         let r = chdir(&self.d);
-        if std::thread::panicking() {
+        if core::thread::panicking() {
             r.unwrap();
         }
     }

--- a/test/test_clearenv.rs
+++ b/test/test_clearenv.rs
@@ -1,4 +1,4 @@
-use std::env;
+use core::env;
 
 #[test]
 fn clearenv() {

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -1,7 +1,7 @@
+use core::fs::File;
 use nix::dir::{Dir, Type};
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
-use std::fs::File;
 use tempfile::tempdir;
 
 #[cfg(test)]
@@ -20,7 +20,7 @@ fn flags() -> OFlag {
 fn read() {
     let tmp = tempdir().unwrap();
     File::create(tmp.path().join("foo")).unwrap();
-    std::os::unix::fs::symlink("foo", tmp.path().join("bar")).unwrap();
+    core::os::unix::fs::symlink("foo", tmp.path().join("bar")).unwrap();
     let mut dir = Dir::open(tmp.path(), flags(), Mode::empty()).unwrap();
     let mut entries: Vec<_> = dir.iter().map(|e| e.unwrap()).collect();
     entries.sort_by(|a, b| a.file_name().cmp(b.file_name()));

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -1,4 +1,10 @@
 #[cfg(not(target_os = "redox"))]
+use core::fs::File;
+#[cfg(not(target_os = "redox"))]
+use core::io::prelude::*;
+#[cfg(not(target_os = "redox"))]
+use core::os::unix::fs;
+#[cfg(not(target_os = "redox"))]
 use nix::errno::*;
 #[cfg(not(target_os = "redox"))]
 use nix::fcntl::{open, readlink, OFlag};
@@ -19,12 +25,6 @@ use nix::fcntl::{renameat2, RenameFlags};
 use nix::sys::stat::Mode;
 #[cfg(not(target_os = "redox"))]
 use nix::unistd::{close, read};
-#[cfg(not(target_os = "redox"))]
-use std::fs::File;
-#[cfg(not(target_os = "redox"))]
-use std::io::prelude::*;
-#[cfg(not(target_os = "redox"))]
-use std::os::unix::fs;
 #[cfg(not(target_os = "redox"))]
 use tempfile::{self, NamedTempFile};
 
@@ -229,10 +229,10 @@ fn test_readlink() {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux_android {
+    use core::io::prelude::*;
+    use core::io::libc::iovec;
+    use core::os::unix::prelude::*;
     use libc::loff_t;
-    use std::io::prelude::*;
-    use std::io::IoSlice;
-    use std::os::unix::prelude::*;
 
     use nix::fcntl::*;
     use nix::unistd::{close, pipe, read, write};
@@ -340,7 +340,7 @@ mod linux_android {
 
         let buf1 = b"abcdef";
         let buf2 = b"defghi";
-        let iovecs = vec![IoSlice::new(&buf1[0..3]), IoSlice::new(&buf2[0..3])];
+        let iovecs = vec![libc::iovec::new(&buf1[0..3]), libc::iovec::new(&buf2[0..3])];
 
         let res = vmsplice(wr, &iovecs[..], SpliceFFlags::empty()).unwrap();
 
@@ -377,8 +377,8 @@ mod linux_android {
     #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     #[cfg_attr(target_env = "uclibc", ignore)] // uclibc doesn't support OFD locks, but the test should still compile
     fn test_ofd_write_lock() {
+        use core::mem;
         use nix::sys::stat::fstat;
-        use std::mem;
 
         let tmp = NamedTempFile::new().unwrap();
 
@@ -415,8 +415,8 @@ mod linux_android {
     #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     #[cfg_attr(target_env = "uclibc", ignore)] // uclibc doesn't support OFD locks, but the test should still compile
     fn test_ofd_read_lock() {
+        use core::mem;
         use nix::sys::stat::fstat;
-        use std::mem;
 
         let tmp = NamedTempFile::new().unwrap();
 
@@ -451,7 +451,7 @@ mod linux_android {
 
     #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     fn lock_info(inode: usize) -> Option<(String, String)> {
-        use std::{fs::File, io::BufReader};
+        use core::{fs::File, io::BufReader};
 
         let file = File::open("/proc/locks").expect("open /proc/locks failed");
         let buf = BufReader::new(file);
@@ -482,10 +482,10 @@ mod linux_android {
 ))]
 mod test_posix_fadvise {
 
+    use crate::os::fd::{AsRawFd, RawFd};
     use nix::errno::Errno;
     use nix::fcntl::*;
     use nix::unistd::pipe;
-    use std::os::unix::io::{AsRawFd, RawFd};
     use tempfile::NamedTempFile;
 
     #[test]
@@ -520,13 +520,13 @@ mod test_posix_fadvise {
 ))]
 mod test_posix_fallocate {
 
-    use nix::errno::Errno;
-    use nix::fcntl::*;
-    use nix::unistd::pipe;
-    use std::{
+    use core::{
         io::Read,
         os::unix::io::{AsRawFd, RawFd},
     };
+    use nix::errno::Errno;
+    use nix::fcntl::*;
+    use nix::unistd::pipe;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/test/test_kmod/mod.rs
+++ b/test/test_kmod/mod.rs
@@ -1,7 +1,7 @@
 use crate::*;
-use std::fs::copy;
-use std::path::PathBuf;
-use std::process::Command;
+use core::fs::copy;
+use core::path::PathBuf;
+use core::process::Command;
 use tempfile::{tempdir, TempDir};
 
 fn compile_kernel_module() -> (PathBuf, String, TempDir) {
@@ -32,12 +32,12 @@ fn compile_kernel_module() -> (PathBuf, String, TempDir) {
     (tmp_dir.path().join("hello.ko"), "hello".to_owned(), tmp_dir)
 }
 
+use core::ffi::CString;
+use core::fs::File;
+use core::io::Read;
 use nix::errno::Errno;
 use nix::kmod::{delete_module, DeleteModuleFlags};
 use nix::kmod::{finit_module, init_module, ModuleInitFlags};
-use std::ffi::CString;
-use std::fs::File;
-use std::io::Read;
 
 #[test]
 fn test_finit_and_delete_module() {

--- a/test/test_mount.rs
+++ b/test/test_mount.rs
@@ -7,11 +7,11 @@ mod common;
 
 #[cfg(target_os = "linux")]
 mod test_mount {
-    use std::fs::{self, File};
-    use std::io::{self, Read, Write};
-    use std::os::unix::fs::OpenOptionsExt;
-    use std::os::unix::fs::PermissionsExt;
-    use std::process::{self, Command};
+    use core::fs::{self, File};
+    use core::io::{self, Read, Write};
+    use core::os::unix::fs::OpenOptionsExt;
+    use core::os::unix::fs::PermissionsExt;
+    use core::process::{self, Command};
 
     use libc::{EACCES, EROFS};
 

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -1,6 +1,6 @@
 use cfg_if::cfg_if;
-use std::ffi::CString;
-use std::str;
+use core::ffi::CString;
+use core::str;
 
 use nix::errno::Errno;
 use nix::mqueue::{

--- a/test/test_nmount.rs
+++ b/test/test_nmount.rs
@@ -1,9 +1,9 @@
 use crate::*;
+use core::{ffi::CString, fs::File, path::Path};
 use nix::{
     errno::Errno,
     mount::{unmount, MntFlags, Nmount},
 };
-use std::{ffi::CString, fs::File, path::Path};
 use tempfile::tempdir;
 
 #[test]

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,9 +1,9 @@
+use crate::os::fd::{BorrowedFd, FromRawFd, OwnedFd};
 use nix::{
     errno::Errno,
     poll::{poll, PollFd, PollFlags},
     unistd::{close, pipe, write},
 };
-use std::os::unix::io::{BorrowedFd, FromRawFd, OwnedFd};
 
 macro_rules! loop_while_eintr {
     ($poll_expr: expr) => {

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -1,7 +1,7 @@
-use std::fs::File;
-use std::io::{Read, Write};
-use std::os::unix::prelude::*;
-use std::path::Path;
+use core::fs::File;
+use core::io::{Read, Write};
+use core::os::unix::prelude::*;
+use core::path::Path;
 
 use libc::{_exit, STDOUT_FILENO};
 use nix::fcntl::{open, OFlag};

--- a/test/test_sendfile.rs
+++ b/test/test_sendfile.rs
@@ -1,6 +1,6 @@
-use std::io::prelude::*;
 #[cfg(any(target_os = "android", target_os = "linux"))]
-use std::os::unix::io::{FromRawFd, OwnedFd};
+use crate::os::fd::{FromRawFd, OwnedFd};
+use core::io::prelude::*;
 
 use libc::off_t;
 use nix::sys::sendfile::*;
@@ -10,8 +10,8 @@ cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "linux"))] {
         use nix::unistd::{close, pipe, read};
     } else if #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios", target_os = "macos"))] {
-        use std::net::Shutdown;
-        use std::os::unix::net::UnixStream;
+        use core::net::Shutdown;
+        use core::os::unix::net::UnixStream;
     }
 }
 
@@ -26,7 +26,7 @@ fn test_sendfile_linux() {
     let mut offset: off_t = 5;
     // The construct of this `OwnedFd` is a temporary workaround, when `pipe(2)`
     // becomes I/O-safe:
-    // pub fn pipe() -> std::result::Result<(OwnedFd, OwnedFd), Error>
+    // pub fn pipe() -> core::result::Result<(OwnedFd, OwnedFd), Error>
     // then it is no longer needed.
     let wr = unsafe { OwnedFd::from_raw_fd(wr) };
     let res = sendfile(&wr, &tmp, Some(&mut offset), 2).unwrap();
@@ -52,7 +52,7 @@ fn test_sendfile64_linux() {
     let mut offset: libc::off64_t = 5;
     // The construct of this `OwnedFd` is a temporary workaround, when `pipe(2)`
     // becomes I/O-safe:
-    // pub fn pipe() -> std::result::Result<(OwnedFd, OwnedFd), Error>
+    // pub fn pipe() -> core::result::Result<(OwnedFd, OwnedFd), Error>
     // then it is no longer needed.
     let wr = unsafe { OwnedFd::from_raw_fd(wr) };
     let res = sendfile64(&wr, &tmp, Some(&mut offset), 2).unwrap();

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,15 +1,15 @@
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-use std::fs;
-use std::fs::File;
+use core::fs;
+use core::fs::File;
 #[cfg(not(target_os = "redox"))]
-use std::os::unix::fs::symlink;
+use core::os::unix::fs::symlink;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::prelude::AsRawFd;
+use core::os::unix::fs::PermissionsExt;
+use core::os::unix::prelude::AsRawFd;
 #[cfg(not(target_os = "redox"))]
-use std::path::Path;
+use core::path::Path;
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-use std::time::{Duration, UNIX_EPOCH};
+use core::time::{Duration, UNIX_EPOCH};
 
 use libc::mode_t;
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -1,13 +1,13 @@
+use core::convert::TryFrom;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::thread;
+use core::time::{Duration, Instant};
 use nix::sys::signal::{
     sigaction, SaFlags, SigAction, SigEvent, SigHandler, SigSet, SigevNotify,
     Signal,
 };
 use nix::sys::timer::{Expiration, Timer, TimerSetTimeFlags};
 use nix::time::ClockId;
-use std::convert::TryFrom;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
-use std::time::{Duration, Instant};
 
 const SIG: Signal = Signal::SIGALRM;
 static ALARM_CALLED: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
Changes `pipe` and `pipe2` to return `OwnedFd`.