### PR TITLE
Economize our Cirrus CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,12 +40,10 @@ task:
   env:
     TARGET: x86_64-unknown-freebsd
   matrix:
-    - name: FreeBSD 12 amd64 & i686
-      freebsd_instance:
-        image: freebsd-12-4-release-amd64
     - name: FreeBSD 14 amd64 & i686
       freebsd_instance:
         image_family: freebsd-14-0-snap
+        cpu: 1
       # Enable tests that would fail on FreeBSD 12
       RUSTFLAGS: --cfg fbsd14 -D warnings
       RUSTDOCFLAGS: --cfg fbsd14
@@ -85,6 +83,14 @@ task:
 # Use cross for QEMU-based testing
 # cross needs to execute Docker, so we must use Cirrus's Docker Builder task.
 task:
+  depends_on:
+    - FreeBSD 14 amd64 & i686
+    - Linux x86_64
+    - macOS aarch64
+    - Rust Formatter
+    - OpenBSD x86_64
+    - Minver
+    - Rust Stable
   env:
     RUST_TEST_THREADS: 1            # QEMU works best with 1 thread
     HOME: /tmp/home
@@ -141,16 +147,35 @@ task:
     - name: Linux aarch64
       arm_container:
         image: rust:1.63.0
+        cpu: 1
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+        - Linux x86_64
+        - macOS aarch64
+        - Rust Formatter
+        - OpenBSD x86_64
+        - Minver
+        - Rust Stable
       env:
         TARGET: aarch64-unknown-linux-gnu
     - name: Linux x86_64
       container:
         image: rust:1.63.0
+        cpu: 1
       env:
         TARGET: x86_64-unknown-linux-gnu
     - name: Linux x86_64 musl
       container:
         image: rust:1.63.0
+        cpu: 1
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+        - Linux x86_64
+        - macOS aarch64
+        - Rust Formatter
+        - OpenBSD x86_64
+        - Minver
+        - Rust Stable
       env:
         TARGET: x86_64-unknown-linux-musl
   setup_script:
@@ -163,6 +188,7 @@ task:
   name: Rust Stable
   container:
     image: rust:latest
+    cpu: 1
   env:
     TARGET: x86_64-unknown-linux-gnu
   setup_script:
@@ -174,6 +200,15 @@ task:
 task:
   container:
     image: rust:1.63.0
+    cpu: 1
+  depends_on:
+    - FreeBSD 14 amd64 & i686
+    - Linux x86_64
+    - macOS aarch64
+    - Rust Formatter
+    - OpenBSD x86_64
+    - Minver
+    - Rust Stable
   env:
     BUILD: check
     HOST: x86_64-unknown-linux-gnu
@@ -211,16 +246,6 @@ task:
         # cargo hack tries to invoke the iphonesimulator SDK for iOS
         NOHACK: 1
         TARGET: aarch64-apple-ios
-    - name: iOS x86_64
-      env:
-        # cargo hack tries to invoke the iphonesimulator SDK for iOS
-        NOHACK: 1
-        TARGET: x86_64-apple-ios
-    # Cross testing on powerpc fails with "undefined reference to renameat2".
-    # Perhaps cross is using too-old a version?
-    - name: Linux powerpc
-      env:
-        TARGET: powerpc-unknown-linux-gnu
     # Cross claims to support Linux powerpc64, but it really doesn't.
     # https://github.com/rust-embedded/cross/issues/441
     - name: Linux powerpc64
@@ -232,9 +257,6 @@ task:
     - name: Linux x32
       env:
         TARGET: x86_64-unknown-linux-gnux32
-    - name: macOS x86_64
-      env:
-        TARGET: x86_64-apple-darwin
     - name: NetBSD x86_64
       env:
         TARGET: x86_64-unknown-netbsd
@@ -248,6 +270,15 @@ task:
   container:
     # Redox's MSRV policy is unclear.  Until they define it, use nightly.
     image: rustlang/rust:nightly
+    cpu: 1
+  depends_on:
+    - FreeBSD 14 amd64 & i686
+    - Linux x86_64
+    - macOS aarch64
+    - Rust Formatter
+    - OpenBSD x86_64
+    - Minver
+    - Rust Stable
   env:
     BUILD: check
   name: Redox x86_64
@@ -265,6 +296,7 @@ task:
 task:
   container:
     image: rustlang/rust:nightly
+    cpu: 1
   env:
     BUILD: check
     HOST: x86_64-unknown-linux-gnu
@@ -272,15 +304,39 @@ task:
     CLIPPYFLAGS: -D warnings
   matrix:
     - name: DragonFly BSD x86_64
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+        - Linux x86_64
+        - macOS aarch64
+        - Rust Formatter
+        - OpenBSD x86_64
+        - Minver
+        - Rust Stable
       env:
         TARGET: x86_64-unknown-dragonfly
     - name: OpenBSD x86_64
       env:
         TARGET: x86_64-unknown-openbsd
     - name: Linux armv7 uclibceabihf
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+        - Linux x86_64
+        - macOS aarch64
+        - Rust Formatter
+        - OpenBSD x86_64
+        - Minver
+        - Rust Stable
       env:
         TARGET: armv7-unknown-linux-uclibceabihf
     - name: Haiku x86_64
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+        - Linux x86_64
+        - macOS aarch64
+        - Rust Formatter
+        - OpenBSD x86_64
+        - Minver
+        - Rust Stable
       env:
         TARGET: x86_64-unknown-haiku
   setup_script:
@@ -297,6 +353,7 @@ task:
     HOST: x86_64-unknown-linux-gnu
   container:
     image: rustlang/rust:nightly
+    cpu: 1
   setup_script:
     - cargo update -Zminimal-versions
   check_script:
@@ -308,5 +365,6 @@ task:
   name: Rust Formatter
   container:
     image: rust:latest
+    cpu: 1
   setup_script: rustup component add rustfmt
   test_script: cargo fmt --all -- --check **/*.rs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pub fn gethostname() -> Result<OsString>;
 
 ## Supported Platforms
 
-nix target support consists of two tiers. While nix attempts to support all
+nix target support consists of three tiers. While nix attempts to support all
 platforms supported by [libc](https://github.com/rust-lang/libc), only some
 platforms are actively supported due to either technical or manpower
 limitations. Support for platforms is split into three tiers:
@@ -41,8 +41,12 @@ limitations. Support for platforms is split into three tiers:
              blocks the inclusion of new code. Tests may be run, but failures
              in tests don't block the inclusion of new code.
   * Tier 3 - Builds for this target are run in CI. Failures during the build
-             *do not* block the inclusion of new code. Testing may be run, but
-             failures in tests don't block the inclusion of new code.
+             *do not* necessarily block the inclusion of new code.  That is, at
+             our discretion a Tier 3 target may be dropped at any time, if it
+             would otherwise block development.
+
+Platforms not listed are supported on a best-effort basis, relying on our users
+to report any problems.
 
 The following targets are supported by `nix`:
 
@@ -80,16 +84,14 @@ The following targets are supported by `nix`:
     <li>arm-unknown-linux-musleabi</li>
     <li>armv7-linux-androideabi</li>
     <li>i686-linux-android</li>
-    <li>powerpc-unknown-linux-gnu</li>
     <li>s390x-unknown-linux-gnu</li>
-    <li>x86_64-apple-ios</li>
     <li>x86_64-linux-android</li>
-    <li>x86_64-apple-darwin</li>
     <li>x86_64-unknown-illumos</li>
     <li>x86_64-unknown-netbsd</li>
    </td>
    <td>
     <li>armv7-unknown-linux-uclibceabihf</li>
+    <li>powerpc64-unknown-linux-gnu</li>
     <li>x86_64-fuchsia</li>
     <li>x86_64-unknown-dragonfly</li>
     <li>x86_64-unknown-haiku</li>


### PR DESCRIPTION
Cirrus CI is eliminating unlimited free open source builds.  Open source projects will now be limited to about 16,000 CPU-minutes per month. Tweak our CI configuration to reduce its demands:

* Eliminate the FreeBSD 12 x86_64, iOS x86_64, macOS x86_64, and Linux powerpc builds.  They weren't providing a useful amount of test coverage.
* Reduce each task to 1 CPU and 2 GB of RAM (but 4 GB for OSX).  Our build rarely uses more than a single CPU anyway.
* Split the tasks up into two groups.  The first group of 8 builds contains broad coverage.  Most build failures will be caught by one of these tasks.  The second group of 29 tasks will only run after the first group completes.

https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/