### PR TITLE
Add `SockProtocol` variants for ICMP{,v6}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
   ([#2137](https://github.com/nix-rust/nix/pull/2137))
 
+### Added
+- Added `Icmp` and `IcmpV6` to `SockProtocol`.
+  (#[2103](https://github.com/nix-rust/nix/pull/2103))
+
 ## [0.27.1] - 2023-08-28
 
 ### Fixed

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -132,11 +132,6 @@ pub enum SockProtocol {
     Udp = libc::IPPROTO_UDP,
     /// Raw sockets ([raw(7)](https://man7.org/linux/man-pages/man7/raw.7.html))
     Raw = libc::IPPROTO_RAW,
-    /// Allows applications and other KEXTs to be notified when certain kernel events occur
-    /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
-    KextEvent = libc::SYSPROTO_EVENT,
     /// Allows applications to configure and control a KEXT
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(any(target_os = "ios", target_os = "macos"))]
@@ -231,20 +226,33 @@ pub enum SockProtocol {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     EthAll = (libc::ETH_P_ALL as u16).to_be() as i32,
+    /// ICMP protocol ([icmp(7)](https://man7.org/linux/man-pages/man7/icmp.7.html))
+    Icmp = libc::IPPROTO_ICMP,
+    /// ICMPv6 protocol (ICMP over IPv6)
+    IcmpV6 = libc::IPPROTO_ICMPV6,
+}
+
+impl SockProtocol {
     /// The Controller Area Network raw socket protocol
     /// ([ref](https://docs.kernel.org/networking/can.html#how-to-use-socketcan))
     #[cfg(target_os = "linux")]
     #[cfg_attr(docsrs, doc(cfg(all())))]
-    CanRaw = libc::CAN_RAW,
-}
+    #[allow(non_upper_case_globals)]
+    pub const CanRaw: SockProtocol = SockProtocol::Icmp; // Matches libc::CAN_RAW
 
-impl SockProtocol {
     /// The Controller Area Network broadcast manager protocol
     /// ([ref](https://docs.kernel.org/networking/can.html#how-to-use-socketcan))
     #[cfg(target_os = "linux")]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(non_upper_case_globals)]
     pub const CanBcm: SockProtocol = SockProtocol::NetlinkUserSock; // Matches libc::CAN_BCM
+
+    /// Allows applications and other KEXTs to be notified when certain kernel events occur
+    /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    #[allow(non_upper_case_globals)]
+    pub const KextEvent: SockProtocol = SockProtocol::Icmp;  // Matches libc::SYSPROTO_EVENT
 }
 #[cfg(any(target_os = "android", target_os = "linux"))]
 libc_bitflags! {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -2680,3 +2680,36 @@ pub fn test_txtime() {
     recvmsg::<()>(rsock.as_raw_fd(), &mut iov2, None, MsgFlags::empty())
         .unwrap();
 }
+
+// cfg needed for capability check.
+#[cfg(any(target_os = "android", target_os = "linux"))]
+#[test]
+fn test_icmp_protocol() {
+    use nix::sys::socket::{
+        sendto, socket, AddressFamily, MsgFlags, SockFlag, SockProtocol,
+        SockType, SockaddrIn,
+    };
+
+    require_capability!("test_icmp_protocol", CAP_NET_RAW);
+
+    let owned_fd = socket(
+        AddressFamily::Inet,
+        SockType::Raw,
+        SockFlag::empty(),
+        SockProtocol::Icmp,
+    )
+    .unwrap();
+
+    // Send a minimal ICMP packet with no payload.
+    let packet = [
+        0x08, // Type
+        0x00, // Code
+        0x84, 0x85, // Checksum
+        0x73, 0x8a, // ID
+        0x00, 0x00, // Sequence Number
+    ];
+
+    let dest_addr = SockaddrIn::new(127, 0, 0, 1, 0);
+    sendto(owned_fd.as_raw_fd(), &packet, &dest_addr, MsgFlags::empty())
+        .unwrap();
+}


### PR DESCRIPTION
`CanRaw`/`KextEvent` have the same value as `ICMP`, which means one of them has to be a constant.
I chose to make `CanRaw` & `KextEvent` constants since as far as I can tell, `Icmp` is always present (similar to Udp/Tcp, etc).

I started writing a test that sends an Echo-Request, but opening an ICMP/Raw socket requires root permissions, so I'm not sure if it's fit as a test.