### PR TITLE
Eliminate the lazy_static dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ zerocopy = ["fs", "uio"]
 
 [dev-dependencies]
 assert-impl = "0.1"
-lazy_static = "1.4"
 parking_lot = "0.12"
 rand = "0.8"
 tempfile = "3.7.1"

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1142,14 +1142,11 @@ pub fn aio_suspend(
 /// # use std::sync::atomic::{AtomicBool, Ordering};
 /// # use std::thread;
 /// # use std::time;
-/// # use lazy_static::lazy_static;
 /// # use nix::errno::Errno;
 /// # use nix::sys::aio::*;
 /// # use nix::sys::signal::*;
 /// # use tempfile::tempfile;
-/// lazy_static! {
-///     pub static ref SIGNALED: AtomicBool = AtomicBool::new(false);
-/// }
+/// pub static SIGNALED: AtomicBool = AtomicBool::new(false);
 ///
 /// extern fn sigfunc(_: c_int) {
 ///     SIGNALED.store(true, Ordering::Relaxed);

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -841,13 +841,10 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// Use a signal handler to set a flag variable:
 ///
 /// ```no_run
-/// # #[macro_use] extern crate lazy_static;
 /// # use std::convert::TryFrom;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
 /// # use nix::sys::signal::{self, Signal, SigHandler};
-/// lazy_static! {
-///    static ref SIGNALED: AtomicBool = AtomicBool::new(false);
-/// }
+/// static SIGNALED: AtomicBool = AtomicBool::new(false);
 ///
 /// extern fn handle_sigint(signal: libc::c_int) {
 ///     let signal = Signal::try_from(signal).unwrap();

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -21,9 +21,7 @@ use nix::{
 };
 use tempfile::tempfile;
 
-lazy_static! {
-    pub static ref SIGNALED: AtomicBool = AtomicBool::new(false);
-}
+pub static SIGNALED: AtomicBool = AtomicBool::new(false);
 
 extern "C" fn sigfunc(_: c_int) {
     SIGNALED.store(true, Ordering::Relaxed);

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -78,9 +78,7 @@ fn test_sigprocmask() {
         .expect("expect to be able to block signals");
 }
 
-lazy_static! {
-    static ref SIGNALED: AtomicBool = AtomicBool::new(false);
-}
+static SIGNALED: AtomicBool = AtomicBool::new(false);
 
 extern "C" fn test_sigaction_handler(signal: libc::c_int) {
     let signal = Signal::try_from(signal).unwrap();

--- a/test/test.rs
+++ b/test/test.rs
@@ -2,8 +2,6 @@
 extern crate cfg_if;
 #[cfg_attr(not(any(target_os = "redox", target_os = "haiku")), macro_use)]
 extern crate nix;
-#[macro_use]
-extern crate lazy_static;
 
 mod common;
 mod sys;
@@ -79,24 +77,22 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     }
 }
 
-lazy_static! {
-    /// Any test that changes the process's current working directory must grab
-    /// the RwLock exclusively.  Any process that cares about the current
-    /// working directory must grab it shared.
-    pub static ref CWD_LOCK: RwLock<()> = RwLock::new(());
-    /// Any test that creates child processes must grab this mutex, regardless
-    /// of what it does with those children.
-    pub static ref FORK_MTX: Mutex<()> = Mutex::new(());
-    /// Any test that changes the process's supplementary groups must grab this
-    /// mutex
-    pub static ref GROUPS_MTX: Mutex<()> = Mutex::new(());
-    /// Any tests that loads or unloads kernel modules must grab this mutex
-    pub static ref KMOD_MTX: Mutex<()> = Mutex::new(());
-    /// Any test that calls ptsname(3) must grab this mutex.
-    pub static ref PTSNAME_MTX: Mutex<()> = Mutex::new(());
-    /// Any test that alters signal handling must grab this mutex.
-    pub static ref SIGNAL_MTX: Mutex<()> = Mutex::new(());
-}
+/// Any test that creates child processes must grab this mutex, regardless
+/// of what it does with those children.
+pub static FORK_MTX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// Any test that changes the process's current working directory must grab
+/// the RwLock exclusively.  Any process that cares about the current
+/// working directory must grab it shared.
+pub static CWD_LOCK: RwLock<()> = RwLock::new(());
+/// Any test that changes the process's supplementary groups must grab this
+/// mutex
+pub static GROUPS_MTX: Mutex<()> = Mutex::new(());
+/// Any tests that loads or unloads kernel modules must grab this mutex
+pub static KMOD_MTX: Mutex<()> = Mutex::new(());
+/// Any test that calls ptsname(3) must grab this mutex.
+pub static PTSNAME_MTX: Mutex<()> = Mutex::new(());
+/// Any test that alters signal handling must grab this mutex.
+pub static SIGNAL_MTX: Mutex<()> = Mutex::new(());
 
 /// RAII object that restores a test's original directory on drop
 struct DirRestore<'a> {


### PR DESCRIPTION
It's no longer needed, because for several versions now AtomicBool::new and parking_lot::Mutex::new are const functions.

Fixes #1791