### PR TITLE
release.toml: compatibility with cargo-release 0.22

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-dev-version = false
 pre-release-replacements = [
 	{ file="CHANGELOG.md", search="Unreleased", replace="{{version}}" },
 	{ file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}" }


### PR DESCRIPTION
which no longer supports dev-version.

[skip ci]