### PR TITLE
Edit CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2085](https://github.com/nix-rust/nix/pull/2085))
 - Added `SO_RTABLE` for OpenBSD and `SO_ACCEPTFILTER` for FreeBSD/NetBSD to `nix::sys::socket::sockopt`.
   ([#2085](https://github.com/nix-rust/nix/pull/2085))
-- Removed `flock` from `::nix::fcntl` on Solaris. ([#2082](https://github.com/nix-rust/nix/pull/2082))
-- Use I/O safety with `copy_file_range`, and expose it on FreeBSD.
-  (#[1906](https://github.com/nix-rust/nix/pull/1906))
 - Added `MSG_WAITFORONE` to `MsgFlags` on Android, Fuchsia, Linux, NetBSD,
   FreeBSD, OpenBSD, and Solaris.
   ([#2014](https://github.com/nix-rust/nix/pull/2014))
@@ -38,10 +35,28 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2093](https://github.com/nix-rust/nix/pull/2093))
 - Added support for prctl in Linux.
   (#[1550](https://github.com/nix-rust/nix/pull/1550))
-
+- `nix::socket` and `nix::select` are now available on Redox.
+  ([#2012](https://github.com/nix-rust/nix/pull/2012))
+- Implemented AsFd, AsRawFd, FromRawFd, and IntoRawFd for `mqueue::MqdT`.
+  ([#2097](https://github.com/nix-rust/nix/pull/2097))
+- Add the ability to set `kevent_flags` on `SigEvent`.
+  ([#1731](https://github.com/nix-rust/nix/pull/1731))
 
 ### Changed
 
+- All Cargo features have been removed from the default set. Users will need to
+  specify which features they depend on in their Cargo.toml.
+  ([#2091](https://github.com/nix-rust/nix/pull/2091))
+- Implemented I/O safety for many, but not all, of Nix's APIs.  Many public
+  functions argument and return types have changed:
+  | Original Type | New Type              |
+  | ------------- | --------------------- |
+  | AsRawFd       | AsFd                  |
+  | RawFd         | BorrowedFd or OwnedFd |
+
+  (#[1906](https://github.com/nix-rust/nix/pull/1906))
+- Use I/O safety with `copy_file_range`, and expose it on FreeBSD.
+  (#[1906](https://github.com/nix-rust/nix/pull/1906))
 - The MSRV is now 1.65
   ([#1862](https://github.com/nix-rust/nix/pull/1862))
   ([#2104](https://github.com/nix-rust/nix/pull/2104))
@@ -50,30 +65,31 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - With I/O-safe type applied in `pty::OpenptyResult` and `pty::ForkptyResult`,
   users no longer need to manually close the file descriptors in these types.
   ([#1921](https://github.com/nix-rust/nix/pull/1921))
+- Refactored `name` parameter of `mq_open` and `mq_unlink` to be generic over
+   `NixPath`.
+  ([#2102](https://github.com/nix-rust/nix/pull/2102)).
+- Made `clone` unsafe, like `fork`.
+  ([#1993](https://github.com/nix-rust/nix/pull/1993))
+
+### Removed
+
 - `sys::event::{kevent, kevent_ts}` are deprecated in favor of
   `sys::kevent::Kqueue::kevent`, and `sys::event::kqueue` is deprecated in
   favor of `sys::kevent::Kqueue::new`.
   ([#1943](https://github.com/nix-rust/nix/pull/1943))
-- `nix::socket` and `nix::select` are now available on Redox.
-  ([#2012](https://github.com/nix-rust/nix/pull/2012))
-- All features have been removed from the default set. Users will need to specify
-  which features they depend on in their Cargo.toml.
-  ([#2091](https://github.com/nix-rust/nix/pull/2091))
+- Removed deprecated IoVec API.
+  ([#1855](https://github.com/nix-rust/nix/pull/1855))
+- Removed deprecated net APIs.
+  ([#1861](https://github.com/nix-rust/nix/pull/1861))
+- `nix::sys::signalfd::signalfd` is deprecated.  Use
+  `nix::sys::signalfd::SignalFd` instead.
+  ([#1938](https://github.com/nix-rust/nix/pull/1938))
+- Removed `SigEvent` support on Fuchsia, where it was unsound.
+  ([#2079](https://github.com/nix-rust/nix/pull/2079))
+- Removed `flock` from `::nix::fcntl` on Solaris.
+  ([#2082](https://github.com/nix-rust/nix/pull/2082))
 
-- Implemented I/O safety.  Many public functions argument and return types have
-  changed:
-  | Original Type | New Type              |
-  | ------------- | --------------------- |
-  | AsRawFd       | AsFd                  |
-  | RawFd         | BorrowedFd or OwnedFd |
-
-  (#[1906](https://github.com/nix-rust/nix/pull/1906))
-- Implemented AsFd, AsRawFd, FromRawFd, and IntoRawFd for `mqueue::MqdT`.
-   See ([#2097](https://github.com/nix-rust/nix/pull/2097))
-- Refactored `name` parameter of `mq_open` and `mq_unlink` to be generic over
-   `NixPath`. See ([#2102](https://github.com/nix-rust/nix/pull/2102)).
-- Made `clone` unsafe, like `fork`.
-  ([#1993](https://github.com/nix-rust/nix/pull/1993))
+## [0.26.3] - 2023-08-27
 
 ### Fixed
 - Fix: send `ETH_P_ALL` in htons format 
@@ -87,18 +103,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2061](https://github.com/nix-rust/nix/pull/2061))
 - Fixed an incorrect lifetime returned from `recvmsg`.
   ([#2095](https://github.com/nix-rust/nix/pull/2095))
-
-### Removed
-
-- Removed deprecated IoVec API.
-  ([#1855](https://github.com/nix-rust/nix/pull/1855))
-- Removed deprecated net APIs.
-  ([#1861](https://github.com/nix-rust/nix/pull/1861))
-- `nix::sys::signalfd::signalfd` is deprecated.  Use
-  `nix::sys::signalfd::SignalFd` instead.
-  ([#1938](https://github.com/nix-rust/nix/pull/1938))
-- Removed `SigEvent` support on Fuchsia, where it was unsound.
-  ([#2079](https://github.com/nix-rust/nix/pull/2079))
 
 ## [0.26.2] - 2023-01-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "nix"
 description = "Rust friendly bindings to *nix APIs"
 edition     = "2021"
-version     = "0.26.1"
+version     = "0.26.3"
 rust-version = "1.65"
 authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"


### PR DESCRIPTION
* Add entry for 0.26.3, released from a separate branch
* Reorder some entries, and tweak a few for consistency.
* Change the crate version to 0.26.3