### PR TITLE
Add IPV6_PKTINFO, Correct documentationn for IPV6_RECVPKTINFO

### DIFF
--- a/changelog/2113.added.md
+++ b/changelog/2113.added.md
@@ -1,0 +1,1 @@
+Add socket option `IPV6_PKTINFO` for BSDs/Linux/Android, also `IPV6_RECVPKTINFO` for DragonFlyBSD

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -922,8 +922,8 @@ sockopt_impl!(
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
-    /// Set delivery of the `IPV6_PKTINFO` control message on incoming
-    /// datagrams.
+    /// Pass an `IPV6_PKTINFO` ancillary message that contains a in6_pktinfo
+    /// structure that supplies some information about the incoming packet.
     Ipv6PacketInfo,
     Both,
     libc::IPPROTO_IPV6,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -905,7 +905,7 @@ sockopt_impl!(
     libc::IP_PKTINFO,
     bool
 );
-#[cfg(any(linux_android))]
+#[cfg(any(linux_android, bsd))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -905,16 +905,29 @@ sockopt_impl!(
     libc::IP_PKTINFO,
     bool
 );
-#[cfg(any(linux_android, target_os = "freebsd", apple_targets, netbsdlike))]
+#[cfg(any(linux_android))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
-    /// Set delivery of the `IPV6_PKTINFO` control message on incoming
+    /// Set delivery of the `IPV6_RECVPKTINFO` control message on incoming
     /// datagrams.
     Ipv6RecvPacketInfo,
     Both,
     libc::IPPROTO_IPV6,
     libc::IPV6_RECVPKTINFO,
+    bool
+);
+
+#[cfg(any(linux_android, bsd))]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Set delivery of the `IPV6_PKTINFO` control message on incoming
+    /// datagrams.
+    Ipv6PacketInfo,
+    Both,
+    libc::IPPROTO_IPV6,
+    libc::IPV6_PKTINFO,
     bool
 );
 #[cfg(bsd)]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -909,7 +909,7 @@ sockopt_impl!(
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
-    /// Set delivery of the `IPV6_RECVPKTINFO` control message on incoming
+    /// Set delivery of the `IPV6_PKTINFO` control message on incoming
     /// datagrams.
     Ipv6RecvPacketInfo,
     Both,


### PR DESCRIPTION
`IPV6_PKTINFO` was missing from `sockopt` so I added it and the documentation for `IPV6_RECVPKTINFO` incorrectly said it was enabling the flag for `IPV6_PKTINFO` so I corrected that. 