### PR TITLE
Revert "Merge #2027 #2057"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 
 [dependencies]
 libc = { version = "0.2.137", features = [ "extra_traits" ] }
-bitflags = "2.3.1"
+bitflags = "1.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::cast_ptr_alignment)]
+#![allow(clippy::bad_bit_mask)]
 
 // Re-exported external crates
 pub use libc;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,8 +63,6 @@ macro_rules! libc_bitflags {
         }
     ) => {
         ::bitflags::bitflags! {
-            #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-            #[repr(transparent)]
             $(#[$outer])*
             pub struct $BitFlags: $T {
                 $(

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -392,7 +392,7 @@ impl<'a> Nmount<'a> {
 
         let niov = self.iov.len() as c_uint;
         let iovp = self.iov.as_mut_ptr();
-        let res = unsafe { libc::nmount(iovp, niov, flags.bits()) };
+        let res = unsafe { libc::nmount(iovp, niov, flags.bits) };
         match Errno::result(res) {
             Ok(_) => Ok(()),
             Err(error) => {
@@ -446,7 +446,7 @@ where
     P: ?Sized + NixPath,
 {
     let res = mountpoint.with_nix_path(|cstr| unsafe {
-        libc::unmount(cstr.as_ptr(), flags.bits())
+        libc::unmount(cstr.as_ptr(), flags.bits)
     })?;
 
     Errno::result(res).map(drop)

--- a/src/mount/linux.rs
+++ b/src/mount/linux.rs
@@ -88,7 +88,7 @@ pub fn mount<
                         s,
                         t.as_ptr(),
                         ty,
-                        flags.bits(),
+                        flags.bits,
                         d as *const libc::c_void,
                     )
                 })
@@ -108,7 +108,7 @@ pub fn umount<P: ?Sized + NixPath>(target: &P) -> Result<()> {
 
 pub fn umount2<P: ?Sized + NixPath>(target: &P, flags: MntFlags) -> Result<()> {
     let res = target.with_nix_path(|cstr| unsafe {
-        libc::umount2(cstr.as_ptr(), flags.bits())
+        libc::umount2(cstr.as_ptr(), flags.bits)
     })?;
 
     Errno::result(res).map(drop)

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -139,7 +139,7 @@ impl MqAttr {
 /// Open a message queue
 ///
 /// See also [`mq_open(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_open.html)
-// The mode.bits() cast is only lossless on some OSes
+// The mode.bits cast is only lossless on some OSes
 #[allow(clippy::cast_lossless)]
 pub fn mq_open(
     name: &CStr,

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -177,7 +177,7 @@ pub fn mknod<P: ?Sized + NixPath>(
     dev: dev_t,
 ) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
-        libc::mknod(cstr.as_ptr(), kind.bits() | perm.bits() as mode_t, dev)
+        libc::mknod(cstr.as_ptr(), kind.bits | perm.bits() as mode_t, dev)
     })?;
 
     Errno::result(res).map(drop)
@@ -202,7 +202,7 @@ pub fn mknodat<P: ?Sized + NixPath>(
         libc::mknodat(
             dirfd,
             cstr.as_ptr(),
-            kind.bits() | perm.bits() as mode_t,
+            kind.bits | perm.bits() as mode_t,
             dev,
         )
     })?;

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -12,6 +12,7 @@ use crate::{errno::Errno, NixPath, Result};
 #[cfg(not(target_os = "redox"))]
 libc_bitflags!(
     /// File system mount Flags
+    #[repr(C)]
     #[derive(Default)]
     pub struct FsFlags: c_ulong {
         /// Read Only

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -309,7 +309,7 @@ impl Termios {
         let termios = *self.inner.borrow_mut();
         self.input_flags = InputFlags::from_bits_truncate(termios.c_iflag);
         self.output_flags = OutputFlags::from_bits_truncate(termios.c_oflag);
-        self.control_flags = ControlFlags::from_bits_retain(termios.c_cflag);
+        self.control_flags = ControlFlags::from_bits_truncate(termios.c_cflag);
         self.local_flags = LocalFlags::from_bits_truncate(termios.c_lflag);
         self.control_chars = termios.c_cc;
         #[cfg(any(
@@ -355,9 +355,9 @@ libc_enum! {
     /// enum.
     ///
     /// B0 is special and will disable the port.
-    #[cfg_attr(target_os = "haiku", repr(u8))]
+    #[cfg_attr(all(any(target_os = "haiku"), target_pointer_width = "64"), repr(u8))]
     #[cfg_attr(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64"), repr(u64))]
-    #[cfg_attr(all(not(all(any(target_os = "ios", target_os = "macos"), target_pointer_width = "64")), not(target_os = "haiku")), repr(u32))]
+    #[cfg_attr(not(all(any(target_os = "ios", target_os = "macos", target_os = "haiku"), target_pointer_width = "64")), repr(u32))]
     #[non_exhaustive]
     pub enum BaudRate {
         B0,

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -91,7 +91,6 @@ pub(crate) mod timer {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     bitflags! {
         /// Flags that are used for arming the timer.
-        #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         pub struct TimerSetTimeFlags: libc::c_int {
             const TFD_TIMER_ABSTIME = libc::TFD_TIMER_ABSTIME;
         }
@@ -104,7 +103,6 @@ pub(crate) mod timer {
     ))]
     bitflags! {
         /// Flags that are used for arming the timer.
-        #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         pub struct TimerSetTimeFlags: libc::c_int {
             const TFD_TIMER_ABSTIME = libc::TIMER_ABSTIME;
         }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2906,7 +2906,7 @@ feature! {
 pub fn access<P: ?Sized + NixPath>(path: &P, amode: AccessFlags) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
-            libc::access(cstr.as_ptr(), amode.bits())
+            libc::access(cstr.as_ptr(), amode.bits)
         }
     })?;
     Errno::result(res).map(drop)
@@ -2947,7 +2947,7 @@ pub fn faccessat<P: ?Sized + NixPath>(dirfd: Option<RawFd>, path: &P, mode: Acce
 pub fn eaccess<P: ?Sized + NixPath>(path: &P, mode: AccessFlags) -> Result<()> {
     let res = path.with_nix_path(|cstr| {
         unsafe {
-            libc::eaccess(cstr.as_ptr(), mode.bits())
+            libc::eaccess(cstr.as_ptr(), mode.bits)
         }
     })?;
     Errno::result(res).map(drop)


### PR DESCRIPTION
This reverts commit 0c3afc27d7bdbea7e5c12969e1ba0607c14b1dc9.

This rolls back the version of bitflags used to 1.1.  Upgrading bitflags to 2.0 inadvertently caused breaking changes in the r0.26 branch, by virtue of the methods that the bitflags! macro adds.

Also, mask the bad_bit_mask lint, triggered by bitflags's generated code.  That lint was the motivation for upgrading bitflags in the first place.  The bitflags maintainers have decided not to fix those warnings in the 1.x release series.
https://github.com/bitflags/bitflags/pull/373

Fixes #2112