### PR TITLE
Add #[inline] to fspacectl to prevent linker errors with dylibs and --no-allow-shlib-undefined

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -849,6 +849,7 @@ impl SpacectlRange {
 /// assert_eq!(buf, b"012\0\0\0\0\0\09abcdef");
 /// ```
 #[cfg(target_os = "freebsd")]
+#[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
 pub fn fspacectl(fd: RawFd, range: SpacectlRange) -> Result<SpacectlRange> {
     let mut rqsr = libc::spacectl_range {
         r_offset: range.0,
@@ -897,6 +898,7 @@ pub fn fspacectl(fd: RawFd, range: SpacectlRange) -> Result<SpacectlRange> {
 /// assert_eq!(buf, b"012\0\0\0\0\0\09abcdef");
 /// ```
 #[cfg(target_os = "freebsd")]
+#[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
 pub fn fspacectl_all(
     fd: RawFd,
     offset: libc::off_t,


### PR DESCRIPTION
This is https://github.com/nix-rust/nix/pull/2049 but for FreeBSD

Failed build is here: https://github.com/rust-lang-ci/rust/actions/runs/6066172674/job/16456459499
With patch: https://github.com/rust-lang-ci/rust/actions/runs/6069815522/job/16464786535

I modified Rust's CI a bit so that it tests all platforms on that PR (https://github.com/rust-lang/rust/pull/111769), there should be no need for another PR after this.