### PR TITLE
Fully disable the personality::set test

### DIFF
--- a/src/sys/personality.rs
+++ b/src/sys/personality.rs
@@ -80,10 +80,9 @@ pub fn get() -> Result<Persona> {
 ///
 /// Example:
 ///
-// Disable test on aarch64 until we know why it fails.
+// Cirrus CI uses seccomp which makes this test fail
 // https://github.com/nix-rust/nix/issues/2060
-#[cfg_attr(target_arch = "aarch64", doc = " ```no_run")]
-#[cfg_attr(not(target_arch = "aarch64"), doc = " ```")]
+/// ```no_run
 /// # use nix::sys::personality::{self, Persona};
 /// let mut pers = personality::get().unwrap();
 /// assert!(!pers.contains(Persona::ADDR_NO_RANDOMIZE));


### PR DESCRIPTION
It looks like this is failing on x86_64 Linux now too :thinking: 