### PR TITLE
unistd: make getpeereid take AsFd rather than a raw FD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- `unistd::getpeereid` now takes an implementation of `AsFd` rather than a
+  `RawFd` ([#2137](https://github.com/nix-rust/nix/pull/2137))
+
 ## [0.27.1] - 2023-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- `unistd::getpeereid` now takes an implementation of `AsFd` rather than a
-  `RawFd` ([#2137](https://github.com/nix-rust/nix/pull/2137))
+- The following APIs now take an implementation of `AsFd` rather than a
+  `RawFd`:
+
+  - `unistd::tcgetpgrp`
+  - `unistd::tcsetpgrp`
+  - `unistd::fpathconf`
+  - `unistd::ttyname`
+  - `unistd::getpeereid`
+
+  ([#2137](https://github.com/nix-rust/nix/pull/2137))
 
 ## [0.27.1] - 2023-08-28
 
@@ -106,7 +114,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.26.3] - 2023-08-27
 
 ### Fixed
-- Fix: send `ETH_P_ALL` in htons format 
+- Fix: send `ETH_P_ALL` in htons format
   ([#1925](https://github.com/nix-rust/nix/pull/1925))
 - Fix: `recvmsg` now sets the length of the received `sockaddr_un` field
   correctly on Linux platforms. ([#2041](https://github.com/nix-rust/nix/pull/2041))
@@ -194,7 +202,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1824](https://github.com/nix-rust/nix/pull/1824))
 - Workaround XNU bug causing netmasks returned by `getifaddrs` to misbehave.
   ([#1788](https://github.com/nix-rust/nix/pull/1788))
-  
+
 ### Removed
 
 - Removed deprecated error constants and conversions.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -550,7 +550,11 @@ cfg_if! {
             TcpMaxSeg, GetOnly, libc::IPPROTO_TCP, libc::TCP_MAXSEG, u32);
     }
 }
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "redox"
+)))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -572,7 +576,11 @@ sockopt_impl!(
     libc::TCP_REPAIR,
     u32
 );
-#[cfg(not(any(target_os = "openbsd", target_os = "haiku", target_os = "redox")))]
+#[cfg(not(any(
+    target_os = "openbsd",
+    target_os = "haiku",
+    target_os = "redox"
+)))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3943,7 +3943,7 @@ feature! {
     target_os = "netbsd",
     target_os = "dragonfly",
 ))]
-pub fn getpeereid<F: AsFd>(fd: &F) -> Result<(Uid, Gid)> {
+pub fn getpeereid<F: AsFd>(fd: F) -> Result<(Uid, Gid)> {
     let mut uid = 1;
     let mut gid = 1;
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3943,11 +3943,11 @@ feature! {
     target_os = "netbsd",
     target_os = "dragonfly",
 ))]
-pub fn getpeereid(fd: RawFd) -> Result<(Uid, Gid)> {
+pub fn getpeereid<F: AsFd>(fd: &F) -> Result<(Uid, Gid)> {
     let mut uid = 1;
     let mut gid = 1;
 
-    let ret = unsafe { libc::getpeereid(fd, &mut uid, &mut gid) };
+    let ret = unsafe { libc::getpeereid(fd.as_fd().as_raw_fd(), &mut uid, &mut gid) };
 
     Errno::result(ret).map(|_| (Uid(uid), Gid(gid)))
 }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -366,8 +366,8 @@ feature! {
 /// Get the group process id (GPID) of the foreground process group on the
 /// terminal associated to file descriptor (FD).
 #[inline]
-pub fn tcgetpgrp(fd: c_int) -> Result<Pid> {
-    let res = unsafe { libc::tcgetpgrp(fd) };
+pub fn tcgetpgrp<F: AsFd>(fd: F) -> Result<Pid> {
+    let res = unsafe { libc::tcgetpgrp(fd.as_fd().as_raw_fd()) };
     Errno::result(res).map(Pid)
 }
 /// Set the terminal foreground process group (see
@@ -376,8 +376,8 @@ pub fn tcgetpgrp(fd: c_int) -> Result<Pid> {
 /// Get the group process id (PGID) to the foreground process group on the
 /// terminal associated to file descriptor (FD).
 #[inline]
-pub fn tcsetpgrp(fd: c_int, pgrp: Pid) -> Result<()> {
-    let res = unsafe { libc::tcsetpgrp(fd, pgrp.into()) };
+pub fn tcsetpgrp<F: AsFd>(fd: F, pgrp: Pid) -> Result<()> {
+    let res = unsafe { libc::tcsetpgrp(fd.as_fd().as_raw_fd(), pgrp.into()) };
     Errno::result(res).map(drop)
 }
 }
@@ -2192,10 +2192,10 @@ pub enum PathconfVar {
 /// - `Ok(None)`: the variable has no limit (for limit variables) or is
 ///     unsupported (for option variables)
 /// - `Err(x)`: an error occurred
-pub fn fpathconf(fd: RawFd, var: PathconfVar) -> Result<Option<c_long>> {
+pub fn fpathconf<F: AsFd>(fd: F, var: PathconfVar) -> Result<Option<c_long>> {
     let raw = unsafe {
         Errno::clear();
-        libc::fpathconf(fd, var as c_int)
+        libc::fpathconf(fd.as_fd().as_raw_fd(), var as c_int)
     };
     if raw == -1 {
         if errno::errno() == 0 {
@@ -3913,12 +3913,12 @@ feature! {
 /// Get the name of the terminal device that is open on file descriptor fd
 /// (see [`ttyname(3)`](https://man7.org/linux/man-pages/man3/ttyname.3.html)).
 #[cfg(not(target_os = "fuchsia"))]
-pub fn ttyname(fd: RawFd) -> Result<PathBuf> {
+pub fn ttyname<F: AsFd>(fd: F) -> Result<PathBuf> {
     const PATH_MAX: usize = libc::PATH_MAX as usize;
     let mut buf = vec![0_u8; PATH_MAX];
     let c_buf = buf.as_mut_ptr() as *mut libc::c_char;
 
-    let ret = unsafe { libc::ttyname_r(fd, c_buf, buf.len()) };
+    let ret = unsafe { libc::ttyname_r(fd.as_fd().as_raw_fd(), c_buf, buf.len()) };
     if ret != 0 {
         return Err(Errno::from_i32(ret));
     }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1269,8 +1269,8 @@ fn test_getpeereid() {
     use std::os::unix::net::UnixStream;
     let (sock_a, sock_b) = UnixStream::pair().unwrap();
 
-    let (uid_a, gid_a) = getpeereid(sock_a.as_raw_fd()).unwrap();
-    let (uid_b, gid_b) = getpeereid(sock_b.as_raw_fd()).unwrap();
+    let (uid_a, gid_a) = getpeereid(&sock_a).unwrap();
+    let (uid_b, gid_b) = getpeereid(&sock_b).unwrap();
 
     let uid = geteuid();
     let gid = getegid();
@@ -1279,20 +1279,6 @@ fn test_getpeereid() {
     assert_eq!(gid, gid_a);
     assert_eq!(uid_a, uid_b);
     assert_eq!(gid_a, gid_b);
-}
-
-#[test]
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "freebsd",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "dragonfly",
-))]
-fn test_getpeereid_invalid_fd() {
-    // getpeereid is not POSIX, so error codes are inconsistent between different Unices.
-    getpeereid(-1).expect_err("assertion failed");
 }
 
 #[test]

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1269,8 +1269,8 @@ fn test_getpeereid() {
     use std::os::unix::net::UnixStream;
     let (sock_a, sock_b) = UnixStream::pair().unwrap();
 
-    let (uid_a, gid_a) = getpeereid(&sock_a).unwrap();
-    let (uid_b, gid_b) = getpeereid(&sock_b).unwrap();
+    let (uid_a, gid_a) = getpeereid(sock_a).unwrap();
+    let (uid_b, gid_b) = getpeereid(sock_b).unwrap();
 
     let uid = geteuid();
     let gid = getegid();


### PR DESCRIPTION
I noticed that the `sockopt` APIs now take `AsFd`, so I figured this API should be made to do the same :slightly_smiling_face: 

`AsFd` returns a `BorrowedFd` that is correct by construction, meaning that this API rejects more error states at the type level (such as passing in `fd = -1`). As such, I've removed the `test_getpeereid_invalid_fd` testcase, since its error state is no longer reachable from Rust users of this API.