### PR TITLE
sys: add MIPS R6 support

### DIFF
--- a/changelog/2138.added.md
+++ b/changelog/2138.added.md
@@ -1,0 +1,1 @@
+Added `mips32r6` and `mips64r6` support for signal, ioctl and ptrace

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -19,7 +19,9 @@ pub const TYPEBITS: ioctl_num_type = 8;
 cfg_if! {
     if #[cfg(any(
         target_arch = "mips",
+        target_arch = "mips32r6",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "powerpc",
         target_arch = "powerpc64",
         target_arch = "sparc64"

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -53,28 +53,36 @@ libc_enum! {
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
+                                               target_arch = "mips32r6",
                                                target_arch = "mips64",
+                                               target_arch = "mips64r6",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_GETREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
+                                               target_arch = "mips32r6",
                                                target_arch = "mips64",
+                                               target_arch = "mips64r6",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_SETREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
+                                               target_arch = "mips32r6",
                                                target_arch = "mips64",
+                                               target_arch = "mips64r6",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_GETFPREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
                                                target_arch = "mips",
+                                               target_arch = "mips32r6",
                                                target_arch = "mips64",
+                                               target_arch = "mips64r6",
                                                target_arch = "x86_64",
                                                target_pointer_width = "32"))))]
         PTRACE_SETFPREGS,
@@ -82,13 +90,17 @@ libc_enum! {
         PTRACE_DETACH,
         #[cfg(all(target_os = "linux", any(target_env = "musl",
                                            target_arch = "mips",
+                                           target_arch = "mips32r6",
                                            target_arch = "mips64",
+                                           target_arch = "mips64r6",
                                            target_arch = "x86",
                                            target_arch = "x86_64")))]
         PTRACE_GETFPXREGS,
         #[cfg(all(target_os = "linux", any(target_env = "musl",
                                            target_arch = "mips",
+                                           target_arch = "mips32r6",
                                            target_arch = "mips64",
+                                           target_arch = "mips64r6",
                                            target_arch = "x86",
                                            target_arch = "x86_64")))]
         PTRACE_SETFPXREGS,
@@ -98,10 +110,14 @@ libc_enum! {
         PTRACE_GETSIGINFO,
         PTRACE_SETSIGINFO,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+                                               target_arch = "mips32r6",
+                                               target_arch = "mips64",
+                                               target_arch = "mips64r6"))))]
         PTRACE_GETREGSET,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+                                               target_arch = "mips32r6",
+                                               target_arch = "mips64",
+                                               target_arch = "mips64r6"))))]
         PTRACE_SETREGSET,
         #[cfg(target_os = "linux")]
         #[cfg_attr(docsrs, doc(cfg(all())))]
@@ -110,10 +126,14 @@ libc_enum! {
         #[cfg_attr(docsrs, doc(cfg(all())))]
         PTRACE_INTERRUPT,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+                                               target_arch = "mips32r6",
+                                               target_arch = "mips64",
+                                               target_arch = "mips64r6"))))]
         PTRACE_LISTEN,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
-                                               target_arch = "mips64"))))]
+                                               target_arch = "mips32r6",
+                                               target_arch = "mips64",
+                                               target_arch = "mips64r6"))))]
         PTRACE_PEEKSIGINFO,
         #[cfg(all(target_os = "linux", target_env = "gnu",
                   any(target_arch = "x86", target_arch = "x86_64")))]

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -67,7 +67,10 @@ libc_enum! {
         /// Stack fault (obsolete)
         #[cfg(all(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux"),
-                  not(any(target_arch = "mips", target_arch = "mips64",
+                  not(any(target_arch = "mips",
+                          target_arch = "mips32r6",
+                          target_arch = "mips64",
+                          target_arch = "mips64r6",
                           target_arch = "sparc64"))))]
         SIGSTKFLT,
         /// To parent on child stop or exit
@@ -152,7 +155,9 @@ impl FromStr for Signal {
                 ),
                 not(any(
                     target_arch = "mips",
+                    target_arch = "mips32r6",
                     target_arch = "mips64",
+                    target_arch = "mips64r6",
                     target_arch = "sparc64"
                 ))
             ))]
@@ -236,7 +241,9 @@ impl Signal {
                 ),
                 not(any(
                     target_arch = "mips",
+                    target_arch = "mips32r6",
                     target_arch = "mips64",
+                    target_arch = "mips64r6",
                     target_arch = "sparc64"
                 ))
             ))]
@@ -329,7 +336,9 @@ const SIGNALS: [Signal; 28] = [
     ),
     not(any(
         target_arch = "mips",
+        target_arch = "mips32r6",
         target_arch = "mips64",
+        target_arch = "mips64r6",
         target_arch = "sparc64"
     ))
 ))]
@@ -347,7 +356,13 @@ const SIGNALS: [Signal; 31] = [
         target_os = "emscripten",
         target_os = "fuchsia"
     ),
-    any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64")
+    any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "sparc64"
+    )
 ))]
 #[cfg(feature = "signal")]
 const SIGNALS: [Signal; 30] = [

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -498,7 +498,9 @@ mod aio_writev {
     any(
         all(target_env = "musl", target_arch = "x86_64"),
         target_arch = "mips",
-        target_arch = "mips64"
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
     ),
     ignore
 )]

--- a/test/sys/test_ioctl.rs
+++ b/test/sys/test_ioctl.rs
@@ -36,7 +36,9 @@ mod linux {
     fn test_op_none() {
         if cfg!(any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc",
             target_arch = "powerpc64"
         )) {
@@ -54,7 +56,9 @@ mod linux {
     fn test_op_write() {
         if cfg!(any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc",
             target_arch = "powerpc64"
         )) {
@@ -69,7 +73,11 @@ mod linux {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_write_64() {
-        if cfg!(any(target_arch = "mips64", target_arch = "powerpc64")) {
+        if cfg!(any(
+            target_arch = "mips64",
+            target_arch = "mips64r6",
+            target_arch = "powerpc64"
+        )) {
             assert_eq!(
                 request_code_write!(b'z', 10, 1u64 << 32) as u32,
                 0x8000_7A0A
@@ -88,7 +96,9 @@ mod linux {
     fn test_op_read() {
         if cfg!(any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc",
             target_arch = "powerpc64"
         )) {
@@ -103,7 +113,11 @@ mod linux {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_op_read_64() {
-        if cfg!(any(target_arch = "mips64", target_arch = "powerpc64")) {
+        if cfg!(any(
+            target_arch = "mips64",
+            target_arch = "mips64r6",
+            target_arch = "powerpc64"
+        )) {
             assert_eq!(
                 request_code_read!(b'z', 10, 1u64 << 32) as u32,
                 0x4000_7A0A

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1676,7 +1676,9 @@ fn loopback_address(
         qemu,
         any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc64",
         )
     ),
@@ -1770,7 +1772,9 @@ pub fn test_recv_ipv4pktinfo() {
         qemu,
         any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc64",
         )
     ),
@@ -2061,7 +2065,9 @@ pub fn test_recvif_ipv6() {
         qemu,
         any(
             target_arch = "mips",
+            target_arch = "mips32r6",
             target_arch = "mips64",
+            target_arch = "mips64r6",
             target_arch = "powerpc64",
         )
     ),

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -33,7 +33,12 @@ fn test_wait_signal() {
     //target_os = "haiku",
     all(target_os = "linux", not(target_env = "uclibc")),
 ))]
-#[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+#[cfg(not(any(
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+)))]
 fn test_waitid_signal() {
     let _m = crate::FORK_MTX.lock();
 
@@ -76,7 +81,12 @@ fn test_wait_exit() {
     target_os = "haiku",
     all(target_os = "linux", not(target_env = "uclibc")),
 ))]
-#[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+#[cfg(not(any(
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+)))]
 fn test_waitid_exit() {
     let _m = crate::FORK_MTX.lock();
 

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -112,7 +112,15 @@ fn test_mq_getattr() {
 // FIXME: Fix failures for mips in QEMU
 #[test]
 #[cfg_attr(
-    all(qemu, any(target_arch = "mips", target_arch = "mips64")),
+    all(
+        qemu,
+        any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ),
     ignore
 )]
 fn test_mq_setattr() {
@@ -162,7 +170,15 @@ fn test_mq_setattr() {
 // FIXME: Fix failures for mips in QEMU
 #[test]
 #[cfg_attr(
-    all(qemu, any(target_arch = "mips", target_arch = "mips64")),
+    all(
+        qemu,
+        any(
+            target_arch = "mips",
+            target_arch = "mips32r6",
+            target_arch = "mips64",
+            target_arch = "mips64r6"
+        )
+    ),
     ignore
 )]
 fn test_mq_set_nonblocking() {


### PR DESCRIPTION
Currently, R6 targets are almost identical to their R2/R5 counterparts. So we add target_arch and bump libc.