### PR TITLE
Changed signature for openat function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - 2023-09-30
+
+### Changed
+
+- Changed `openat()` and `Dir::openat()` now take optional `dirfd`s
+  ([#1850](https://github.com/nix-rust/nix/pull/2139))
+
+
 ## [0.27.1] - 2023-08-28
 
 ### Fixed
@@ -99,7 +107,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.26.3] - 2023-08-27
 
 ### Fixed
-- Fix: send `ETH_P_ALL` in htons format 
+- Fix: send `ETH_P_ALL` in htons format
   ([#1925](https://github.com/nix-rust/nix/pull/1925))
 - Fix: `recvmsg` now sets the length of the received `sockaddr_un` field
   correctly on Linux platforms. ([#2041](https://github.com/nix-rust/nix/pull/2041))
@@ -187,7 +195,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#1824](https://github.com/nix-rust/nix/pull/1824))
 - Workaround XNU bug causing netmasks returned by `getifaddrs` to misbehave.
   ([#1788](https://github.com/nix-rust/nix/pull/1788))
-  
+
 ### Removed
 
 - Removed deprecated error constants and conversions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Changed `openat()` and `Dir::openat()` now take optional `dirfd`s
-  ([#1850](https://github.com/nix-rust/nix/pull/2139))
+- Changed `openat()` and `Dir::openat()`, now take optional `dirfd`s
+  ([#2139](https://github.com/nix-rust/nix/pull/2139))
 
 
 ## [0.27.1] - 2023-08-28

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -44,7 +44,7 @@ impl Dir {
 
     /// Opens the given path as with `fcntl::openat`.
     pub fn openat<P: ?Sized + NixPath>(
-        dirfd: RawFd,
+        dirfd: Option<RawFd>,
         path: &P,
         oflag: OFlag,
         mode: sys::stat::Mode,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -220,13 +220,13 @@ pub fn open<P: ?Sized + NixPath>(
 #[allow(clippy::useless_conversion)]
 #[cfg(not(target_os = "redox"))]
 pub fn openat<P: ?Sized + NixPath>(
-    dirfd: RawFd,
+    dirfd: Option<RawFd>,
     path: &P,
     oflag: OFlag,
     mode: Mode,
 ) -> Result<RawFd> {
     let fd = path.with_nix_path(|cstr| unsafe {
-        libc::openat(dirfd, cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint)
+        libc::openat(at_rawfd(dirfd), cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint)
     })?;
     Errno::result(fd)
 }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -42,7 +42,7 @@ fn test_openat() {
         open(tmp.path().parent().unwrap(), OFlag::empty(), Mode::empty())
             .unwrap();
     let fd = openat(
-        dirfd,
+        Some(dirfd),
         tmp.path().file_name().unwrap(),
         OFlag::O_RDONLY,
         Mode::empty(),


### PR DESCRIPTION
Fixing  #1850 ,  Changed signature to use an Optional `rawfd`