### PR TITLE
Cast pointers more carefully

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,5 +1,5 @@
 use crate::errno::Errno;
-use libc::{self, c_char, c_int, c_uint, size_t, ssize_t};
+use libc::{self, c_int, c_uint, size_t, ssize_t};
 use std::ffi::OsString;
 #[cfg(not(target_os = "redox"))]
 use std::os::raw;
@@ -306,12 +306,12 @@ fn readlink_maybe_at<P: ?Sized + NixPath>(
             Some(dirfd) => libc::readlinkat(
                 dirfd,
                 cstr.as_ptr(),
-                v.as_mut_ptr() as *mut c_char,
+                v.as_mut_ptr().cast(),
                 v.capacity() as size_t,
             ),
             None => libc::readlink(
                 cstr.as_ptr(),
-                v.as_mut_ptr() as *mut c_char,
+                v.as_mut_ptr().cast(),
                 v.capacity() as size_t,
             ),
         }
@@ -724,7 +724,7 @@ pub fn vmsplice(
     let ret = unsafe {
         libc::vmsplice(
             fd,
-            iov.as_ptr() as *const libc::iovec,
+            iov.as_ptr().cast(),
             iov.len(),
             flags.bits(),
         )

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -65,7 +65,7 @@ unsafe fn workaround_xnu_bug(info: &libc::ifaddrs) -> Option<SockaddrStorage> {
     // memcpy only sa_len bytes, assume the rest is zero
     std::ptr::copy_nonoverlapping(
         src_sock as *const u8,
-        dst_sock.as_mut_ptr() as *mut u8,
+        dst_sock.as_mut_ptr().cast(),
         (*src_sock).sa_len.into(),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl NixPath for [u8] {
         }
 
         let mut buf = MaybeUninit::<[u8; MAX_STACK_ALLOCATION]>::uninit();
-        let buf_ptr = buf.as_mut_ptr() as *mut u8;
+        let buf_ptr = buf.as_mut_ptr().cast();
 
         unsafe {
             ptr::copy_nonoverlapping(self.as_ptr(), buf_ptr, self.len());

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -215,7 +215,7 @@ impl<'a> Nmount<'a> {
     /// Helper function to push a slice onto the `iov` array.
     fn push_slice(&mut self, val: &'a [u8], is_owned: bool) {
         self.iov.push(libc::iovec {
-            iov_base: val.as_ptr() as *mut _,
+            iov_base: val.as_ptr().cast_mut().cast(),
             iov_len: val.len(),
         });
         self.is_owned.push(is_owned);
@@ -386,7 +386,7 @@ impl<'a> Nmount<'a> {
         // SAFETY: we are pushing a mutable iovec here, so we can't use
         //         the above method
         self.iov.push(libc::iovec {
-            iov_base: errmsg.as_mut_ptr() as *mut c_void,
+            iov_base: errmsg.as_mut_ptr().cast(),
             iov_len: errmsg.len(),
         });
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -35,7 +35,7 @@ use crate::NixPath;
 use crate::Result;
 
 use crate::sys::stat::Mode;
-use libc::{self, c_char, mqd_t, size_t};
+use libc::{self, mqd_t, size_t};
 use std::mem;
 #[cfg(any(
     target_os = "linux",
@@ -205,7 +205,7 @@ pub fn mq_receive(
     let res = unsafe {
         libc::mq_receive(
             mqdes.0,
-            message.as_mut_ptr() as *mut c_char,
+            message.as_mut_ptr().cast(),
             len,
             msg_prio as *mut u32,
         )
@@ -229,7 +229,7 @@ feature! {
         let res = unsafe {
             libc::mq_timedreceive(
                 mqdes.0,
-                message.as_mut_ptr() as *mut c_char,
+                message.as_mut_ptr().cast(),
                 len,
                 msg_prio as *mut u32,
                 abstime.as_ref(),
@@ -244,12 +244,7 @@ feature! {
 /// See also [`mq_send(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_send.html)
 pub fn mq_send(mqdes: &MqdT, message: &[u8], msq_prio: u32) -> Result<()> {
     let res = unsafe {
-        libc::mq_send(
-            mqdes.0,
-            message.as_ptr() as *const c_char,
-            message.len(),
-            msq_prio,
-        )
+        libc::mq_send(mqdes.0, message.as_ptr().cast(), message.len(), msq_prio)
     };
     Errno::result(res).map(drop)
 }

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -373,6 +373,7 @@ mod if_nameindex {
     }
 
     /// A list of the network interfaces available on this system. Obtained from [`if_nameindex()`].
+    #[repr(transparent)]
     pub struct Interfaces {
         ptr: NonNull<libc::if_nameindex>,
     }
@@ -388,7 +389,7 @@ mod if_nameindex {
         /// null-terminated, so calling this calculates the length. If random access isn't needed,
         /// [`Interfaces::iter()`] should be used instead.
         pub fn to_slice(&self) -> &[Interface] {
-            let ifs = self.ptr.as_ptr() as *const Interface;
+            let ifs = self.ptr.as_ptr().cast();
             let len = self.iter().count();
             unsafe { std::slice::from_raw_parts(ifs, len) }
         }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -190,11 +190,7 @@ libc_bitflags! {
 /// ready.
 pub fn poll(fds: &mut [PollFd], timeout: libc::c_int) -> Result<libc::c_int> {
     let res = unsafe {
-        libc::poll(
-            fds.as_mut_ptr() as *mut libc::pollfd,
-            fds.len() as libc::nfds_t,
-            timeout,
-        )
+        libc::poll(fds.as_mut_ptr().cast(), fds.len() as libc::nfds_t, timeout)
     };
 
     Errno::result(res)
@@ -223,7 +219,7 @@ pub fn ppoll(
     let timeout = timeout.as_ref().map_or(core::ptr::null(), |r| r.as_ref());
     let sigmask = sigmask.as_ref().map_or(core::ptr::null(), |r| r.as_ref());
     let res = unsafe {
-        libc::ppoll(fds.as_mut_ptr() as *mut libc::pollfd,
+        libc::ppoll(fds.as_mut_ptr().cast(),
                     fds.len() as libc::nfds_t,
                     timeout,
                     sigmask)

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -35,7 +35,7 @@ use std::{
     ptr, thread,
 };
 
-use libc::{c_void, off_t};
+use libc::off_t;
 use pin_utils::unsafe_pinned;
 
 use crate::{
@@ -581,7 +581,7 @@ impl<'a> AioRead<'a> {
     ) -> Self {
         let mut aiocb = AioCb::common_init(fd, prio, sigev_notify);
         aiocb.aiocb.0.aio_nbytes = buf.len();
-        aiocb.aiocb.0.aio_buf = buf.as_mut_ptr() as *mut c_void;
+        aiocb.aiocb.0.aio_buf = buf.as_mut_ptr().cast();
         aiocb.aiocb.0.aio_lio_opcode = libc::LIO_READ;
         aiocb.aiocb.0.aio_offset = offs;
         AioRead {
@@ -702,7 +702,7 @@ impl<'a> AioReadv<'a> {
         // In vectored mode, aio_nbytes stores the length of the iovec array,
         // not the byte count.
         aiocb.aiocb.0.aio_nbytes = bufs.len();
-        aiocb.aiocb.0.aio_buf = bufs.as_mut_ptr() as *mut c_void;
+        aiocb.aiocb.0.aio_buf = bufs.as_mut_ptr().cast();
         aiocb.aiocb.0.aio_lio_opcode = libc::LIO_READV;
         aiocb.aiocb.0.aio_offset = offs;
         AioReadv {
@@ -817,7 +817,7 @@ impl<'a> AioWrite<'a> {
         // but technically its only unsafe to dereference it, not to create
         // it.  Type Safety guarantees that we'll never pass aiocb to
         // aio_read or aio_readv.
-        aiocb.aiocb.0.aio_buf = buf.as_ptr() as *mut c_void;
+        aiocb.aiocb.0.aio_buf = buf.as_ptr().cast_mut().cast();
         aiocb.aiocb.0.aio_lio_opcode = libc::LIO_WRITE;
         aiocb.aiocb.0.aio_offset = offs;
         AioWrite {
@@ -935,7 +935,7 @@ impl<'a> AioWritev<'a> {
         // but technically its only unsafe to dereference it, not to create
         // it.  Type Safety guarantees that we'll never pass aiocb to
         // aio_read or aio_readv.
-        aiocb.aiocb.0.aio_buf = bufs.as_ptr() as *mut c_void;
+        aiocb.aiocb.0.aio_buf = bufs.as_ptr().cast_mut().cast();
         aiocb.aiocb.0.aio_lio_opcode = libc::LIO_WRITEV;
         aiocb.aiocb.0.aio_offset = offs;
         AioWritev {

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -148,7 +148,7 @@ impl Epoll {
         let res = unsafe {
             libc::epoll_wait(
                 self.0.as_raw_fd(),
-                events.as_mut_ptr() as *mut libc::epoll_event,
+                events.as_mut_ptr().cast(),
                 events.len() as c_int,
                 timeout as c_int,
             )
@@ -240,7 +240,7 @@ pub fn epoll_wait(
     let res = unsafe {
         libc::epoll_wait(
             epfd,
-            events.as_mut_ptr() as *mut libc::epoll_event,
+            events.as_mut_ptr().cast(),
             events.len() as c_int,
             timeout_ms as c_int,
         )

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -63,9 +63,9 @@ impl Kqueue {
         let res = unsafe {
             libc::kevent(
                 self.0.as_raw_fd(),
-                changelist.as_ptr() as *const libc::kevent,
+                changelist.as_ptr().cast(),
                 changelist.len() as type_of_nchanges,
-                eventlist.as_mut_ptr() as *mut libc::kevent,
+                eventlist.as_mut_ptr().cast(),
                 eventlist.len() as type_of_nchanges,
                 if let Some(ref timeout) = timeout_opt {
                     timeout as *const timespec

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -202,7 +202,7 @@ impl Inotify {
                 let mut event = MaybeUninit::<libc::inotify_event>::uninit();
                 ptr::copy_nonoverlapping(
                     buffer.as_ptr().add(offset),
-                    event.as_mut_ptr() as *mut u8,
+                    event.as_mut_ptr().cast(),
                     (BUFSIZ - offset).min(header_size),
                 );
                 event.assume_init()

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -241,13 +241,13 @@ pub fn setregs(pid: Pid, regs: user_regs_struct) -> Result<()> {
 /// and therefore use the data field to return values. This function handles these
 /// requests.
 fn ptrace_get_data<T>(request: Request, pid: Pid) -> Result<T> {
-    let mut data = mem::MaybeUninit::uninit();
+    let mut data = mem::MaybeUninit::<T>::uninit();
     let res = unsafe {
         libc::ptrace(
             request as RequestType,
             libc::pid_t::from(pid),
             ptr::null_mut::<T>(),
-            data.as_mut_ptr() as *const _ as *const c_void,
+            data.as_mut_ptr(),
         )
     };
     Errno::result(res)?;

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -264,7 +264,7 @@ pub fn quotactl_on<P: ?Sized + NixPath>(
 ) -> Result<()> {
     quota_file.with_nix_path(|path| {
         let mut path_copy = path.to_bytes_with_nul().to_owned();
-        let p: *mut c_char = path_copy.as_mut_ptr() as *mut c_char;
+        let p: *mut c_char = path_copy.as_mut_ptr().cast();
         quotactl(
             QuotaCmd(QuotaSubCmd::Q_QUOTAON, which),
             Some(special),
@@ -308,12 +308,12 @@ pub fn quotactl_get<P: ?Sized + NixPath>(
     special: &P,
     id: c_int,
 ) -> Result<Dqblk> {
-    let mut dqblk = mem::MaybeUninit::uninit();
+    let mut dqblk = mem::MaybeUninit::<libc::dqblk>::uninit();
     quotactl(
         QuotaCmd(QuotaSubCmd::Q_GETQUOTA, which),
         Some(special),
         id,
-        dqblk.as_mut_ptr() as *mut c_char,
+        dqblk.as_mut_ptr().cast(),
     )?;
     Ok(unsafe { Dqblk(dqblk.assume_init()) })
 }

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -96,22 +96,24 @@ cfg_if! {
                 headers: Option<&'a [&'a [u8]]>,
                 trailers: Option<&'a [&'a [u8]]>
             ) -> SendfileHeaderTrailer<'a> {
-                let header_iovecs: Option<Vec<IoSlice<'_>>> =
+                let mut header_iovecs: Option<Vec<IoSlice<'_>>> =
                     headers.map(|s| s.iter().map(|b| IoSlice::new(b)).collect());
-                let trailer_iovecs: Option<Vec<IoSlice<'_>>> =
+                let mut trailer_iovecs: Option<Vec<IoSlice<'_>>> =
                     trailers.map(|s| s.iter().map(|b| IoSlice::new(b)).collect());
                 SendfileHeaderTrailer(
                     libc::sf_hdtr {
                         headers: {
                             header_iovecs
-                                .as_ref()
-                                .map_or(ptr::null(), |v| v.as_ptr()) as *mut libc::iovec
+                                .as_mut()
+                                .map_or(ptr::null_mut(), |v| v.as_mut_ptr())
+                                .cast()
                         },
                         hdr_cnt: header_iovecs.as_ref().map(|v| v.len()).unwrap_or(0) as i32,
                         trailers: {
                             trailer_iovecs
-                                .as_ref()
-                                .map_or(ptr::null(), |v| v.as_ptr()) as *mut libc::iovec
+                                .as_mut()
+                                .map_or(ptr::null_mut(), |v| v.as_mut_ptr())
+                                .cast()
                         },
                         trl_cnt: trailer_iovecs.as_ref().map(|v| v.len()).unwrap_or(0) as i32
                     },

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -109,7 +109,7 @@ impl SignalFd {
 
         let size = mem::size_of_val(&buffer);
         let res = Errno::result(unsafe {
-            libc::read(self.0.as_raw_fd(), buffer.as_mut_ptr() as *mut libc::c_void, size)
+            libc::read(self.0.as_raw_fd(), buffer.as_mut_ptr().cast(), size)
         })
         .map(|r| r as usize);
         match res {

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -9,10 +9,10 @@ use crate::sys::time::TimeSpec;
 use crate::sys::time::TimeVal;
 use crate::{errno::Errno, Result};
 use cfg_if::cfg_if;
-use libc::{self, c_int, c_void, size_t, socklen_t};
+use libc::{self, c_int, size_t, socklen_t};
 #[cfg(all(feature = "uio", not(target_os = "redox")))]
 use libc::{
-    iovec, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE,
+    c_void, iovec, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE,
 };
 #[cfg(not(target_os = "redox"))]
 use std::io::{IoSlice, IoSliceMut};
@@ -487,7 +487,7 @@ cfg_if! {
             pub fn groups(&self) -> &[libc::gid_t] {
                 unsafe {
                     std::slice::from_raw_parts(
-                        self.0.cmcred_groups.as_ptr() as *const libc::gid_t,
+                        self.0.cmcred_groups.as_ptr().cast(),
                         self.0.cmcred_ngroups as _
                     )
                 }
@@ -2025,7 +2025,7 @@ fn pack_mhdr_to_send<'a, I, C, S>(
 
     // The message header must be initialized before the individual cmsgs.
     let cmsg_ptr = if capacity > 0 {
-        cmsg_buffer.as_mut_ptr() as *mut c_void
+        cmsg_buffer.as_mut_ptr().cast()
     } else {
         ptr::null_mut()
     };
@@ -2035,11 +2035,11 @@ fn pack_mhdr_to_send<'a, I, C, S>(
         // initialize it.
         let mut mhdr = mem::MaybeUninit::<msghdr>::zeroed();
         let p = mhdr.as_mut_ptr();
-        (*p).msg_name = addr.map(S::as_ptr).unwrap_or(ptr::null()) as *mut _;
+        (*p).msg_name = addr.map(S::as_ptr).unwrap_or(ptr::null()).cast_mut().cast();
         (*p).msg_namelen = addr.map(S::len).unwrap_or(0);
         // transmute iov into a mutable pointer.  sendmsg doesn't really mutate
         // the buffer, but the standard says that it takes a mutable pointer
-        (*p).msg_iov = iov.as_ref().as_ptr() as *mut _;
+        (*p).msg_iov = iov.as_ref().as_ptr().cast_mut().cast();
         (*p).msg_iovlen = iov.as_ref().len() as _;
         (*p).msg_control = cmsg_ptr;
         (*p).msg_controllen = capacity as _;
@@ -2245,7 +2245,7 @@ pub fn recv(sockfd: RawFd, buf: &mut [u8], flags: MsgFlags) -> Result<usize> {
     unsafe {
         let ret = libc::recv(
             sockfd,
-            buf.as_mut_ptr() as *mut c_void,
+            buf.as_mut_ptr().cast(),
             buf.len() as size_t,
             flags.bits(),
         );
@@ -2269,10 +2269,10 @@ pub fn recvfrom<T: SockaddrLike>(
 
         let ret = Errno::result(libc::recvfrom(
             sockfd,
-            buf.as_mut_ptr() as *mut c_void,
+            buf.as_mut_ptr().cast(),
             buf.len() as size_t,
             0,
-            addr.as_mut_ptr() as *mut sockaddr,
+            addr.as_mut_ptr().cast(),
             &mut len as *mut socklen_t,
         ))? as usize;
 
@@ -2298,7 +2298,7 @@ pub fn sendto(
     let ret = unsafe {
         libc::sendto(
             fd,
-            buf.as_ptr() as *const c_void,
+            buf.as_ptr().cast(),
             buf.len() as size_t,
             flags.bits(),
             addr.as_ptr(),
@@ -2316,7 +2316,7 @@ pub fn send(fd: RawFd, buf: &[u8], flags: MsgFlags) -> Result<usize> {
     let ret = unsafe {
         libc::send(
             fd,
-            buf.as_ptr() as *const c_void,
+            buf.as_ptr().cast(),
             buf.len() as size_t,
             flags.bits(),
         )
@@ -2387,7 +2387,7 @@ pub fn getpeername<T: SockaddrLike>(fd: RawFd) -> Result<T> {
         let mut len = T::size();
 
         let ret =
-            libc::getpeername(fd, addr.as_mut_ptr() as *mut sockaddr, &mut len);
+            libc::getpeername(fd, addr.as_mut_ptr().cast(), &mut len);
 
         Errno::result(ret)?;
 
@@ -2404,7 +2404,7 @@ pub fn getsockname<T: SockaddrLike>(fd: RawFd) -> Result<T> {
         let mut len = T::size();
 
         let ret =
-            libc::getsockname(fd, addr.as_mut_ptr() as *mut sockaddr, &mut len);
+            libc::getsockname(fd, addr.as_mut_ptr().cast(), &mut len);
 
         Errno::result(ret)?;
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -487,7 +487,7 @@ cfg_if! {
             pub fn groups(&self) -> &[libc::gid_t] {
                 unsafe {
                     std::slice::from_raw_parts(
-                        self.0.cmcred_groups.as_ptr().cast(),
+                        self.0.cmcred_groups.as_ptr(),
                         self.0.cmcred_ngroups as _
                     )
                 }

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1111,7 +1111,7 @@ where
                 fd.as_fd().as_raw_fd(),
                 libc::SOL_ALG,
                 libc::ALG_SET_KEY,
-                val.as_ref().as_ptr() as *const _,
+                val.as_ref().as_ptr().cast(),
                 val.as_ref().len() as libc::socklen_t,
             );
             Errno::result(res).map(drop)
@@ -1166,7 +1166,7 @@ impl<T> Get<T> for GetStruct<T> {
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        self.val.as_mut_ptr() as *mut c_void
+        self.val.as_mut_ptr().cast()
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -1217,7 +1217,7 @@ impl Get<bool> for GetBool {
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        self.val.as_mut_ptr() as *mut c_void
+        self.val.as_mut_ptr().cast()
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -1270,7 +1270,7 @@ impl Get<u8> for GetU8 {
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        self.val.as_mut_ptr() as *mut c_void
+        self.val.as_mut_ptr().cast()
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -1321,7 +1321,7 @@ impl Get<usize> for GetUsize {
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        self.val.as_mut_ptr() as *mut c_void
+        self.val.as_mut_ptr().cast()
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -1372,7 +1372,7 @@ impl<T: AsMut<[u8]>> Get<OsString> for GetOsString<T> {
     }
 
     fn ffi_ptr(&mut self) -> *mut c_void {
-        self.val.as_mut_ptr() as *mut c_void
+        self.val.as_mut_ptr().cast()
     }
 
     fn ffi_len(&mut self) -> *mut socklen_t {
@@ -1399,7 +1399,7 @@ impl<'a> Set<'a, OsString> for SetOsString<'a> {
     }
 
     fn ffi_ptr(&self) -> *const c_void {
-        self.val.as_bytes().as_ptr() as *const c_void
+        self.val.as_bytes().as_ptr().cast()
     }
 
     fn ffi_len(&self) -> socklen_t {

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -2,7 +2,7 @@
 
 use crate::errno::Errno;
 use crate::Result;
-use libc::{self, c_int, c_void, off_t, size_t};
+use libc::{self, c_int, off_t, size_t};
 use std::io::{IoSlice, IoSliceMut};
 use std::os::unix::io::{AsFd, AsRawFd};
 
@@ -18,7 +18,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, iov: &[IoSlice<'_>]) -> Result<usize> {
     //
     // Because it is ABI compatible, a pointer cast here is valid
     let res = unsafe {
-        libc::writev(fd.as_fd().as_raw_fd(), iov.as_ptr() as *const libc::iovec, iov.len() as c_int)
+        libc::writev(fd.as_fd().as_raw_fd(), iov.as_ptr().cast(), iov.len() as c_int)
     };
 
     Errno::result(res).map(|r| r as usize)
@@ -33,7 +33,7 @@ pub fn writev<Fd: AsFd>(fd: Fd, iov: &[IoSlice<'_>]) -> Result<usize> {
 pub fn readv<Fd: AsFd>(fd: Fd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
     // SAFETY: same as in writev(), IoSliceMut is ABI-compatible with iovec
     let res = unsafe {
-        libc::readv(fd.as_fd().as_raw_fd(), iov.as_ptr() as *const libc::iovec, iov.len() as c_int)
+        libc::readv(fd.as_fd().as_raw_fd(), iov.as_ptr().cast(), iov.len() as c_int)
     };
 
     Errno::result(res).map(|r| r as usize)
@@ -55,7 +55,7 @@ pub fn pwritev<Fd: AsFd>(fd: Fd, iov: &[IoSlice<'_>], offset: off_t) -> Result<u
     let res = unsafe {
         libc::pwritev(
             fd.as_fd().as_raw_fd(),
-            iov.as_ptr() as *const libc::iovec,
+            iov.as_ptr().cast(),
             iov.len() as c_int,
             offset,
         )
@@ -88,7 +88,7 @@ pub fn preadv<Fd: AsFd>(
     let res = unsafe {
         libc::preadv(
             fd.as_fd().as_raw_fd(),
-            iov.as_ptr() as *const libc::iovec,
+            iov.as_ptr().cast(),
             iov.len() as c_int,
             offset,
         )
@@ -105,7 +105,7 @@ pub fn pwrite<Fd: AsFd>(fd: Fd, buf: &[u8], offset: off_t) -> Result<usize> {
     let res = unsafe {
         libc::pwrite(
             fd.as_fd().as_raw_fd(),
-            buf.as_ptr() as *const c_void,
+            buf.as_ptr().cast(),
             buf.len() as size_t,
             offset,
         )
@@ -122,7 +122,7 @@ pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: off_t) -> Result<usize> {
     let res = unsafe {
         libc::pread(
             fd.as_fd().as_raw_fd(),
-            buf.as_mut_ptr() as *mut c_void,
+            buf.as_mut_ptr().cast(),
             buf.len() as size_t,
             offset,
         )
@@ -181,8 +181,8 @@ pub fn process_vm_writev(
 {
     let res = unsafe {
         libc::process_vm_writev(pid.into(),
-                                local_iov.as_ptr() as *const libc::iovec, local_iov.len() as libc::c_ulong,
-                                remote_iov.as_ptr() as *const libc::iovec, remote_iov.len() as libc::c_ulong, 0)
+                                local_iov.as_ptr().cast(), local_iov.len() as libc::c_ulong,
+                                remote_iov.as_ptr().cast(), remote_iov.len() as libc::c_ulong, 0)
     };
 
     Errno::result(res).map(|r| r as usize)
@@ -216,8 +216,8 @@ pub fn process_vm_readv(
 {
     let res = unsafe {
         libc::process_vm_readv(pid.into(),
-                               local_iov.as_ptr() as *const libc::iovec, local_iov.len() as libc::c_ulong,
-                               remote_iov.as_ptr() as *const libc::iovec, remote_iov.len() as libc::c_ulong, 0)
+                               local_iov.as_ptr().cast(), local_iov.len() as libc::c_ulong,
+                               remote_iov.as_ptr().cast(), remote_iov.len() as libc::c_ulong, 0)
     };
 
     Errno::result(res).map(|r| r as usize)

--- a/test/sys/test_mman.rs
+++ b/test/sys/test_mman.rs
@@ -22,7 +22,7 @@ fn test_mmap_anonymous() {
 #[test]
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 fn test_mremap_grow() {
-    use nix::libc::{c_void, size_t};
+    use nix::libc::size_t;
     use nix::sys::mman::{mremap, MRemapFlags};
 
     const ONE_K: size_t = 1024;
@@ -47,7 +47,7 @@ fn test_mremap_grow() {
     let slice: &mut [u8] = unsafe {
         #[cfg(target_os = "linux")]
         let mem = mremap(
-            slice.as_mut_ptr() as *mut c_void,
+            slice.as_mut_ptr().cast(),
             ONE_K,
             10 * ONE_K,
             MRemapFlags::MREMAP_MAYMOVE,
@@ -56,7 +56,7 @@ fn test_mremap_grow() {
         .unwrap();
         #[cfg(target_os = "netbsd")]
         let mem = mremap(
-            slice.as_mut_ptr() as *mut c_void,
+            slice.as_mut_ptr().cast(),
             ONE_K,
             10 * ONE_K,
             MRemapFlags::MAP_REMAPDUP,
@@ -80,7 +80,7 @@ fn test_mremap_grow() {
 // Segfaults for unknown reasons under QEMU for 32-bit targets
 #[cfg_attr(all(target_pointer_width = "32", qemu), ignore)]
 fn test_mremap_shrink() {
-    use nix::libc::{c_void, size_t};
+    use nix::libc::size_t;
     use nix::sys::mman::{mremap, MRemapFlags};
     use std::num::NonZeroUsize;
 
@@ -104,7 +104,7 @@ fn test_mremap_shrink() {
 
     let slice: &mut [u8] = unsafe {
         let mem = mremap(
-            slice.as_mut_ptr() as *mut c_void,
+            slice.as_mut_ptr().cast(),
             ten_one_k.into(),
             ONE_K,
             MRemapFlags::empty(),
@@ -113,7 +113,7 @@ fn test_mremap_shrink() {
         .unwrap();
         // Since we didn't supply MREMAP_MAYMOVE, the address should be the
         // same.
-        assert_eq!(mem, slice.as_mut_ptr() as *mut c_void);
+        assert_eq!(mem, slice.as_mut_ptr().cast());
         std::slice::from_raw_parts_mut(mem as *mut u8, ONE_K)
     };
 

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -78,9 +78,8 @@ pub fn test_path_to_sock_addr() {
     let actual = Path::new(path);
     let addr = UnixAddr::new(actual).unwrap();
 
-    let expect: &[c_char] = unsafe {
-        slice::from_raw_parts(path.as_ptr() as *const c_char, path.len())
-    };
+    let expect: &[c_char] =
+        unsafe { slice::from_raw_parts(path.as_ptr().cast(), path.len()) };
     assert_eq!(unsafe { &(*addr.as_ptr()).sun_path[..8] }, expect);
 
     assert_eq!(addr.path(), Some(actual));


### PR DESCRIPTION
Prefer ptr::{cast, cast_const, cast_mut} over `as`.  The latter makes it too easy to accidentally change both the type and mutability when changing only one was intended.

This exercise caught an unintended mutability cast in one function, the BSD version of sendfile.  In this case there's no UB because it isn't possible for anything else to get a reference to the data that was incorrectly cast.

There was also a type cast that wasn't guaranteed to be correct (but probably was) due to memory layout guarantees in if_nametoindex.