### PR TITLE
Fix SignalFd::set_mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed the function signature of `recvmmsg`, potentially causing UB
   ([#2119](https://github.com/nix-rust/nix/issues/2119))
 
+- Fix `SignalFd::set_mask`.  In 0.27.0 it would actually close the file
+  descriptor.
+  ([#2141](https://github.com/nix-rust/nix/pull/2141))
+
 ### Changed
 
 - The following APIs now take an implementation of `AsFd` rather than a

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -25,3 +25,32 @@ fn test_signalfd() {
     let signo = Signal::try_from(res.ssi_signo as i32).unwrap();
     assert_eq!(signo, signal::SIGUSR1);
 }
+
+/// Update the signal mask of an already existing signalfd.
+#[test]
+fn test_signalfd_setmask() {
+    use nix::sys::signal::{self, raise, SigSet, Signal};
+    use nix::sys::signalfd::SignalFd;
+
+    // Grab the mutex for altering signals so we don't interfere with other tests.
+    let _m = crate::SIGNAL_MTX.lock();
+
+    // Block the SIGUSR1 signal from automatic processing for this thread
+    let mut mask = SigSet::empty();
+
+    let mut fd = SignalFd::new(&mask).unwrap();
+
+    mask.add(signal::SIGUSR1);
+    mask.thread_block().unwrap();
+    fd.set_mask(&mask).unwrap();
+
+    // Send a SIGUSR1 signal to the current process. Note that this uses `raise` instead of `kill`
+    // because `kill` with `getpid` isn't correct during multi-threaded execution like during a
+    // cargo test session. Instead use `raise` which does the correct thing by default.
+    raise(signal::SIGUSR1).expect("Error: raise(SIGUSR1) failed");
+
+    // And now catch that same signal.
+    let res = fd.read_signal().unwrap().unwrap();
+    let signo = Signal::try_from(res.ssi_signo as i32).unwrap();
+    assert_eq!(signo, signal::SIGUSR1);
+}


### PR DESCRIPTION
In 0.27.0 it inadvertently closed the file descriptor, leaving the SignalFd object accessing a stale file descriptor.

Fixes #2116