### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## What does this PR do
+
+## Checklist:
+
+- [ ] I have read `CONTRIBUTING.md`
+- [ ] I have written necessary tests and rustdoc comments
+- [ ] A change log has been added if this PR modifies nix's API


### PR DESCRIPTION
This PR adds a PR template to nix.

One obvious benefit is that, with this, we no longer need to manually remind our contributors to add their change log