### PR TITLE
Add `unistd::close_range()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   MacOS, FreeBSD, DragonflyBSD, Android, iOS and Haiku.
   ([#2074](https://github.com/nix-rust/nix/pull/2074))
 
+- Added `close_range(2)` on Linux
+
 ## [0.27.1] - 2023-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   ([#2074](https://github.com/nix-rust/nix/pull/2074))
 
 - Added `close_range(2)` on Linux
+  ([#2153](https://github.com/nix-rust/nix/pull/2153))
 
 ## [0.27.1] - 2023-08-28
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1124,7 +1124,7 @@ libc_bitflags! {
 /// use nix::unistd::{close_range, CloseRangeFlags};
 ///
 /// let f = tempfile::tempfile().unwrap();
-/// close_range(f.as_raw_fd(), f.as_raw_fd(), CloseRangeFlags::empty()).unwrap();   // Bad!  f will also close on drop!
+/// unsafe { close_range(f.as_raw_fd(), f.as_raw_fd(), CloseRangeFlags::empty()).unwrap() };   // Bad!  f will also close on drop!
 /// ```
 ///
 /// ```rust
@@ -1133,10 +1133,10 @@ libc_bitflags! {
 ///
 /// let f = tempfile::tempfile().unwrap();
 /// let fd = f.into_raw_fd(); // Good.  into_raw_fd consumes f
-/// close_range(fd, fd, CloseRangeFlags::empty()).unwrap();
+/// unsafe { close_range(fd, fd, CloseRangeFlags::empty()).unwrap(); }
 /// ```
 #[cfg(target_os = "linux")]
-pub fn close_range(
+pub unsafe fn close_range(
     first: RawFd,
     last: RawFd,
     flags: CloseRangeFlags,

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1098,6 +1098,36 @@ pub fn close(fd: RawFd) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+#[cfg(target_os = "linux")]
+libc_bitflags! {
+    /// Options for close_range()
+    pub struct CloseRangeFlags : c_uint {
+        /// Unshare file descriptors before closing them.
+        CLOSE_RANGE_UNSHARE;
+        /// Set close-on-exec instead of closing file descriptors.
+        CLOSE_RANGE_CLOEXEC;
+    }
+}
+
+/// Close a range of raw file descriptors.
+/// [close_range(2)](https://man7.org/linux/man-pages/man2/close_range.2.html).
+#[cfg(target_os = "linux")]
+pub fn close_range(
+    first: RawFd,
+    last: RawFd,
+    flags: CloseRangeFlags,
+) -> Result<()> {
+    let res = unsafe {
+        libc::syscall(
+            libc::SYS_close_range,
+            first as libc::c_uint,
+            last as libc::c_uint,
+            flags.bits(),
+        )
+    };
+    Errno::result(res).map(drop)
+}
+
 /// Read from a raw file descriptor.
 ///
 /// See also [read(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html)

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1112,6 +1112,8 @@ libc_bitflags! {
 /// Close a range of raw file descriptors.
 /// [close_range(2)](https://man7.org/linux/man-pages/man2/close_range.2.html).
 ///
+/// # Safety
+///
 /// Be aware that many Rust types implicitly close-on-drop, including
 /// `std::fs::File`.  Explicitly closing them with this method too can result in
 /// a double-close condition, which can cause confusing `EBADF` errors in


### PR DESCRIPTION
## What does this PR do

This adds `close_range(2)` on Linux which allows efficiently closing (or marking "close on exec") many file descriptors at once without needing procfs.

I have added comments, but am unsure if new tests are warranted.  I have manually tested and used test programs and `strace` to validate that it is working as intended (both with and without various CLOSE_RANGE_* flag permutations.

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
