### PR TITLE
refactor: change `dirfd` arg of `xxxat()` to `Option<fd>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,68 +2,6 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 # Change Log
-## [Unreleased] - ReleaseDate
-
-### Fixed
-- Fix `SigSet` incorrect implementation of `Eq`, `PartialEq` and `Hash`
-  ([#1946](https://github.com/nix-rust/nix/pull/1946))
-
-- Fixed the function signature of `recvmmsg`, potentially causing UB
-  ([#2119](https://github.com/nix-rust/nix/issues/2119))
-
-- Fix `SignalFd::set_mask`.  In 0.27.0 it would actually close the file
-  descriptor.
-  ([#2141](https://github.com/nix-rust/nix/pull/2141))
-
-### Changed
-
-- The MSRV is now 1.69
-  ([#2144](https://github.com/nix-rust/nix/pull/2144))
-
-- The following APIs now take an implementation of `AsFd` rather than a
-  `RawFd`:
-
-  - `unistd::tcgetpgrp`
-  - `unistd::tcsetpgrp`
-  - `unistd::fpathconf`
-  - `unistd::ttyname`
-  - `unistd::getpeereid`
-
-  ([#2137](https://github.com/nix-rust/nix/pull/2137))
-  
-- Changed `openat()` and `Dir::openat()`, now take optional `dirfd`s
-  ([#2139](https://github.com/nix-rust/nix/pull/2139))
-
-- `PollFd::new` now takes a `BorrowedFd` argument, with relaxed lifetime
-  requirements relative to the previous version.
-  ([#2134](https://github.com/nix-rust/nix/pull/2134))
-
-- `FdSet::{insert, remove, contains}` now take `BorrowedFd` arguments, and have
-  relaxed lifetime requirements relative to 0.27.1.
-  ([#2136](https://github.com/nix-rust/nix/pull/2136))
-
-- Simplified the function signatures of `recvmmsg` and `sendmmsg`
-
-- The following APIs now take optional `dirfd`s:
-
-  - `readlinkat()`
-  - `fstatat()`
-  - `mknodat()`
-  - `mkdirat()`
-  - `execveat()`
-
-  ([#2157](https://github.com/nix-rust/nix/pull/2157))
-
-### Added
-- Added `Icmp` and `IcmpV6` to `SockProtocol`.
-  (#[2103](https://github.com/nix-rust/nix/pull/2103))
-
-- Added `F_GETPATH` FcntlFlags entry on Apple/NetBSD/DragonflyBSD for `::nix::fcntl`.
-  ([#2142](https://github.com/nix-rust/nix/pull/2142))
-  
-- Added `Ipv6HopLimit` to `::nix::sys::socket::ControlMessage` for Linux,
-  MacOS, FreeBSD, DragonflyBSD, Android, iOS and Haiku.
-  ([#2074](https://github.com/nix-rust/nix/pull/2074))
 
 ## [0.27.1] - 2023-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 # Change Log
+## [Unreleased] - ReleaseDate
+
+### Fixed
+- Fix `SigSet` incorrect implementation of `Eq`, `PartialEq` and `Hash`
+  ([#1946](https://github.com/nix-rust/nix/pull/1946))
+
+- Fixed the function signature of `recvmmsg`, potentially causing UB
+  ([#2119](https://github.com/nix-rust/nix/issues/2119))
+
+- Fix `SignalFd::set_mask`.  In 0.27.0 it would actually close the file
+  descriptor.
+  ([#2141](https://github.com/nix-rust/nix/pull/2141))
+
+### Changed
+
+- The MSRV is now 1.69
+  ([#2144](https://github.com/nix-rust/nix/pull/2144))
+
+- The following APIs now take an implementation of `AsFd` rather than a
+  `RawFd`:
+
+  - `unistd::tcgetpgrp`
+  - `unistd::tcsetpgrp`
+  - `unistd::fpathconf`
+  - `unistd::ttyname`
+  - `unistd::getpeereid`
+
+  ([#2137](https://github.com/nix-rust/nix/pull/2137))
+  
+- Changed `openat()` and `Dir::openat()`, now take optional `dirfd`s
+  ([#2139](https://github.com/nix-rust/nix/pull/2139))
+
+- `PollFd::new` now takes a `BorrowedFd` argument, with relaxed lifetime
+  requirements relative to the previous version.
+  ([#2134](https://github.com/nix-rust/nix/pull/2134))
+
+- `FdSet::{insert, remove, contains}` now take `BorrowedFd` arguments, and have
+  relaxed lifetime requirements relative to 0.27.1.
+  ([#2136](https://github.com/nix-rust/nix/pull/2136))
+
+- Simplified the function signatures of `recvmmsg` and `sendmmsg`
+
+- The following APIs now take optional `dirfd`s:
+
+  - `readlinkat()`
+  - `fstatat()`
+  - `mknodat()`
+  - `mkdirat()`
+  - `execveat()`
+
+  ([#2157](https://github.com/nix-rust/nix/pull/2157))
+
+### Added
+- Added `Icmp` and `IcmpV6` to `SockProtocol`.
+  (#[2103](https://github.com/nix-rust/nix/pull/2103))
+
+- Added `F_GETPATH` FcntlFlags entry on Apple/NetBSD/DragonflyBSD for `::nix::fcntl`.
+  ([#2142](https://github.com/nix-rust/nix/pull/2142))
+  
+- Added `Ipv6HopLimit` to `::nix::sys::socket::ControlMessage` for Linux,
+  MacOS, FreeBSD, DragonflyBSD, Android, iOS and Haiku.
+  ([#2074](https://github.com/nix-rust/nix/pull/2074))
 
 ## [0.27.1] - 2023-08-28
 

--- a/changelog/2157.changed.md
+++ b/changelog/2157.changed.md
@@ -1,0 +1,7 @@
+The following APIs now take optional `dirfd`s:
+
+- `readlinkat()`
+- `fstatat()`
+- `mknodat()`
+- `mkdirat()`
+- `execveat()`

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -366,7 +366,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
                     AtFlags::empty()
                 };
                 super::sys::stat::fstatat(
-                    dirfd,
+                    Some(dirfd),
                     path,
                     flags | AtFlags::AT_SYMLINK_NOFOLLOW,
                 )
@@ -424,9 +424,10 @@ pub fn readlink<P: ?Sized + NixPath>(path: &P) -> Result<OsString> {
 
 #[cfg(not(target_os = "redox"))]
 pub fn readlinkat<P: ?Sized + NixPath>(
-    dirfd: RawFd,
+    dirfd: Option<RawFd>,
     path: &P,
 ) -> Result<OsString> {
+    let dirfd = at_rawfd(dirfd);
     inner_readlink(Some(dirfd), path)
 }
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -223,10 +223,7 @@ libc_bitflags!(
     all(feature = "process", any(target_os = "android", target_os = "linux"))
 ))]
 pub(crate) fn at_rawfd(fd: Option<RawFd>) -> raw::c_int {
-    match fd {
-        None => libc::AT_FDCWD,
-        Some(fd) => fd,
-    }
+    fd.unwrap_or(libc::AT_FDCWD)
 }
 
 feature! {

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -218,8 +218,10 @@ libc_bitflags!(
 );
 
 /// Computes the raw fd consumed by a function of the form `*at`.
-#[cfg(any(feature = "process", feature = "fs"))]
-#[cfg(not(target_os = "redox"))]
+#[cfg(any(
+    all(feature = "fs", not(target_os = "redox")),
+    all(feature = "process", any(target_os = "android", target_os = "linux"))
+))]
 pub(crate) fn at_rawfd(fd: Option<RawFd>) -> raw::c_int {
     match fd {
         None => libc::AT_FDCWD,

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -192,12 +192,13 @@ pub fn mknod<P: ?Sized + NixPath>(
 )))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mknodat<P: ?Sized + NixPath>(
-    dirfd: RawFd,
+    dirfd: Option<RawFd>,
     path: &P,
     kind: SFlag,
     perm: Mode,
     dev: dev_t,
 ) -> Result<()> {
+    let dirfd = at_rawfd(dirfd);
     let res = path.with_nix_path(|cstr| unsafe {
         libc::mknodat(
             dirfd,
@@ -270,10 +271,11 @@ pub fn fstat(fd: RawFd) -> Result<FileStat> {
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn fstatat<P: ?Sized + NixPath>(
-    dirfd: RawFd,
+    dirfd: Option<RawFd>,
     pathname: &P,
     f: AtFlags,
 ) -> Result<FileStat> {
+    let dirfd = at_rawfd(dirfd);
     let mut dst = mem::MaybeUninit::uninit();
     let res = pathname.with_nix_path(|cstr| unsafe {
         libc::fstatat(
@@ -468,10 +470,11 @@ pub fn utimensat<P: ?Sized + NixPath>(
 #[cfg(not(target_os = "redox"))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mkdirat<P: ?Sized + NixPath>(
-    fd: RawFd,
+    fd: Option<RawFd>,
     path: &P,
     mode: Mode,
 ) -> Result<()> {
+    let fd = at_rawfd(fd);
     let res = path.with_nix_path(|cstr| unsafe {
         libc::mkdirat(fd, cstr.as_ptr(), mode.bits() as mode_t)
     })?;

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2,7 +2,7 @@
 
 use crate::errno::{self, Errno};
 #[cfg(not(target_os = "redox"))]
-#[cfg(feature = "fs")]
+#[cfg(any(feature = "fs", feature = "process"))]
 use crate::fcntl::{at_rawfd, AtFlags};
 #[cfg(feature = "fs")]
 use crate::fcntl::{fcntl, FcntlArg::F_SETFD, FdFlag, OFlag};

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -939,12 +939,13 @@ pub fn fexecve<SA: AsRef<CStr>, SE: AsRef<CStr>>(
 #[cfg(any(target_os = "android", target_os = "linux"))]
 #[inline]
 pub fn execveat<SA: AsRef<CStr>, SE: AsRef<CStr>>(
-    dirfd: RawFd,
+    dirfd: Option<RawFd>,
     pathname: &CStr,
     args: &[SA],
     env: &[SE],
     flags: super::fcntl::AtFlags,
 ) -> Result<Infallible> {
+    let dirfd = at_rawfd(dirfd);
     let args_p = to_exec_array(args);
     let env_p = to_exec_array(env);
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,9 +1,16 @@
 //! Safe wrappers around functions found in libc "unistd.h" header
 
 use crate::errno::{self, Errno};
+
+#[cfg(any(
+    all(feature = "fs", not(target_os = "redox")),
+    all(feature = "process", any(target_os = "android", target_os = "linux"))
+))]
+use crate::fcntl::at_rawfd;
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(feature = "fs", feature = "process"))]
-use crate::fcntl::{at_rawfd, AtFlags};
+#[cfg(feature = "fs")]
+use crate::fcntl::AtFlags;
+
 #[cfg(feature = "fs")]
 use crate::fcntl::{fcntl, FcntlArg::F_SETFD, FdFlag, OFlag};
 #[cfg(all(

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -222,7 +222,7 @@ fn test_readlink() {
 
     assert_eq!(readlink(&dst).unwrap().to_str().unwrap(), expected_dir);
     assert_eq!(
-        readlinkat(dirfd, "b").unwrap().to_str().unwrap(),
+        readlinkat(Some(dirfd), "b").unwrap().to_str().unwrap(),
         expected_dir
     );
 }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -117,7 +117,7 @@ fn test_fstatat() {
         fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty());
 
     let result =
-        stat::fstatat(dirfd.unwrap(), &filename, fcntl::AtFlags::empty());
+        stat::fstatat(Some(dirfd.unwrap()), &filename, fcntl::AtFlags::empty());
     assert_stat_results(result);
 }
 
@@ -323,7 +323,7 @@ fn test_mkdirat_success_path() {
     let dirfd =
         fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
             .unwrap();
-    mkdirat(dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(Some(dirfd), filename, Mode::S_IRWXU).expect("mkdirat failed");
     assert!(Path::exists(&tempdir.path().join(filename)));
 }
 
@@ -337,7 +337,7 @@ fn test_mkdirat_success_mode() {
     let dirfd =
         fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
             .unwrap();
-    mkdirat(dirfd, filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(Some(dirfd), filename, Mode::S_IRWXU).expect("mkdirat failed");
     let permissions = fs::metadata(tempdir.path().join(filename))
         .unwrap()
         .permissions();
@@ -357,7 +357,7 @@ fn test_mkdirat_fail() {
         stat::Mode::empty(),
     )
     .unwrap();
-    let result = mkdirat(dirfd, filename, Mode::S_IRWXU).unwrap_err();
+    let result = mkdirat(Some(dirfd), filename, Mode::S_IRWXU).unwrap_err();
     assert_eq!(result, Errno::ENOTDIR);
 }
 
@@ -402,7 +402,7 @@ fn test_mknodat() {
     let target_dir =
         Dir::open(tempdir.path(), OFlag::O_DIRECTORY, Mode::S_IRWXU).unwrap();
     mknodat(
-        target_dir.as_raw_fd(),
+        Some(target_dir.as_raw_fd()),
         file_name,
         SFlag::S_IFREG,
         Mode::S_IRWXU,
@@ -410,7 +410,7 @@ fn test_mknodat() {
     )
     .unwrap();
     let mode = fstatat(
-        target_dir.as_raw_fd(),
+        Some(target_dir.as_raw_fd()),
         file_name,
         AtFlags::AT_SYMLINK_NOFOLLOW,
     )

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -430,13 +430,13 @@ cfg_if! {
     if #[cfg(target_os = "android")] {
         use nix::fcntl::AtFlags;
         execve_test_factory!(test_execveat_empty, execveat,
-                             File::open("/system/bin/sh").unwrap().into_raw_fd(),
+                             Some(File::open("/system/bin/sh").unwrap().into_raw_fd()),
                              "", AtFlags::AT_EMPTY_PATH);
         execve_test_factory!(test_execveat_relative, execveat,
-                             File::open("/system/bin/").unwrap().into_raw_fd(),
+                             Some(File::open("/system/bin/").unwrap().into_raw_fd()),
                              "./sh", AtFlags::empty());
         execve_test_factory!(test_execveat_absolute, execveat,
-                             File::open("/").unwrap().into_raw_fd(),
+                             Some(File::open("/").unwrap().into_raw_fd()),
                              "/system/bin/sh", AtFlags::empty());
     } else if #[cfg(all(target_os = "linux", any(target_arch ="x86_64", target_arch ="x86")))] {
         use nix::fcntl::AtFlags;

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -163,7 +163,8 @@ fn test_mkfifoat() {
     mkfifoat(Some(dirfd), mkfifoat_name, Mode::S_IRUSR).unwrap();
 
     let stats =
-        stat::fstatat(dirfd, mkfifoat_name, fcntl::AtFlags::empty()).unwrap();
+        stat::fstatat(Some(dirfd), mkfifoat_name, fcntl::AtFlags::empty())
+            .unwrap();
     let typ = stat::SFlag::from_bits_truncate(stats.st_mode);
     assert_eq!(typ, SFlag::S_IFIFO);
 }
@@ -197,7 +198,7 @@ fn test_mkfifoat_directory() {
     let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let mkfifoat_dir = "mkfifoat_dir";
-    stat::mkdirat(dirfd, mkfifoat_dir, Mode::S_IRUSR).unwrap();
+    stat::mkdirat(Some(dirfd), mkfifoat_dir, Mode::S_IRUSR).unwrap();
 
     mkfifoat(Some(dirfd), mkfifoat_dir, Mode::S_IRUSR)
         .expect_err("assertion failed");
@@ -439,11 +440,11 @@ cfg_if! {
                              "/system/bin/sh", AtFlags::empty());
     } else if #[cfg(all(target_os = "linux", any(target_arch ="x86_64", target_arch ="x86")))] {
         use nix::fcntl::AtFlags;
-        execve_test_factory!(test_execveat_empty, execveat, File::open("/bin/sh").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_empty, execveat, Some(File::open("/bin/sh").unwrap().into_raw_fd()),
                              "", AtFlags::AT_EMPTY_PATH);
-        execve_test_factory!(test_execveat_relative, execveat, File::open("/bin/").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_relative, execveat, Some(File::open("/bin/").unwrap().into_raw_fd()),
                              "./sh", AtFlags::empty());
-        execve_test_factory!(test_execveat_absolute, execveat, File::open("/").unwrap().into_raw_fd(),
+        execve_test_factory!(test_execveat_absolute, execveat, Some(File::open("/").unwrap().into_raw_fd()),
                              "/bin/sh", AtFlags::empty());
     }
 }


### PR DESCRIPTION
## What does this PR do

The following APIs now take optional `dirfd`s:

  - `readlinkat()`
  - `fstatat()`
  - `mknodat()`
  - `mkdirat()`
  - `execveat()`


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

