### PR TITLE
Revert signature simplification for `sendmmsg` and `recvmmsg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   relaxed lifetime requirements relative to 0.27.1.
   ([#2136](https://github.com/nix-rust/nix/pull/2136))
 
-- Simplified the function signatures of `recvmmsg` and `sendmmsg`
-
 ## [0.27.1] - 2023-08-28
 
 ### Fixed

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1606,9 +1606,9 @@ pub fn sendmmsg<'a, XS, AS, C, I, S>(
     flags: MsgFlags
 ) -> crate::Result<MultiResults<'a, S>>
     where
-        XS: IntoIterator<Item = I>,
+        XS: IntoIterator<Item = &'a I>,
         AS: AsRef<[Option<S>]>,
-        I: AsRef<[IoSlice<'a>]>,
+        I: AsRef<[IoSlice<'a>]> + 'a,
         C: AsRef<[ControlMessage<'a>]>,
         S: SockaddrLike,
 {
@@ -1772,11 +1772,11 @@ pub fn recvmmsg<'a, XS, S, I>(
     mut timeout: Option<crate::sys::time::TimeSpec>,
 ) -> crate::Result<MultiResults<'a, S>>
 where
-    XS: IntoIterator<Item = I>,
-    I: AsMut<[IoSliceMut<'a>]>,
+    XS: IntoIterator<Item = &'a mut I>,
+    I: AsMut<[IoSliceMut<'a>]> + 'a,
 {
     let mut count = 0;
-    for (i, (mut slice, mmsghdr)) in slices.into_iter().zip(data.items.iter_mut()).enumerate() {
+    for (i, (slice, mmsghdr)) in slices.into_iter().zip(data.items.iter_mut()).enumerate() {
         let p = &mut mmsghdr.msg_hdr;
         p.msg_iov = slice.as_mut().as_mut_ptr().cast();
         p.msg_iovlen = slice.as_mut().len() as _;


### PR DESCRIPTION
Changes the Iterator Item of `XS` of `recvmmsg` back to `Item = &'a mut AsMut<I>` and of  `sendmmsg` back to `Item = &'a AsRef<I>`.

This partially reverts #2120. Short explanation using `recvmmsg`:

```rust
pub fn recvmmsg<'a, XS, S, I>(
    // elided...
    slices: XS,
) -> crate::Result<MultiResults<'a, S>>
where
    XS: IntoIterator<Item = I>,
    I: AsMut<[IoSliceMut<'a>]>,
{
    for (i, (slice, mmsghdr)) in slices.into_iter().zip(data.items.iter_mut()).enumerate() {
        let p = &mut mmsghdr.msg_hdr;
        p.msg_iov = slice.as_mut().as_mut_ptr().cast();
        p.msg_iovlen = slice.as_mut().len() as _;
        
        // `slice` gets dropped here! If `slice` was not a pointer, `p.msg_iov` could be dangling now!
    }

    // elided ...
}
```