### PR TITLE
chore: move cargo fmt to pre-commit script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -151,7 +151,6 @@ task:
         - FreeBSD 14 amd64 & i686
         - Linux x86_64
         - macOS aarch64
-        - Rust Formatter
         - OpenBSD x86_64
         - Minver
         - Rust Stable
@@ -171,7 +170,6 @@ task:
         - FreeBSD 14 amd64 & i686
         - Linux x86_64
         - macOS aarch64
-        - Rust Formatter
         - OpenBSD x86_64
         - Minver
         - Rust Stable
@@ -204,7 +202,6 @@ task:
     - FreeBSD 14 amd64 & i686
     - Linux x86_64
     - macOS aarch64
-    - Rust Formatter
     - OpenBSD x86_64
     - Minver
     - Rust Stable
@@ -274,7 +271,6 @@ task:
     - FreeBSD 14 amd64 & i686
     - Linux x86_64
     - macOS aarch64
-    - Rust Formatter
     - OpenBSD x86_64
     - Minver
     - Rust Stable
@@ -307,7 +303,6 @@ task:
         - FreeBSD 14 amd64 & i686
         - Linux x86_64
         - macOS aarch64
-        - Rust Formatter
         - OpenBSD x86_64
         - Minver
         - Rust Stable
@@ -321,7 +316,6 @@ task:
         - FreeBSD 14 amd64 & i686
         - Linux x86_64
         - macOS aarch64
-        - Rust Formatter
         - OpenBSD x86_64
         - Minver
         - Rust Stable
@@ -332,7 +326,6 @@ task:
         - FreeBSD 14 amd64 & i686
         - Linux x86_64
         - macOS aarch64
-        - Rust Formatter
         - OpenBSD x86_64
         - Minver
         - Rust Stable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,7 +87,6 @@ task:
     - FreeBSD 14 amd64 & i686
     - Linux x86_64
     - macOS aarch64
-    - Rust Formatter
     - OpenBSD x86_64
     - Minver
     - Rust Stable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -359,12 +359,3 @@ task:
   check_script:
     - cargo check
   before_cache_script: rm -rf $CARGO_HOME/registry/index
-
-# Tasks that checks if the code is formatted right using `cargo fmt` tool
-task:
-  name: Rust Formatter
-  container:
-    image: rust:latest
-    cpu: 1
-  setup_script: rustup component add rustfmt
-  test_script: cargo fmt --all -- --check **/*.rs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,50 @@ pull' model described there.
 
 Please make pull requests against the `master` branch.
 
+## Check your code format
+
+We use [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
+to automate code formatting. However, you need to manually link our script to the correct 
+location first, assume you are in the root of the nix project:
+
+```sh
+ln -s  ../../pre-commit.sh .git/hooks/pre-commit
+```
+
+Let's add some a commit:
+
+```shell
+$ git add {CHANGES}
+$ git commit -m "Some commit message"
+```
+
+If your code is not formatted, then you will see a message like this:
+
+```shell
+INFO: Checking code format...
+WARN: Unformatted code detected
+INFO: Formatting...
+FAIL: git commit ABORTED, please have a look and run git add/commit again
+```
+
+Our `pre-commit` script will find code that is not formatted and format it for
+you, your commit operation will be aborted, add the changes and commit again:
+
+```shell
+$ git add {CHANGES_MADE_BY_THE_FORMATTER}
+$ git commit -m "Some commit message"
+INFO: Checking code format...
+INFO: Check passed
+```
+Since the code has been formatted by the formatter, the check will pass and you
+are good to go!
+
+## CHANGELOG
+
 If you change the API by way of adding, removing or changing something or if
 you fix a bug, please add an appropriate note, every note should be a new markdown 
 file under the [changelog directory][cl] stating the change made by your pull request, 
-the filename should be in the following foramt:
+the filename should be in the following format:
 
 ```
 <PULL_REQUEST_ID>.<TYPE>.md
@@ -108,6 +148,19 @@ describe the reason it shouldn't run under CI, and a link to an issue if
 possible!  Other tests cannot be run under QEMU, which is used for some
 architectures.  To skip them, add a `#[cfg_attr(qemu, ignore)]` attribute to
 the test.
+
+### Skip the CI
+
+It is highly recommended to skip the CI if your PR doesn't change nix's code 
+as this will save our CI usage.
+
+To do this, add:
+
+```
+[skip ci]
+```
+to your PR description, just like [#2158](https://github.com/nix-rust/nix/pull/2158) 
+does.
 
 ## GitHub Merge Queues
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+function red() {
+	echo "\033[0;31m$@\033[0m"
+}
+
+function green() {
+	echo "\033[0;32m$@\033[0m"
+}
+
+function byellow() {
+	echo "\033[1;33m$@\033[0m"
+}
+
+CHANGED_BY_CARGO_FMT=false
+
+
+echo -e "$(green INFO): Checking code format..."
+
+cargo fmt --all -q -- --check 2>/dev/null
+if [ $? -ne 0 ]; then
+    echo -e "$(byellow WARN): Unformatted code detected"
+    echo -e "$(green INFO): Formatting..."
+    cargo fmt --all
+    CHANGED_BY_CARGO_FMT=true
+fi
+
+if ${CHANGED_BY_CARGO_FMT}; 
+then
+	echo -e "$(red FAIL): git commit $(red ABORTED), please have a look and run git add/commit again"
+	exit 1
+else
+    echo -e "$(green INFO): Check passed"
+fi
+
+exit 0


### PR DESCRIPTION
## What does this PR do
1. Move `cargo fmt` task to a pre-commit script, and add a doc for it in `CONTRIBUTING.md`
2. Add a doc on how to skip the CI (Cirrus CI, will add the GitHub Action version when we finish our migration) in `CONTRIBUTING.md`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API

[skip ci]
