### PR TITLE
Add `SetSockOpt` definitions related to Linux Kernel TLS.

### DIFF
--- a/changelog/2175.added.md
+++ b/changelog/2175.added.md
@@ -1,0 +1,1 @@
+Added `SetSockOpt` impls to enable Linux Kernel TLS on a TCP socket and to import TLS parameters.

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -2,14 +2,14 @@ use cfg_if::cfg_if;
 
 #[macro_export]
 macro_rules! skip {
-    ($($reason: expr),+) => {
+    ($($reason: expr),+) => {{
         use ::std::io::{self, Write};
 
         let stderr = io::stderr();
         let mut handle = stderr.lock();
         writeln!(handle, $($reason),+).unwrap();
         return;
-    }
+    }}
 }
 
 cfg_if! {


### PR DESCRIPTION
1. kTLS is implemented as a TCP ULP, so add a `SetSockOpt` impl for it.

2. kTLS parameters are pushed to the kernel using `setsockopt(SOL_TLS)`,
   so add `SetSockOpt` impls for them.

Other test fixes:

1. Change `setsockopt` tests to bind to port 0 so that
   they bind to an unbound port and don't affect each other.

2. Fix `skip!` macro used to skip tests to generate its own block so that
   it can be used as an expr.

---

## What does this PR do

Implement additional definitions needed to set up kTLS.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API