### PR TITLE
docs: document that having multi logs for 1 PR is allowed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ be added (assume it is PR #0)
 Added a new API xxx
 ```
 
+And having multiple change logs for one PR is allowed.
+
 [cl]: https://github.com/nix-rust/nix/tree/master/changelog
 [pr-docs]: https://help.github.com/articles/using-pull-requests/
 


### PR DESCRIPTION
## What does this PR do

1. Document that we can have multiple change logs in 1 PR as our contributors [may be confused about this](https://github.com/nix-rust/nix/pull/2127#issuecomment-1793728040)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
