### PR TITLE
refactor: enable lint unsafe_op_in_unsafe_fn

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -46,7 +46,7 @@ pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
                      target_os = "linux",
                      target_os = "android",
                      target_os = "emscripten"))] {
-            let ret = libc::clearenv();
+            let ret = unsafe { libc::clearenv() };
         } else {
             use std::env;
             for (name, _) in env::vars_os() {

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -10,32 +10,32 @@ cfg_if! {
     if #[cfg(any(target_os = "freebsd",
                  apple_targets,))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::__error()
+            unsafe { libc::__error() }
         }
     } else if #[cfg(any(target_os = "android",
                         target_os = "netbsd",
                         target_os = "openbsd"))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::__errno()
+            unsafe { libc::__errno() }
         }
     } else if #[cfg(any(target_os = "linux",
                         target_os = "redox",
                         target_os = "dragonfly",
                         target_os = "fuchsia"))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::__errno_location()
+            unsafe { libc::__errno_location() }
         }
     } else if #[cfg(any(target_os = "illumos", target_os = "solaris"))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::___errno()
+            unsafe { libc::___errno() }
         }
     } else if #[cfg(any(target_os = "haiku",))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::_errnop()
+            unsafe { libc::_errnop() }
         }
     } else if #[cfg(any(target_os = "aix"))] {
         unsafe fn errno_location() -> *mut c_int {
-            libc::_Errno()
+            unsafe { libc::_Errno() }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::cast_ptr_alignment)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 // Re-exported external crates
 pub use libc;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -169,12 +169,12 @@ pub fn posix_openpt(flags: fcntl::OFlag) -> Result<PtyMaster> {
 /// For a threadsafe and non-`unsafe` alternative on Linux, see `ptsname_r()`.
 #[inline]
 pub unsafe fn ptsname(fd: &PtyMaster) -> Result<String> {
-    let name_ptr = libc::ptsname(fd.as_raw_fd());
+    let name_ptr = unsafe { libc::ptsname(fd.as_raw_fd()) };
     if name_ptr.is_null() {
         return Err(Errno::last());
     }
 
-    let name = CStr::from_ptr(name_ptr);
+    let name = unsafe { CStr::from_ptr(name_ptr) };
     Ok(name.to_string_lossy().into_owned())
 }
 
@@ -341,7 +341,7 @@ pub unsafe fn forkpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b T
         .map(|ws| ws as *const Winsize as *mut _)
         .unwrap_or(ptr::null_mut());
 
-    let res = libc::forkpty(master.as_mut_ptr(), ptr::null_mut(), term, win);
+    let res = unsafe { libc::forkpty(master.as_mut_ptr(), ptr::null_mut(), term, win) };
 
     let fork_result = Errno::result(res).map(|res| match res {
         0 => ForkResult::Child,
@@ -349,7 +349,7 @@ pub unsafe fn forkpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b T
     })?;
 
     Ok(ForkptyResult {
-        master: OwnedFd::from_raw_fd(master.assume_init()),
+        master: unsafe { OwnedFd::from_raw_fd( master.assume_init() ) },
         fork_result,
     })
 }

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -244,7 +244,7 @@ impl Inotify {
 impl FromRawFd for Inotify {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Inotify {
-            fd: OwnedFd::from_raw_fd(fd),
+            fd: unsafe { OwnedFd::from_raw_fd(fd) },
         }
     }
 }

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -72,7 +72,7 @@
 //! # const SPI_IOC_MAGIC: u8 = b'k'; // Defined in linux/spi/spidev.h
 //! # const SPI_IOC_TYPE_MODE: u8 = 1;
 //! pub unsafe fn spi_read_mode(fd: c_int, data: *mut u8) -> Result<c_int> {
-//!     let res = libc::ioctl(fd, request_code_read!(SPI_IOC_MAGIC, SPI_IOC_TYPE_MODE, mem::size_of::<u8>()), data);
+//!     let res = unsafe { libc::ioctl(fd, request_code_read!(SPI_IOC_MAGIC, SPI_IOC_TYPE_MODE, mem::size_of::<u8>()), data) };
 //!     Errno::result(res)
 //! }
 //! # fn main() {}
@@ -179,9 +179,13 @@
 //! # const SPI_IOC_TYPE_MESSAGE: u8 = 0;
 //! # pub struct spi_ioc_transfer(u64);
 //! pub unsafe fn spi_message(fd: c_int, data: &mut [spi_ioc_transfer]) -> Result<c_int> {
-//!     let res = libc::ioctl(fd,
-//!                           request_code_write!(SPI_IOC_MAGIC, SPI_IOC_TYPE_MESSAGE, data.len() * mem::size_of::<spi_ioc_transfer>()),
-//!                           data.as_ptr());
+//!     let res = unsafe {
+//!         libc::ioctl(
+//!             fd,
+//!             request_code_write!(SPI_IOC_MAGIC, SPI_IOC_TYPE_MESSAGE, data.len() * mem::size_of::<spi_ioc_transfer>()),
+//!             data
+//!         )
+//!     };
 //!     Errno::result(res)
 //! }
 //! # fn main() {}
@@ -303,7 +307,9 @@ macro_rules! ioctl_none {
         $(#[$attr])*
         pub unsafe fn $name(fd: $crate::libc::c_int)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_none!($ioty, $nr) as $crate::sys::ioctl::ioctl_num_type))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_none!($ioty, $nr) as $crate::sys::ioctl::ioctl_num_type))
+            }
         }
     )
 }
@@ -343,7 +349,9 @@ macro_rules! ioctl_none_bad {
         $(#[$attr])*
         pub unsafe fn $name(fd: $crate::libc::c_int)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type))
+            }
         }
     )
 }
@@ -381,7 +389,9 @@ macro_rules! ioctl_read {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -417,7 +427,9 @@ macro_rules! ioctl_read_bad {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -454,7 +466,9 @@ macro_rules! ioctl_write_ptr {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *const $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -490,7 +504,9 @@ macro_rules! ioctl_write_ptr_bad {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *const $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -531,7 +547,9 @@ cfg_if! {
                 pub unsafe fn $name(fd: $crate::libc::c_int,
                                     data: $crate::sys::ioctl::ioctl_param_type)
                                     -> $crate::Result<$crate::libc::c_int> {
-                    convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write_int!($ioty, $nr) as $crate::sys::ioctl::ioctl_num_type, data))
+                    unsafe {
+                        convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write_int!($ioty, $nr) as $crate::sys::ioctl::ioctl_num_type, data))
+                    }
                 }
             )
         }
@@ -572,7 +590,9 @@ cfg_if! {
                 pub unsafe fn $name(fd: $crate::libc::c_int,
                                     data: $crate::sys::ioctl::ioctl_param_type)
                                     -> $crate::Result<$crate::libc::c_int> {
-                    convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$crate::libc::c_int>()) as $crate::sys::ioctl::ioctl_num_type, data))
+                    unsafe {
+                        convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of::<$crate::libc::c_int>()) as $crate::sys::ioctl::ioctl_num_type, data))
+                    }
                 }
             )
         }
@@ -616,7 +636,9 @@ macro_rules! ioctl_write_int_bad {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: $crate::libc::c_int)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -653,7 +675,9 @@ macro_rules! ioctl_readwrite {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -681,7 +705,9 @@ macro_rules! ioctl_readwrite_bad {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))
+            }
         }
     )
 }
@@ -710,7 +736,9 @@ macro_rules! ioctl_read_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &mut [$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_mut_ptr()))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_read!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_mut_ptr()))
+            }
         }
     )
 }
@@ -749,7 +777,9 @@ macro_rules! ioctl_write_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &[$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_ptr()))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_write!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_ptr()))
+            }
         }
     )
 }
@@ -778,7 +808,9 @@ macro_rules! ioctl_readwrite_buf {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: &mut [$ty])
                             -> $crate::Result<$crate::libc::c_int> {
-            convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_mut_ptr()))
+            unsafe {
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of_val(data)) as $crate::sys::ioctl::ioctl_num_type, data.as_mut_ptr()))
+            }
         }
     )
 }

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -61,13 +61,15 @@ unsafe fn ptrace_other(
     addr: AddressType,
     data: c_int,
 ) -> Result<c_int> {
-    Errno::result(libc::ptrace(
-        request as RequestType,
-        libc::pid_t::from(pid),
-        addr,
-        data,
-    ))
-    .map(|_| 0)
+    unsafe {
+        Errno::result(libc::ptrace(
+            request as RequestType,
+            libc::pid_t::from(pid),
+            addr,
+            data,
+        ))
+            .map(|_| 0)
+    }
 }
 
 /// Sets the process as traceable, as with `ptrace(PT_TRACEME, ...)`

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -278,13 +278,15 @@ unsafe fn ptrace_other(
     addr: AddressType,
     data: *mut c_void,
 ) -> Result<c_long> {
-    Errno::result(libc::ptrace(
-        request as RequestType,
-        libc::pid_t::from(pid),
-        addr,
-        data,
-    ))
-    .map(|_| 0)
+    unsafe {
+        Errno::result(libc::ptrace(
+            request as RequestType,
+            libc::pid_t::from(pid),
+            addr,
+            data,
+        ))
+        .map(|_| 0)
+    }
 }
 
 /// Set options, as with `ptrace(PTRACE_SETOPTIONS, ...)`.
@@ -551,7 +553,7 @@ pub unsafe fn write(
     addr: AddressType,
     data: *mut c_void,
 ) -> Result<()> {
-    ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(drop)
+    unsafe { ptrace_other(Request::PTRACE_POKEDATA, pid, addr, data).map(drop) }
 }
 
 /// Reads a word from a user area at `offset`, as with ptrace(PTRACE_PEEKUSER, ...).
@@ -572,5 +574,7 @@ pub unsafe fn write_user(
     offset: AddressType,
     data: *mut c_void,
 ) -> Result<()> {
-    ptrace_other(Request::PTRACE_POKEUSER, pid, offset, data).map(drop)
+    unsafe {
+        ptrace_other(Request::PTRACE_POKEUSER, pid, offset, data).map(drop)
+    }
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -889,7 +889,7 @@ impl ControlMessageOwned {
     #[allow(clippy::cast_ptr_alignment)]
     unsafe fn decode_from(header: &cmsghdr) -> ControlMessageOwned
     {
-        let p = CMSG_DATA(header);
+        let p = unsafe { CMSG_DATA(header) };
         // The cast is not unnecessary on all platforms.
         #[allow(clippy::unnecessary_cast)]
         let len = header as *const _ as usize + header.cmsg_len as usize
@@ -899,39 +899,41 @@ impl ControlMessageOwned {
                 let n = len / mem::size_of::<RawFd>();
                 let mut fds = Vec::with_capacity(n);
                 for i in 0..n {
-                    let fdp = (p as *const RawFd).add(i);
-                    fds.push(ptr::read_unaligned(fdp));
+                    unsafe {
+                        let fdp = (p as *const RawFd).add(i);
+                        fds.push(ptr::read_unaligned(fdp));
+                    }
                 }
                 ControlMessageOwned::ScmRights(fds)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
             (libc::SOL_SOCKET, libc::SCM_CREDENTIALS) => {
-                let cred: libc::ucred = ptr::read_unaligned(p as *const _);
+                let cred: libc::ucred = unsafe { ptr::read_unaligned(p as *const _) };
                 ControlMessageOwned::ScmCredentials(cred.into())
             }
             #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
             (libc::SOL_SOCKET, libc::SCM_CREDS) => {
-                let cred: libc::cmsgcred = ptr::read_unaligned(p as *const _);
+                let cred: libc::cmsgcred = unsafe { ptr::read_unaligned(p as *const _) };
                 ControlMessageOwned::ScmCreds(cred.into())
             }
             #[cfg(not(any(target_os = "aix", target_os = "haiku")))]
             (libc::SOL_SOCKET, libc::SCM_TIMESTAMP) => {
-                let tv: libc::timeval = ptr::read_unaligned(p as *const _);
+                let tv: libc::timeval = unsafe { ptr::read_unaligned(p as *const _) };
                 ControlMessageOwned::ScmTimestamp(TimeVal::from(tv))
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
             (libc::SOL_SOCKET, libc::SCM_TIMESTAMPNS) => {
-                let ts: libc::timespec = ptr::read_unaligned(p as *const _);
+                let ts: libc::timespec = unsafe { ptr::read_unaligned(p as *const _) };
                 ControlMessageOwned::ScmTimestampns(TimeSpec::from(ts))
             }
             #[cfg(any(target_os = "android", target_os = "linux"))]
             (libc::SOL_SOCKET, libc::SCM_TIMESTAMPING) => {
                 let tp = p as *const libc::timespec;
-                let ts: libc::timespec = ptr::read_unaligned(tp);
+                let ts: libc::timespec = unsafe { ptr::read_unaligned(tp) };
                 let system = TimeSpec::from(ts);
-                let ts: libc::timespec = ptr::read_unaligned(tp.add(1));
+                let ts: libc::timespec = unsafe { ptr::read_unaligned(tp.add(1)) };
                 let hw_trans = TimeSpec::from(ts);
-                let ts: libc::timespec = ptr::read_unaligned(tp.add(2));
+                let ts: libc::timespec = unsafe { ptr::read_unaligned(tp.add(2)) };
                 let hw_raw = TimeSpec::from(ts);
                 let timestamping = Timestamps { system, hw_trans, hw_raw };
                 ControlMessageOwned::ScmTimestampsns(timestamping)
@@ -944,7 +946,7 @@ impl ControlMessageOwned {
             ))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
-                let info = ptr::read_unaligned(p as *const libc::in6_pktinfo);
+                let info = unsafe { ptr::read_unaligned(p as *const libc::in6_pktinfo) };
                 ControlMessageOwned::Ipv6PacketInfo(info)
             }
             #[cfg(any(
@@ -955,7 +957,7 @@ impl ControlMessageOwned {
             ))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_PKTINFO) => {
-                let info = ptr::read_unaligned(p as *const libc::in_pktinfo);
+                let info = unsafe { ptr::read_unaligned(p as *const libc::in_pktinfo) };
                 ControlMessageOwned::Ipv4PacketInfo(info)
             }
             #[cfg(any(
@@ -966,7 +968,7 @@ impl ControlMessageOwned {
             ))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVIF) => {
-                let dl = ptr::read_unaligned(p as *const libc::sockaddr_dl);
+                let dl = unsafe { ptr::read_unaligned(p as *const libc::sockaddr_dl) };
                 ControlMessageOwned::Ipv4RecvIf(dl)
             },
             #[cfg(any(
@@ -977,51 +979,51 @@ impl ControlMessageOwned {
             ))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVDSTADDR) => {
-                let dl = ptr::read_unaligned(p as *const libc::in_addr);
+                let dl = unsafe { ptr::read_unaligned(p as *const libc::in_addr) };
                 ControlMessageOwned::Ipv4RecvDstAddr(dl)
             },
             #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_ORIGDSTADDR) => {
-                let dl = ptr::read_unaligned(p as *const libc::sockaddr_in);
+                let dl = unsafe { ptr::read_unaligned(p as *const libc::sockaddr_in) };
                 ControlMessageOwned::Ipv4OrigDstAddr(dl)
             },
             #[cfg(target_os = "linux")]
             #[cfg(feature = "net")]
             (libc::SOL_UDP, libc::UDP_GRO) => {
-                let gso_size: u16 = ptr::read_unaligned(p as *const _);
+                let gso_size: u16 = unsafe { ptr::read_unaligned(p as *const _) };
                 ControlMessageOwned::UdpGroSegments(gso_size)
             },
             #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             (libc::SOL_SOCKET, libc::SO_RXQ_OVFL) => {
-                let drop_counter = ptr::read_unaligned(p as *const u32);
+                let drop_counter = unsafe { ptr::read_unaligned(p as *const u32) };
                 ControlMessageOwned::RxqOvfl(drop_counter)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVERR) => {
-                let (err, addr) = Self::recv_err_helper::<sockaddr_in>(p, len);
+                let (err, addr) = unsafe { Self::recv_err_helper::<sockaddr_in>(p, len) };
                 ControlMessageOwned::Ipv4RecvErr(err, addr)
             },
             #[cfg(any(target_os = "android", target_os = "linux"))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IPV6, libc::IPV6_RECVERR) => {
-                let (err, addr) = Self::recv_err_helper::<sockaddr_in6>(p, len);
+                let (err, addr) = unsafe { Self::recv_err_helper::<sockaddr_in6>(p, len) };
                 ControlMessageOwned::Ipv6RecvErr(err, addr)
             },
             #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IPV6, libc::IPV6_ORIGDSTADDR) => {
-                let dl = ptr::read_unaligned(p as *const libc::sockaddr_in6);
+                let dl = unsafe { ptr::read_unaligned(p as *const libc::sockaddr_in6) };
                 ControlMessageOwned::Ipv6OrigDstAddr(dl)
             },
             #[cfg(any(target_os = "linux"))]
             (libc::SOL_TLS, libc::TLS_GET_RECORD_TYPE) => {
-                let content_type = ptr::read_unaligned(p as *const u8);
+                let content_type = unsafe { ptr::read_unaligned(p as *const u8) };
                 ControlMessageOwned::TlsGetRecordType(content_type.into())
             },
             (_, _) => {
-                let sl = std::slice::from_raw_parts(p, len);
+                let sl = unsafe { std::slice::from_raw_parts(p, len) };
                 let ucmsg = UnknownCmsg(*header, Vec::<u8>::from(sl));
                 ControlMessageOwned::Unknown(ucmsg)
             }
@@ -1033,18 +1035,18 @@ impl ControlMessageOwned {
     #[allow(clippy::cast_ptr_alignment)]    // False positive
     unsafe fn recv_err_helper<T>(p: *mut libc::c_uchar, len: usize) -> (libc::sock_extended_err, Option<T>) {
         let ee = p as *const libc::sock_extended_err;
-        let err = ptr::read_unaligned(ee);
+        let err = unsafe { ptr::read_unaligned(ee) };
 
         // For errors originating on the network, SO_EE_OFFENDER(ee) points inside the p[..len]
         // CMSG_DATA buffer.  For local errors, there is no address included in the control
         // message, and SO_EE_OFFENDER(ee) points beyond the end of the buffer.  So, we need to
         // validate that the address object is in-bounds before we attempt to copy it.
-        let addrp = libc::SO_EE_OFFENDER(ee) as *const T;
+        let addrp = unsafe { libc::SO_EE_OFFENDER(ee) as *const T };
 
-        if addrp.offset(1) as usize - (p as usize) > len {
+        if unsafe { addrp.offset(1) } as usize - (p as usize) > len {
             (err, None)
         } else {
-            (err, Some(ptr::read_unaligned(addrp)))
+            (err, Some(unsafe { ptr::read_unaligned(addrp) }))
         }
     }
 }
@@ -1482,10 +1484,12 @@ impl<'a> ControlMessage<'a> {
     // Unsafe: cmsg must point to a valid cmsghdr with enough space to
     // encode self.
     unsafe fn encode_into(&self, cmsg: *mut cmsghdr) {
-        (*cmsg).cmsg_level = self.cmsg_level();
-        (*cmsg).cmsg_type = self.cmsg_type();
-        (*cmsg).cmsg_len = self.cmsg_len();
-        self.copy_to_cmsg_data(CMSG_DATA(cmsg));
+        unsafe {
+            (*cmsg).cmsg_level = self.cmsg_level();
+            (*cmsg).cmsg_type = self.cmsg_type();
+            (*cmsg).cmsg_len = self.cmsg_len();
+            self.copy_to_cmsg_data( CMSG_DATA(cmsg) );
+        }
     }
 }
 
@@ -1993,19 +1997,23 @@ unsafe fn read_mhdr<'a, 'i, S>(
     // The cast is not unnecessary on all platforms.
     #[allow(clippy::unnecessary_cast)]
     let cmsghdr = {
-        if mhdr.msg_controllen > 0 {
+        let ptr = if mhdr.msg_controllen > 0 {
             debug_assert!(!mhdr.msg_control.is_null());
             debug_assert!(msg_controllen >= mhdr.msg_controllen as usize);
-            CMSG_FIRSTHDR(&mhdr as *const msghdr)
+            unsafe { CMSG_FIRSTHDR(&mhdr as *const msghdr) }
         } else {
             ptr::null()
-        }.as_ref()
+        };
+
+        unsafe {
+            ptr.as_ref()
+        }
     };
 
     // Ignore errors if this socket address has statically-known length
     //
     // This is to ensure that unix socket addresses have their length set appropriately.
-    let _ = address.set_length(mhdr.msg_namelen as usize);
+    let _ = unsafe { address.set_length(mhdr.msg_namelen as usize) };
 
     RecvMsg {
         bytes: r as usize,
@@ -2042,14 +2050,16 @@ unsafe fn pack_mhdr_to_receive<S>(
     // initialize it.
     let mut mhdr = mem::MaybeUninit::<msghdr>::zeroed();
     let p = mhdr.as_mut_ptr();
-    (*p).msg_name = address as *mut c_void;
-    (*p).msg_namelen = S::size();
-    (*p).msg_iov = iov_buffer as *mut iovec;
-    (*p).msg_iovlen = iov_buffer_len as _;
-    (*p).msg_control = cmsg_buffer as *mut c_void;
-    (*p).msg_controllen = cmsg_capacity as _;
-    (*p).msg_flags = 0;
-    mhdr.assume_init()
+    unsafe {
+        (*p).msg_name = address as *mut c_void;
+        (*p).msg_namelen = S::size();
+        (*p).msg_iov = iov_buffer as *mut iovec;
+        (*p).msg_iovlen = iov_buffer_len as _;
+        (*p).msg_control = cmsg_buffer as *mut c_void;
+        (*p).msg_controllen = cmsg_capacity as _;
+        (*p).msg_flags = 0;
+        mhdr.assume_init()
+    }
 }
 
 fn pack_mhdr_to_send<'a, I, C, S>(

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1164,7 +1164,7 @@ impl<T> Get<T> for GetStruct<T> {
             mem::size_of::<T>(),
             "invalid getsockopt implementation"
         );
-        self.val.assume_init()
+        unsafe { self.val.assume_init() }
     }
 }
 
@@ -1215,7 +1215,7 @@ impl Get<bool> for GetBool {
             mem::size_of::<c_int>(),
             "invalid getsockopt implementation"
         );
-        self.val.assume_init() != 0
+        unsafe { self.val.assume_init() != 0 }
     }
 }
 
@@ -1268,7 +1268,7 @@ impl Get<u8> for GetU8 {
             mem::size_of::<u8>(),
             "invalid getsockopt implementation"
         );
-        self.val.assume_init()
+        unsafe { self.val.assume_init() }
     }
 }
 
@@ -1319,7 +1319,7 @@ impl Get<usize> for GetUsize {
             mem::size_of::<c_int>(),
             "invalid getsockopt implementation"
         );
-        self.val.assume_init() as usize
+        unsafe { self.val.assume_init() as usize }
     }
 }
 
@@ -1366,7 +1366,7 @@ impl<T: AsMut<[u8]>> Get<OsString> for GetOsString<T> {
 
     unsafe fn assume_init(self) -> OsString {
         let len = self.len as usize;
-        let mut v = self.val.assume_init();
+        let mut v = unsafe { self.val.assume_init() };
         OsStr::from_bytes(&v.as_mut()[0..len]).to_owned()
     }
 }

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -53,7 +53,7 @@ impl AsFd for TimerFd {
 impl FromRawFd for TimerFd {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         TimerFd {
-            fd: OwnedFd::from_raw_fd(fd),
+            fd: unsafe { OwnedFd::from_raw_fd(fd) },
         }
     }
 }

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -248,7 +248,7 @@ impl WaitStatus {
         all(target_os = "linux", not(target_env = "uclibc")),
     ))]
     unsafe fn from_siginfo(siginfo: &libc::siginfo_t) -> Result<WaitStatus> {
-        let si_pid = siginfo.si_pid();
+        let si_pid = unsafe { siginfo.si_pid() };
         if si_pid == 0 {
             return Ok(WaitStatus::StillAlive);
         }
@@ -256,7 +256,7 @@ impl WaitStatus {
         assert_eq!(siginfo.si_signo, libc::SIGCHLD);
 
         let pid = Pid::from_raw(si_pid);
-        let si_status = siginfo.si_status();
+        let si_status = unsafe { siginfo.si_status() };
 
         let status = match siginfo.si_code {
             libc::CLD_EXITED => WaitStatus::Exited(pid, si_status),

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -293,7 +293,7 @@ impl ForkResult {
 #[inline]
 pub unsafe fn fork() -> Result<ForkResult> {
     use self::ForkResult::*;
-    let res = libc::fork();
+    let res = unsafe { libc::fork() };
 
     Errno::result(res).map(|res| match res {
         0 => Child,
@@ -3508,7 +3508,7 @@ impl User {
                 } else {
                     // SAFETY: `f` guarantees that `pwd` is initialized if `res`
                     // is not null.
-                    let pwd = pwd.assume_init();
+                    let pwd = unsafe { pwd.assume_init() };
                     return Ok(Some(User::from(&pwd)));
                 }
             } else if Errno::last() == Errno::ERANGE {
@@ -3618,11 +3618,11 @@ impl Group {
         let mut ret = Vec::new();
 
         for i in 0.. {
-            let u = mem.offset(i);
-            if (*u).is_null() {
+            let u = unsafe { mem.offset(i) };
+            if unsafe { (*u).is_null() } {
                 break;
             } else {
-                let s = CStr::from_ptr(*u).to_string_lossy().into_owned();
+                let s = unsafe {CStr::from_ptr(*u).to_string_lossy().into_owned()};
                 ret.push(s);
             }
         }
@@ -3667,7 +3667,7 @@ impl Group {
                 } else {
                     // SAFETY: `f` guarantees that `grp` is initialized if `res`
                     // is not null.
-                    let grp = grp.assume_init();
+                    let grp = unsafe { grp.assume_init() };
                     return Ok(Some(Group::from(&grp)));
                 }
             } else if Errno::last() == Errno::ERANGE {


### PR DESCRIPTION
## What does this PR do

Enable the `unsafe_op_in_unsafe_fn` lint, closes #2165

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
