### PR TITLE
Added `sigaction_is_default()`, `sigaction_is_ignore()`, and `sigaction_current()` functions

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -911,6 +911,22 @@ pub unsafe fn sigaction_current(signal: Signal) -> Result<SigAction> {
     sigaction_inner(signal, None)
 }
 
+/// Whether the specified signal currently has its default action.
+///
+/// `signal` can be any signal except `SIGKILL` or `SIGSTOP`.
+pub fn sigaction_is_default(signal: Signal) -> Result<bool> {
+    // SAFETY: fetching the current action is safe if the handler isn't called
+    unsafe { sigaction_current(signal) }.map(|sigaction| sigaction.handler() == SigHandler::SigDfl)
+}
+
+/// Whether the specified signal is currently ignored.
+///
+/// `signal` can be any signal except `SIGKILL` or `SIGSTOP`.
+pub fn sigaction_is_ignore(signal: Signal) -> Result<bool> {
+    // SAFETY: fetching the current action is safe if the handler isn't called
+    unsafe { sigaction_current(signal) }.map(|sigaction| sigaction.handler() == SigHandler::SigIgn)
+}
+
 /// Signal management (see [signal(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))
 ///
 /// Installs `handler` for the given `signal`, returning the previous signal

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -864,6 +864,16 @@ impl SigAction {
     }
 }
 
+unsafe fn sigaction_inner(signal: Signal, sigaction: Option<&SigAction>) -> Result<SigAction> {
+    let mut oldact = mem::MaybeUninit::<libc::sigaction>::uninit();
+
+    let res = libc::sigaction(signal as libc::c_int,
+            sigaction.map_or(ptr::null(), |sigaction| &sigaction.sigaction as *const libc::sigaction),
+                              oldact.as_mut_ptr());
+
+    Errno::result(res).map(|_| SigAction { sigaction: oldact.assume_init() })
+}
+
 /// Changes the action taken by a process on receipt of a specific signal.
 ///
 /// `signal` can be any signal except `SIGKILL` or `SIGSTOP`. On success, it returns the previous
@@ -882,13 +892,23 @@ impl SigAction {
 ///   pointer is valid.  In that case, this function effectively dereferences a
 ///   raw pointer of unknown provenance.
 pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigAction> {
-    let mut oldact = mem::MaybeUninit::<libc::sigaction>::uninit();
+    sigaction_inner(signal, Some(sigaction))
+}
 
-    let res = libc::sigaction(signal as libc::c_int,
-                              &sigaction.sigaction as *const libc::sigaction,
-                              oldact.as_mut_ptr());
-
-    Errno::result(res).map(|_| SigAction { sigaction: oldact.assume_init() })
+/// Gets the current action a process will take on receipt of a specific signal.
+///
+/// `signal` can be any signal except `SIGKILL` or `SIGSTOP`. On success, it returns the current
+/// action for the given signal. The current action will always remain in place, unchanged.
+///
+/// # Safety
+///
+/// There is no guarantee that the old signal handler was installed
+/// correctly.  If it was installed by this crate, it will be.  But if it was
+/// installed by, for example, C code, then there is no guarantee its function
+/// pointer is valid.  In that case, this function effectively dereferences a
+/// raw pointer of unknown provenance.
+pub unsafe fn sigaction_current(signal: Signal) -> Result<SigAction> {
+    sigaction_inner(signal, None)
 }
 
 /// Signal management (see [signal(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -29,8 +29,10 @@ fn test_old_sigaction_flags() {
     );
     let oact = unsafe { sigaction(SIGINT, &act) }.unwrap();
     let _flags = oact.flags();
-    let oact = unsafe { sigaction(SIGINT, &act) }.unwrap();
-    let _flags = oact.flags();
+    let _flags = unsafe { sigaction(SIGINT, &act) }.unwrap().flags();
+
+    // restore original
+    unsafe { sigaction(SIGINT, &oact) }.unwrap();
 }
 
 #[test]

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -55,6 +55,8 @@ fn test_current_sigaction() {
         unsafe { sigaction_current(SIGINT) }.unwrap().handler(),
         SigHandler::SigDfl
     );
+    assert!(sigaction_is_default(SIGINT).unwrap());
+    assert!(!sigaction_is_ignore(SIGINT).unwrap());
 
     unsafe {
         sigaction(
@@ -72,6 +74,8 @@ fn test_current_sigaction() {
         unsafe { sigaction_current(SIGINT) }.unwrap().handler(),
         SigHandler::SigIgn
     );
+    assert!(!sigaction_is_default(SIGINT).unwrap());
+    assert!(sigaction_is_ignore(SIGINT).unwrap());
 
     // restore original
     unsafe { sigaction(SIGINT, &oact) }.unwrap();


### PR DESCRIPTION
## What does this PR do

Provide safe mechanisms to determine whether a signal's action is the default or ignore.
This covers the majority of real-world calls to `sigaction()` with a NULL action without needing any unsafe code.

Provide an unsafe way to query the currently installed sigaction.

The decision to add `sigaction_current()` instead of just exposing the (new) `sigaction_inner()` function was to avoid any confusion over the semantics of passing in a `None` `sigaction` argument (eg: someone thinking that it meant remove or reset the action).

This closes #2172

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
