### PR TITLE
refactor: remove legacy `#[doc(cfg(all()))]` attributes

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -73,7 +73,6 @@ libc_bitflags!(
         O_ACCMODE;
         /// Use alternate I/O semantics.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_ALT_IO;
         /// Open the file in append-only mode.
         O_APPEND;
@@ -82,7 +81,6 @@ libc_bitflags!(
                       target_os = "illumos",
                       target_os = "solaris",
                       target_os = "haiku")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_ASYNC;
         /// Closes the file descriptor once an `execve` call is made.
         ///
@@ -96,11 +94,9 @@ libc_bitflags!(
                   target_os = "freebsd",
                   target_os = "linux",
                   target_os = "netbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DIRECT;
         /// If the specified path isn't a directory, fail.
         #[cfg(not(any(target_os = "illumos", target_os = "solaris")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DIRECTORY;
         /// Implicitly follow each `write()` with an `fdatasync()`.
         #[cfg(any(target_os = "android",
@@ -108,13 +104,11 @@ libc_bitflags!(
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DSYNC;
         /// Error out if a file was not created.
         O_EXCL;
         /// Open for execute only.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_EXEC;
         /// Open with an exclusive file lock.
         #[cfg(any(target_os = "dragonfly",
@@ -123,7 +117,6 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_EXLOCK;
         /// Same as `O_SYNC`.
         #[cfg(any(target_os = "dragonfly",
@@ -133,23 +126,18 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_FSYNC;
         /// Allow files whose sizes can't be represented in an `off_t` to be opened.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_LARGEFILE;
         /// Do not update the file last access time during `read(2)`s.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOATIME;
         /// Don't attach the device as the process' controlling terminal.
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOCTTY;
         /// Same as `O_NONBLOCK`.
         #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NDELAY;
         /// `open()` will fail if the given path is a symbolic link.
         O_NOFOLLOW;
@@ -157,13 +145,11 @@ libc_bitflags!(
         O_NONBLOCK;
         /// Don't deliver `SIGPIPE`.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_NOSIGPIPE;
         /// Obtain a file descriptor for low-level access.
         ///
         /// The file itself is not opened and other file operations will fail.
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_PATH;
         /// Only allow reading.
         ///
@@ -175,11 +161,9 @@ libc_bitflags!(
         O_RDWR;
         /// Similar to `O_DSYNC` but applies to `read`s instead.
         #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_RSYNC;
         /// Skip search permission checks.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SEARCH;
         /// Open with a shared file lock.
         #[cfg(any(target_os = "dragonfly",
@@ -188,21 +172,17 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SHLOCK;
         /// Implicitly follow each `write()` with an `fsync()`.
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_SYNC;
         /// Create an unnamed temporary file.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_TMPFILE;
         /// Truncate an existing regular file to 0 length if it allows writing.
         O_TRUNC;
         /// Restore default TTY attributes.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_TTY_INIT;
         /// Only allow writing.
         ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //! * `zerocopy` - APIs like `sendfile` and `copy_file_range`
 #![crate_name = "nix"]
 #![cfg(unix)]
-#![cfg_attr(docsrs, doc(cfg(all())))]
 #![allow(non_camel_case_types)]
 #![cfg_attr(test, deny(warnings))]
 #![recursion_limit = "500"]

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -17,36 +17,29 @@ libc_bitflags!(
     pub struct MntFlags: c_int {
         /// ACL support enabled.
         #[cfg(any(target_os = "netbsd", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_ACLS;
         /// All I/O to the file system should be done asynchronously.
         MNT_ASYNC;
         /// dir should instead be a file system ID encoded as “FSID:val0:val1”.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_BYFSID;
         /// Force a read-write mount even if the file system appears to be
         /// unclean.
         MNT_FORCE;
         /// GEOM journal support enabled.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_GJOURNAL;
         /// MAC support for objects.
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_MULTILABEL;
         /// Disable read clustering.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOCLUSTERR;
         /// Disable write clustering.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOCLUSTERW;
         /// Enable NFS version 4 ACLs.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NFS4ACLS;
         /// Do not update access times.
         MNT_NOATIME;
@@ -56,7 +49,6 @@ libc_bitflags!(
         MNT_NOSUID;
         /// Do not follow symlinks.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NOSYMFOLLOW;
         /// Mount read-only.
         MNT_RDONLY;
@@ -67,7 +59,6 @@ libc_bitflags!(
         ///
         /// See [mksnap_ffs(8)](https://www.freebsd.org/cgi/man.cgi?query=mksnap_ffs)
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SNAPSHOT;
         /// Using soft updates.
         #[cfg(any(
@@ -76,12 +67,10 @@ libc_bitflags!(
                 target_os = "netbsd",
                 target_os = "openbsd"
         ))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SOFTDEP;
         /// Directories with the SUID bit set chown new files to their own
         /// owner.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_SUIDDIR;
         /// All I/O to the file system should be done synchronously.
         MNT_SYNCHRONOUS;
@@ -91,14 +80,12 @@ libc_bitflags!(
                 target_os = "freebsd",
                 target_os = "netbsd"
         ))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_UNION;
         /// Indicates that the mount command is being applied to an already
         /// mounted file system.
         MNT_UPDATE;
         /// Check vnode use counts.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MNT_NONBUSY;
     }
 );
@@ -198,7 +185,6 @@ pub type NmountResult = std::result::Result<(), NmountError>;
 /// * [`nmount(2)`](https://www.freebsd.org/cgi/man.cgi?query=nmount)
 /// * [`nullfs(5)`](https://www.freebsd.org/cgi/man.cgi?query=nullfs)
 #[cfg(target_os = "freebsd")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 #[derive(Debug, Default)]
 pub struct Nmount<'a> {
     // n.b. notgull: In reality, this is a list that contains
@@ -210,7 +196,6 @@ pub struct Nmount<'a> {
 }
 
 #[cfg(target_os = "freebsd")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 impl<'a> Nmount<'a> {
     /// Helper function to push a slice onto the `iov` array.
     fn push_slice(&mut self, val: &'a [u8], is_owned: bool) {

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,6 +1,5 @@
 //! Mount file systems
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod linux;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -13,7 +12,6 @@ pub use self::linux::*;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod bsd;
 
 #[cfg(any(

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -88,11 +88,9 @@ pub struct MqdT(mqd_t);
 // See https://sourceware.org/bugzilla/show_bug.cgi?id=21279
 /// Size of a message queue attribute member
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "32"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type mq_attr_member_t = i64;
 /// Size of a message queue attribute member
 #[cfg(not(all(target_arch = "x86_64", target_pointer_width = "32")))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type mq_attr_member_t = libc::c_long;
 
 impl MqAttr {

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -46,11 +46,9 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "illumos",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOTRAILERS;
         /// Interface manages own routes.
         #[cfg(any(target_os = "dragonfly"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SMART;
         /// Resources allocated. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -64,7 +62,6 @@ libc_bitflags!(
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_RUNNING;
         /// No arp protocol, L2 destination address not set. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -78,23 +75,19 @@ libc_bitflags!(
         /// Master of a load balancing bundle. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MASTER;
         /// transmission in progress, tx hardware queue is full
         #[cfg(any(target_os = "freebsd",
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_OACTIVE;
         /// Protocol code on board.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_INTELLIGENT;
         /// Slave of a load balancing bundle. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SLAVE;
         /// Can't hear own transmissions.
         #[cfg(any(target_os = "dragonfly",
@@ -102,7 +95,6 @@ libc_bitflags!(
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_SIMPLEX;
         /// Supports multicast. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
@@ -113,16 +105,13 @@ libc_bitflags!(
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK0;
         /// Multicast using broadcast.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MULTI_BCAST;
         /// Is able to select media type via ifmap. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PORTSEL;
         /// Per link layer defined bit.
         #[cfg(any(target_os = "dragonfly",
@@ -130,16 +119,13 @@ libc_bitflags!(
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK1;
         /// Non-unique address.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_UNNUMBERED;
         /// Auto media selection active. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_AUTOMEDIA;
         /// Per link layer defined bit.
         #[cfg(any(target_os = "dragonfly",
@@ -147,173 +133,131 @@ libc_bitflags!(
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LINK2;
         /// Use alternate physical connection.
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   apple_targets,))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ALTPHYS;
         /// DHCP controls interface.
         #[cfg(any(target_os = "solaris", target_os = "illumos"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DHCPRUNNING;
         /// The addresses are lost when the interface goes down. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DYNAMIC;
         /// Do not advertise.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PRIVATE;
         /// Driver signals L1 up. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_LOWER_UP;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_POLLING_COMPAT;
         /// Unconfigurable using ioctl(2).
         #[cfg(any(target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_CANTCONFIG;
         /// Do not transmit packets.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOXMIT;
         /// Driver signals dormant. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DORMANT;
         /// User-requested promisc mode.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PPROMISC;
         /// Just on-link subnet.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOLOCAL;
         /// Echo sent packets. Volatile.
         #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ECHO;
         /// User-requested monitor mode.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_MONITOR;
         /// Address is deprecated.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DEPRECATED;
         /// Static ARP.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_STATICARP;
         /// Address from stateless addrconf.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ADDRCONF;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NPOLLING;
         /// Router on interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ROUTER;
         /// Interface is in polling mode.
         #[cfg(any(target_os = "dragonfly"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IDIRECT;
         /// Interface is winding down
         #[cfg(any(target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DYING;
         /// No NUD on interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NONUD;
         /// Interface is being renamed
         #[cfg(any(target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_RENAMING;
         /// Anycast address.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_ANYCAST;
         /// Don't exchange routing info.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NORTEXCH;
         /// Do not provide packet information
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NO_PI as libc::c_int;
         /// TUN device (no Ethernet headers)
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TUN as libc::c_int;
         /// TAP device
         #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TAP as libc::c_int;
         /// IPv4 interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPV4;
         /// IPv6 interface.
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPV6;
         /// in.mpathd test address
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_NOFAILOVER;
         /// Interface has failed
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_FAILED;
         /// Interface is a hot-spare
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_STANDBY;
         /// Functioning but not used
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_INACTIVE;
         /// Interface is offline
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_OFFLINE;
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_COS_ENABLED;
         /// Prefer as source addr.
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_PREFERRED;
         /// RFC3041
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_TEMPORARY;
         /// MTU set with SIOCSLIFMTU
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_FIXEDMTU;
         /// Cannot send / receive packets
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_VIRTUAL;
         /// Local address in use
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_DUPLICATE;
         /// IPMP IP interface
         #[cfg(target_os = "solaris")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IFF_IPMP;
     }
 );
@@ -328,7 +272,6 @@ libc_bitflags!(
     target_os = "openbsd",
     target_os = "illumos",
 ))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod if_nameindex {
     use super::*;
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -144,19 +144,15 @@ libc_bitflags! {
         POLLOUT;
         /// Equivalent to [`POLLIN`](constant.POLLIN.html)
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLRDNORM;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Equivalent to [`POLLOUT`](constant.POLLOUT.html)
         POLLWRNORM;
         /// Priority band data can be read (generally unused on Linux).
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLRDBAND;
         /// Priority data may be written.
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         POLLWRBAND;
         /// Error condition (only returned in
         /// [`PollFd::revents`](struct.PollFd.html#method.revents);

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -188,7 +188,6 @@ pub unsafe fn ptsname(fd: &PtyMaster) -> Result<String> {
 /// This value is useful for opening the slave ptty once the master has already been opened with
 /// `posix_openpt()`.
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 #[inline]
 pub fn ptsname_r(fd: &PtyMaster) -> Result<String> {
     let mut name_buf = Vec::<libc::c_char>::with_capacity(64);

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -8,7 +8,6 @@ use crate::{Errno, Result};
 pub use self::sched_linux_like::*;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod sched_linux_like {
     use crate::errno::Errno;
     use crate::unistd::Pid;

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -57,7 +57,6 @@ libc_enum! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         O_DSYNC
     }
     impl TryFrom<i32>

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -144,6 +144,9 @@ libc_bitflags! {
         MAP_NOCACHE;
         /// Allows the W/X bit on the page, it's necessary on aarch64 architecture.
         #[cfg(apple_targets)]
+        MAP_JIT;
+        /// Allows to use large pages, underlying alignment based on size.
+        #[cfg(target_os = "freebsd")]
         MAP_ALIGNED_SUPER;
         /// Pages will be discarded in the core dumps.
         #[cfg(target_os = "openbsd")]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -24,11 +24,9 @@ libc_bitflags! {
         PROT_EXEC;
         /// Apply protection up to the end of a mapping that grows upwards.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PROT_GROWSDOWN;
         /// Apply protection down to the beginning of a mapping that grows downwards.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PROT_GROWSUP;
     }
 }
@@ -46,12 +44,10 @@ libc_bitflags! {
         MAP_FIXED;
         /// Place the mapping at exactly the address specified in `addr`, but never clobber an existing range.
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_FIXED_NOREPLACE;
         /// To be used with `MAP_FIXED`, to forbid the system
         /// to select a different address than the one specified.
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_EXCL;
         /// Synonym for `MAP_ANONYMOUS`.
         MAP_ANON;
@@ -62,128 +58,95 @@ libc_bitflags! {
                       any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "linux", target_env = "musl", any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "freebsd", target_pointer_width = "64")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_32BIT;
         /// Used for stacks; indicates to the kernel that the mapping should extend downward in memory.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_GROWSDOWN;
         /// Compatibility flag. Ignored.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_DENYWRITE;
         /// Compatibility flag. Ignored.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_EXECUTABLE;
         /// Mark the mmaped region to be locked in the same way as `mlock(2)`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_LOCKED;
         /// Do not reserve swap space for this mapping.
         ///
         /// This was removed in FreeBSD 11 and is unused in DragonFlyBSD.
         #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd", target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NORESERVE;
         /// Populate page tables for a mapping.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_POPULATE;
         /// Only meaningful when used with `MAP_POPULATE`. Don't perform read-ahead.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NONBLOCK;
         /// Allocate the mapping using "huge pages."
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGETLB;
         /// Make use of 64KB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_64KB;
         /// Make use of 512KB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_512KB;
         /// Make use of 1MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_1MB;
         /// Make use of 2MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_2MB;
         /// Make use of 8MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_8MB;
         /// Make use of 16MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_16MB;
         /// Make use of 32MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_32MB;
         /// Make use of 256MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_256MB;
         /// Make use of 512MB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_512MB;
         /// Make use of 1GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_1GB;
         /// Make use of 2GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_2GB;
         /// Make use of 16GB huge page (must be supported by the system)
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HUGE_16GB;
 
         /// Lock the mapped region into memory as with `mlock(2)`.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_WIRED;
         /// Causes dirtied data in the specified range to be flushed to disk only when necessary.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NOSYNC;
         /// Rename private pages to a file.
         ///
         /// This was removed in FreeBSD 11 and is unused in DragonFlyBSD.
         #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_RENAME;
         /// Region may contain semaphores.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_HASSEMAPHORE;
         /// Region grows down, like a stack.
         #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "freebsd", target_os = "linux", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_STACK;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_NOCACHE;
         /// Allows the W/X bit on the page, it's necessary on aarch64 architecture.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        MAP_JIT;
-        /// Allows to use large pages, underlying alignment based on size.
-        #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_ALIGNED_SUPER;
         /// Pages will be discarded in the core dumps.
         #[cfg(target_os = "openbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_CONCEAL;
     }
 }
@@ -194,19 +157,15 @@ libc_bitflags! {
     pub struct MRemapFlags: c_int {
         /// Permit the kernel to relocate the mapping to a new virtual address, if necessary.
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MREMAP_MAYMOVE;
         /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MREMAP_FIXED;
         /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_FIXED;
         /// Allows to duplicate the mapping to be able to apply different flags on the copy.
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MAP_REMAPDUP;
     }
 }
@@ -230,29 +189,23 @@ libc_enum! {
         MADV_DONTNEED,
         /// Free up a given range of pages and its associated backing store.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_REMOVE,
         /// Do not make pages in this range available to the child after a `fork(2)`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DONTFORK,
         /// Undo the effect of `MADV_DONTFORK`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DOFORK,
         /// Poison the given pages.
         ///
         /// Subsequent references to those pages are treated like hardware memory corruption.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_HWPOISON,
         /// Enable Kernel Samepage Merging (KSM) for the given pages.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_MERGEABLE,
         /// Undo the effect of `MADV_MERGEABLE`
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_UNMERGEABLE,
         /// Preserve the memory of each page but offline the original page.
         #[cfg(any(target_os = "android",
@@ -268,67 +221,51 @@ libc_enum! {
         MADV_SOFT_OFFLINE,
         /// Enable Transparent Huge Pages (THP) for pages in the given range.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_HUGEPAGE,
         /// Undo the effect of `MADV_HUGEPAGE`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOHUGEPAGE,
         /// Exclude the given range from a core dump.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DONTDUMP,
         /// Undo the effect of an earlier `MADV_DONTDUMP`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_DODUMP,
         /// Specify that the application no longer needs the pages in the given range.
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_FREE,
         /// Request that the system not flush the current range to disk unless it needs to.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOSYNC,
         /// Undoes the effects of `MADV_NOSYNC` for any future pages dirtied within the given range.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_AUTOSYNC,
         /// Region is not included in a core file.
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_NOCORE,
         /// Include region in a core file
         #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_CORE,
         /// This process should not be killed when swap space is exhausted.
         #[cfg(any(target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_PROTECT,
         /// Invalidate the hardware page table for the given region.
         #[cfg(target_os = "dragonfly")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_INVAL,
         /// Set the offset of the page directory page to `value` for the virtual page table.
         #[cfg(target_os = "dragonfly")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_SETMAP,
         /// Indicates that the application will not need the data in the given range.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_ZERO_WIRED_PAGES,
         /// Pages can be reused (by anyone).
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_FREE_REUSABLE,
         /// Caller wants to reuse those pages.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MADV_FREE_REUSE,
         // Darwin doesn't document this flag's behavior.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         #[allow(missing_docs)]
         MADV_CAN_REUSE,
     }
@@ -343,11 +280,9 @@ libc_bitflags! {
         MS_INVALIDATE;
         /// Invalidate pages, but leave them mapped.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MS_KILLPAGES;
         /// Deactivate pages, but leave them mapped.
         #[cfg(apple_targets)]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MS_DEACTIVATE;
         /// Perform an update and wait for it to complete.
         MS_SYNC;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -170,7 +170,6 @@ feature! {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 #[allow(missing_docs)]
 pub mod sysinfo;
 

--- a/src/sys/personality.rs
+++ b/src/sys/personality.rs
@@ -21,7 +21,6 @@ libc_bitflags! {
         ADDR_LIMIT_3GB;
         /// User-space function pointers to signal handlers point to descriptors.
         #[cfg(not(any(target_env = "musl", target_env = "uclibc")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         FDPIC_FUNCPTRS;
         /// Map page 0 as read-only.
         MMAP_PAGE_ZERO;
@@ -43,7 +42,6 @@ libc_bitflags! {
         ///
         /// [`uname(2)`]: https://man7.org/linux/man-pages/man2/uname.2.html
         #[cfg(not(any(target_env = "musl", target_env = "uclibc")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         UNAME26;
         /// No effects.
         WHOLE_SECONDS;

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -30,12 +30,10 @@ libc_enum! {
         PT_READ_I,
         PT_READ_D,
         #[cfg(target_os = "macos")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_READ_U,
         PT_WRITE_I,
         PT_WRITE_D,
         #[cfg(target_os = "macos")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_WRITE_U,
         PT_CONTINUE,
         PT_KILL,
@@ -49,13 +47,10 @@ libc_enum! {
         PT_ATTACH,
         PT_DETACH,
         #[cfg(target_os = "macos")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_SIGEXC,
         #[cfg(target_os = "macos")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_THUPDATE,
         #[cfg(target_os = "macos")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PT_ATTACHEXC
     }
 }

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -120,10 +120,8 @@ libc_enum! {
                                                target_arch = "mips64r6"))))]
         PTRACE_SETREGSET,
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PTRACE_SEIZE,
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PTRACE_INTERRUPT,
         #[cfg(all(target_os = "linux", not(any(target_arch = "mips",
                                                target_arch = "mips32r6",
@@ -401,7 +399,6 @@ pub fn attach(pid: Pid) -> Result<()> {
 ///
 /// Attaches to the process specified in pid, making it a tracee of the calling process.
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn seize(pid: Pid, options: Options) -> Result<()> {
     unsafe {
         ptrace_other(
@@ -448,7 +445,6 @@ pub fn cont<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
 ///
 /// This request is equivalent to `ptrace(PTRACE_INTERRUPT, ...)`
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn interrupt(pid: Pid) -> Result<()> {
     unsafe {
         ptrace_other(

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -56,7 +56,6 @@ libc_enum! {
     #[non_exhaustive]
     pub enum Resource {
         #[cfg(not(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum amount (in bytes) of virtual memory the process is
         /// allowed to map.
         RLIMIT_AS,
@@ -75,12 +74,10 @@ libc_enum! {
         RLIMIT_STACK,
 
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of kqueues this user id is allowed to create.
         RLIMIT_KQUEUES,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the combined number of flock locks and fcntl leases that
         /// this process may establish.
         RLIMIT_LOCKS,
@@ -92,19 +89,16 @@ libc_enum! {
             target_os = "linux",
             target_os = "netbsd"
         ))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) which a process may lock into memory
         /// using the mlock(2) system call.
         RLIMIT_MEMLOCK,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the number of bytes that can be allocated for POSIX
         /// message queues  for  the  real  user  ID  of  the  calling process.
         RLIMIT_MSGQUEUE,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A ceiling to which the process's nice value can be raised using
         /// setpriority or nice.
         RLIMIT_NICE,
@@ -117,12 +111,10 @@ libc_enum! {
             target_os = "linux",
             target_os = "aix",
         ))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of simultaneous processes for this user id.
         RLIMIT_NPROC,
 
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum number of pseudo-terminals this user id is allowed to
         /// create.
         RLIMIT_NPTS,
@@ -134,43 +126,36 @@ libc_enum! {
             target_os = "linux",
             target_os = "aix",
         ))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// When there is memory pressure and swap is available, prioritize
         /// eviction of a process' resident pages beyond this amount (in bytes).
         RLIMIT_RSS,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A ceiling on the real-time priority that may be set for this process
         /// using sched_setscheduler and  sched_set‐ param.
         RLIMIT_RTPRIO,
 
         #[cfg(any(target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit (in microseconds) on the amount of CPU time that a process
         /// scheduled under a real-time scheduling policy may con‐ sume without
         /// making a blocking system call.
         RLIMIT_RTTIME,
 
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// A limit on the number of signals that may be queued for the real
         /// user ID of the  calling  process.
         RLIMIT_SIGPENDING,
 
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) of socket buffer usage for this user.
         RLIMIT_SBSIZE,
 
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// The maximum size (in bytes) of the swap space that may be reserved
         /// or used by all of this user id's processes.
         RLIMIT_SWAP,
 
         #[cfg(target_os = "freebsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// An alias for RLIMIT_AS.
         RLIMIT_VMEM,
     }
@@ -279,7 +264,6 @@ libc_enum! {
         RUSAGE_CHILDREN,
 
         #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Resource usage for the calling thread.
         RUSAGE_THREAD,
     }

--- a/src/sys/sendfile.rs
+++ b/src/sys/sendfile.rs
@@ -22,7 +22,6 @@ use crate::Result;
 ///
 /// For more information, see [the sendfile(2) man page.](https://man7.org/linux/man-pages/man2/sendfile.2.html)
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn sendfile<F1: AsFd, F2: AsFd>(
     out_fd: F1,
     in_fd: F2,
@@ -56,7 +55,6 @@ pub fn sendfile<F1: AsFd, F2: AsFd>(
 ///
 /// For more information, see [the sendfile(2) man page.](https://man7.org/linux/man-pages/man2/sendfile.2.html)
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn sendfile64<F1: AsFd, F2: AsFd>(
     out_fd: F1,
     in_fd: F2,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -99,12 +99,10 @@ libc_enum! {
         SIGWINCH,
         /// Input/output possible signal
         #[cfg(not(target_os = "haiku"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         SIGIO,
         #[cfg(any(target_os = "android", target_os = "emscripten",
                   target_os = "fuchsia", target_os = "linux",
                   target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Power failure imminent.
         SIGPWR,
         /// Bad system call
@@ -112,14 +110,12 @@ libc_enum! {
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
                       target_os = "redox", target_os = "haiku")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Emulator trap
         SIGEMT,
         #[cfg(not(any(target_os = "android", target_os = "emscripten",
                       target_os = "fuchsia", target_os = "linux",
                       target_os = "redox", target_os = "haiku",
                       target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Information request
         SIGINFO,
     }
@@ -594,7 +590,6 @@ impl SigSet {
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
     #[cfg(not(target_os = "redox"))] // RedoxFS does not yet support sigwait
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn wait(&self) -> Result<Signal> {
         use std::convert::TryFrom;
 
@@ -744,7 +739,6 @@ pub enum SigHandler {
     /// Use the given signal-catching function, which takes in the signal, information about how
     /// the signal was generated, and a pointer to the threads `ucontext_t`.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigAction(extern fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void))
 }
 
@@ -1116,7 +1110,6 @@ pub enum SigevNotify {
     // Note: SIGEV_THREAD is not implemented, but could be if desired.
     /// Notify by delivering an event to a kqueue.
     #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigevKevent {
         /// File descriptor of the kqueue to notify.
         kq: RawFd,
@@ -1125,7 +1118,6 @@ pub enum SigevNotify {
     },
     /// Notify by delivering an event to a kqueue, with optional event flags set
     #[cfg(target_os = "freebsd")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[cfg(feature = "event")]
     SigevKeventFlags {
         /// File descriptor of the kqueue to notify.
@@ -1141,7 +1133,6 @@ pub enum SigevNotify {
             target_env = "gnu",
             target_env = "uclibc",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SigevThreadId {
         /// Signal to send
         signal: Signal,
@@ -1159,7 +1150,6 @@ pub enum SigevNotify {
     target_os = "openbsd",
     target_os = "redox"
 )))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod sigevent {
     feature! {
     #![any(feature = "aio", feature = "signal")]

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -73,7 +73,6 @@ pub enum AddressFamily {
     Inet6 = libc::AF_INET6,
     /// Kernel user interface device (see [`netlink(7)`](https://man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Netlink = libc::AF_NETLINK,
     /// Kernel interface for interacting with the routing table
     #[cfg(not(any(
@@ -90,19 +89,15 @@ pub enum AddressFamily {
         target_os = "fuchsia",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Packet = libc::AF_PACKET,
     /// KEXT Controls and Notifications
     #[cfg(apple_targets)]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     System = libc::AF_SYSTEM,
     /// Amateur radio AX.25 protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ax25 = libc::AF_AX25,
     /// IPX - Novell protocols
     #[cfg(not(any(target_os = "aix", target_os = "redox")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ipx = libc::AF_IPX,
     /// AppleTalk
     #[cfg(not(target_os = "redox"))]
@@ -110,96 +105,76 @@ pub enum AddressFamily {
     /// AX.25 packet layer protocol.
     /// (see [netrom(4)](https://www.unix.com/man-page/linux/4/netrom/))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetRom = libc::AF_NETROM,
     /// Can't be used for creating sockets; mostly used for bridge
     /// links in
     /// [rtnetlink(7)](https://man7.org/linux/man-pages/man7/rtnetlink.7.html)
     /// protocol commands.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Bridge = libc::AF_BRIDGE,
     /// Access to raw ATM PVCs
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AtmPvc = libc::AF_ATMPVC,
     /// ITU-T X.25 / ISO-8208 protocol (see [`x25(7)`](https://man7.org/linux/man-pages/man7/x25.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     X25 = libc::AF_X25,
     /// RATS (Radio Amateur Telecommunications Society) Open
     /// Systems environment (ROSE) AX.25 packet layer protocol.
     /// (see [netrom(4)](https://www.unix.com/man-page/linux/4/netrom/))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Rose = libc::AF_ROSE,
     /// DECet protocol sockets.
     #[cfg(not(any(target_os = "haiku", target_os = "redox")))]
     Decnet = libc::AF_DECnet,
     /// Reserved for "802.2LLC project"; never used.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetBeui = libc::AF_NETBEUI,
     /// This was a short-lived (between Linux 2.1.30 and
     /// 2.1.99pre2) protocol family for firewall upcalls.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Security = libc::AF_SECURITY,
     /// Key management protocol.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Key = libc::AF_KEY,
     #[allow(missing_docs)] // Not documented anywhere that I can find
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ash = libc::AF_ASH,
     /// Acorn Econet protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Econet = libc::AF_ECONET,
     /// Access to ATM Switched Virtual Circuits
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AtmSvc = libc::AF_ATMSVC,
     /// Reliable Datagram Sockets (RDS) protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Rds = libc::AF_RDS,
     /// IBM SNA
     #[cfg(not(any(target_os = "haiku", target_os = "redox")))]
     Sna = libc::AF_SNA,
     /// Socket interface over IrDA
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Irda = libc::AF_IRDA,
     /// Generic PPP transport layer, for setting up L2 tunnels (L2TP and PPPoE)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Pppox = libc::AF_PPPOX,
     /// Legacy protocol for wide area network (WAN) connectivity that was used
     /// by Sangoma WAN cards
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Wanpipe = libc::AF_WANPIPE,
     /// Logical link control (IEEE 802.2 LLC) protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Llc = libc::AF_LLC,
     /// InfiniBand native addressing
     #[cfg(all(target_os = "linux", not(target_env = "uclibc")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ib = libc::AF_IB,
     /// Multiprotocol Label Switching
     #[cfg(all(target_os = "linux", not(target_env = "uclibc")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Mpls = libc::AF_MPLS,
     /// Controller Area Network automotive bus protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Can = libc::AF_CAN,
     /// TIPC, "cluster domain sockets" protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Tipc = libc::AF_TIPC,
     /// Bluetooth low-level socket protocol
     #[cfg(not(any(
@@ -209,16 +184,13 @@ pub enum AddressFamily {
         target_os = "solaris",
         target_os = "redox",
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Bluetooth = libc::AF_BLUETOOTH,
     /// IUCV (inter-user communication vehicle) z/VM protocol for
     /// hypervisor-guest interaction
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Iucv = libc::AF_IUCV,
     /// Rx, Andrew File System remote procedure call protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxRpc = libc::AF_RXRPC,
     /// New "modular ISDN" driver interface protocol
     #[cfg(not(any(
@@ -228,28 +200,22 @@ pub enum AddressFamily {
         target_os = "haiku",
         target_os = "redox",
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Isdn = libc::AF_ISDN,
     /// Nokia cellular modem IPC/RPC interface
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Phonet = libc::AF_PHONET,
     /// IEEE 802.15.4 WPAN (wireless personal area network) raw packet protocol
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ieee802154 = libc::AF_IEEE802154,
     /// Ericsson's Communication CPU to Application CPU interface (CAIF)
     /// protocol.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Caif = libc::AF_CAIF,
     /// Interface to kernel crypto API
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Alg = libc::AF_ALG,
     /// Near field communication
     #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Nfc = libc::AF_NFC,
     /// VMWare VSockets protocol for hypervisor-guest interaction.
     #[cfg(any(
@@ -257,7 +223,6 @@ pub enum AddressFamily {
         target_os = "linux",
         target_os = "macos"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Vsock = libc::AF_VSOCK,
     /// ARPANet IMP addresses
     #[cfg(any(
@@ -267,7 +232,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ImpLink = libc::AF_IMPLINK,
     /// PUP protocols, e.g. BSP
     #[cfg(any(
@@ -277,7 +241,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Pup = libc::AF_PUP,
     /// MIT CHAOS protocols
     #[cfg(any(
@@ -287,11 +250,9 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Chaos = libc::AF_CHAOS,
     /// Novell and Xerox protocol
     #[cfg(any(apple_targets, target_os = "netbsd", target_os = "openbsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ns = libc::AF_NS,
     #[allow(missing_docs)] // Not documented anywhere that I can find
     #[cfg(any(
@@ -301,7 +262,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Iso = libc::AF_ISO,
     /// Bell Labs virtual circuit switch ?
     #[cfg(any(
@@ -311,7 +271,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Datakit = libc::AF_DATAKIT,
     /// CCITT protocols, X.25 etc
     #[cfg(any(
@@ -321,7 +280,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Ccitt = libc::AF_CCITT,
     /// DEC Direct data link interface
     #[cfg(any(
@@ -331,7 +289,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Dli = libc::AF_DLI,
     #[allow(missing_docs)] // Not documented anywhere that I can find
     #[cfg(any(
@@ -341,7 +298,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Lat = libc::AF_LAT,
     /// NSC Hyperchannel
     #[cfg(any(
@@ -351,7 +307,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Hylink = libc::AF_HYLINK,
     /// Link layer interface
     #[cfg(any(
@@ -362,7 +317,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Link = libc::AF_LINK,
     /// connection-oriented IP, aka ST II
     #[cfg(any(
@@ -372,7 +326,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Coip = libc::AF_COIP,
     /// Computer Network Technology
     #[cfg(any(
@@ -382,7 +335,6 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Cnt = libc::AF_CNT,
     /// Native ATM access
     #[cfg(any(
@@ -392,11 +344,9 @@ pub enum AddressFamily {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Natm = libc::AF_NATM,
     /// Unspecified address family, (see [`getaddrinfo(3)`](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     Unspec = libc::AF_UNSPEC,
 }
 
@@ -560,7 +510,6 @@ impl UnixAddr {
     /// This is a Linux-specific extension, primarily used to allow chrooted
     /// processes to communicate with processes having a different filesystem view.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(clippy::unnecessary_cast)] // Not unnecessary on all platforms
     pub fn new_abstract(path: &[u8]) -> Result<UnixAddr> {
         unsafe {
@@ -591,7 +540,6 @@ impl UnixAddr {
 
     /// Create a new `sockaddr_un` representing an "unnamed" unix socket address.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_unnamed() -> UnixAddr {
         let ret = libc::sockaddr_un {
             sun_family: AddressFamily::Unix as sa_family_t,
@@ -653,7 +601,6 @@ impl UnixAddr {
     /// For abstract sockets only the bare name is returned, without the
     /// leading NUL byte. `None` is returned for unnamed or path-backed sockets.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn as_abstract(&self) -> Option<&[u8]> {
         match self.kind() {
             UnixAddrKind::Abstract(name) => Some(name),
@@ -663,7 +610,6 @@ impl UnixAddr {
 
     /// Check if this address is an "unnamed" unix socket address.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[inline]
     pub fn is_unnamed(&self) -> bool {
         matches!(self.kind(), UnixAddrKind::Unnamed)
@@ -1277,15 +1223,12 @@ impl std::str::FromStr for SockaddrIn6 {
 #[repr(C)]
 pub union SockaddrStorage {
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     alg: AlgAddr,
     #[cfg(all(feature = "net", not(target_os = "redox")))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     dl: LinkAddr,
     #[cfg(any(target_os = "android", target_os = "linux"))]
     nl: NetlinkAddr,
     #[cfg(all(feature = "ioctl", apple_targets))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     sctl: SysControlAddr,
     #[cfg(feature = "net")]
     sin: SockaddrIn,
@@ -1298,7 +1241,6 @@ pub union SockaddrStorage {
         target_os = "linux",
         target_os = "macos"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     vsock: VsockAddr,
 }
 impl private::SockaddrLikePriv for SockaddrStorage {}
@@ -1561,7 +1503,6 @@ impl SockaddrStorage {
     AddressFamily::Netlink, libc::sockaddr_nl, nl}
 
     #[cfg(all(feature = "ioctl", apple_targets))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     accessors! {as_sys_control_addr, as_sys_control_addr_mut, SysControlAddr,
     AddressFamily::System, libc::sockaddr_ctl, sctl}
 
@@ -1570,7 +1511,6 @@ impl SockaddrStorage {
         target_os = "linux",
         target_os = "macos"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     accessors! {as_vsock_addr, as_vsock_addr_mut, VsockAddr,
     AddressFamily::Vsock, libc::sockaddr_vm, vsock}
 }
@@ -1769,7 +1709,6 @@ pub(super) mod private {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod netlink {
     use super::*;
     use crate::sys::socket::addr::AddressFamily;
@@ -1843,7 +1782,6 @@ pub mod netlink {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod alg {
     use super::*;
     use libc::{sockaddr_alg, AF_ALG};
@@ -2072,7 +2010,6 @@ pub mod sys_control {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod datalink {
     feature! {
     #![feature = "net"]
@@ -2175,7 +2112,6 @@ mod datalink {
     target_os = "aix",
     target_os = "openbsd"
 ))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 mod datalink {
     feature! {
     #![feature = "net"]
@@ -2289,7 +2225,6 @@ mod datalink {
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub mod vsock {
     use super::*;
     use crate::sys::socket::addr::AddressFamily;

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1225,10 +1225,12 @@ pub union SockaddrStorage {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     alg: AlgAddr,
     #[cfg(all(feature = "net", not(target_os = "redox")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     dl: LinkAddr,
     #[cfg(any(target_os = "android", target_os = "linux"))]
     nl: NetlinkAddr,
     #[cfg(all(feature = "ioctl", apple_targets))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     sctl: SysControlAddr,
     #[cfg(feature = "net")]
     sin: SockaddrIn,
@@ -1503,6 +1505,7 @@ impl SockaddrStorage {
     AddressFamily::Netlink, libc::sockaddr_nl, nl}
 
     #[cfg(all(feature = "ioctl", apple_targets))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     accessors! {as_sys_control_addr, as_sys_control_addr_mut, SysControlAddr,
     AddressFamily::System, libc::sockaddr_ctl, sctl}
 

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -139,96 +139,78 @@ pub enum SockProtocol {
     /// Allows applications to configure and control a KEXT
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(apple_targets)]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     KextControl = libc::SYSPROTO_CONTROL,
     /// Receives routing and link updates and may be used to modify the routing tables (both IPv4 and IPv6), IP addresses, link
     // parameters, neighbor setups, queueing disciplines, traffic classes and packet classifiers
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkRoute = libc::NETLINK_ROUTE,
     /// Reserved for user-mode socket protocols
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkUserSock = libc::NETLINK_USERSOCK,
     /// Query information about sockets of various protocol families from the kernel
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSockDiag = libc::NETLINK_SOCK_DIAG,
     /// Netfilter/iptables ULOG.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkNFLOG = libc::NETLINK_NFLOG,
     /// SELinux event notifications.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSELinux = libc::NETLINK_SELINUX,
     /// Open-iSCSI
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkISCSI = libc::NETLINK_ISCSI,
     /// Auditing
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkAudit = libc::NETLINK_AUDIT,
     /// Access to FIB lookup from user space
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkFIBLookup = libc::NETLINK_FIB_LOOKUP,
     /// Netfilter subsystem
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkNetFilter = libc::NETLINK_NETFILTER,
     /// SCSI Transports
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkSCSITransport = libc::NETLINK_SCSITRANSPORT,
     /// Infiniband RDMA
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkRDMA = libc::NETLINK_RDMA,
     /// Transport IPv6 packets from netfilter to user space.  Used by ip6_queue kernel module.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkIPv6Firewall = libc::NETLINK_IP6_FW,
     /// DECnet routing messages
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkDECNetRoutingMessage = libc::NETLINK_DNRTMSG,
     /// Kernel messages to user space
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkKObjectUEvent = libc::NETLINK_KOBJECT_UEVENT,
     /// Generic netlink family for simplified netlink usage.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkGeneric = libc::NETLINK_GENERIC,
     /// Netlink interface to request information about ciphers registered with the kernel crypto API as well as allow
     /// configuration of the kernel crypto API.
     /// ([ref](https://www.man7.org/linux/man-pages/man7/netlink.7.html))
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     NetlinkCrypto = libc::NETLINK_CRYPTO,
     /// Non-DIX type protocol number defined for the Ethernet IEEE 802.3 interface that allows packets of all protocols
     /// defined in the interface to be received.
     /// ([ref](https://man7.org/linux/man-pages/man7/packet.7.html))
     // The protocol number is fed into the socket syscall in network byte order.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     EthAll = (libc::ETH_P_ALL as u16).to_be() as i32,
     /// ICMP protocol ([icmp(7)](https://man7.org/linux/man-pages/man7/icmp.7.html))
     Icmp = libc::IPPROTO_ICMP,
@@ -240,21 +222,18 @@ impl SockProtocol {
     /// The Controller Area Network raw socket protocol
     /// ([ref](https://docs.kernel.org/networking/can.html#how-to-use-socketcan))
     #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(non_upper_case_globals)]
     pub const CanRaw: SockProtocol = SockProtocol::Icmp; // Matches libc::CAN_RAW
 
     /// The Controller Area Network broadcast manager protocol
     /// ([ref](https://docs.kernel.org/networking/can.html#how-to-use-socketcan))
     #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(non_upper_case_globals)]
     pub const CanBcm: SockProtocol = SockProtocol::NetlinkUserSock; // Matches libc::CAN_BCM
 
     /// Allows applications and other KEXTs to be notified when certain kernel events occur
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
     #[cfg(apple_targets)]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(non_upper_case_globals)]
     pub const KextEvent: SockProtocol = SockProtocol::Icmp; // Matches libc::SYSPROTO_EVENT
 }
@@ -295,7 +274,6 @@ libc_bitflags! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_NONBLOCK;
         /// Set close-on-exec on the new descriptor
         #[cfg(any(target_os = "android",
@@ -305,16 +283,13 @@ libc_bitflags! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_CLOEXEC;
         /// Return `EPIPE` instead of raising `SIGPIPE`
         #[cfg(target_os = "netbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_NOSIGPIPE;
         /// For domains `AF_INET(6)`, only allow `connect(2)`, `sendto(2)`, or `sendmsg(2)`
         /// to the DNS port (typically 53)
         #[cfg(target_os = "openbsd")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         SOCK_DNS;
     }
 }
@@ -345,7 +320,6 @@ libc_bitflags! {
         /// the calling process and as well as other processes that hold
         /// file descriptors referring to the same open file description.
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_DONTWAIT;
         /// Receive flags: Control Data was discarded (buffer too small)
         MSG_CTRUNC;
@@ -365,7 +339,6 @@ libc_bitflags! {
         /// the socket error queue. (For more details, see
         /// [recvfrom(2)](https://linux.die.net/man/2/recvfrom))
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_ERRQUEUE;
         /// Set the `close-on-exec` flag for the file descriptor received via a UNIX domain
         /// file descriptor using the `SCM_RIGHTS` operation (described in
@@ -380,7 +353,6 @@ libc_bitflags! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_CMSG_CLOEXEC;
         /// Requests not to send `SIGPIPE` errors when the other end breaks the connection.
         /// (For more details, see [send(2)](https://linux.die.net/man/2/send)).
@@ -394,7 +366,6 @@ libc_bitflags! {
                   target_os = "netbsd",
                   target_os = "openbsd",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_NOSIGNAL;
         /// Turns on [`MSG_DONTWAIT`] after the first message has been received (only for
         /// `recvmmsg()`).
@@ -405,7 +376,6 @@ libc_bitflags! {
                   target_os = "freebsd",
                   target_os = "openbsd",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MSG_WAITFORONE;
     }
 }
@@ -704,11 +674,9 @@ pub enum ControlMessageOwned {
     ScmRights(Vec<RawFd>),
     /// Received version of [`ControlMessage::ScmCredentials`]
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCredentials(UnixCredentials),
     /// Received version of [`ControlMessage::ScmCreds`]
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCreds(UnixCredentials),
     /// A message of type `SCM_TIMESTAMP`, containing the time the
     /// packet was received by the kernel.
@@ -777,7 +745,6 @@ pub enum ControlMessageOwned {
     ///
     /// [Further reading](https://www.kernel.org/doc/html/latest/networking/timestamping.html)
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmTimestampns(TimeSpec),
     #[cfg(any(
         target_os = "android",
@@ -849,7 +816,6 @@ pub enum ControlMessageOwned {
     /// `RxqOvfl` socket option should be enabled on a socket
     /// to allow receiving the drop counter.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxqOvfl(u32),
 
     /// Socket error queue control messages read with the `MSG_ERRQUEUE` flag.
@@ -1114,7 +1080,6 @@ pub enum ControlMessage<'a> {
     /// For further information, please refer to the
     /// [`unix(7)`](https://man7.org/linux/man-pages/man7/unix.7.html) man page.
     #[cfg(any(target_os = "android", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCredentials(&'a UnixCredentials),
     /// A message of type `SCM_CREDS`, containing the pid, uid, euid, gid and groups of
     /// a process connected to the socket.
@@ -1129,7 +1094,6 @@ pub enum ControlMessage<'a> {
     /// For further information, please refer to the
     /// [`unix(4)`](https://www.freebsd.org/cgi/man.cgi?query=unix) man page.
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ScmCreds,
 
     /// Set IV for `AF_ALG` crypto API.
@@ -1140,7 +1104,6 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetIv(&'a [u8]),
     /// Set crypto operation for `AF_ALG` crypto API. It may be one of
     /// `ALG_OP_ENCRYPT` or `ALG_OP_DECRYPT`
@@ -1151,7 +1114,6 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetOp(&'a libc::c_int),
     /// Set the length of associated authentication data (AAD) (applicable only to AEAD algorithms)
     /// for `AF_ALG` crypto API.
@@ -1162,7 +1124,6 @@ pub enum ControlMessage<'a> {
         target_os = "android",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AlgSetAeadAssoclen(&'a u32),
 
     /// UDP GSO makes it possible for applications to generate network packets
@@ -1235,7 +1196,6 @@ pub enum ControlMessage<'a> {
     /// socket between the last recieved packet and this
     /// received packet.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     RxqOvfl(&'a u32),
 
     /// Configure the transmission time of packets.

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -83,7 +83,6 @@ pub type type_of_file_flag = c_ulong;
 ))]
 libc_bitflags! {
     /// File flags.
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub struct FileFlag: type_of_file_flag {
         /// The file may only be appended to.
         SF_APPEND;
@@ -183,7 +182,6 @@ pub fn mknod<P: ?Sized + NixPath>(
 
 /// Create a special or ordinary file, relative to a given directory.
 #[cfg(not(any(apple_targets, target_os = "redox", target_os = "haiku")))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mknodat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -205,19 +203,16 @@ pub fn mknodat<P: ?Sized + NixPath>(
 }
 
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn major(dev: dev_t) -> u64 {
     ((dev >> 32) & 0xffff_f000) | ((dev >> 8) & 0x0000_0fff)
 }
 
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn minor(dev: dev_t) -> u64 {
     ((dev >> 12) & 0xffff_ff00) | ((dev) & 0x0000_00ff)
 }
 
 #[cfg(target_os = "linux")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub const fn makedev(major: u64, minor: u64) -> dev_t {
     ((major & 0xffff_f000) << 32)
         | ((major & 0x0000_0fff) << 8)
@@ -262,7 +257,6 @@ pub fn fstat(fd: RawFd) -> Result<FileStat> {
 }
 
 #[cfg(not(target_os = "redox"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn fstatat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     pathname: &P,
@@ -319,7 +313,6 @@ pub enum FchmodatFlags {
 ///
 /// [fchmodat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmodat.html).
 #[cfg(not(target_os = "redox"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn fchmodat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -382,7 +375,6 @@ pub fn utimes<P: ?Sized + NixPath>(
     target_os = "freebsd",
     target_os = "netbsd"
 ))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn lutimes<P: ?Sized + NixPath>(
     path: &P,
     atime: &TimeVal,
@@ -434,7 +426,6 @@ pub enum UtimensatFlags {
 ///
 /// [utimensat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimens.html).
 #[cfg(not(target_os = "redox"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn utimensat<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
@@ -460,7 +451,6 @@ pub fn utimensat<P: ?Sized + NixPath>(
 }
 
 #[cfg(not(target_os = "redox"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn mkdirat<P: ?Sized + NixPath>(
     fd: Option<RawFd>,
     path: &P,

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -26,11 +26,9 @@ use crate::{errno::Errno, NixPath, Result};
 
 /// Identifies a mounted file system
 #[cfg(target_os = "android")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type fsid_t = libc::__fsid_t;
 /// Identifies a mounted file system
 #[cfg(not(target_os = "android"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub type fsid_t = libc::fsid_t;
 
 cfg_if! {
@@ -304,14 +302,12 @@ impl Statfs {
         target_os = "dragonfly",
         apple_targets,
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn filesystem_type(&self) -> FsType {
         FsType(self.0.f_type)
     }
 
     /// Magic code defining system type
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn filesystem_type_name(&self) -> &str {
         let c_str = unsafe { CStr::from_ptr(self.0.f_fstypename.as_ptr()) };
         c_str.to_str().unwrap()
@@ -319,21 +315,18 @@ impl Statfs {
 
     /// Optimal transfer block size
     #[cfg(apple_targets)]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> i32 {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "openbsd")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -343,7 +336,6 @@ impl Statfs {
         target_os = "android",
         all(target_os = "linux", target_env = "musl")
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
@@ -357,35 +349,30 @@ impl Statfs {
             target_env = "uclibc"
         ))
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::__fsword_t {
         self.0.f_bsize
     }
 
     /// Optimal transfer block size
     #[cfg(all(target_os = "linux", target_env = "uclibc"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::c_int {
         self.0.f_bsize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> libc::c_long {
         self.0.f_iosize
     }
 
     /// Optimal transfer block size
     #[cfg(target_os = "freebsd")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn optimal_transfer_size(&self) -> u64 {
         self.0.f_iosize
     }
 
     /// Size of a block
     #[cfg(any(apple_targets, target_os = "openbsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -393,7 +380,6 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -401,7 +387,6 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", target_env = "musl"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
@@ -409,7 +394,6 @@ impl Statfs {
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(target_os = "linux", target_env = "uclibc"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_int {
         self.0.f_bsize
     }
@@ -424,28 +408,24 @@ impl Statfs {
             target_env = "uclibc"
         ))
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::__fsword_t {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "freebsd")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> u64 {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "android")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
 
     /// Size of a block
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn block_size(&self) -> libc::c_long {
         self.0.f_bsize
     }
@@ -461,7 +441,6 @@ impl Statfs {
             target_os = "openbsd"
         )
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     #[allow(clippy::unnecessary_cast)] // Not unnecessary on all arches
     pub fn flags(&self) -> MntFlags {
         MntFlags::from_bits_truncate(self.0.f_flags as i32)
@@ -471,35 +450,30 @@ impl Statfs {
     // The f_flags field exists on Android and Fuchsia too, but without man
     // pages I can't tell if it can be cast to FsFlags.
     #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn flags(&self) -> FsFlags {
         FsFlags::from_bits_truncate(self.0.f_flags as libc::c_ulong)
     }
 
     /// Maximum length of filenames
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namemax
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", target_arch = "s390x"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", target_env = "musl"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::c_ulong {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(all(target_os = "linux", target_env = "uclibc"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::c_int {
         self.0.f_namelen
     }
@@ -513,14 +487,12 @@ impl Statfs {
             target_env = "uclibc"
         ))
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::__fsword_t {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
     #[cfg(target_os = "android")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn maximum_name_length(&self) -> libc::c_ulong {
         self.0.f_namelen
     }
@@ -534,21 +506,18 @@ impl Statfs {
         target_os = "openbsd",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> u64 {
         self.0.f_blocks
     }
 
     /// Total data blocks in filesystem
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> libc::c_long {
         self.0.f_blocks
     }
 
     /// Total data blocks in filesystem
     #[cfg(target_os = "emscripten")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks(&self) -> u32 {
         self.0.f_blocks
     }
@@ -562,21 +531,18 @@ impl Statfs {
         target_os = "openbsd",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> u64 {
         self.0.f_bfree
     }
 
     /// Free blocks in filesystem
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> libc::c_long {
         self.0.f_bfree
     }
 
     /// Free blocks in filesystem
     #[cfg(target_os = "emscripten")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_free(&self) -> u32 {
         self.0.f_bfree
     }
@@ -588,28 +554,24 @@ impl Statfs {
         target_os = "fuchsia",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> u64 {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> libc::c_long {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> i64 {
         self.0.f_bavail
     }
 
     /// Free blocks available to unprivileged user
     #[cfg(target_os = "emscripten")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn blocks_available(&self) -> u32 {
         self.0.f_bavail
     }
@@ -623,21 +585,18 @@ impl Statfs {
         target_os = "openbsd",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> u64 {
         self.0.f_files
     }
 
     /// Total file nodes in filesystem
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> libc::c_long {
         self.0.f_files
     }
 
     /// Total file nodes in filesystem
     #[cfg(target_os = "emscripten")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files(&self) -> u32 {
         self.0.f_files
     }
@@ -650,28 +609,24 @@ impl Statfs {
         target_os = "openbsd",
         target_os = "linux",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> u64 {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(target_os = "dragonfly")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> libc::c_long {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(target_os = "freebsd")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> i64 {
         self.0.f_ffree
     }
 
     /// Free file nodes in filesystem
     #[cfg(target_os = "emscripten")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn files_free(&self) -> u32 {
         self.0.f_ffree
     }

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -22,43 +22,33 @@ libc_bitflags!(
         ST_NOSUID;
         /// Do not interpret character or block-special devices
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NODEV;
         /// Do not allow execution of binaries on the filesystem
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NOEXEC;
         /// All IO should be done synchronously
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_SYNCHRONOUS;
         /// Allow mandatory locks on the filesystem
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_MANDLOCK;
         /// Write on file/directory/symlink
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_WRITE;
         /// Append-only file
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_APPEND;
         /// Immutable file
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_IMMUTABLE;
         /// Do not update access times on files
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NOATIME;
         /// Do not update access times on files
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_NODIRATIME;
         /// Update access time relative to modify/change time
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_env = "musl"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ST_RELATIME;
     }
 );
@@ -120,7 +110,6 @@ impl Statvfs {
 
     /// Get the mount flags
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn flags(&self) -> FsFlags {
         FsFlags::from_bits_truncate(self.0.f_flag)
     }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -370,7 +370,6 @@ libc_enum! {
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B7200,
         B9600,
         #[cfg(any(target_os = "dragonfly",
@@ -378,7 +377,6 @@ libc_enum! {
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B14400,
         B19200,
         #[cfg(any(target_os = "dragonfly",
@@ -386,30 +384,23 @@ libc_enum! {
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B28800,
         B38400,
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B57600,
         #[cfg(any(target_os = "dragonfly",
                 target_os = "freebsd",
                 target_os = "macos",
                 target_os = "netbsd",
                 target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B76800,
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B115200,
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B153600,
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B230400,
         #[cfg(any(target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B307200,
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -417,13 +408,10 @@ libc_enum! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B460800,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B500000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B576000,
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
@@ -431,31 +419,22 @@ libc_enum! {
                   target_os = "linux",
                   target_os = "netbsd",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B921600,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1000000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1152000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B1500000,
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B2000000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B2500000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B3000000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B3500000,
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "sparc64"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         B4000000,
     }
     impl TryFrom<libc::speed_t>
@@ -540,7 +519,6 @@ libc_enum! {
     #[non_exhaustive]
     pub enum SpecialCharacterIndices {
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VDISCARD,
         #[cfg(any(target_os = "dragonfly",
                 target_os = "freebsd",
@@ -550,7 +528,6 @@ libc_enum! {
                 target_os = "openbsd",
                 target_os = "aix",
                 target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VDSUSP,
         VEOF,
         VEOL,
@@ -560,14 +537,12 @@ libc_enum! {
                   target_os = "freebsd",
                   target_os = "illumos",
                   target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VERASE2,
         VINTR,
         VKILL,
         VLNEXT,
         #[cfg(not(any(all(target_os = "linux", target_arch = "sparc64"),
                 target_os = "illumos", target_os = "solaris", target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VMIN,
         VQUIT,
         VREPRINT,
@@ -579,25 +554,19 @@ libc_enum! {
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSTATUS,
         VSTOP,
         VSUSP,
         #[cfg(target_os = "linux")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSWTC,
         #[cfg(any(target_os = "haiku", target_os = "illumos", target_os = "solaris"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VSWTCH,
         #[cfg(not(any(all(target_os = "linux", target_arch = "sparc64"),
                 target_os = "illumos", target_os = "solaris", target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VTIME,
         #[cfg(not(target_os = "aix"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VWERASE,
         #[cfg(target_os = "dragonfly")]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VCHECKPT,
     }
 }
@@ -624,7 +593,6 @@ pub use libc::NCCS;
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub use libc::_POSIX_VDISABLE;
 
 libc_bitflags! {
@@ -642,13 +610,10 @@ libc_bitflags! {
         IXON;
         IXOFF;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IXANY;
         #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IMAXBEL;
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         IUTF8;
     }
 }
@@ -661,7 +626,6 @@ libc_bitflags! {
                   target_os = "haiku",
                   target_os = "linux",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         OLCUC;
         ONLCR;
         OCRNL as tcflag_t;
@@ -671,128 +635,102 @@ libc_bitflags! {
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
-        OFILL as tcflag_t;
-        #[cfg(any(target_os = "android",
-                  target_os = "haiku",
-                  target_os = "linux",
-                  apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         OFDEL as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         NL0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         NL1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR2 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CR3 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB2 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         TAB3 as tcflag_t;
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         XTABS;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         BS0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         BS1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VT0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VT1 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         FF0 as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         FF1 as tcflag_t;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         OXTABS;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ONOEOT as tcflag_t;
 
         // Bitmasks for use with OutputFlags to select specific settings
@@ -803,38 +741,32 @@ libc_bitflags! {
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         NLDLY as tcflag_t; // FIXME: Datatype needs to be corrected in libc for mac
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "freebsd",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         TABDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         BSDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         VTDLY as tcflag_t;
         #[cfg(any(target_os = "android",
                   target_os = "haiku",
                   target_os = "linux",
                   apple_targets))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         FFDLY as tcflag_t;
     }
 }
@@ -847,7 +779,6 @@ libc_bitflags! {
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CIGNORE;
         CS5;
         CS6;
@@ -860,54 +791,43 @@ libc_bitflags! {
         HUPCL;
         CLOCAL;
         #[cfg(not(any(target_os = "redox", target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRTSCTS;
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CBAUD;
         #[cfg(any(target_os = "android", all(target_os = "linux", not(target_arch = "mips"))))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CMSPAR;
         #[cfg(any(target_os = "android",
                   all(target_os = "linux",
                       not(any(target_arch = "powerpc", target_arch = "powerpc64")))))]
         CIBAUD;
         #[cfg(any(target_os = "android", target_os = "linux"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CBAUDEX;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "macos",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         MDMBUF;
         #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CHWFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CCTS_OFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd",
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CRTS_IFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CDTR_IFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CDSR_OFLOW;
         #[cfg(any(target_os = "dragonfly",
                   target_os = "freebsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         CCAR_OFLOW;
 
         // Bitmasks for use with ControlFlags to select specific settings
@@ -922,17 +842,14 @@ libc_bitflags! {
     /// Flags for setting any local modes
     pub struct LocalFlags: tcflag_t {
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOKE;
         ECHOE;
         ECHOK;
         ECHO;
         ECHONL;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOPRT;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ECHOCTL;
         ISIG;
         ICANON;
@@ -941,25 +858,20 @@ libc_bitflags! {
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         ALTWERASE;
         IEXTEN;
         #[cfg(not(any(target_os = "redox", target_os = "haiku", target_os = "aix")))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         EXTPROC;
         TOSTOP;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         FLUSHO;
         #[cfg(any(target_os = "freebsd",
                   target_os = "dragonfly",
                   apple_targets,
                   target_os = "netbsd",
                   target_os = "openbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         NOKERNINFO;
         #[cfg(not(target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         PENDIN;
         NOFLSH;
     }
@@ -1103,7 +1015,6 @@ pub fn cfmakeraw(termios: &mut Termios) {
 ///
 /// Note that this is a non-standard function, available on FreeBSD.
 #[cfg(target_os = "freebsd")]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn cfmakesane(termios: &mut Termios) {
     let inner_termios = unsafe { termios.get_libc_termios_mut() };
     unsafe {

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -54,7 +54,6 @@ pub fn readv<Fd: AsFd>(fd: Fd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
 ///
 /// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn pwritev<Fd: AsFd>(
     fd: Fd,
     iov: &[IoSlice<'_>],
@@ -84,7 +83,6 @@ pub fn pwritev<Fd: AsFd>(
 ///
 /// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 // Clippy doesn't know that we need to pass iov mutably only because the
 // mutation happens after converting iov to a pointer
 #[allow(clippy::needless_pass_by_ref_mut)]
@@ -152,7 +150,6 @@ pub fn pread<Fd: AsFd>(fd: Fd, buf: &mut [u8], offset: off_t) -> Result<usize> {
 /// is used with [`process_vm_readv`](fn.process_vm_readv.html)
 /// and [`process_vm_writev`](fn.process_vm_writev.html).
 #[cfg(any(target_os = "linux", target_os = "android"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RemoteIoVec {

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -31,7 +31,6 @@ libc_bitflags!(
                   target_os = "linux",
                   target_os = "redox",
                   target_os = "netbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         WEXITED;
         /// Report the status of selected processes that have continued from a
         /// job control stop by receiving a
@@ -45,7 +44,6 @@ libc_bitflags!(
                   target_os = "linux",
                   target_os = "redox",
                   target_os = "netbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         WSTOPPED;
         /// Don't reap, just poll status.
         #[cfg(any(target_os = "android",
@@ -55,19 +53,15 @@ libc_bitflags!(
                   target_os = "linux",
                   target_os = "redox",
                   target_os = "netbsd"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         WNOWAIT;
         /// Don't wait on children of other threads in this group
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WNOTHREAD;
         /// Wait on all children, regardless of type
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WALL;
         /// Wait for "clone" children only.
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
-        #[cfg_attr(docsrs, doc(cfg(all())))]
         __WCLONE;
     }
 );
@@ -105,7 +99,6 @@ pub enum WaitStatus {
     /// [`nix::sys::ptrace`]: ../ptrace/index.html
     /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PtraceEvent(Pid, Signal, c_int),
     /// The traced process was stopped by execution of a system call,
     /// and `PTRACE_O_TRACESYSGOOD` is in effect. See [`ptrace`(2)] for
@@ -113,7 +106,6 @@ pub enum WaitStatus {
     ///
     /// [`ptrace`(2)]: https://man7.org/linux/man-pages/man2/ptrace.2.html
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PtraceSyscall(Pid),
     /// The process was previously stopped but has resumed execution
     /// after receiving a `SIGCONT` signal. This is only reported if

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,7 +35,6 @@ impl ClockId {
         target_os = "android",
         target_os = "emscripten",
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn pid_cpu_clock_id(pid: Pid) -> Result<Self> {
         clock_getcpuclockid(pid)
     }
@@ -43,7 +42,6 @@ impl ClockId {
 
     /// Returns resolution of the clock id
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn res(self) -> Result<TimeSpec> {
         clock_getres(self)
     }
@@ -55,7 +53,6 @@ impl ClockId {
 
     /// Sets time to `timespec` on the clock id
     #[cfg(not(any(apple_targets, target_os = "redox", target_os = "hermit",)))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn set_time(self, timespec: TimeSpec) -> Result<()> {
         clock_settime(self, timespec)
     }
@@ -71,7 +68,6 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_BOOTTIME: ClockId = ClockId(libc::CLOCK_BOOTTIME);
     #[cfg(any(
         target_os = "android",
@@ -79,7 +75,6 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_BOOTTIME_ALARM: ClockId =
         ClockId(libc::CLOCK_BOOTTIME_ALARM);
     pub const CLOCK_MONOTONIC: ClockId = ClockId(libc::CLOCK_MONOTONIC);
@@ -89,15 +84,12 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_COARSE: ClockId =
         ClockId(libc::CLOCK_MONOTONIC_COARSE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_FAST: ClockId =
         ClockId(libc::CLOCK_MONOTONIC_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_PRECISE: ClockId =
         ClockId(libc::CLOCK_MONOTONIC_PRECISE);
     #[cfg(any(
@@ -106,7 +98,6 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_MONOTONIC_RAW: ClockId = ClockId(libc::CLOCK_MONOTONIC_RAW);
     #[cfg(any(
         target_os = "android",
@@ -118,11 +109,9 @@ impl ClockId {
         target_os = "redox",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_PROCESS_CPUTIME_ID: ClockId =
         ClockId(libc::CLOCK_PROCESS_CPUTIME_ID);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_PROF: ClockId = ClockId(libc::CLOCK_PROF);
     pub const CLOCK_REALTIME: ClockId = ClockId(libc::CLOCK_REALTIME);
     #[cfg(any(
@@ -131,7 +120,6 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_ALARM: ClockId =
         ClockId(libc::CLOCK_REALTIME_ALARM);
     #[cfg(any(
@@ -140,25 +128,20 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_COARSE: ClockId =
         ClockId(libc::CLOCK_REALTIME_COARSE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_FAST: ClockId = ClockId(libc::CLOCK_REALTIME_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_REALTIME_PRECISE: ClockId =
         ClockId(libc::CLOCK_REALTIME_PRECISE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_SECOND: ClockId = ClockId(libc::CLOCK_SECOND);
     #[cfg(any(
         target_os = "emscripten",
         target_os = "fuchsia",
         all(target_os = "linux", target_env = "musl")
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_SGI_CYCLE: ClockId = ClockId(libc::CLOCK_SGI_CYCLE);
     #[cfg(any(
         target_os = "android",
@@ -166,7 +149,6 @@ impl ClockId {
         target_os = "fuchsia",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_TAI: ClockId = ClockId(libc::CLOCK_TAI);
     #[cfg(any(
         target_os = "android",
@@ -177,21 +159,16 @@ impl ClockId {
         target_os = "dragonfly",
         target_os = "linux"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_THREAD_CPUTIME_ID: ClockId =
         ClockId(libc::CLOCK_THREAD_CPUTIME_ID);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME: ClockId = ClockId(libc::CLOCK_UPTIME);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME_FAST: ClockId = ClockId(libc::CLOCK_UPTIME_FAST);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_UPTIME_PRECISE: ClockId =
         ClockId(libc::CLOCK_UPTIME_PRECISE);
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub const CLOCK_VIRTUAL: ClockId = ClockId(libc::CLOCK_VIRTUAL);
 }
 
@@ -216,7 +193,6 @@ impl std::fmt::Display for ClockId {
 /// Get the resolution of the specified clock, (see
 /// [clock_getres(2)](https://pubs.opengroup.org/onlinepubs/7908799/xsh/clock_getres.html)).
 #[cfg(not(target_os = "redox"))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn clock_getres(clock_id: ClockId) -> Result<TimeSpec> {
     let mut c_time: MaybeUninit<libc::timespec> = MaybeUninit::uninit();
     let ret =
@@ -240,7 +216,6 @@ pub fn clock_gettime(clock_id: ClockId) -> Result<TimeSpec> {
 /// Set the time of the specified clock, (see
 /// [clock_settime(2)](https://pubs.opengroup.org/onlinepubs/7908799/xsh/clock_settime.html)).
 #[cfg(not(any(apple_targets, target_os = "redox", target_os = "hermit",)))]
-#[cfg_attr(docsrs, doc(cfg(all())))]
 pub fn clock_settime(clock_id: ClockId, timespec: TimeSpec) -> Result<()> {
     let ret =
         unsafe { libc::clock_settime(clock_id.as_raw(), timespec.as_ref()) };

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2016,7 +2016,6 @@ pub enum PathconfVar {
     ))]
     /// Minimum number of bits needed to represent, as a signed integer value,
     /// the maximum size of a regular file allowed in the specified directory.
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     FILESIZEBITS = libc::_PC_FILESIZEBITS,
     /// Maximum number of links to a single file.
     LINK_MAX = libc::_PC_LINK_MAX,
@@ -2047,7 +2046,6 @@ pub enum PathconfVar {
         target_os = "redox",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Symbolic links can be created.
     POSIX2_SYMLINKS = libc::_PC_2_SYMLINKS,
     #[cfg(any(
@@ -2058,7 +2056,6 @@ pub enum PathconfVar {
         target_os = "openbsd",
         target_os = "redox"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Minimum number of bytes of storage actually allocated for any portion of
     /// a file.
     POSIX_ALLOC_SIZE_MIN = libc::_PC_ALLOC_SIZE_MIN,
@@ -2069,7 +2066,6 @@ pub enum PathconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Recommended increment for file transfer sizes between the
     /// `POSIX_REC_MIN_XFER_SIZE` and `POSIX_REC_MAX_XFER_SIZE` values.
     POSIX_REC_INCR_XFER_SIZE = libc::_PC_REC_INCR_XFER_SIZE,
@@ -2081,7 +2077,6 @@ pub enum PathconfVar {
         target_os = "openbsd",
         target_os = "redox"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum recommended file transfer size.
     POSIX_REC_MAX_XFER_SIZE = libc::_PC_REC_MAX_XFER_SIZE,
     #[cfg(any(
@@ -2092,7 +2087,6 @@ pub enum PathconfVar {
         target_os = "openbsd",
         target_os = "redox"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Minimum recommended file transfer size.
     POSIX_REC_MIN_XFER_SIZE = libc::_PC_REC_MIN_XFER_SIZE,
     #[cfg(any(
@@ -2103,7 +2097,6 @@ pub enum PathconfVar {
         target_os = "openbsd",
         target_os = "redox"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ///  Recommended file transfer buffer alignment.
     POSIX_REC_XFER_ALIGN = libc::_PC_REC_XFER_ALIGN,
     #[cfg(any(
@@ -2117,7 +2110,6 @@ pub enum PathconfVar {
         target_os = "redox",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum number of bytes in a symbolic link.
     SYMLINK_MAX = libc::_PC_SYMLINK_MAX,
     /// The use of `chown` and `fchown` is restricted to a process with
@@ -2140,7 +2132,6 @@ pub enum PathconfVar {
         target_os = "redox",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Asynchronous input or output operations may be performed for the
     /// associated file.
     _POSIX_ASYNC_IO = libc::_PC_ASYNC_IO,
@@ -2154,7 +2145,6 @@ pub enum PathconfVar {
         target_os = "redox",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Prioritized input or output operations may be performed for the
     /// associated file.
     _POSIX_PRIO_IO = libc::_PC_PRIO_IO,
@@ -2169,12 +2159,10 @@ pub enum PathconfVar {
         target_os = "redox",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Synchronized input or output operations may be performed for the
     /// associated file.
     _POSIX_SYNC_IO = libc::_PC_SYNC_IO,
     #[cfg(any(target_os = "dragonfly", target_os = "openbsd"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The resolution in nanoseconds for all file timestamps.
     _POSIX_TIMESTAMP_RESOLUTION = libc::_PC_TIMESTAMP_RESOLUTION,
 }
@@ -2278,12 +2266,10 @@ pub enum SysconfVar {
     /// Maximum number of I/O operations in a single list I/O call supported by
     /// the implementation.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_LISTIO_MAX = libc::_SC_AIO_LISTIO_MAX,
     /// Maximum number of outstanding asynchronous I/O operations supported by
     /// the implementation.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     AIO_MAX = libc::_SC_AIO_MAX,
     #[cfg(any(
         target_os = "android",
@@ -2293,7 +2279,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The maximum amount by which a process can decrease its asynchronous I/O
     /// priority level from its own scheduling priority.
     AIO_PRIO_DELTA_MAX = libc::_SC_AIO_PRIO_DELTA_MAX,
@@ -2301,23 +2286,18 @@ pub enum SysconfVar {
     ARG_MAX = libc::_SC_ARG_MAX,
     /// Maximum number of functions that may be registered with `atexit`.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     ATEXIT_MAX = libc::_SC_ATEXIT_MAX,
     /// Maximum obase values allowed by the bc utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_BASE_MAX = libc::_SC_BC_BASE_MAX,
     /// Maximum number of elements permitted in an array by the bc utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_DIM_MAX = libc::_SC_BC_DIM_MAX,
     /// Maximum scale value allowed by the bc utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_SCALE_MAX = libc::_SC_BC_SCALE_MAX,
     /// Maximum length of a string constant accepted by the bc utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     BC_STRING_MAX = libc::_SC_BC_STRING_MAX,
     /// Maximum number of simultaneous processes per real user ID.
     CHILD_MAX = libc::_SC_CHILD_MAX,
@@ -2326,16 +2306,13 @@ pub enum SysconfVar {
     /// Maximum number of weights that can be assigned to an entry of the
     /// LC_COLLATE order keyword in the locale definition file
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     COLL_WEIGHTS_MAX = libc::_SC_COLL_WEIGHTS_MAX,
     /// Maximum number of timer expiration overruns.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     DELAYTIMER_MAX = libc::_SC_DELAYTIMER_MAX,
     /// Maximum number of expressions that can be nested within parentheses by
     /// the expr utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     EXPR_NEST_MAX = libc::_SC_EXPR_NEST_MAX,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2347,21 +2324,18 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Maximum length of a host name (not including the terminating null) as
     /// returned from the `gethostname` function
     HOST_NAME_MAX = libc::_SC_HOST_NAME_MAX,
     /// Maximum number of iovec structures that one process has available for
     /// use with `readv` or `writev`.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     IOV_MAX = libc::_SC_IOV_MAX,
     /// Unless otherwise noted, the maximum length, in bytes, of a utility's
     /// input line (either standard input or another file), when the utility is
     /// described as processing text files. The length includes room for the
     /// trailing newline.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     LINE_MAX = libc::_SC_LINE_MAX,
     /// Maximum length of a login name.
     #[cfg(not(target_os = "haiku"))]
@@ -2370,19 +2344,15 @@ pub enum SysconfVar {
     NGROUPS_MAX = libc::_SC_NGROUPS_MAX,
     /// Initial size of `getgrgid_r` and `getgrnam_r` data buffers
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     GETGR_R_SIZE_MAX = libc::_SC_GETGR_R_SIZE_MAX,
     /// Initial size of `getpwuid_r` and `getpwnam_r` data buffers
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     GETPW_R_SIZE_MAX = libc::_SC_GETPW_R_SIZE_MAX,
     /// The maximum number of open message queue descriptors a process may hold.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_OPEN_MAX = libc::_SC_MQ_OPEN_MAX,
     /// The maximum number of message priorities supported by the implementation.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     MQ_PRIO_MAX = libc::_SC_MQ_PRIO_MAX,
     /// A value one greater than the maximum value that the system may assign to
     /// a newly-created file descriptor.
@@ -2394,7 +2364,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Advisory Information option.
     _POSIX_ADVISORY_INFO = libc::_SC_ADVISORY_INFO,
     #[cfg(any(
@@ -2407,12 +2376,10 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports barriers.
     _POSIX_BARRIERS = libc::_SC_BARRIERS,
     /// The implementation supports asynchronous input and output.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_ASYNCHRONOUS_IO = libc::_SC_ASYNCHRONOUS_IO,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2424,7 +2391,6 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports clock selection.
     _POSIX_CLOCK_SELECTION = libc::_SC_CLOCK_SELECTION,
     #[cfg(any(
@@ -2437,12 +2403,10 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Process CPU-Time Clocks option.
     _POSIX_CPUTIME = libc::_SC_CPUTIME,
     /// The implementation supports the File Synchronization option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_FSYNC = libc::_SC_FSYNC,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2453,36 +2417,28 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the IPv6 option.
     _POSIX_IPV6 = libc::_SC_IPV6,
     /// The implementation supports job control.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_JOB_CONTROL = libc::_SC_JOB_CONTROL,
     /// The implementation supports memory mapped Files.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MAPPED_FILES = libc::_SC_MAPPED_FILES,
     /// The implementation supports the Process Memory Locking option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK = libc::_SC_MEMLOCK,
     /// The implementation supports the Range Memory Locking option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMLOCK_RANGE = libc::_SC_MEMLOCK_RANGE,
     /// The implementation supports memory protection.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MEMORY_PROTECTION = libc::_SC_MEMORY_PROTECTION,
     /// The implementation supports the Message Passing option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MESSAGE_PASSING = libc::_SC_MESSAGE_PASSING,
     /// The implementation supports the Monotonic Clock option.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_MONOTONIC_CLOCK = libc::_SC_MONOTONIC_CLOCK,
     #[cfg(any(
         target_os = "android",
@@ -2494,12 +2450,10 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Prioritized Input and Output option.
     _POSIX_PRIORITIZED_IO = libc::_SC_PRIORITIZED_IO,
     /// The implementation supports the Process Scheduling option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_PRIORITY_SCHEDULING = libc::_SC_PRIORITY_SCHEDULING,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2510,7 +2464,6 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Raw Sockets option.
     _POSIX_RAW_SOCKETS = libc::_SC_RAW_SOCKETS,
     #[cfg(any(
@@ -2523,7 +2476,6 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports read-write locks.
     _POSIX_READER_WRITER_LOCKS = libc::_SC_READER_WRITER_LOCKS,
     #[cfg(any(
@@ -2534,7 +2486,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports realtime signals.
     _POSIX_REALTIME_SIGNALS = libc::_SC_REALTIME_SIGNALS,
     #[cfg(any(
@@ -2547,20 +2498,16 @@ pub enum SysconfVar {
         target_os = "openbsd",
         target_os = "solaris"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Regular Expression Handling option.
     _POSIX_REGEXP = libc::_SC_REGEXP,
     /// Each process has a saved set-user-ID and a saved set-group-ID.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SAVED_IDS = libc::_SC_SAVED_IDS,
     /// The implementation supports semaphores.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SEMAPHORES = libc::_SC_SEMAPHORES,
     /// The implementation supports the Shared Memory Objects option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SHARED_MEMORY_OBJECTS = libc::_SC_SHARED_MEMORY_OBJECTS,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2570,7 +2517,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the POSIX shell.
     _POSIX_SHELL = libc::_SC_SHELL,
     #[cfg(any(
@@ -2581,7 +2527,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Spawn option.
     _POSIX_SPAWN = libc::_SC_SPAWN,
     #[cfg(any(
@@ -2592,7 +2537,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports spin locks.
     _POSIX_SPIN_LOCKS = libc::_SC_SPIN_LOCKS,
     #[cfg(any(
@@ -2602,7 +2546,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Process Sporadic Server option.
     _POSIX_SPORADIC_SERVER = libc::_SC_SPORADIC_SERVER,
     #[cfg(any(
@@ -2610,19 +2553,15 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SS_REPL_MAX = libc::_SC_SS_REPL_MAX,
     /// The implementation supports the Synchronized Input and Output option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_SYNCHRONIZED_IO = libc::_SC_SYNCHRONIZED_IO,
     /// The implementation supports the Thread Stack Address Attribute option.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_ATTR_STACKADDR = libc::_SC_THREAD_ATTR_STACKADDR,
     /// The implementation supports the Thread Stack Size Attribute option.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_ATTR_STACKSIZE = libc::_SC_THREAD_ATTR_STACKSIZE,
     #[cfg(any(
         apple_targets,
@@ -2630,21 +2569,17 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread CPU-Time Clocks option.
     _POSIX_THREAD_CPUTIME = libc::_SC_THREAD_CPUTIME,
     /// The implementation supports the Non-Robust Mutex Priority Inheritance
     /// option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_INHERIT = libc::_SC_THREAD_PRIO_INHERIT,
     /// The implementation supports the Non-Robust Mutex Priority Protection option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIO_PROTECT = libc::_SC_THREAD_PRIO_PROTECT,
     /// The implementation supports the Thread Execution Scheduling option.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_PRIORITY_SCHEDULING = libc::_SC_THREAD_PRIORITY_SCHEDULING,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2654,7 +2589,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread Process-Shared Synchronization
     /// option.
     _POSIX_THREAD_PROCESS_SHARED = libc::_SC_THREAD_PROCESS_SHARED,
@@ -2663,7 +2597,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Robust Mutex Priority Inheritance option.
     _POSIX_THREAD_ROBUST_PRIO_INHERIT = libc::_SC_THREAD_ROBUST_PRIO_INHERIT,
     #[cfg(any(
@@ -2671,12 +2604,10 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Robust Mutex Priority Protection option.
     _POSIX_THREAD_ROBUST_PRIO_PROTECT = libc::_SC_THREAD_ROBUST_PRIO_PROTECT,
     /// The implementation supports thread-safe functions.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREAD_SAFE_FUNCTIONS = libc::_SC_THREAD_SAFE_FUNCTIONS,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2685,12 +2616,10 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Thread Sporadic Server option.
     _POSIX_THREAD_SPORADIC_SERVER = libc::_SC_THREAD_SPORADIC_SERVER,
     /// The implementation supports threads.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_THREADS = libc::_SC_THREADS,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2699,12 +2628,10 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports timeouts.
     _POSIX_TIMEOUTS = libc::_SC_TIMEOUTS,
     /// The implementation supports timers.
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TIMERS = libc::_SC_TIMERS,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2713,7 +2640,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace option.
     _POSIX_TRACE = libc::_SC_TRACE,
     #[cfg(any(
@@ -2723,7 +2649,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Event Filter option.
     _POSIX_TRACE_EVENT_FILTER = libc::_SC_TRACE_EVENT_FILTER,
     #[cfg(any(
@@ -2731,7 +2656,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_EVENT_NAME_MAX = libc::_SC_TRACE_EVENT_NAME_MAX,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2740,7 +2664,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Inherit option.
     _POSIX_TRACE_INHERIT = libc::_SC_TRACE_INHERIT,
     #[cfg(any(
@@ -2750,7 +2673,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Trace Log option.
     _POSIX_TRACE_LOG = libc::_SC_TRACE_LOG,
     #[cfg(any(
@@ -2758,21 +2680,18 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_NAME_MAX = libc::_SC_TRACE_NAME_MAX,
     #[cfg(any(
         apple_targets,
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_SYS_MAX = libc::_SC_TRACE_SYS_MAX,
     #[cfg(any(
         apple_targets,
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX_TRACE_USER_EVENT_MAX = libc::_SC_TRACE_USER_EVENT_MAX,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2781,7 +2700,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Typed Memory Objects option.
     _POSIX_TYPED_MEMORY_OBJECTS = libc::_SC_TYPED_MEMORY_OBJECTS,
     /// Integer value indicating version of this standard (C-language binding)
@@ -2796,7 +2714,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int`, `long`, `pointer`, and `off_t` types.
     _POSIX_V6_ILP32_OFF32 = libc::_SC_V6_ILP32_OFF32,
@@ -2808,7 +2725,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int`, `long`, and pointer types and an `off_t` type using at
     /// least 64 bits.
@@ -2821,7 +2737,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with
     /// 32-bit `int` and 64-bit `long`, `pointer`, and `off_t` types.
     _POSIX_V6_LP64_OFF64 = libc::_SC_V6_LP64_OFF64,
@@ -2833,35 +2748,28 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation provides a C-language compilation environment with an
     /// `int` type using at least 32 bits and `long`, pointer, and `off_t` types
     /// using at least 64 bits.
     _POSIX_V6_LPBIG_OFFBIG = libc::_SC_V6_LPBIG_OFFBIG,
     /// The implementation supports the C-Language Binding option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_BIND = libc::_SC_2_C_BIND,
     /// The implementation supports the C-Language Development Utilities option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_C_DEV = libc::_SC_2_C_DEV,
     /// The implementation supports the Terminal Characteristics option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_CHAR_TERM = libc::_SC_2_CHAR_TERM,
     /// The implementation supports the FORTRAN Development Utilities option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_DEV = libc::_SC_2_FORT_DEV,
     /// The implementation supports the FORTRAN Runtime Utilities option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_FORT_RUN = libc::_SC_2_FORT_RUN,
     /// The implementation supports the creation of locales by the localedef
     /// utility.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_LOCALEDEF = libc::_SC_2_LOCALEDEF,
     #[cfg(any(
         target_os = "dragonfly",
@@ -2871,7 +2779,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Environment Services and Utilities
     /// option.
     _POSIX2_PBS = libc::_SC_2_PBS,
@@ -2883,7 +2790,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Accounting option.
     _POSIX2_PBS_ACCOUNTING = libc::_SC_2_PBS_ACCOUNTING,
     #[cfg(any(
@@ -2894,7 +2800,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Checkpoint/Restart option.
     _POSIX2_PBS_CHECKPOINT = libc::_SC_2_PBS_CHECKPOINT,
     #[cfg(any(
@@ -2905,7 +2810,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Locate Batch Job Request option.
     _POSIX2_PBS_LOCATE = libc::_SC_2_PBS_LOCATE,
     #[cfg(any(
@@ -2916,7 +2820,6 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Batch Job Message Request option.
     _POSIX2_PBS_MESSAGE = libc::_SC_2_PBS_MESSAGE,
     #[cfg(any(
@@ -2927,21 +2830,17 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Track Batch Job Request option.
     _POSIX2_PBS_TRACK = libc::_SC_2_PBS_TRACK,
     /// The implementation supports the Software Development Utilities option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_SW_DEV = libc::_SC_2_SW_DEV,
     /// The implementation supports the User Portability Utilities option.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_UPE = libc::_SC_2_UPE,
     /// Integer value indicating version of the Shell and Utilities volume of
     /// POSIX.1 to which the implementation conforms.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _POSIX2_VERSION = libc::_SC_2_VERSION,
     /// The size of a system page in bytes.
     ///
@@ -2949,16 +2848,12 @@ pub enum SysconfVar {
     /// enum constants to have the same value, so nix omits `PAGESIZE`.
     PAGE_SIZE = libc::_SC_PAGE_SIZE,
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_DESTRUCTOR_ITERATIONS = libc::_SC_THREAD_DESTRUCTOR_ITERATIONS,
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_KEYS_MAX = libc::_SC_THREAD_KEYS_MAX,
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_STACK_MIN = libc::_SC_THREAD_STACK_MIN,
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     PTHREAD_THREADS_MAX = libc::_SC_THREAD_THREADS_MAX,
     #[cfg(not(target_os = "haiku"))]
     RE_DUP_MAX = libc::_SC_RE_DUP_MAX,
@@ -2970,10 +2865,8 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     RTSIG_MAX = libc::_SC_RTSIG_MAX,
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SEM_NSEMS_MAX = libc::_SC_SEM_NSEMS_MAX,
     #[cfg(any(
         target_os = "android",
@@ -2983,7 +2876,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SEM_VALUE_MAX = libc::_SC_SEM_VALUE_MAX,
     #[cfg(any(
         target_os = "android",
@@ -2993,7 +2885,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SIGQUEUE_MAX = libc::_SC_SIGQUEUE_MAX,
     STREAM_MAX = libc::_SC_STREAM_MAX,
     #[cfg(any(
@@ -3004,10 +2895,8 @@ pub enum SysconfVar {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     SYMLOOP_MAX = libc::_SC_SYMLOOP_MAX,
     #[cfg(not(target_os = "redox"))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     TIMER_MAX = libc::_SC_TIMER_MAX,
     TTY_NAME_MAX = libc::_SC_TTY_NAME_MAX,
     TZNAME_MAX = libc::_SC_TZNAME_MAX,
@@ -3019,7 +2908,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Encryption Option Group.
     _XOPEN_CRYPT = libc::_SC_XOPEN_CRYPT,
     #[cfg(any(
@@ -3030,7 +2918,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the Issue 4, Version 2 Enhanced
     /// Internationalization Option Group.
     _XOPEN_ENH_I18N = libc::_SC_XOPEN_ENH_I18N,
@@ -3042,7 +2929,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _XOPEN_LEGACY = libc::_SC_XOPEN_LEGACY,
     #[cfg(any(
         target_os = "android",
@@ -3052,7 +2938,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Realtime Option Group.
     _XOPEN_REALTIME = libc::_SC_XOPEN_REALTIME,
     #[cfg(any(
@@ -3063,13 +2948,11 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the X/Open Realtime Threads Option Group.
     _XOPEN_REALTIME_THREADS = libc::_SC_XOPEN_REALTIME_THREADS,
     /// The implementation supports the Issue 4, Version 2 Shared Memory Option
     /// Group.
     #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     _XOPEN_SHM = libc::_SC_XOPEN_SHM,
     #[cfg(any(
         target_os = "dragonfly",
@@ -3078,7 +2961,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the XSI STREAMS Option Group.
     _XOPEN_STREAMS = libc::_SC_XOPEN_STREAMS,
     #[cfg(any(
@@ -3089,7 +2971,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// The implementation supports the XSI option
     _XOPEN_UNIX = libc::_SC_XOPEN_UNIX,
     #[cfg(any(
@@ -3100,7 +2981,6 @@ pub enum SysconfVar {
         target_os = "linux",
         target_os = "openbsd"
     ))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     /// Integer value indicating version of the X/Open Portability Guide to
     /// which the implementation conforms.
     _XOPEN_VERSION = libc::_SC_XOPEN_VERSION,
@@ -3419,7 +3299,6 @@ pub struct User {
         target_os = "linux",
         target_os = "solaris"
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub class: CString,
     /// Last password change
     #[cfg(not(any(
@@ -3431,7 +3310,6 @@ pub struct User {
         target_os = "linux",
         target_os = "solaris"
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub change: libc::time_t,
     /// Expiration time of account
     #[cfg(not(any(
@@ -3443,7 +3321,6 @@ pub struct User {
         target_os = "linux",
         target_os = "solaris"
     )))]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub expire: libc::time_t,
 }
 


### PR DESCRIPTION
## What does this PR do

Remove all the `#[cfg_attr(docsrs, doc(cfg(all())))]` attributes as [they are useless now](https://github.com/nix-rust/nix/pull/1611#discussion_r1391729184)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
