### PR TITLE
docs: document ptr type casting in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -84,3 +84,13 @@ the variable.
 [enum]: https://doc.rust-lang.org/reference.html#enumerations
 [libc]: https://crates.io/crates/libc/
 [std_MaybeUninit]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html
+
+## Pointer type casting
+
+We prefer [`cast()`], [`cast_mut()`] and [`cast_const()`] to cast pointer types
+over the `as` keyword because it is way more easier to change both type and 
+mutability accidentally.
+
+[`cast()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast
+[`cast_mut()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_mut
+[`cast_const()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_const

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -88,8 +88,8 @@ the variable.
 ## Pointer type casting
 
 We prefer [`cast()`], [`cast_mut()`] and [`cast_const()`] to cast pointer types
-over the `as` keyword because they are much more difficult to change both type 
-and mutability accidentally.
+over the `as` keyword because it is much more difficult to accidentally change
+type or mutability that way.
 
 [`cast()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast
 [`cast_mut()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_mut

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -88,8 +88,8 @@ the variable.
 ## Pointer type casting
 
 We prefer [`cast()`], [`cast_mut()`] and [`cast_const()`] to cast pointer types
-over the `as` keyword because it is way more easier to change both type and 
-mutability accidentally.
+over the `as` keyword because they are much more difficult to change both type 
+and mutability accidentally.
 
 [`cast()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast
 [`cast_mut()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_mut


### PR DESCRIPTION
## What does this PR do

Document that we prefer `cast()`, `cast_mut()` and `cast_const()` to cast pointer types over the `as` keyword in `CONVENTIONS.md`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
