### PR TITLE
Temporarily disable armv7-unknown-linux-uclibceabihf in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,9 @@ jobs:
         include:
           - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
-          - target: armv7-unknown-linux-uclibceabihf
+          # Temporarily disable armv7-unknown-linux-uclibceabihf
+          # https://github.com/nix-rust/nix/issues/2200
+          #- target: armv7-unknown-linux-uclibceabihf
           - target: x86_64-unknown-haiku
     steps:
       - name: checkout


### PR DESCRIPTION
Issue #2200

## What does this PR do
Disables a target which fails in CI due to a toolchain bug.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
