### PR TITLE
fix(vendor): declare build.rs as included file in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"
 categories  = ["os::unix-apis"]
-include = ["src/**/*", "test/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+include = ["build.rs", "src/**/*", "test/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## What does this PR do

It adds the file `build.rs` to the package included files in `Cargo.toml`. Without it, when vendoring a project that depends on `nix`, `build.rs` is not added in vendor cache, then macos targets are broken since the `cfg_aliases` configuration added in https://github.com/nix-rust/nix/pull/2169 is missing.

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
