### PR TITLE
impl Display for InterfaceFlags

### DIFF
--- a/changelog/2206.added.md
+++ b/changelog/2206.added.md
@@ -1,0 +1,1 @@
+impl Display for InterfaceFlags

--- a/examples/getifaddrs.rs
+++ b/examples/getifaddrs.rs
@@ -1,0 +1,57 @@
+//! Print all interfaces and interface addresses on the system, in a format
+//! similar to ifconfig(8).
+#![cfg(feature = "net")]
+#[cfg(any(bsd, linux_android, target_os = "illumos"))]
+fn main() {
+    use nix::ifaddrs::getifaddrs;
+    use nix::sys::socket::{SockaddrLike, SockaddrStorage};
+
+    let addrs = getifaddrs().unwrap();
+    let mut ifname = None;
+    for addr in addrs {
+        if ifname.as_ref() != Some(&addr.interface_name) {
+            if ifname.is_some() {
+                println!();
+            }
+            ifname = Some(addr.interface_name.clone());
+            println!(
+                "{}: flags={:x}<{}>",
+                addr.interface_name,
+                addr.flags.bits(),
+                addr.flags
+            );
+        }
+        if let Some(dl) = addr.address.as_ref().unwrap().as_link_addr() {
+            if dl.addr().is_none() {
+                continue;
+            }
+        }
+        let family = addr
+            .address
+            .as_ref()
+            .and_then(SockaddrStorage::family)
+            .map(|af| format!("{:?}", af))
+            .unwrap_or("".to_owned());
+        match (
+            &addr.address,
+            &addr.netmask,
+            &addr.broadcast,
+            &addr.destination,
+        ) {
+            (Some(a), Some(nm), Some(b), None) => {
+                println!("\t{} {} netmask {} broadcast {}", family, a, nm, b)
+            }
+            (Some(a), Some(nm), None, None) => {
+                println!("\t{} {} netmask {}", family, a, nm)
+            }
+            (Some(a), None, None, None) => println!("\t{} {}", family, a),
+            (Some(a), None, None, Some(d)) => {
+                println!("\t{} {} -> {}", family, a, d)
+            }
+            x => todo!("{:?}", x),
+        }
+    }
+}
+
+#[cfg(not(any(bsd, linux_android, target_os = "illumos")))]
+fn main() {}

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -3,6 +3,7 @@
 //! Uses Linux and/or POSIX functions to resolve interface names like "eth0"
 //! or "socan1" into device numbers.
 
+use std::fmt;
 use crate::{Error, NixPath, Result};
 use libc::c_uint;
 
@@ -245,6 +246,13 @@ libc_bitflags!(
         IFF_IPMP;
     }
 );
+
+impl fmt::Display for InterfaceFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        bitflags::parser::to_writer(self, f)
+    }
+}
+
 
 #[cfg(any(
     bsd,


### PR DESCRIPTION
And add a full example for getifaddrs.

## What does this PR do

implements fmt::Display for InterfaceFlags, and adds an example for getifaddrs

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
