### PR TITLE
fix: fix wrong solaris alias

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,10 @@ fn main() {
         macos: { target_os = "macos" },
         netbsd: { target_os = "netbsd" },
         openbsd: { target_os = "openbsd" },
-        solarish: { target_os = "solaris" },
+        solaris: { target_os = "solaris" },
         watchos: { target_os = "watchos" },
         tvos: { target_os = "tvos" },
+
         apple_targets: { any(ios, macos, watchos, tvos) },
         bsd: { any(freebsd, dragonfly, netbsd, openbsd, apple_targets) },
         linux_android: { any(android, linux) },


### PR DESCRIPTION
## What does this PR do

fix the wrong Solaris alias in `build.rs`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
