### PR TITLE
docs: document how to remove/deprecate an interface

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -100,3 +100,20 @@ type or mutability that way.
 [`cast()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast
 [`cast_mut()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_mut
 [`cast_const()`]: https://doc.rust-lang.org/std/primitive.pointer.html#method.cast_const
+
+## Remove/deprecate an interface
+
+In Nix, if we want to remove something, we don't do it immediately, instead, we
+deprecate it for at least one release before removing it.
+
+To deprecate an interface, put the following attribute on the top of it:
+
+```
+#[deprecated(since = "<Version>", note = "<Note to our user>")]
+```
+
+`<Version>` is the version where this interface will be deprecated, in most 
+cases, it will be the version of the next release. And a user-friendly note 
+should be added. Normally, there should be a new interface that will replace
+the old one, so a note should be something like: "<New Interface> should be 
+used instead".


### PR DESCRIPTION
## What does this PR do

 Document how to remove/deprecate an interface in `CONVENTIONs.md`, I saw this in [this comment](https://github.com/nix-rust/nix/pull/1882#issuecomment-1329968842) and #2170

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
