### PR TITLE
Converts `AddressFamily` to struct with associated consts

### DIFF
--- a/changelog/2210.added.md
+++ b/changelog/2210.added.md
@@ -1,0 +1,1 @@
+Added more `AddressFamily` variants.

--- a/changelog/2210.changed.md
+++ b/changelog/2210.changed.md
@@ -1,0 +1,1 @@
+Converted `AddressFamily` to struct with associated constants to support vendor-defined address families.

--- a/examples/getifaddrs.rs
+++ b/examples/getifaddrs.rs
@@ -29,7 +29,7 @@ fn main() {
         let family = addr
             .address
             .as_ref()
-            .and_then(SockaddrStorage::family)
+            .map(SockaddrStorage::family)
             .map(|af| format!("{:?}", af))
             .unwrap_or("".to_owned());
         match (

--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -200,11 +200,10 @@ mod tests {
             } else {
                 continue;
             };
-            if sock.family() == Some(crate::sys::socket::AddressFamily::Inet) {
+            if sock.family() == crate::sys::socket::AddressFamily::INET {
                 let _ = sock.as_sockaddr_in().unwrap();
                 return;
-            } else if sock.family()
-                == Some(crate::sys::socket::AddressFamily::Inet6)
+            } else if sock.family() == crate::sys::socket::AddressFamily::INET6
             {
                 let _ = sock.as_sockaddr_in6().unwrap();
                 return;

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -689,7 +689,7 @@ pub enum ControlMessageOwned {
     /// // Set up
     /// let message = "Ohayō!".as_bytes();
     /// let in_socket = socket(
-    ///     AddressFamily::Inet,
+    ///     AddressFamily::INET,
     ///     SockType::Datagram,
     ///     SockFlag::empty(),
     ///     None).unwrap();
@@ -1458,7 +1458,7 @@ impl<'a> ControlMessage<'a> {
 /// # use nix::unistd::pipe;
 /// # use std::io::IoSlice;
 /// # use std::os::unix::io::AsRawFd;
-/// let (fd1, fd2) = socketpair(AddressFamily::Unix, SockType::Stream, None,
+/// let (fd1, fd2) = socketpair(AddressFamily::UNIX, SockType::Stream, None,
 ///     SockFlag::empty())
 ///     .unwrap();
 /// let (r, w) = pipe().unwrap();
@@ -1476,7 +1476,7 @@ impl<'a> ControlMessage<'a> {
 /// # use std::str::FromStr;
 /// # use std::os::unix::io::AsRawFd;
 /// let localhost = SockaddrIn::from_str("1.2.3.4:8080").unwrap();
-/// let fd = socket(AddressFamily::Inet, SockType::Datagram, SockFlag::empty(),
+/// let fd = socket(AddressFamily::INET, SockType::Datagram, SockFlag::empty(),
 ///     None).unwrap();
 /// let (r, w) = pipe().unwrap();
 ///
@@ -1827,14 +1827,14 @@ mod test {
         let sock_addr = SockaddrIn::from_str("127.0.0.1:6790").unwrap();
 
         let ssock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
         )?;
 
         let rsock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::SOCK_NONBLOCK,
             None,
@@ -2100,7 +2100,7 @@ pub fn socket<T: Into<Option<SockProtocol>>>(
     let mut ty = ty as c_int;
     ty |= flags.bits();
 
-    let res = unsafe { libc::socket(domain as c_int, ty, protocol) };
+    let res = unsafe { libc::socket(domain.family(), ty, protocol) };
 
     match res {
         -1 => Err(Errno::last()),
@@ -2134,7 +2134,7 @@ pub fn socketpair<T: Into<Option<SockProtocol>>>(
     let mut fds = [-1, -1];
 
     let res = unsafe {
-        libc::socketpair(domain as c_int, ty, protocol, fds.as_mut_ptr())
+        libc::socketpair(domain.family(), ty, protocol, fds.as_mut_ptr())
     };
     Errno::result(res)?;
 
@@ -2408,7 +2408,7 @@ mod tests {
     #[test]
     fn can_open_routing_socket() {
         let _ = super::socket(
-            super::AddressFamily::Route,
+            super::AddressFamily::ROUTE,
             super::SockType::Raw,
             super::SockFlag::empty(),
             None,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1382,7 +1382,7 @@ mod test {
         use super::super::*;
 
         let (a, b) = socketpair(
-            AddressFamily::Unix,
+            AddressFamily::UNIX,
             SockType::Stream,
             None,
             SockFlag::empty(),
@@ -1399,7 +1399,7 @@ mod test {
         use super::super::*;
 
         let (a, _b) = socketpair(
-            AddressFamily::Unix,
+            AddressFamily::UNIX,
             SockType::Stream,
             None,
             SockFlag::empty(),
@@ -1414,7 +1414,7 @@ mod test {
         use super::super::*;
 
         let s = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -1430,7 +1430,7 @@ mod test {
         use super::super::*;
 
         let s = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Stream,
             SockFlag::empty(),
             None,

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -24,7 +24,7 @@ pub fn test_timestamping() {
     let sock_addr = SockaddrIn::from_str("127.0.0.1:6790").unwrap();
 
     let ssock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -32,7 +32,7 @@ pub fn test_timestamping() {
     .expect("send socket failed");
 
     let rsock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -85,7 +85,7 @@ pub fn test_timestamping_realtime() {
     let sock_addr = SockaddrIn::from_str("127.0.0.1:6792").unwrap();
 
     let ssock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -93,7 +93,7 @@ pub fn test_timestamping_realtime() {
     .expect("send socket failed");
 
     let rsock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -147,7 +147,7 @@ pub fn test_timestamping_monotonic() {
     let sock_addr = SockaddrIn::from_str("127.0.0.1:6803").unwrap();
 
     let ssock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -155,7 +155,7 @@ pub fn test_timestamping_monotonic() {
     .expect("send socket failed");
 
     let rsock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -293,7 +293,7 @@ pub fn test_getsockname() {
     let tempdir = tempfile::tempdir().unwrap();
     let sockname = tempdir.path().join("sock");
     let sock = socket(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -313,7 +313,7 @@ pub fn test_socketpair() {
     use nix::unistd::{read, write};
 
     let (fd1, fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -335,7 +335,7 @@ pub fn test_recvmsg_sockaddr_un() {
     let tempdir = tempfile::tempdir().unwrap();
     let sockname = tempdir.path().join("sock");
     let sock = socket(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -422,7 +422,7 @@ mod recvfrom {
     #[test]
     pub fn stream() {
         let (fd2, fd1) = socketpair(
-            AddressFamily::Unix,
+            AddressFamily::UNIX,
             SockType::Stream,
             None,
             SockFlag::empty(),
@@ -437,7 +437,7 @@ mod recvfrom {
         let std_sa = SocketAddrV4::from_str("127.0.0.1:6789").unwrap();
         let sock_addr = SockaddrIn::from(std_sa);
         let rsock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -445,7 +445,7 @@ mod recvfrom {
         .unwrap();
         bind(rsock.as_raw_fd(), &sock_addr).unwrap();
         let ssock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -458,7 +458,7 @@ mod recvfrom {
             |_, _| {},
         );
         // UDP sockets should set the from address
-        assert_eq!(AddressFamily::Inet, from.unwrap().family().unwrap());
+        assert_eq!(AddressFamily::INET, from.unwrap().family());
     }
 
     #[cfg(target_os = "linux")]
@@ -481,7 +481,7 @@ mod recvfrom {
 
             let sock_addr = SockaddrIn::new(127, 0, 0, 1, 6791);
             let rsock = socket(
-                AddressFamily::Inet,
+                AddressFamily::INET,
                 SockType::Datagram,
                 SockFlag::empty(),
                 None,
@@ -493,7 +493,7 @@ mod recvfrom {
 
             bind(rsock.as_raw_fd(), &sock_addr).unwrap();
             let ssock = socket(
-                AddressFamily::Inet,
+                AddressFamily::INET,
                 SockType::Datagram,
                 SockFlag::empty(),
                 None,
@@ -544,7 +544,7 @@ mod recvfrom {
             // that `setsockopt` doesn't fail with error
 
             let rsock = socket(
-                AddressFamily::Inet,
+                AddressFamily::INET,
                 SockType::Datagram,
                 SockFlag::empty(),
                 None,
@@ -572,7 +572,7 @@ mod recvfrom {
         let sock_addr2 = SockaddrIn::from(std_sa2);
 
         let rsock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -580,7 +580,7 @@ mod recvfrom {
         .unwrap();
         bind(rsock.as_raw_fd(), &sock_addr).unwrap();
         let ssock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -620,7 +620,7 @@ mod recvfrom {
             |_, _| {},
         );
         // UDP sockets should set the from address
-        assert_eq!(AddressFamily::Inet, from.unwrap().family().unwrap());
+        assert_eq!(AddressFamily::INET, from.unwrap().family());
     }
 
     #[cfg(any(
@@ -641,7 +641,7 @@ mod recvfrom {
         let sock_addr = SockaddrIn::from(inet_addr);
 
         let rsock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -649,7 +649,7 @@ mod recvfrom {
         .unwrap();
         bind(rsock.as_raw_fd(), &sock_addr).unwrap();
         let ssock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -693,7 +693,7 @@ mod recvfrom {
         assert_eq!(res.len(), DATA.len());
 
         for RecvMsg { address, bytes, .. } in res.into_iter() {
-            assert_eq!(AddressFamily::Inet, address.unwrap().family().unwrap());
+            assert_eq!(AddressFamily::INET, address.unwrap().family());
             assert_eq!(DATA.len(), bytes);
         }
 
@@ -722,7 +722,7 @@ mod recvfrom {
         let sock_addr = SockaddrIn::from(inet_addr);
 
         let rsock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -730,7 +730,7 @@ mod recvfrom {
         .unwrap();
         bind(rsock.as_raw_fd(), &sock_addr).unwrap();
         let ssock = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -781,7 +781,7 @@ mod recvfrom {
         assert_eq!(res.len(), NUM_MESSAGES_SENT);
 
         for RecvMsg { address, bytes, .. } in res.into_iter() {
-            assert_eq!(AddressFamily::Inet, address.unwrap().family().unwrap());
+            assert_eq!(AddressFamily::INET, address.unwrap().family());
             assert_eq!(DATA.len(), bytes);
         }
 
@@ -800,7 +800,7 @@ mod recvfrom {
         let sstd_sa = SocketAddrV6::new(addr, sport, 0, 0);
         let saddr = SockaddrIn6::from(sstd_sa);
         let rsock = socket(
-            AddressFamily::Inet6,
+            AddressFamily::INET6,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -815,7 +815,7 @@ mod recvfrom {
             Ok(()) => (),
         }
         let ssock = socket(
-            AddressFamily::Inet6,
+            AddressFamily::INET6,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -828,7 +828,7 @@ mod recvfrom {
             move |s, m, flags| sendto(s.as_raw_fd(), m, &raddr, flags),
             |_, _| {},
         );
-        assert_eq!(AddressFamily::Inet6, from.unwrap().family().unwrap());
+        assert_eq!(AddressFamily::INET6, from.unwrap().family());
         let osent_addr = from.unwrap();
         let sent_addr = osent_addr.as_sockaddr_in6().unwrap();
         assert_eq!(sent_addr.ip(), addr);
@@ -865,7 +865,7 @@ pub fn test_scm_rights() {
     use std::io::{IoSlice, IoSliceMut};
 
     let (fd1, fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -958,7 +958,7 @@ pub fn test_af_alg_cipher() {
     let payload = vec![2u8; payload_len];
 
     let sock = socket(
-        AddressFamily::Alg,
+        AddressFamily::ALG,
         SockType::SeqPacket,
         SockFlag::empty(),
         None,
@@ -1067,7 +1067,7 @@ pub fn test_af_alg_aead() {
     }
 
     let sock = socket(
-        AddressFamily::Alg,
+        AddressFamily::ALG,
         SockType::SeqPacket,
         SockFlag::empty(),
         None,
@@ -1167,7 +1167,7 @@ pub fn test_sendmsg_ipv4packetinfo() {
     use std::io::IoSlice;
 
     let sock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -1232,7 +1232,7 @@ pub fn test_sendmsg_ipv6packetinfo() {
     use std::io::IoSlice;
 
     let sock = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -1290,7 +1290,7 @@ pub fn test_sendmsg_ipv4sendsrcaddr() {
     use std::io::IoSlice;
 
     let sock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -1390,7 +1390,7 @@ pub fn test_sendmsg_empty_cmsgs() {
     use std::io::{IoSlice, IoSliceMut};
 
     let (fd1, fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -1447,7 +1447,7 @@ fn test_scm_credentials() {
     use std::io::{IoSlice, IoSliceMut};
 
     let (send, recv) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -1549,7 +1549,7 @@ fn test_impl_scm_credentials_and_rights(mut space: Vec<u8>) {
     use std::io::{IoSlice, IoSliceMut};
 
     let (send, recv) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -1644,7 +1644,7 @@ pub fn test_named_unixdomain() {
     let tempdir = tempfile::tempdir().unwrap();
     let sockname = tempdir.path().join("sock");
     let s1 = socket(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -1656,7 +1656,7 @@ pub fn test_named_unixdomain() {
 
     let thr = thread::spawn(move || {
         let s2 = socket(
-            AddressFamily::Unix,
+            AddressFamily::UNIX,
             SockType::Stream,
             SockFlag::empty(),
             None,
@@ -1683,7 +1683,7 @@ pub fn test_unnamed_unixdomain() {
     use nix::sys::socket::{SockFlag, SockType};
 
     let (fd_1, _fd_2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -1703,7 +1703,7 @@ pub fn test_unnamed_unixdomain_autobind() {
     use nix::sys::socket::{SockFlag, SockType};
 
     let fd = socket(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -1733,7 +1733,7 @@ pub fn test_syscontrol() {
     };
 
     let fd = socket(
-        AddressFamily::System,
+        AddressFamily::SYSTEM,
         SockType::Datagram,
         SockFlag::empty(),
         SockProtocol::KextControl,
@@ -1779,8 +1779,7 @@ fn loopback_address(
     // return first address matching family
     addrs.find(|ifaddr| {
         ifaddr.flags.contains(InterfaceFlags::IFF_LOOPBACK)
-            && ifaddr.address.as_ref().and_then(SockaddrLike::family)
-                == Some(family)
+            && ifaddr.address.as_ref().map(SockaddrLike::family) == Some(family)
     })
 }
 
@@ -1813,7 +1812,7 @@ pub fn test_recv_ipv4pktinfo() {
     use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
     use std::io::{IoSlice, IoSliceMut};
 
-    let lo_ifaddr = loopback_address(AddressFamily::Inet);
+    let lo_ifaddr = loopback_address(AddressFamily::INET);
     let (lo_name, lo) = match lo_ifaddr {
         Some(ifaddr) => (
             ifaddr.interface_name,
@@ -1822,7 +1821,7 @@ pub fn test_recv_ipv4pktinfo() {
         None => return,
     };
     let receive = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -1838,7 +1837,7 @@ pub fn test_recv_ipv4pktinfo() {
         let iov = [IoSlice::new(&slice)];
 
         let send = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -1909,7 +1908,7 @@ pub fn test_recvif() {
     use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
     use std::io::{IoSlice, IoSliceMut};
 
-    let lo_ifaddr = loopback_address(AddressFamily::Inet);
+    let lo_ifaddr = loopback_address(AddressFamily::INET);
     let (lo_name, lo) = match lo_ifaddr {
         Some(ifaddr) => (
             ifaddr.interface_name,
@@ -1918,7 +1917,7 @@ pub fn test_recvif() {
         None => return,
     };
     let receive = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -1937,7 +1936,7 @@ pub fn test_recvif() {
         let iov = [IoSlice::new(&slice)];
 
         let send = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -2009,7 +2008,7 @@ pub fn test_recvif_ipv4() {
     use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
     use std::io::{IoSlice, IoSliceMut};
 
-    let lo_ifaddr = loopback_address(AddressFamily::Inet);
+    let lo_ifaddr = loopback_address(AddressFamily::INET);
     let (_lo_name, lo) = match lo_ifaddr {
         Some(ifaddr) => (
             ifaddr.interface_name,
@@ -2018,7 +2017,7 @@ pub fn test_recvif_ipv4() {
         None => return,
     };
     let receive = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2035,7 +2034,7 @@ pub fn test_recvif_ipv4() {
         let iov = [IoSlice::new(&slice)];
 
         let send = socket(
-            AddressFamily::Inet,
+            AddressFamily::INET,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -2095,7 +2094,7 @@ pub fn test_recvif_ipv6() {
     use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
     use std::io::{IoSlice, IoSliceMut};
 
-    let lo_ifaddr = loopback_address(AddressFamily::Inet6);
+    let lo_ifaddr = loopback_address(AddressFamily::INET6);
     let (_lo_name, lo) = match lo_ifaddr {
         Some(ifaddr) => (
             ifaddr.interface_name,
@@ -2104,7 +2103,7 @@ pub fn test_recvif_ipv6() {
         None => return,
     };
     let receive = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2121,7 +2120,7 @@ pub fn test_recvif_ipv6() {
         let iov = [IoSlice::new(&slice)];
 
         let send = socket(
-            AddressFamily::Inet6,
+            AddressFamily::INET6,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -2202,7 +2201,7 @@ pub fn test_recv_ipv6pktinfo() {
     use nix::sys::socket::{recvmsg, sendmsg, ControlMessageOwned, MsgFlags};
     use std::io::{IoSlice, IoSliceMut};
 
-    let lo_ifaddr = loopback_address(AddressFamily::Inet6);
+    let lo_ifaddr = loopback_address(AddressFamily::INET6);
     let (lo_name, lo) = match lo_ifaddr {
         Some(ifaddr) => (
             ifaddr.interface_name,
@@ -2211,7 +2210,7 @@ pub fn test_recv_ipv6pktinfo() {
         None => return,
     };
     let receive = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2227,7 +2226,7 @@ pub fn test_recv_ipv6pktinfo() {
         let iov = [IoSlice::new(&slice)];
 
         let send = socket(
-            AddressFamily::Inet6,
+            AddressFamily::INET6,
             SockType::Datagram,
             SockFlag::empty(),
             None,
@@ -2303,7 +2302,7 @@ pub fn test_vsock() {
     .unwrap();
     assert_eq!(
         addr3.as_ref().svm_family,
-        AddressFamily::Vsock as libc::sa_family_t
+        AddressFamily::VSOCK.family() as libc::sa_family_t
     );
     assert_eq!(addr3.as_ref().svm_cid, addr1.cid());
     assert_eq!(addr3.as_ref().svm_port, addr1.port());
@@ -2344,7 +2343,7 @@ pub fn test_vsock() {
     .unwrap();
     assert_eq!(
         addr3.as_ref().svm_family,
-        AddressFamily::Vsock as libc::sa_family_t
+        AddressFamily::VSOCK.family() as libc::sa_family_t
     );
     let cid = addr3.as_ref().svm_cid;
     let port = addr3.as_ref().svm_port;
@@ -2366,7 +2365,7 @@ fn test_recvmsg_timestampns() {
     // Set up
     let message = "Ohayō!".as_bytes();
     let in_socket = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2425,7 +2424,7 @@ fn test_recvmmsg_timestampns() {
     // Set up
     let message = "Ohayō!".as_bytes();
     let in_socket = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2487,14 +2486,14 @@ fn test_recvmsg_rxq_ovfl() {
     let bufsize = message.len() * 2;
 
     let in_socket = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
     )
     .unwrap();
     let out_socket = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2593,7 +2592,7 @@ mod linux_errqueue {
 
         test_recverr_impl::<sockaddr_in, _, _>(
             "127.0.0.1:6800",
-            AddressFamily::Inet,
+            AddressFamily::INET,
             sockopt::Ipv4RecvErr,
             libc::SO_EE_ORIGIN_ICMP,
             IcmpTypes::DestUnreach as u8,
@@ -2606,7 +2605,10 @@ mod linux_errqueue {
                 {
                     if let Some(origin) = err_addr {
                         // Validate that our network error originated from 127.0.0.1:0.
-                        assert_eq!(origin.sin_family, AddressFamily::Inet as _);
+                        assert_eq!(
+                            origin.sin_family,
+                            AddressFamily::INET.family() as _
+                        );
                         assert_eq!(
                             origin.sin_addr.s_addr,
                             u32::from_be(0x7f000001)
@@ -2641,7 +2643,7 @@ mod linux_errqueue {
 
         test_recverr_impl::<sockaddr_in6, _, _>(
             "[::1]:6801",
-            AddressFamily::Inet6,
+            AddressFamily::INET6,
             sockopt::Ipv6RecvErr,
             libc::SO_EE_ORIGIN_ICMP6,
             IcmpV6Types::DestUnreach as u8,
@@ -2656,7 +2658,7 @@ mod linux_errqueue {
                         // Validate that our network error originated from localhost:0.
                         assert_eq!(
                             origin.sin6_family,
-                            AddressFamily::Inet6 as _
+                            AddressFamily::INET6.family() as _
                         );
                         assert_eq!(
                             origin.sin6_addr.s6_addr,
@@ -2763,7 +2765,7 @@ pub fn test_txtime() {
     let sock_addr = SockaddrIn::from_str("127.0.0.1:6802").unwrap();
 
     let ssock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2777,7 +2779,7 @@ pub fn test_txtime() {
     setsockopt(&ssock, sockopt::TxTime, &txtime_cfg).unwrap();
 
     let rsock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -2820,7 +2822,7 @@ fn test_icmp_protocol() {
     require_capability!("test_icmp_protocol", CAP_NET_RAW);
 
     let owned_fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Raw,
         SockFlag::empty(),
         SockProtocol::Icmp,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -17,7 +17,7 @@ pub fn test_local_peercred_seqpacket() {
     };
 
     let (fd1, _fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::SeqPacket,
         None,
         SockFlag::empty(),
@@ -38,7 +38,7 @@ pub fn test_local_peercred_stream() {
     };
 
     let (fd1, _fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -56,7 +56,7 @@ pub fn test_local_peer_pid() {
     use nix::sys::socket::socketpair;
 
     let (fd1, _fd2) = socketpair(
-        AddressFamily::Unix,
+        AddressFamily::UNIX,
         SockType::Stream,
         None,
         SockFlag::empty(),
@@ -74,7 +74,7 @@ fn is_so_mark_functional() {
     require_capability!("is_so_mark_functional", CAP_NET_ADMIN);
 
     let s = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -88,7 +88,7 @@ fn is_so_mark_functional() {
 #[test]
 fn test_so_buf() {
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         SockProtocol::Udp,
@@ -114,7 +114,7 @@ fn test_so_tcp_maxseg() {
     let sock_addr = SockaddrIn::from(std_sa);
 
     let rsock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -138,7 +138,7 @@ fn test_so_tcp_maxseg() {
 
     // Connect and check the MSS that was advertised
     let ssock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -165,7 +165,7 @@ fn test_so_tcp_maxseg() {
 #[test]
 fn test_so_type() {
     let sockfd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -203,7 +203,7 @@ fn test_tcp_congestion() {
     use std::ffi::OsString;
 
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -229,7 +229,7 @@ fn test_bindtodevice() {
     skip_if_not_root!("test_bindtodevice");
 
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         None,
@@ -245,7 +245,7 @@ fn test_bindtodevice() {
 #[test]
 fn test_so_tcp_keepalive() {
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -287,7 +287,7 @@ fn test_get_mtu() {
     let std_sb = SocketAddrV4::from_str("127.0.0.1:4002").unwrap();
 
     let usock = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         SockProtocol::Udp,
@@ -306,7 +306,7 @@ fn test_get_mtu() {
 #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
 fn test_ttl_opts() {
     let fd4 = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -315,7 +315,7 @@ fn test_ttl_opts() {
     setsockopt(&fd4, sockopt::Ipv4Ttl, &1)
         .expect("setting ipv4ttl on an inet socket should succeed");
     let fd6 = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -329,7 +329,7 @@ fn test_ttl_opts() {
 #[cfg(apple_targets)]
 fn test_dontfrag_opts() {
     let fd4 = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -341,7 +341,7 @@ fn test_dontfrag_opts() {
         "unsetting IP_DONTFRAG on an inet stream socket should succeed",
     );
     let fd4d = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -362,7 +362,7 @@ fn test_dontfrag_opts() {
 #[cfg_attr(qemu, ignore)]
 fn test_v6dontfrag_opts() {
     let fd6 = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -375,7 +375,7 @@ fn test_v6dontfrag_opts() {
         "unsetting IPV6_DONTFRAG on an inet6 stream socket should succeed",
     );
     let fd6d = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -393,7 +393,7 @@ fn test_v6dontfrag_opts() {
 #[cfg(target_os = "linux")]
 fn test_so_priority() {
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -408,7 +408,7 @@ fn test_so_priority() {
 #[cfg(target_os = "linux")]
 fn test_ip_tos() {
     let fd = socket(
-        AddressFamily::Inet,
+        AddressFamily::INET,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -426,7 +426,7 @@ fn test_ip_tos() {
 #[cfg_attr(qemu, ignore)]
 fn test_ipv6_tclass() {
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Stream,
         SockFlag::empty(),
         SockProtocol::Tcp,
@@ -441,7 +441,7 @@ fn test_ipv6_tclass() {
 #[cfg(target_os = "freebsd")]
 fn test_receive_timestamp() {
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -457,7 +457,7 @@ fn test_ts_clock_realtime_micro() {
     use nix::sys::socket::SocketTimestamp;
 
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -485,7 +485,7 @@ fn test_ts_clock_bintime() {
     use nix::sys::socket::SocketTimestamp;
 
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -508,7 +508,7 @@ fn test_ts_clock_realtime() {
     use nix::sys::socket::SocketTimestamp;
 
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,
@@ -532,7 +532,7 @@ fn test_ts_clock_monotonic() {
     use nix::sys::socket::SocketTimestamp;
 
     let fd = socket(
-        AddressFamily::Inet6,
+        AddressFamily::INET6,
         SockType::Datagram,
         SockFlag::empty(),
         None,


### PR DESCRIPTION
Split off from #2199

Script I used to generate the variants: https://gist.github.com/Jan561/067d64641c93017a9bf6b346ac078ec1

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
