### PR TITLE
Add `fctrl::SealFlag::F_SEAL_FUTURE_WRITE`

### DIFF
--- a/changelog/2213.added.md
+++ b/changelog/2213.added.md
@@ -1,0 +1,1 @@
+Added `fctrl::SealFlag::F_SEAL_FUTURE_WRITE`

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -420,6 +420,10 @@ libc_bitflags!(
         F_SEAL_GROW;
         /// The file contents cannot be modified.
         F_SEAL_WRITE;
+        /// The file contents cannot be modified, except via shared writable mappings that were
+        /// created prior to the seal being set. Since Linux 5.1.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        F_SEAL_FUTURE_WRITE;
     }
 );
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -422,7 +422,7 @@ libc_bitflags!(
         F_SEAL_WRITE;
         /// The file contents cannot be modified, except via shared writable mappings that were
         /// created prior to the seal being set. Since Linux 5.1.
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(linux_android)]
         F_SEAL_FUTURE_WRITE;
     }
 );


### PR DESCRIPTION
## What does this PR do

Add `fctrl::SealFlag::F_SEAL_FUTURE_WRITE`, a file sealing flag available since Linux 5.1 which prevents modification except via shared writable mappings that were created prior to the seal being set.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
