### PR TITLE
refactor: remove the l4re target

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -230,8 +230,7 @@ impl Entry {
                          target_os = "haiku",
                          solarish,
                          linux_android,
-                         apple_targets,
-                         target_os = "l4re"))] {
+                         apple_targets))] {
                 self.0.d_ino as u64
             } else {
                 u64::from(self.0.d_fileno)


### PR DESCRIPTION
## What does this PR do

Remove the `l4re` target from `src/dir.rs` as requested in this [comment](https://github.com/nix-rust/nix/pull/2214#discussion_r1405421337)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
