### PR TITLE
refactor: cfg for sys/time.rs

### DIFF
--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -97,11 +97,7 @@ pub(crate) mod timer {
             const TFD_TIMER_CANCEL_ON_SET = libc::TFD_TIMER_CANCEL_ON_SET;
         }
     }
-    #[cfg(any(
-        freebsdlike,
-        target_os = "netbsd",
-        target_os = "illumos"
-    ))]
+    #[cfg(any(freebsdlike, target_os = "netbsd", target_os = "illumos"))]
     bitflags! {
         /// Flags that are used for arming the timer.
         #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -98,9 +98,8 @@ pub(crate) mod timer {
         }
     }
     #[cfg(any(
-        target_os = "freebsd",
+        freebsdlike,
         target_os = "netbsd",
-        target_os = "dragonfly",
         target_os = "illumos"
     ))]
     bitflags! {


### PR DESCRIPTION
## What does this PR do

cfg for `src/sys/time.rs`, this should be done in #2221, but I accidentally modified `src/time.rs` rather than `src/sys/time.rs` in that PR.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
