### PR TITLE
Fix the 3rd argument type of ioctl_write_int_bad

### DIFF
--- a/changelog/2233.changed.md
+++ b/changelog/2233.changed.md
@@ -1,0 +1,1 @@
+`ioctl_write_int_bad!` now properly supports passing a `c_ulong` as the parameter on Linux targets.

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -589,8 +589,12 @@ cfg_if! {
 /// The generated function has the following signature:
 ///
 /// ```rust,ignore
-/// pub unsafe fn FUNCTION_NAME(fd: libc::c_int, data: libc::c_int) -> Result<libc::c_int>
+/// pub unsafe fn FUNCTION_NAME(fd: libc::c_int, data: nix::sys::ioctl::ioctl_param_type) -> Result<libc::c_int>
 /// ```
+///
+/// `nix::sys::ioctl::ioctl_param_type` depends on the OS:
+/// *   BSD - `libc::c_int`
+/// *   Linux - `libc::c_ulong`
 ///
 /// For a more in-depth explanation of ioctls, see [`::sys::ioctl`](sys/ioctl/index.html).
 ///
@@ -614,7 +618,7 @@ macro_rules! ioctl_write_int_bad {
     ($(#[$attr:meta])* $name:ident, $nr:expr) => (
         $(#[$attr])*
         pub unsafe fn $name(fd: $crate::libc::c_int,
-                            data: $crate::libc::c_int)
+                            data: $crate::sys::ioctl::ioctl_param_type)
                             -> $crate::Result<$crate::libc::c_int> {
             unsafe {
                 convert_ioctl_res!($crate::libc::ioctl(fd, $nr as $crate::sys::ioctl::ioctl_num_type, data))


### PR DESCRIPTION
This patch follows 5dad660fd4b5 'Correct the third argument to ioctl on appropriate platforms', where only ioctl_write_int was fixed.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
