### PR TITLE
Definition of the `SockaddrFromRaw` trait

### DIFF
--- a/changelog/2235.added.md
+++ b/changelog/2235.added.md
@@ -1,0 +1,1 @@
+Added the `SockaddrFromRaw` trait.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -32,7 +32,7 @@ pub mod sockopt;
  *
  */
 
-pub use self::addr::{SockaddrLike, SockaddrStorage};
+pub use self::addr::{SockaddrFromRaw, SockaddrLike, SockaddrStorage};
 
 #[cfg(solarish)]
 pub use self::addr::{AddressFamily, UnixAddr};


### PR DESCRIPTION
Preparation to fyx #2177.

Example Implementation for `SockaddrIn`:

```rust
unsafe impl private::SockaddrFromRawPriv for Option<SockaddrIn> {
    type Storage = libc::sockaddr_in;

    unsafe fn from_raw(
        addr: *const Self::Storage,
        len: usize,
    ) -> Self {
        if len > mem::size_of::<libc::sockaddr_in>() {
            return None;
        }

        // SAFETY: `sa_family` has been initialized by `Self::init_storage` or by the syscall.
        unsafe {
            if addr_of!((*addr).sin_family).read() as libc::c_int != libc::AF_INET {
                return None;
            }
        }

        unsafe {
            Some(*addr.cast())
        }
    }

    fn init_storage(buf: &mut MaybeUninit<Self::Storage>) {
        // The family of `Self` is `AF_INET`, so setting the family to `AF_UNSPEC` is sufficient.
        let ptr = buf.as_mut_ptr() as *mut libc::sockaddr;
        unsafe { addr_of_mut!((*ptr).sa_family).write(libc::AF_UNSPEC as _) }
    }
}

impl SockaddrFromRaw for Option<SockaddrIn> {}
```

## Alternatives

The functionality of this trait could also be embedded into `SockaddrLike`. But this would force us to set the return type of the `from_raw` function to `Option<XXX>`. This has one disadvantage:

- The conversion to `SockaddrStorage` can never fail. We can assume that `len` is always in bounds of `libc::sockaddr_storage` or otherwise panic.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
