### PR TITLE
feat: ControlMessageOwned::{Ipv4RecvIf,Ipv4RecvDstAddr} for DragonFlyBSD

### DIFF
--- a/changelog/2240.added.md
+++ b/changelog/2240.added.md
@@ -1,0 +1,1 @@
+Enable `ControlMessageOwned::Ipv4RecvIf` and  `ControlMessageOwned::Ipv4RecvDstAddr` for DragonFlyBSD

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -748,11 +748,11 @@ pub enum ControlMessageOwned {
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv6PacketInfo(libc::in6_pktinfo),
-    #[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+    #[cfg(bsd)]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv4RecvIf(libc::sockaddr_dl),
-    #[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+    #[cfg(bsd)]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv4RecvDstAddr(libc::in_addr),
@@ -931,13 +931,13 @@ impl ControlMessageOwned {
                 let info = unsafe { ptr::read_unaligned(p as *const libc::in_pktinfo) };
                 ControlMessageOwned::Ipv4PacketInfo(info)
             }
-            #[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+            #[cfg(bsd)]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVIF) => {
                 let dl = unsafe { ptr::read_unaligned(p as *const libc::sockaddr_dl) };
                 ControlMessageOwned::Ipv4RecvIf(dl)
             },
-            #[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+            #[cfg(bsd)]
             #[cfg(feature = "net")]
             (libc::IPPROTO_IP, libc::IP_RECVDSTADDR) => {
                 let dl = unsafe { ptr::read_unaligned(p as *const libc::in_addr) };

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -842,7 +842,7 @@ sockopt_impl!(
     libc::IPV6_RECVPKTINFO,
     bool
 );
-#[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+#[cfg(bsd)]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -854,7 +854,7 @@ sockopt_impl!(
     libc::IP_RECVIF,
     bool
 );
-#[cfg(any(target_os = "freebsd", apple_targets, netbsdlike))]
+#[cfg(bsd)]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1750,7 +1750,7 @@ pub fn test_syscontrol() {
     // connect(fd.as_raw_fd(), &sockaddr).expect("connect failed");
 }
 
-#[cfg(bsd)]
+#[cfg(bsd, linux_android)]
 fn loopback_address(
     family: AddressFamily,
 ) -> Option<nix::ifaddrs::InterfaceAddress> {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1750,14 +1750,7 @@ pub fn test_syscontrol() {
     // connect(fd.as_raw_fd(), &sockaddr).expect("connect failed");
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "freebsd",
-    apple_targets,
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "openbsd",
-))]
+#[cfg(bsd)]
 fn loopback_address(
     family: AddressFamily,
 ) -> Option<nix::ifaddrs::InterfaceAddress> {

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1880,12 +1880,7 @@ pub fn test_recv_ipv4pktinfo() {
     }
 }
 
-#[cfg(any(
-    target_os = "freebsd",
-    apple_targets,
-    target_os = "netbsd",
-    target_os = "openbsd",
-))]
+#[cfg(bsd)]
 // qemu doesn't seem to be emulating this correctly in these architectures
 #[cfg_attr(
     all(

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1750,7 +1750,7 @@ pub fn test_syscontrol() {
     // connect(fd.as_raw_fd(), &sockaddr).expect("connect failed");
 }
 
-#[cfg(bsd, linux_android)]
+#[cfg(any(bsd, linux_android))]
 fn loopback_address(
     family: AddressFamily,
 ) -> Option<nix::ifaddrs::InterfaceAddress> {


### PR DESCRIPTION
## What does this PR do

Enable `ControlMessageOwned::{Ipv4RecvIf,Ipv4RecvDstAddr}` for DragonFlyBSD as requested in [this comment](https://github.com/nix-rust/nix/pull/2231/files#r1411115229)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
