### PR TITLE
refactor: enable most macOS funcs for apple_targets

### DIFF
--- a/changelog/2241.added.md
+++ b/changelog/2241.added.md
@@ -1,0 +1,1 @@
+`ClockId::set_time()` is now enabled on macOS

--- a/changelog/2241.added.md
+++ b/changelog/2241.added.md
@@ -1,1 +1,1 @@
-`ClockId::set_time()` is now enabled on macOS
+`ClockId::set_time()` and `time::clock_settime()` are now enabled on macOS

--- a/changelog/2241.changed.md
+++ b/changelog/2241.changed.md
@@ -1,0 +1,1 @@
+`ClockId::set_time()` has been disabled on iOS/tvOS/watchOS given that it is only available on macOS

--- a/changelog/2241.changed.md
+++ b/changelog/2241.changed.md
@@ -1,1 +1,0 @@
-`ClockId::set_time()` has been disabled on iOS/tvOS/watchOS given that it is only available on macOS

--- a/src/mount/bsd.rs
+++ b/src/mount/bsd.rs
@@ -30,7 +30,7 @@ libc_bitflags!(
         #[cfg(target_os = "freebsd")]
         MNT_GJOURNAL;
         /// MAC support for objects.
-        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        #[cfg(any(apple_targets, target_os = "freebsd"))]
         MNT_MULTILABEL;
         /// Disable read clustering.
         #[cfg(freebsdlike)]
@@ -58,7 +58,7 @@ libc_bitflags!(
         /// Create a snapshot of the file system.
         ///
         /// See [mksnap_ffs(8)](https://www.freebsd.org/cgi/man.cgi?query=mksnap_ffs)
-        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        #[cfg(any(apple_targets, target_os = "freebsd"))]
         MNT_SNAPSHOT;
         /// Using soft updates.
         #[cfg(any(freebsdlike, netbsdlike))]
@@ -71,7 +71,7 @@ libc_bitflags!(
         MNT_SYNCHRONOUS;
         /// Union with underlying fs.
         #[cfg(any(
-                target_os = "macos",
+                apple_targets,
                 target_os = "freebsd",
                 target_os = "netbsd"
         ))]

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -5,8 +5,8 @@ mod linux;
 #[cfg(linux_android)]
 pub use self::linux::*;
 
-#[cfg(any(freebsdlike, netbsdlike, target_os = "macos"))]
+#[cfg(bsd)]
 mod bsd;
 
-#[cfg(any(freebsdlike, netbsdlike, target_os = "macos"))]
+#[cfg(bsd)]
 pub use self::bsd::*;

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -82,7 +82,7 @@ libc_bitflags!(
         #[cfg(any(linux_android, target_os = "fuchsia"))]
         IFF_SLAVE;
         /// Can't hear own transmissions.
-        #[cfg(any(freebsdlike, netbsdlike, target_os = "macos"))]
+        #[cfg(bsd)]
         IFF_SIMPLEX;
         /// Supports multicast. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -191,7 +191,7 @@ libc_bitflags! {
         EV_NODATA;
         #[allow(missing_docs)]
         EV_ONESHOT;
-        #[cfg(any(target_os = "macos", target_os = "tvos"))]
+        #[cfg(apple_targets)]
         #[allow(missing_docs)]
         EV_OOBAND;
         #[cfg(apple_targets)]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -66,7 +66,7 @@ feature! {
     pub mod pthread;
 }
 
-#[cfg(any(linux_android, freebsdlike, target_os = "macos", netbsdlike))]
+#[cfg(any(linux_android, bsd))]
 feature! {
     #![feature = "ptrace"]
     #[allow(missing_docs)]

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -9,7 +9,7 @@ use std::ptr;
 pub type RequestType = c_int;
 
 cfg_if! {
-    if #[cfg(any(freebsdlike, target_os = "macos", target_os = "openbsd"))] {
+    if #[cfg(any(freebsdlike, apple_targets, target_os = "openbsd"))] {
         #[doc(hidden)]
         pub type AddressType = *mut ::libc::c_char;
     } else {
@@ -26,26 +26,26 @@ libc_enum! {
         PT_TRACE_ME,
         PT_READ_I,
         PT_READ_D,
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         PT_READ_U,
         PT_WRITE_I,
         PT_WRITE_D,
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         PT_WRITE_U,
         PT_CONTINUE,
         PT_KILL,
-        #[cfg(any(any(freebsdlike, target_os = "macos"),
+        #[cfg(any(any(freebsdlike, apple_targets),
                   all(target_os = "openbsd", target_arch = "x86_64"),
                   all(target_os = "netbsd", any(target_arch = "x86_64",
                                                 target_arch = "powerpc"))))]
         PT_STEP,
         PT_ATTACH,
         PT_DETACH,
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         PT_SIGEXC,
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         PT_THUPDATE,
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         PT_ATTACHEXC
     }
 }
@@ -149,7 +149,7 @@ pub fn kill(pid: Pid) -> Result<()> {
 /// }
 /// ```
 #[cfg(any(
-    any(freebsdlike, target_os = "macos"),
+    any(freebsdlike, apple_targets),
     all(target_os = "openbsd", target_arch = "x86_64"),
     all(
         target_os = "netbsd",

--- a/src/sys/ptrace/mod.rs
+++ b/src/sys/ptrace/mod.rs
@@ -6,8 +6,8 @@ mod linux;
 #[cfg(linux_android)]
 pub use self::linux::*;
 
-#[cfg(any(freebsdlike, netbsdlike, target_os = "macos"))]
+#[cfg(bsd)]
 mod bsd;
 
-#[cfg(any(freebsdlike, netbsdlike, target_os = "macos"))]
+#[cfg(bsd)]
 pub use self::bsd::*;

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -8,7 +8,7 @@
 ))]
 #[cfg(feature = "net")]
 pub use self::datalink::LinkAddr;
-#[cfg(any(linux_android, target_os = "macos"))]
+#[cfg(any(linux_android, apple_targets))]
 pub use self::vsock::VsockAddr;
 use super::sa_family_t;
 use crate::errno::Errno;
@@ -197,7 +197,7 @@ pub enum AddressFamily {
     #[cfg(target_os = "linux")]
     Nfc = libc::AF_NFC,
     /// VMWare VSockets protocol for hypervisor-guest interaction.
-    #[cfg(any(linux_android, target_os = "macos"))]
+    #[cfg(any(linux_android, apple_targets))]
     Vsock = libc::AF_VSOCK,
     /// ARPANet IMP addresses
     #[cfg(bsd)]
@@ -259,7 +259,7 @@ impl AddressFamily {
             libc::AF_INET6 => Some(AddressFamily::Inet6),
             #[cfg(linux_android)]
             libc::AF_NETLINK => Some(AddressFamily::Netlink),
-            #[cfg(target_os = "macos")]
+            #[cfg(apple_targets)]
             libc::AF_SYSTEM => Some(AddressFamily::System),
             #[cfg(not(any(linux_android, target_os = "redox")))]
             libc::PF_ROUTE => Some(AddressFamily::Route),
@@ -267,7 +267,7 @@ impl AddressFamily {
             libc::AF_PACKET => Some(AddressFamily::Packet),
             #[cfg(any(bsd, target_os = "illumos"))]
             libc::AF_LINK => Some(AddressFamily::Link),
-            #[cfg(any(linux_android, target_os = "macos"))]
+            #[cfg(any(linux_android, apple_targets))]
             libc::AF_VSOCK => Some(AddressFamily::Vsock),
             _ => None,
         }
@@ -1078,7 +1078,7 @@ pub union SockaddrStorage {
     sin6: SockaddrIn6,
     ss: libc::sockaddr_storage,
     su: UnixAddr,
-    #[cfg(any(linux_android, target_os = "macos"))]
+    #[cfg(any(linux_android, apple_targets))]
     vsock: VsockAddr,
 }
 impl private::SockaddrLikePriv for SockaddrStorage {}
@@ -1154,7 +1154,7 @@ impl SockaddrLike for SockaddrStorage {
                 libc::AF_SYSTEM => unsafe {
                     SysControlAddr::from_raw(addr, l).map(|sctl| Self { sctl })
                 },
-                #[cfg(any(linux_android, target_os = "macos"))]
+                #[cfg(any(linux_android, apple_targets))]
                 libc::AF_VSOCK => unsafe {
                     VsockAddr::from_raw(addr, l).map(|vsock| Self { vsock })
                 },
@@ -1312,7 +1312,7 @@ impl SockaddrStorage {
     accessors! {as_sys_control_addr, as_sys_control_addr_mut, SysControlAddr,
     AddressFamily::System, libc::sockaddr_ctl, sctl}
 
-    #[cfg(any(linux_android, target_os = "macos"))]
+    #[cfg(any(linux_android, apple_targets))]
     accessors! {as_vsock_addr, as_vsock_addr_mut, VsockAddr,
     AddressFamily::Vsock, libc::sockaddr_vm, vsock}
 }
@@ -1349,7 +1349,7 @@ impl fmt::Display for SockaddrStorage {
                 #[cfg(feature = "ioctl")]
                 libc::AF_SYSTEM => self.sctl.fmt(f),
                 libc::AF_UNIX => self.su.fmt(f),
-                #[cfg(any(linux_android, target_os = "macos"))]
+                #[cfg(any(linux_android, apple_targets))]
                 libc::AF_VSOCK => self.vsock.fmt(f),
                 _ => "<Address family unspecified>".fmt(f),
             }
@@ -1411,7 +1411,7 @@ impl Hash for SockaddrStorage {
                 #[cfg(feature = "ioctl")]
                 libc::AF_SYSTEM => self.sctl.hash(s),
                 libc::AF_UNIX => self.su.hash(s),
-                #[cfg(any(linux_android, target_os = "macos"))]
+                #[cfg(any(linux_android, apple_targets))]
                 libc::AF_VSOCK => self.vsock.hash(s),
                 _ => self.ss.hash(s),
             }
@@ -1441,7 +1441,7 @@ impl PartialEq for SockaddrStorage {
                 #[cfg(feature = "ioctl")]
                 (libc::AF_SYSTEM, libc::AF_SYSTEM) => self.sctl == other.sctl,
                 (libc::AF_UNIX, libc::AF_UNIX) => self.su == other.su,
-                #[cfg(any(linux_android, target_os = "macos"))]
+                #[cfg(any(linux_android, apple_targets))]
                 (libc::AF_VSOCK, libc::AF_VSOCK) => self.vsock == other.vsock,
                 _ => false,
             }
@@ -1972,7 +1972,7 @@ mod datalink {
     }
 }
 
-#[cfg(any(linux_android, target_os = "macos"))]
+#[cfg(any(linux_android, apple_targets))]
 pub mod vsock {
     use super::*;
     use crate::sys::socket::addr::AddressFamily;
@@ -2023,7 +2023,7 @@ pub mod vsock {
             (inner.svm_family, inner.svm_cid, inner.svm_port)
                 == (other.svm_family, other.svm_cid, other.svm_port)
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         fn eq(&self, other: &Self) -> bool {
             let (inner, other) = (self.0, other.0);
             (
@@ -2048,7 +2048,7 @@ pub mod vsock {
             let inner = self.0;
             (inner.svm_family, inner.svm_cid, inner.svm_port).hash(s);
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(apple_targets)]
         fn hash<H: Hasher>(&self, s: &mut H) {
             let inner = self.0;
             (
@@ -2073,7 +2073,7 @@ pub mod vsock {
             addr.svm_cid = cid;
             addr.svm_port = port;
 
-            #[cfg(target_os = "macos")]
+            #[cfg(apple_targets)]
             {
                 addr.svm_len = std::mem::size_of::<sockaddr_vm>() as u8;
             }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -52,7 +52,7 @@ pub use crate::sys::socket::addr::netlink::NetlinkAddr;
 #[cfg(apple_targets)]
 #[cfg(feature = "ioctl")]
 pub use crate::sys::socket::addr::sys_control::SysControlAddr;
-#[cfg(any(linux_android, target_os = "macos"))]
+#[cfg(any(linux_android, apple_targets))]
 pub use crate::sys::socket::addr::vsock::VsockAddr;
 
 #[cfg(all(feature = "uio", not(target_os = "redox")))]

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -9,10 +9,7 @@ use std::os::unix::io::{AsFd, AsRawFd};
 
 use cfg_if::cfg_if;
 
-#[cfg(all(
-    feature = "mount",
-    any(freebsdlike, target_os = "macos", netbsdlike)
-))]
+#[cfg(all(feature = "mount", bsd))]
 use crate::mount::MntFlags;
 #[cfg(target_os = "linux")]
 use crate::sys::statvfs::FsFlags;
@@ -422,10 +419,7 @@ impl Statfs {
     }
 
     /// Get the mount flags
-    #[cfg(all(
-        feature = "mount",
-        any(freebsdlike, target_os = "macos", netbsdlike)
-    ))]
+    #[cfg(all(feature = "mount", bsd))]
     #[allow(clippy::unnecessary_cast)] // Not unnecessary on all arches
     pub fn flags(&self) -> MntFlags {
         MntFlags::from_bits_truncate(self.0.f_flags as i32)
@@ -624,10 +618,7 @@ impl Debug for Statfs {
         ds.field("files", &self.files());
         ds.field("files_free", &self.files_free());
         ds.field("filesystem_id", &self.filesystem_id());
-        #[cfg(all(
-            feature = "mount",
-            any(freebsdlike, target_os = "macos", netbsdlike)
-        ))]
+        #[cfg(all(feature = "mount", bsd))]
         ds.field("flags", &self.flags());
         ds.finish()
     }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -277,18 +277,18 @@ libc_enum! {
         B1800,
         B2400,
         B4800,
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         B7200,
         B9600,
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         B14400,
         B19200,
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         B28800,
         B38400,
         #[cfg(not(target_os = "aix"))]
         B57600,
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         B76800,
         #[cfg(not(target_os = "aix"))]
         B115200,
@@ -405,10 +405,8 @@ libc_enum! {
     pub enum SpecialCharacterIndices {
         #[cfg(not(any(target_os = "aix", target_os = "haiku")))]
         VDISCARD,
-        #[cfg(any(freebsdlike,
+        #[cfg(any(bsd,
                 solarish,
-                target_os = "macos",
-                netbsdlike,
                 target_os = "aix"))]
         VDSUSP,
         VEOF,
@@ -428,10 +426,7 @@ libc_enum! {
         #[cfg(not(target_os = "haiku"))]
         VREPRINT,
         VSTART,
-        #[cfg(any(freebsdlike,
-                solarish,
-                target_os = "macos",
-                netbsdlike))]
+        #[cfg(any(bsd, solarish))]
         VSTATUS,
         VSTOP,
         VSUSP,
@@ -461,13 +456,7 @@ impl SpecialCharacterIndices {
 }
 
 pub use libc::NCCS;
-#[cfg(any(
-    linux_android,
-    freebsdlike,
-    target_os = "aix",
-    target_os = "macos",
-    netbsdlike
-))]
+#[cfg(any(linux_android, target_os = "aix", bsd))]
 pub use libc::_POSIX_VDISABLE;
 
 libc_bitflags! {
@@ -488,7 +477,7 @@ libc_bitflags! {
         IXANY;
         #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
         IMAXBEL;
-        #[cfg(any(linux_android, target_os = "macos"))]
+        #[cfg(any(linux_android, apple_targets))]
         IUTF8;
     }
 }
@@ -579,7 +568,7 @@ libc_bitflags! {
         FF1 as tcflag_t;
         #[cfg(bsd)]
         OXTABS;
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         ONOEOT as tcflag_t;
 
         // Bitmasks for use with OutputFlags to select specific settings
@@ -641,7 +630,7 @@ libc_bitflags! {
         CIBAUD;
         #[cfg(linux_android)]
         CBAUDEX;
-        #[cfg(any(freebsdlike, target_os = "macos", netbsdlike))]
+        #[cfg(bsd)]
         MDMBUF;
         #[cfg(netbsdlike)]
         CHWFLOW;

--- a/src/time.rs
+++ b/src/time.rs
@@ -40,7 +40,11 @@ impl ClockId {
     }
 
     /// Sets time to `timespec` on the clock id
-    #[cfg(not(any(apple_targets, target_os = "redox", target_os = "hermit",)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "redox",
+        target_os = "hermit"
+    )))]
     pub fn set_time(self, timespec: TimeSpec) -> Result<()> {
         clock_settime(self, timespec)
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -170,7 +170,13 @@ pub fn clock_gettime(clock_id: ClockId) -> Result<TimeSpec> {
 
 /// Set the time of the specified clock, (see
 /// [clock_settime(2)](https://pubs.opengroup.org/onlinepubs/7908799/xsh/clock_settime.html)).
-#[cfg(not(any(apple_targets, target_os = "redox", target_os = "hermit",)))]
+#[cfg(not(any(
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "redox",
+    target_os = "hermit"
+)))]
 pub fn clock_settime(clock_id: ClockId, timespec: TimeSpec) -> Result<()> {
     let ret =
         unsafe { libc::clock_settime(clock_id.as_raw(), timespec.as_ref()) };

--- a/src/time.rs
+++ b/src/time.rs
@@ -41,7 +41,9 @@ impl ClockId {
 
     /// Sets time to `timespec` on the clock id
     #[cfg(not(any(
-        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
         target_os = "redox",
         target_os = "hermit"
     )))]

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -52,7 +52,7 @@ mod test_pthread;
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "linux",
-    target_os = "macos",
+    apple_targets,
     target_os = "netbsd",
     target_os = "openbsd"
 ))]

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -67,7 +67,7 @@ mod aio_fsync {
     // Skip on Linux, because Linux's AIO implementation can't detect errors
     // synchronously
     #[test]
-    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    #[cfg(any(target_os = "freebsd", apple_targets))]
     fn error() {
         use std::mem;
 
@@ -157,7 +157,7 @@ mod aio_read {
     // Skip on Linux, because Linux's AIO implementation can't detect errors
     // synchronously
     #[test]
-    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    #[cfg(any(target_os = "freebsd", apple_targets))]
     fn error() {
         const INITIAL: &[u8] = b"abcdef123456";
         let mut rbuf = vec![0; 4];
@@ -411,7 +411,7 @@ mod aio_write {
     // Skip on Linux, because Linux's AIO implementation can't detect errors
     // synchronously
     #[test]
-    #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+    #[cfg(any(target_os = "freebsd", apple_targets))]
     fn error() {
         let wbuf = "CDEF".to_string().into_bytes();
         let mut aiow = Box::pin(AioWrite::new(
@@ -574,7 +574,7 @@ fn test_aio_cancel_all() {
 #[cfg_attr(target_os = "linux", ignore)]
 // On Cirrus, aio_suspend is failing with EINVAL
 // https://github.com/nix-rust/nix/issues/1361
-#[cfg_attr(target_os = "macos", ignore)]
+#[cfg_attr(apple_targets, ignore)]
 fn test_aio_suspend() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEFG";

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1156,7 +1156,7 @@ pub fn test_af_alg_aead() {
 // This would be a more interesting test if we could assume that the test host
 // has more than one IP address (since we could select a different address to
 // test from).
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", apple_targets, target_os = "netbsd"))]
 #[test]
 pub fn test_sendmsg_ipv4packetinfo() {
     use cfg_if::cfg_if;
@@ -1218,7 +1218,7 @@ pub fn test_sendmsg_ipv4packetinfo() {
 // test from).
 #[cfg(any(
     target_os = "linux",
-    target_os = "macos",
+    apple_targets,
     target_os = "netbsd",
     target_os = "freebsd"
 ))]
@@ -2309,7 +2309,7 @@ pub fn test_vsock() {
     assert_eq!(addr3.as_ref().svm_port, addr1.port());
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(apple_targets)]
 #[test]
 pub fn test_vsock() {
     use nix::sys::socket::SockaddrLike;


### PR DESCRIPTION
## What does this PR do

1. Enable most macOS functions for apple_targets
2. Enable `ClockId::setime()` and `time::clock_settime()` on macOS

Closes #2238

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
