### PR TITLE
Added IpBindAddressNoPort sockopt

### DIFF
--- a/changelog/2244.added.md
+++ b/changelog/2244.added.md
@@ -1,0 +1,1 @@
+Added `IpBindAddressNoPort` sockopt to support `IP_BIND_ADDRESS_NO_PORT` available on linux.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -412,6 +412,20 @@ sockopt_impl!(
     libc::IP_FREEBIND,
     bool
 );
+#[cfg(linux_android)]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// If enabled, the kernel will not reserve an ephemeral port when binding
+    /// socket with a port number of 0. The port will later be automatically
+    /// chosen at connect time, in a way that allows sharing a source port as
+    /// long as the 4-tuple is unique.
+    IpBindAddressNoPort,
+    Both,
+    libc::IPPROTO_IP,
+    libc::IP_BIND_ADDRESS_NO_PORT,
+    bool
+);
 sockopt_impl!(
     /// Specify the receiving timeout until reporting an error.
     ReceiveTimeout,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -549,3 +549,30 @@ fn test_ts_clock_monotonic() {
         SocketTimestamp::SO_TS_MONOTONIC
     );
 }
+
+#[test]
+#[cfg(linux_android)]
+// Disable the test under emulation because it failsi with ENOPROTOOPT in CI
+// on cross target. Lack of QEMU support is suspected.
+#[cfg_attr(qemu, ignore)]
+fn test_ip_bind_address_no_port() {
+    let fd = socket(
+        AddressFamily::Inet,
+        SockType::Stream,
+        SockFlag::empty(),
+        SockProtocol::Tcp,
+    )
+    .unwrap();
+    setsockopt(&fd, sockopt::IpBindAddressNoPort, &true).expect(
+        "setting IP_BIND_ADDRESS_NO_PORT on an inet stream socket should succeed",
+    );
+    assert!(getsockopt(&fd, sockopt::IpBindAddressNoPort).expect(
+        "getting IP_BIND_ADDRESS_NO_PORT on an inet stream socket should succeed",
+    ));
+    setsockopt(&fd, sockopt::IpBindAddressNoPort, &false).expect(
+        "unsetting IP_BIND_ADDRESS_NO_PORT on an inet stream socket should succeed",
+    );
+    assert!(!getsockopt(&fd, sockopt::IpBindAddressNoPort).expect(
+        "getting IP_BIND_ADDRESS_NO_PORT on an inet stream socket should succeed",
+    ));
+}


### PR DESCRIPTION
From [man page](https://man7.org/linux/man-pages/man7/ip.7.html):
```
IP_BIND_ADDRESS_NO_PORT (since Linux 4.2)
       Inform the kernel to not reserve an ephemeral port when
       using bind(2) with a port number of 0.  The port will
       later be automatically chosen at connect(2) time, in a way
       that allows sharing a source port as long as the 4-tuple
       is unique.
```

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
