### PR TITLE
feat: MapFlags::map_hugetlb_with_size_log2 for Android/Fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.148", features = ["extra_traits"] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "497ac428bc010b5db9682ecf94cd567b31d53e5c", features = [ "extra_traits" ] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "497ac428bc010b5db9682ecf94cd567b31d53e5c", features = [ "extra_traits" ] }
+libc = { git = "https://github.com/rust-lang/libc", rev = "497ac428bc010b5db9682ecf94cd567b31d53e5c", features = ["extra_traits"] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2245.added.md
+++ b/changelog/2245.added.md
@@ -1,0 +1,1 @@
+Enable `MapFlags::map_hugetlb_with_size_log2` method for Android/Fuchsia

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -169,10 +169,7 @@ impl MapFlags {
     /// let f = MapFlags::map_hugetlb_with_size_log2(30).unwrap();
     /// assert_eq!(f, MapFlags::MAP_HUGETLB | MapFlags::MAP_HUGE_1GB);
     /// ```
-    // TODO: support Andorid and Fuchsia when https://github.com/rust-lang/libc/pull/3444
-    // will be released
-    #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(all())))]
+    #[cfg(any(linux_android, target_os = "fuchsia"))]
     pub fn map_hugetlb_with_size_log2(
         huge_page_size_log2: u32,
     ) -> Option<Self> {


### PR DESCRIPTION
## What does this PR do

Enable `MapFlags::map_hugetlb_with_size_log2` for Android/Fuchsia

This is a TODO left in #2125


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
