### PR TITLE
docs: document that we should use libc from git repo when under dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Please make pull requests against the `master` branch.
 If you change the API by way of adding, removing or changing something or if
 you fix a bug, please add an appropriate note, every note should be a new markdown 
 file under the [changelog directory][cl] stating the change made by your pull request, 
-the filename should be in the following foramt:
+the filename should be in the following format:
 
 ```
 <PULL_REQUEST_ID>.<TYPE>.md
@@ -104,17 +104,17 @@ run once you open a pull request.
 
 ### Disabling a test in the CI environment
 
-Sometimes there are features that cannot be tested in the CI environment.  To
+Sometimes there are features that cannot be tested in the CI environment. To
 stop a test from running under CI, add `skip_if_cirrus!()` to it. Please
 describe the reason it shouldn't run under CI, and a link to an issue if
-possible!  Other tests cannot be run under QEMU, which is used for some
-architectures.  To skip them, add a `#[cfg_attr(qemu, ignore)]` attribute to
+possible! Other tests cannot be run under QEMU, which is used for some
+architectures. To skip them, add a `#[cfg_attr(qemu, ignore)]` attribute to
 the test.
 
 ## GitHub Merge Queues
 
 We use GitHub merge queues to ensure that subtle merge conflicts won't result
-in failing code.  If you add or remove a CI job, remember to adjust the
+in failing code. If you add or remove a CI job, remember to adjust the
 required status checks in the repository's branch protection rules!
 
 ## API conventions

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -18,7 +18,13 @@ We follow the conventions laid out in [Keep A CHANGELOG][kacl].
 ## libc constants, functions and structs
 
 We do not define integer constants ourselves, but use or reexport them from the
-[libc crate][libc].
+[libc crate][libc], if your PR uses something that does not exist in the libc crate,
+you should add it to libc first, once your libc PR gets merged, you can adjust
+the `rev` number in our `Cargo.toml` to include that libc change.
+
+```toml
+libc = { git = "https://github.com/rust-lang/libc", rev = "the commit includes your libc PR", ... }
+```
 
 We use the functions exported from [libc][libc] instead of writing our own
 `extern` declarations.
@@ -115,5 +121,5 @@ To deprecate an interface, put the following attribute on the top of it:
 `<Version>` is the version where this interface will be deprecated, in most 
 cases, it will be the version of the next release. And a user-friendly note 
 should be added. Normally, there should be a new interface that will replace
-the old one, so a note should be something like: "<New Interface> should be 
+the old one, so a note should be something like: "`<New Interface>` should be 
 used instead".

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,10 +17,11 @@ We follow the conventions laid out in [Keep A CHANGELOG][kacl].
 
 ## libc constants, functions and structs
 
-We do not define integer constants ourselves, but use or reexport them from the
-[libc crate][libc], if your PR uses something that does not exist in the libc crate,
-you should add it to libc first, once your libc PR gets merged, you can adjust
-the `rev` number in our `Cargo.toml` to include that libc change.
+We do not define ffi functions or their associated constants and types ourselves,
+but use or reexport them from the [libc crate][libc], if your PR uses something 
+that does not exist in the libc crate, you should add it to libc first. Once 
+your libc PR gets merged, you can adjust our `libc` dependency to include that 
+libc change. Use a git dependency if necessary.
 
 ```toml
 libc = { git = "https://github.com/rust-lang/libc", rev = "the commit includes your libc PR", ... }
@@ -46,7 +47,7 @@ When creating newtypes, we use Rust's `CamelCase` type naming convention.
 ## cfg gates
 
 When creating operating-system-specific functionality, we gate it by
-`#[cfg(target_os = ...)]`.  If more than one operating system is affected, we
+`#[cfg(target_os = ...)]`. If more than one operating system is affected, we
 prefer to use the cfg aliases defined in build.rs, like `#[cfg(bsd)]`.
 
 ## Bitflags

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -4,15 +4,22 @@ library.
 # Before Release
 
 Nix uses [cargo release](https://github.com/crate-ci/cargo-release) to automate
-the release process.  Based on changes since the last release, pick a new
+the release process. Based on changes since the last release, pick a new
 version number following semver conventions. For nix, a change that drops
 support for some Rust versions counts as a breaking change, and requires a
 major bump.
 
 The release is prepared as follows:
 
-- Ask for a new libc version if, necessary. It usually is.  Then update the
-  dependency in Cargo.toml accordingly.
+- Ask for a new libc version if, necessary. It usually is. Then update the
+  dependency in `Cargo.toml` to rely on a release from crates.io.
+ 
+  ```toml
+  [dependencies]
+  -libc = { git = "https://github.com/rust-lang/libc", rev = "<Revision>", features = ["extra_traits"] }
+  +libc = { version = "<New Version>", features = ["extra_traits"] }
+  ```
+  
 - Update the version number in `Cargo.toml`
 - Generate `CHANGELOG.md` for this release by 
   `towncrier build --version=<VERSION> --yes`

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -16,8 +16,8 @@ The release is prepared as follows:
  
   ```toml
   [dependencies]
-  -libc = { git = "https://github.com/rust-lang/libc", rev = "<Revision>", features = ["extra_traits"] }
-  +libc = { version = "<New Version>", features = ["extra_traits"] }
+  - libc = { git = "https://github.com/rust-lang/libc", rev = "<Revision>", features = ["extra_traits"] }
+  + libc = { version = "<New Version>", features = ["extra_traits"] }
   ```
   
 - Update the version number in `Cargo.toml`

--- a/RELEASE_PROCEDURE.md
+++ b/RELEASE_PROCEDURE.md
@@ -14,10 +14,10 @@ The release is prepared as follows:
 - Ask for a new libc version if, necessary. It usually is. Then update the
   dependency in `Cargo.toml` to rely on a release from crates.io.
  
-  ```toml
+  ```diff
   [dependencies]
-  - libc = { git = "https://github.com/rust-lang/libc", rev = "<Revision>", features = ["extra_traits"] }
-  + libc = { version = "<New Version>", features = ["extra_traits"] }
+  -libc = { git = "https://github.com/rust-lang/libc", rev = "<Revision>", features = ["extra_traits"] }
+  +libc = { version = "<New Version>", features = ["extra_traits"] }
   ```
   
 - Update the version number in `Cargo.toml`


### PR DESCRIPTION
## What does this PR do

1. Document that we should use the libc from its git repo when under development, closes #2243
2. style: make all the documents use one space between sentences
3. Fix a typo and a code snippet that was not correctly rendered

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
