### PR TITLE
Fixes recvm(m)sg blindly assuming correct initialization of received address

### DIFF
--- a/changelog/2249.fixed.md
+++ b/changelog/2249.fixed.md
@@ -1,0 +1,1 @@
+Fixed `recvm(m)sg` not checking the address family field of the received address.


### PR DESCRIPTION
`recvm(m)sg` now calling `SockaddrLike::from_raw` instead of `assume_init` on the received address

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
