### PR TITLE
refactor: some clippy warnings

### DIFF
--- a/src/poll_timeout.rs
+++ b/src/poll_timeout.rs
@@ -14,7 +14,7 @@ impl PollTimeout {
     /// > Specifying a timeout of zero causes poll() to return immediately, even if no file
     /// > descriptors are ready.
     pub const ZERO: Self = Self(0);
-    /// Blocks for at most [`std::i32::MAX`] milliseconds.
+    /// Blocks for at most [`i32::MAX`] milliseconds.
     pub const MAX: Self = Self(i32::MAX);
     /// Returns if `self` equals [`PollTimeout::NONE`].
     pub fn is_none(&self) -> bool {

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1599,7 +1599,7 @@ impl<S> MultiHeaders<S> {
             .enumerate()
             .map(|(ix, address)| {
                 let (ptr, cap) = match &mut cmsg_buffers {
-                    Some(v) => ((&mut v[ix * msg_controllen] as *mut u8), msg_controllen),
+                    Some(v) => (&mut v[ix * msg_controllen] as *mut u8, msg_controllen),
                     None => (std::ptr::null_mut(), 0),
                 };
                 let msg_hdr = unsafe { pack_mhdr_to_receive(std::ptr::null_mut(), 0, ptr, cap, address.as_mut_ptr()) };

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1520,7 +1520,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
     // equal to the value of {NGROUPS_MAX} + 1.
     let ngroups_max = match sysconf(SysconfVar::NGROUPS_MAX) {
         Ok(Some(n)) => (n + 1) as usize,
-        Ok(None) | Err(_) => <usize>::max_value(),
+        Ok(None) | Err(_) => usize::MAX,
     };
 
     // Next, get the number of groups so we can size our Vec
@@ -1654,7 +1654,7 @@ pub fn setgroups(groups: &[Gid]) -> Result<()> {
 pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
     let ngroups_max = match sysconf(SysconfVar::NGROUPS_MAX) {
         Ok(Some(n)) => n as c_int,
-        Ok(None) | Err(_) => <c_int>::max_value(),
+        Ok(None) | Err(_) => c_int::MAX,
     };
     use std::cmp::min;
     let mut groups = Vec::<Gid>::with_capacity(min(ngroups_max, 8) as usize);
@@ -2861,9 +2861,9 @@ mod getres {
     ///
     #[inline]
     pub fn getresuid() -> Result<ResUid> {
-        let mut ruid = libc::uid_t::max_value();
-        let mut euid = libc::uid_t::max_value();
-        let mut suid = libc::uid_t::max_value();
+        let mut ruid = libc::uid_t::MAX;
+        let mut euid = libc::uid_t::MAX;
+        let mut suid = libc::uid_t::MAX;
         let res = unsafe { libc::getresuid(&mut ruid, &mut euid, &mut suid) };
 
         Errno::result(res).map(|_| ResUid {
@@ -2884,9 +2884,9 @@ mod getres {
     ///
     #[inline]
     pub fn getresgid() -> Result<ResGid> {
-        let mut rgid = libc::gid_t::max_value();
-        let mut egid = libc::gid_t::max_value();
-        let mut sgid = libc::gid_t::max_value();
+        let mut rgid = libc::gid_t::MAX;
+        let mut egid = libc::gid_t::MAX;
+        let mut sgid = libc::gid_t::MAX;
         let res = unsafe { libc::getresgid(&mut rgid, &mut egid, &mut sgid) };
 
         Errno::result(res).map(|_| ResGid {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1063,8 +1063,8 @@ fn test_linkat_follow_symlink() {
 
     // Check the file type of the new link
     assert_eq!(
-        (stat::SFlag::from_bits_truncate(newfilestat.st_mode as mode_t)
-            & SFlag::S_IFMT),
+        stat::SFlag::from_bits_truncate(newfilestat.st_mode as mode_t)
+            & SFlag::S_IFMT,
         SFlag::S_IFREG
     );
 


### PR DESCRIPTION
## What does this PR do

Fix some clippy warnings

1. Some deprecated `type::max_valus()` functions, replace them with `type::MAX`
2. Two unnecessary parentheses

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
