### PR TITLE
chore: more platofrms to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
 # Tasks for Linux aarch64 native builds 
 task:
   matrix:
-    - name: Linux aarch64
+    - name: Linux aarch64 glibc
       arm_container:
         image: rust:1.69.0
         cpu: 1
@@ -76,6 +76,14 @@ task:
         - FreeBSD 14 amd64 & i686
       env:
         TARGET: aarch64-unknown-linux-gnu
+    - name: Linux aarch64 musl
+      arm_container:
+        image: rust:1.69.0
+        cpu: 1
+      depends_on:
+        - FreeBSD 14 amd64 & i686
+      env:
+        TARGET: aarch64-unknown-linux-musl
   setup_script:
     - rustup target add $TARGET
     - rustup component add clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
           #- target: armv7-unknown-linux-uclibceabihf
           - target: x86_64-unknown-haiku
           - target: i686-unknown-hurd-gnu
+          - target: sparc64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnux32
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           - target: powerpc64-unknown-linux-gnu
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
+          - target: sparc64-unknown-linux-gnu
           - target: x86_64-unknown-netbsd
 
     steps:
@@ -272,8 +273,6 @@ jobs:
           #- target: armv7-unknown-linux-uclibceabihf
           - target: x86_64-unknown-haiku
           - target: i686-unknown-hurd-gnu
-          - target: sparc64-unknown-linux-gnu
-          - target: x86_64-unknown-linux-gnux32
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do

Pick up the work of #986 as the author is no longer active on GitHub

Add the following targets to CI, #986 want to make them tier 3 in Nix, should we still do this?

* aarch64-unknown-linux-musl
 
  `x86_64-unknown-linux-musl` is tier 1 in Nix, both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` are tier 2 in the Rust.

   I added the check for this target in Cirrus Linux native builds, which is not the place a tier 3 should go though.

* ~~x86_64-unknown-linux-gnux32~~
  
  tier 2 in Rust, this **has already been added** to Nix, with tier 3 support, and is tested under qemu.
  
* sparc64-unknown-linux-gnu

  tier 2 in Rust, maybe we should also test it with qemu but make it a tier 3 in Nix.
 


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
