### PR TITLE
docs: add hurd to tier 3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The following targets are supported by `nix`:
     <li>x86_64-unknown-linux-gnux32</li>
     <li>x86_64-unknown-openbsd</li>
     <li>x86_64-unknown-redox</li>
+    <li>i686-unknown-hurd-gnu</li>
    </td>
   </tr>
 </table>


### PR DESCRIPTION
## What does this PR do

Add `i686-unknown-hurd-gnu` to tier 3 in README and the branch protection rule as we forgot to do this in #2131

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
