### PR TITLE
feat: expose the inner fd of Kqueue

### DIFF
--- a/changelog/2258.added.md
+++ b/changelog/2258.added.md
@@ -1,0 +1,4 @@
+Expose the inner fd of `Kqueue` through:
+
+* impl AsFd for Kqueue
+* impl From\<Kqueue\> for OwnedFd

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -10,6 +10,7 @@ use libc::{c_int, c_long, intptr_t, time_t, timespec, uintptr_t};
 use libc::{c_long, intptr_t, size_t, time_t, timespec, uintptr_t};
 use std::convert::TryInto;
 use std::mem;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
 use std::ptr;
 
@@ -28,6 +29,18 @@ pub struct KEvent {
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct Kqueue(OwnedFd);
+
+impl AsFd for Kqueue {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+impl From<Kqueue> for OwnedFd {
+    fn from(value: Kqueue) -> Self {
+        value.0
+    }
+}
 
 impl Kqueue {
     /// Create a new kernel event queue.


### PR DESCRIPTION
## What does this PR do

1. impl AsFd for Kqueue
2. impl From\<Kqueue\> for OwnedFd

The author of #2183 wants to use the inner fd to identify a Kqueue instance, this PR implements it, so closes #2183

Should we do `impl AsRawFd` for it as well, I don't have any strong view over this, but if we have made decision on this, we should do it to all the I/O-safe types

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
