### PR TITLE
test: enable test_aio_suspend on both Linux and macOS

### DIFF
--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -569,12 +569,6 @@ fn test_aio_cancel_all() {
 }
 
 #[test]
-// On Cirrus on Linux, this test fails due to a glibc bug.
-// https://github.com/nix-rust/nix/issues/1099
-#[cfg_attr(target_os = "linux", ignore)]
-// On Cirrus, aio_suspend is failing with EINVAL
-// https://github.com/nix-rust/nix/issues/1361
-#[cfg_attr(apple_targets, ignore)]
 fn test_aio_suspend() {
     const INITIAL: &[u8] = b"abcdef123456";
     const WBUF: &[u8] = b"CDEFG";


### PR DESCRIPTION
## What does this PR do

Ref:

* [test_aio_suspend crashes on Linux with rust nightly](https://github.com/nix-rust/nix/issues/1099)
* [aio_suspend returns EINVAL on OSX in CI](https://github.com/nix-rust/nix/issues/1361)

Since we migrated our macOS CI to GHA, Let's try if it works on GHA. For that glibc bug, let's see if it got fixed in the past 2 years.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
