### PR TITLE
Add the ListenQLimit sockopt (SO_LISTENQLIMIT)

### DIFF
--- a/changelog/2263.added.md
+++ b/changelog/2263.added.md
@@ -1,0 +1,1 @@
+Added the `SO_LISTENQLIMIT` sockopt.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -522,6 +522,17 @@ sockopt_impl!(
     libc::SO_PEERCRED,
     super::UnixCredentials
 );
+#[cfg(target_os = "freebsd")]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Get backlog limit of the socket
+    ListenQLimit,
+    GetOnly,
+    libc::SOL_SOCKET,
+    libc::SO_LISTENQLIMIT,
+    u32
+);
 #[cfg(apple_targets)]
 #[cfg(feature = "net")]
 sockopt_impl!(


### PR DESCRIPTION
## What does this PR do
Adds a new sockopt: `ListenQLimit`, which wraps `libc::SO_LISTENQLIMIT`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
