### PR TITLE
Use the latest libc release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc", rev = "f37806e499409eab8cfa897280a869bc5e2623a9", features = ["extra_traits"] }
+libc = { version = "0.2.151", features = ["extra_traits"] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }


### PR DESCRIPTION
## What does this PR do

It looks like the libc team cut a release just after @devnexen's last PR.  Switch to it.  That makes it easier for downstream crates to use a git dependency on Nix.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
