### PR TITLE
feat: AT_EMPTY_PATH for fchownat on Linux/Android/FreeBSD/Hurd

### DIFF
--- a/changelog/2267.added.md
+++ b/changelog/2267.added.md
@@ -1,0 +1,1 @@
+Enable the `AT_EMPTY_PATH` flag for the `fchownat()` function

--- a/changelog/2267.removed.md
+++ b/changelog/2267.removed.md
@@ -1,0 +1,1 @@
+The `FchownatFlags` type has been deprecated, please use `AtFlags` instead.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -43,7 +43,7 @@ use crate::{sys::stat::Mode, NixPath, Result};
 pub use self::posix_fadvise::{posix_fadvise, PosixFadviseAdvice};
 
 #[cfg(not(target_os = "redox"))]
-#[cfg(any(feature = "fs", feature = "process"))]
+#[cfg(any(feature = "fs", feature = "process", feature = "user"))]
 libc_bitflags! {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "fs", feature = "process"))))]
     pub struct AtFlags: c_int {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -551,6 +551,8 @@ fn test_fchown() {
 #[test]
 #[cfg(not(target_os = "redox"))]
 fn test_fchownat() {
+    use nix::fcntl::AtFlags;
+
     let _dr = crate::DirRestore::new();
     // Testing for anything other than our own UID/GID is hard.
     let uid = Some(getuid());
@@ -564,14 +566,13 @@ fn test_fchownat() {
 
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
-    fchownat(Some(dirfd), "file", uid, gid, FchownatFlags::FollowSymlink)
-        .unwrap();
+    fchownat(Some(dirfd), "file", uid, gid, AtFlags::empty()).unwrap();
 
     chdir(tempdir.path()).unwrap();
-    fchownat(None, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap();
+    fchownat(None, "file", uid, gid, AtFlags::empty()).unwrap();
 
     fs::remove_file(&path).unwrap();
-    fchownat(None, "file", uid, gid, FchownatFlags::FollowSymlink).unwrap_err();
+    fchownat(None, "file", uid, gid, AtFlags::empty()).unwrap_err();
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do

Picks up #1128

Closes #1128 Closes #1029

Enable the `AT_EMPTY_PATH` flag for `fchownat()` on Linux/Android/FreeBSD/Hurd


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
