### PR TITLE
refactor: make dup3 wrapper call the real dup3

### DIFF
--- a/changelog/2268.changed.md
+++ b/changelog/2268.changed.md
@@ -1,0 +1,1 @@
+Changed the `dup3` wrapper to perform a real call to `dup3` instead of emulating it via `dup2` and `fcntl` 

--- a/changelog/2268.changed.md
+++ b/changelog/2268.changed.md
@@ -1,1 +1,0 @@
-Changed the `dup3` wrapper to perform a real call to `dup3` instead of emulating it via `dup2` and `fcntl` 

--- a/changelog/2268.fixed.md
+++ b/changelog/2268.fixed.md
@@ -1,0 +1,1 @@
+Changed the `dup3` wrapper to perform a real call to `dup3` instead of emulating it via `dup2` and `fcntl` to get rid of race condition

--- a/changelog/2268.removed.md
+++ b/changelog/2268.removed.md
@@ -1,0 +1,1 @@
+Removed the `dup3` wrapper on macOS, which was emulated via `dup2` and `fcntl` and could cause a race condition. The `dup3` system call is not supported on macOS.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -12,6 +12,16 @@ use crate::fcntl::at_rawfd;
 use crate::fcntl::AtFlags;
 
 #[cfg(feature = "fs")]
+#[cfg(any(
+    linux_android,
+    freebsdlike,
+    solarish,
+    netbsdlike,
+    target_os = "emscripten",
+    target_os = "fuchsia",
+    target_os = "hurd",
+    target_os = "redox",
+))]
 use crate::fcntl::OFlag;
 #[cfg(all(feature = "fs", bsd))]
 use crate::sys::stat::FileFlag;


### PR DESCRIPTION
## What does this PR do

Pick up #960, closes #939

Before this PR, we were emulating `dup3()` with `dup2()` and `fcntl()`, and thus can cause a race condition, this PR makes the `dup3()` wrapper involve the real `dup3()`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
