### PR TITLE
Fix the mount tests

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -5,6 +5,11 @@ inputs:
   TARGET:
     required: true
 
+  SUDO:
+    description: 'Set it to an empty string to run the tests as the current user, leave it with the default value to test with "sudo"'
+    required: false
+    default: sudo --preserve-env=HOME 
+
   TOOL: 
     description: 'Tool used to involve the test command, can be cargo or cross'
     required: false
@@ -24,4 +29,4 @@ runs:
 
     - name: test
       shell: bash
-      run: ${{ inputs.TOOL }} test --target ${{ inputs.TARGET }} --all-features
+      run: ${{ inputs.SUDO }} $(which ${{ inputs.TOOL }}) test --target ${{ inputs.TARGET }} --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         uses: ./.github/actions/test
         with:
           TARGET: '${{ matrix.target }}'
+          SUDO: ""
           TOOL: cross
           RUSTFLAGS: --cfg qemu -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ path = "test/test_clearenv.rs"
 [[test]]
 name = "test-mount"
 path = "test/test_mount.rs"
-harness = false
 
 [[test]]
 name = "test-prctl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,5 @@ name = "test-clearenv"
 path = "test/test_clearenv.rs"
 
 [[test]]
-name = "test-mount"
-path = "test/test_mount.rs"
-
-[[test]]
 name = "test-prctl"
 path = "test/sys/test_prctl.rs"

--- a/test/test.rs
+++ b/test/test.rs
@@ -11,6 +11,8 @@ mod test_errno;
 mod test_fcntl;
 #[cfg(linux_android)]
 mod test_kmod;
+#[cfg(target_os = "linux")]
+mod test_mount;
 #[cfg(any(
     freebsdlike,
     target_os = "fushsia",

--- a/test/test_mount.rs
+++ b/test/test_mount.rs
@@ -1,187 +1,183 @@
-#[macro_use]
-mod common;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
 
-#[cfg(target_os = "linux")]
-mod test_mount {
-    use std::fs::{self, File};
-    use std::io::{Read, Write};
-    use std::os::unix::fs::OpenOptionsExt;
-    use std::os::unix::fs::PermissionsExt;
-    use std::process::Command;
+use libc::{EACCES, EROFS};
 
-    use libc::{EACCES, EROFS};
+use nix::mount::{mount, umount, MsFlags};
+use nix::sys::stat::{self, Mode};
 
-    use nix::mount::{mount, umount, MsFlags};
-    use nix::sys::stat::{self, Mode};
+use crate::*;
 
-    static SCRIPT_CONTENTS: &[u8] = b"#!/bin/sh
+static SCRIPT_CONTENTS: &[u8] = b"#!/bin/sh
 exit 23";
 
-    const EXPECTED_STATUS: i32 = 23;
+const EXPECTED_STATUS: i32 = 23;
 
-    const NONE: Option<&'static [u8]> = None;
+const NONE: Option<&'static [u8]> = None;
 
-    #[test]
-    fn test_mount_tmpfs_without_flags_allows_rwx() {
-        require_capability!(
-            "test_mount_tmpfs_without_flags_allows_rwx",
-            CAP_SYS_ADMIN
-        );
-        let tempdir = tempfile::tempdir().unwrap();
+#[test]
+fn test_mount_tmpfs_without_flags_allows_rwx() {
+    require_capability!(
+        "test_mount_tmpfs_without_flags_allows_rwx",
+        CAP_SYS_ADMIN
+    );
+    let tempdir = tempfile::tempdir().unwrap();
+
+    mount(
+        NONE,
+        tempdir.path(),
+        Some(b"tmpfs".as_ref()),
+        MsFlags::empty(),
+        NONE,
+    )
+    .unwrap_or_else(|e| panic!("mount failed: {e}"));
+
+    let test_path = tempdir.path().join("test");
+
+    // Verify write.
+    fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
+        .open(&test_path)
+        .and_then(|mut f| f.write(SCRIPT_CONTENTS))
+        .unwrap_or_else(|e| panic!("write failed: {e}"));
+
+    // Verify read.
+    let mut buf = Vec::new();
+    File::open(&test_path)
+        .and_then(|mut f| f.read_to_end(&mut buf))
+        .unwrap_or_else(|e| panic!("read failed: {e}"));
+    assert_eq!(buf, SCRIPT_CONTENTS);
+
+    // Verify execute.
+    assert_eq!(
+        EXPECTED_STATUS,
+        Command::new(&test_path)
+            .status()
+            .unwrap_or_else(|e| panic!("exec failed: {e}"))
+            .code()
+            .unwrap_or_else(|| panic!("child killed by signal"))
+    );
+
+    umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
+}
+
+#[test]
+fn test_mount_rdonly_disallows_write() {
+    require_capability!("test_mount_rdonly_disallows_write", CAP_SYS_ADMIN);
+    let tempdir = tempfile::tempdir().unwrap();
+
+    mount(
+        NONE,
+        tempdir.path(),
+        Some(b"tmpfs".as_ref()),
+        MsFlags::MS_RDONLY,
+        NONE,
+    )
+    .unwrap_or_else(|e| panic!("mount failed: {e}"));
+
+    // EROFS: Read-only file system
+    assert_eq!(
+        EROFS,
+        File::create(tempdir.path().join("test"))
+            .unwrap_err()
+            .raw_os_error()
+            .unwrap()
+    );
+
+    umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
+}
+
+#[test]
+fn test_mount_noexec_disallows_exec() {
+    require_capability!("test_mount_noexec_disallows_exec", CAP_SYS_ADMIN);
+    let tempdir = tempfile::tempdir().unwrap();
+
+    mount(
+        NONE,
+        tempdir.path(),
+        Some(b"tmpfs".as_ref()),
+        MsFlags::MS_NOEXEC,
+        NONE,
+    )
+    .unwrap_or_else(|e| panic!("mount failed: {e}"));
+
+    let test_path = tempdir.path().join("test");
+
+    fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
+        .open(&test_path)
+        .and_then(|mut f| f.write(SCRIPT_CONTENTS))
+        .unwrap_or_else(|e| panic!("write failed: {e}"));
+
+    // Verify that we cannot execute despite a+x permissions being set.
+    let mode = stat::Mode::from_bits_truncate(
+        fs::metadata(&test_path)
+            .map(|md| md.permissions().mode())
+            .unwrap_or_else(|e| panic!("metadata failed: {e}")),
+    );
+
+    assert!(
+        mode.contains(Mode::S_IXUSR | Mode::S_IXGRP | Mode::S_IXOTH),
+        "{:?} did not have execute permissions",
+        &test_path
+    );
+
+    // EACCES: Permission denied
+    assert_eq!(
+        EACCES,
+        Command::new(&test_path)
+            .status()
+            .unwrap_err()
+            .raw_os_error()
+            .unwrap()
+    );
+
+    umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
+}
+
+#[test]
+fn test_mount_bind() {
+    require_capability!("test_mount_bind", CAP_SYS_ADMIN);
+    let tempdir = tempfile::tempdir().unwrap();
+    let file_name = "test";
+
+    {
+        let mount_point = tempfile::tempdir().unwrap();
 
         mount(
+            Some(tempdir.path()),
+            mount_point.path(),
             NONE,
-            tempdir.path(),
-            Some(b"tmpfs".as_ref()),
-            MsFlags::empty(),
+            MsFlags::MS_BIND,
             NONE,
         )
         .unwrap_or_else(|e| panic!("mount failed: {e}"));
 
-        let test_path = tempdir.path().join("test");
-
-        // Verify write.
         fs::OpenOptions::new()
             .create(true)
             .write(true)
             .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
-            .open(&test_path)
+            .open(mount_point.path().join(file_name))
             .and_then(|mut f| f.write(SCRIPT_CONTENTS))
             .unwrap_or_else(|e| panic!("write failed: {e}"));
 
-        // Verify read.
-        let mut buf = Vec::new();
-        File::open(&test_path)
-            .and_then(|mut f| f.read_to_end(&mut buf))
-            .unwrap_or_else(|e| panic!("read failed: {e}"));
-        assert_eq!(buf, SCRIPT_CONTENTS);
-
-        // Verify execute.
-        assert_eq!(
-            EXPECTED_STATUS,
-            Command::new(&test_path)
-                .status()
-                .unwrap_or_else(|e| panic!("exec failed: {e}"))
-                .code()
-                .unwrap_or_else(|| panic!("child killed by signal"))
-        );
-
-        umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
+        umount(mount_point.path())
+            .unwrap_or_else(|e| panic!("umount failed: {e}"));
     }
 
-    #[test]
-    fn test_mount_rdonly_disallows_write() {
-        require_capability!("test_mount_rdonly_disallows_write", CAP_SYS_ADMIN);
-        let tempdir = tempfile::tempdir().unwrap();
+    // Verify the file written in the mount shows up in source directory, even
+    // after unmounting.
 
-        mount(
-            NONE,
-            tempdir.path(),
-            Some(b"tmpfs".as_ref()),
-            MsFlags::MS_RDONLY,
-            NONE,
-        )
-        .unwrap_or_else(|e| panic!("mount failed: {e}"));
-
-        // EROFS: Read-only file system
-        assert_eq!(
-            EROFS,
-            File::create(tempdir.path().join("test"))
-                .unwrap_err()
-                .raw_os_error()
-                .unwrap()
-        );
-
-        umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
-    }
-
-    #[test]
-    fn test_mount_noexec_disallows_exec() {
-        require_capability!("test_mount_noexec_disallows_exec", CAP_SYS_ADMIN);
-        let tempdir = tempfile::tempdir().unwrap();
-
-        mount(
-            NONE,
-            tempdir.path(),
-            Some(b"tmpfs".as_ref()),
-            MsFlags::MS_NOEXEC,
-            NONE,
-        )
-        .unwrap_or_else(|e| panic!("mount failed: {e}"));
-
-        let test_path = tempdir.path().join("test");
-
-        fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
-            .open(&test_path)
-            .and_then(|mut f| f.write(SCRIPT_CONTENTS))
-            .unwrap_or_else(|e| panic!("write failed: {e}"));
-
-        // Verify that we cannot execute despite a+x permissions being set.
-        let mode = stat::Mode::from_bits_truncate(
-            fs::metadata(&test_path)
-                .map(|md| md.permissions().mode())
-                .unwrap_or_else(|e| panic!("metadata failed: {e}")),
-        );
-
-        assert!(
-            mode.contains(Mode::S_IXUSR | Mode::S_IXGRP | Mode::S_IXOTH),
-            "{:?} did not have execute permissions",
-            &test_path
-        );
-
-        // EACCES: Permission denied
-        assert_eq!(
-            EACCES,
-            Command::new(&test_path)
-                .status()
-                .unwrap_err()
-                .raw_os_error()
-                .unwrap()
-        );
-
-        umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
-    }
-
-    #[test]
-    fn test_mount_bind() {
-        require_capability!("test_mount_bind", CAP_SYS_ADMIN);
-        let tempdir = tempfile::tempdir().unwrap();
-        let file_name = "test";
-
-        {
-            let mount_point = tempfile::tempdir().unwrap();
-
-            mount(
-                Some(tempdir.path()),
-                mount_point.path(),
-                NONE,
-                MsFlags::MS_BIND,
-                NONE,
-            )
-            .unwrap_or_else(|e| panic!("mount failed: {e}"));
-
-            fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
-                .open(mount_point.path().join(file_name))
-                .and_then(|mut f| f.write(SCRIPT_CONTENTS))
-                .unwrap_or_else(|e| panic!("write failed: {e}"));
-
-            umount(mount_point.path())
-                .unwrap_or_else(|e| panic!("umount failed: {e}"));
-        }
-
-        // Verify the file written in the mount shows up in source directory, even
-        // after unmounting.
-
-        let mut buf = Vec::new();
-        File::open(tempdir.path().join(file_name))
-            .and_then(|mut f| f.read_to_end(&mut buf))
-            .unwrap_or_else(|e| panic!("read failed: {e}"));
-        assert_eq!(buf, SCRIPT_CONTENTS);
-    }
+    let mut buf = Vec::new();
+    File::open(tempdir.path().join(file_name))
+        .and_then(|mut f| f.read_to_end(&mut buf))
+        .unwrap_or_else(|e| panic!("read failed: {e}"));
+    assert_eq!(buf, SCRIPT_CONTENTS);
 }


### PR DESCRIPTION
As originally written by @kamalmarhubi in #231, these tests made clever use of Linux namespaces in order to run as unprivileged users. However, a subsequent kernel bug broke this functionality, and it hasn't been fixed even 6 years later.  The tests have been skipped ever since.

Get the tests to run again by removing the namespace stuff and requiring privileges instead.  Also, remove the custom test harness. Now Nix will be compatible with tools like cargo-nextest.

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1659087

## What does this PR do

Fixes the long-skipped mount tests so they can run again.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
