### PR TITLE
feat: AT_EMPTY_PATH for FreeBSD/Hurd

### DIFF
--- a/changelog/2270.added.md
+++ b/changelog/2270.added.md
@@ -1,0 +1,1 @@
+Add `AtFlags::AT_EMPTY_FLAG` for FreeBSD and Hurd

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -52,7 +52,7 @@ libc_bitflags! {
         AT_SYMLINK_NOFOLLOW;
         #[cfg(linux_android)]
         AT_NO_AUTOMOUNT;
-        #[cfg(linux_android)]
+        #[cfg(any(linux_android, target_os = "freebsd", target_os = "hurd"))]
         AT_EMPTY_PATH;
         #[cfg(not(target_os = "android"))]
         AT_EACCESS;
@@ -328,7 +328,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
         let reported_size = match dirfd {
             #[cfg(target_os = "redox")]
             Some(_) => unreachable!(),
-            #[cfg(linux_android)]
+            #[cfg(any(linux_android, target_os = "freebsd", target_os = "hurd"))]
             Some(dirfd) => {
                 let flags = if path.is_empty() {
                     AtFlags::AT_EMPTY_PATH
@@ -343,7 +343,9 @@ fn inner_readlink<P: ?Sized + NixPath>(
             }
             #[cfg(not(any(
                 linux_android,
-                target_os = "redox"
+                target_os = "redox",
+                target_os = "freebsd",
+                target_os = "hurd"
             )))]
             Some(dirfd) => super::sys::stat::fstatat(
                 Some(dirfd),


### PR DESCRIPTION
## What does this PR do

Add `AtFlags::AT_EMPTY_FLAG` for FreeBSD and Hurd as discussed in https://github.com/nix-rust/nix/pull/2267#discussion_r1428832072

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
