### PR TITLE
chore: fix wrong changelog of 2270[skip ci]

### DIFF
--- a/changelog/2270.added.md
+++ b/changelog/2270.added.md
@@ -1,1 +1,1 @@
-Add `AtFlags::AT_EMPTY_FLAG` for FreeBSD and Hurd
+Add `AtFlags::AT_EMPTY_PATH` for FreeBSD and Hurd


### PR DESCRIPTION
## What does this PR do

Fix the wrong changelog of #2270, [found by @devnexen](https://github.com/nix-rust/nix/commit/cc42c028a24223af88dd12e826ebbccfd846c4fe#r135529221)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
