### PR TITLE
Fix: typo "fr"

### DIFF
--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -39,7 +39,7 @@ libc_bitflags! {
         S_IXUSR;
         /// Read write and execute for group.
         S_IRWXG;
-        /// Read fr group.
+        /// Read for group.
         S_IRGRP;
         /// Write for group.
         S_IWGRP;


### PR DESCRIPTION
## What does this PR do

There is a typo in `stat.rs`. "fr" should be "for".

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
