### PR TITLE
Enable OFlag::O_DIRECTORY for Solarish

### DIFF
--- a/changelog/2275.added.md
+++ b/changelog/2275.added.md
@@ -1,0 +1,1 @@
+Enable `OFlag::O_DIRECTORY for Solarish

--- a/changelog/2275.changed.md
+++ b/changelog/2275.changed.md
@@ -1,1 +1,0 @@
-No longer omit `O_DIRECTORY` for Solarish

--- a/changelog/2275.changed.md
+++ b/changelog/2275.changed.md
@@ -1,0 +1,1 @@
+No longer omit `O_DIRECTORY` for Solarish

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -96,7 +96,6 @@ libc_bitflags!(
         ))]
         O_DIRECT;
         /// If the specified path isn't a directory, fail.
-        #[cfg(not(solarish))]
         O_DIRECTORY;
         /// Implicitly follow each `write()` with an `fdatasync()`.
         #[cfg(any(linux_android, apple_targets, netbsdlike))]


### PR DESCRIPTION
## What does this PR do

Allows `O_DIRECTORY` to be used on illumos and Solaris.

Confirmed that `O_DIRECTORY` was defined on Solaris (confirmed on at least 11.4) and illumos (added via [illumos bug 9965](https://www.illumos.org/issues/9965) in early 2020)

See discussion on: nix-rust/nix/issues/2273

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

