### PR TITLE
Correct a comment

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -567,8 +567,6 @@ feature! {
 /// let _ = cmsg_space!(RawFd, TimeVal);
 /// # }
 /// ```
-// Unfortunately, CMSG_SPACE isn't a const_fn, or else we could return a
-// stack-allocated array.
 #[macro_export]
 macro_rules! cmsg_space {
     ( $( $x:ty ),* ) => {
@@ -581,7 +579,7 @@ macro_rules! cmsg_space {
 
 #[inline]
 #[doc(hidden)]
-pub fn cmsg_space<T>() -> usize {
+pub const fn cmsg_space<T>() -> usize {
     // SAFETY: CMSG_SPACE is always safe
     unsafe { libc::CMSG_SPACE(mem::size_of::<T>() as libc::c_uint) as usize }
 }


### PR DESCRIPTION
And while here, make cmsg_space a const fn, though I doubt it will make a difference since it's already inline.

The original comment was _almost_ correct.  Changing the cmsg_space macro to return an array works in most locations.  However, it fails in the test_recverr_impl function in the tests due to a E0401 Error "Inner items do not inherit the generic parameters from the items they are embedded in."  That error is very difficult to fix in our test, and it might occur in user code, too.  The root of the problem is that each length of array is its own distinct type, and in a generic function cmsg_space returns an array type that may depend on the generic parameters.

Alternatively we could provide a second macro that always heap allocates.  But that may be too complicated just to save a single allocation.

## What does this PR do

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
