### PR TITLE
Introduce set_errno

### DIFF
--- a/changelog/2283.added.md
+++ b/changelog/2283.added.md
@@ -1,1 +1,4 @@
-Added `errno::set_errno` function
+- Added `errno::Errno::set` function
+- Added `errno::Errno::set_raw` function
+- Added `errno::Errno::last_raw` function
+- Added `errno::Errno::from_raw` function

--- a/changelog/2283.added.md
+++ b/changelog/2283.added.md
@@ -1,0 +1,1 @@
+Added `errno::set_errno` function

--- a/changelog/2283.changed.md
+++ b/changelog/2283.changed.md
@@ -1,0 +1,3 @@
+- Deprecated `errno::errno()` function (use `Errno::last_raw()`)
+- Deprecated `errno::from_i32()` function (use `Errno::from_raw()`)
+- Deprecated `errno::Errno::from_i32()` function (use `Errno::from_raw()`)

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -79,8 +79,8 @@ impl Errno {
     ///
     /// assert_eq!(Errno::last(), Errno::EIO);
     /// ```
-    pub fn set(errno: Self) {
-        Self::set_raw(errno as i32)
+    pub fn set(self) {
+        Self::set_raw(self as i32)
     }
 
     /// Sets the raw i32 value of errno.

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -4,7 +4,7 @@
 //! ```
 //! use nix::errno::Errno;
 //!
-//! Errno::set(Errno::EIO);
+//! Errno::EIO.set();
 //! assert_eq!(Errno::last(), Errno::EIO);
 //!
 //! Errno::clear();
@@ -75,7 +75,7 @@ impl Errno {
     /// ```
     /// use nix::errno::Errno;
     ///
-    /// Errno::set(Errno::EIO);
+    /// Errno::EIO.set();
     ///
     /// assert_eq!(Errno::last(), Errno::EIO);
     /// ```
@@ -113,7 +113,7 @@ impl Errno {
     /// ```
     /// use nix::errno::Errno;
     ///
-    /// Errno::set(Errno::EIO);
+    /// Errno::EIO.set();
     ///
     /// Errno::clear();
     ///

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -52,6 +52,14 @@ pub fn errno() -> i32 {
     unsafe { *errno_location() }
 }
 
+/// Sets the platform-specific value of errno.
+pub fn set_errno(errno: Errno) {
+    // Safe because errno is a thread-local variable
+    unsafe {
+        *errno_location() = errno as i32;
+    }
+}
+
 impl Errno {
     pub fn last() -> Self {
         last()

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -53,7 +53,7 @@ cfg_if! {
 }
 
 /// Returns the platform-specific value of errno
-#[deprecated(note = "please use `Errno::last_raw()` instead")]
+#[deprecated(since = "0.28.0", note = "please use `Errno::last_raw()` instead")]
 pub fn errno() -> i32 {
     Errno::last_raw()
 }
@@ -91,7 +91,10 @@ impl Errno {
         }
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(err: i32) -> Errno {
         Self::from_raw(err)
     }
@@ -981,7 +984,10 @@ mod consts {
         pub const ENOTSUP: Errno = Errno::EOPNOTSUPP;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1245,7 +1251,10 @@ mod consts {
         pub const EDEADLOCK: Errno = Errno::EDEADLK;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1473,7 +1482,10 @@ mod consts {
         pub const EOPNOTSUPP: Errno = Errno::ENOTSUP;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1691,7 +1703,10 @@ mod consts {
         pub const EOPNOTSUPP: Errno = Errno::ENOTSUP;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -1904,7 +1919,10 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2119,7 +2137,10 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2323,7 +2344,10 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2553,7 +2577,10 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2774,7 +2801,10 @@ mod consts {
         pub const EOPNOTSUPP: Errno = Errno::ENOTSUP;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -2966,7 +2996,10 @@ mod consts {
         EOPNOTSUPP = libc::EOPNOTSUPP,
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 
@@ -3190,7 +3223,10 @@ mod consts {
         pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     }
 
-    #[deprecated(note = "please use `Errno::from_raw()` instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "please use `Errno::from_raw()` instead"
+    )]
     pub const fn from_i32(e: i32) -> Errno {
         use self::Errno::*;
 

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -108,9 +108,9 @@ impl Errno {
     /// Sets the platform-specific errno to no-error
     ///
     /// ```
-    /// use nix::errno::{Errno, set_errno};
+    /// use nix::errno::Errno;
     ///
-    /// set_errno(Errno::EIO);
+    /// Errno::set(Errno::EIO);
     ///
     /// Errno::clear();
     ///

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,3 +1,16 @@
+//! Safe wrappers around errno functions
+//!
+//! # Example
+//! ```
+//! use nix::errno::{Errno, set_errno};
+//!
+//! set_errno(Errno::EIO);
+//! assert_eq!(Errno::last(), Errno::EIO);
+//!
+//! Errno::clear();
+//! assert_eq!(Errno::last(), Errno::from_i32(0));
+//! ```
+
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{c_int, c_void};
@@ -53,6 +66,15 @@ pub fn errno() -> i32 {
 }
 
 /// Sets the platform-specific value of errno.
+///
+/// # Example
+/// ```
+/// use nix::errno::{Errno, set_errno};
+///
+/// set_errno(Errno::EIO);
+///
+/// assert_eq!(Errno::last(), Errno::EIO);
+/// ```
 pub fn set_errno(errno: Errno) {
     // Safe because errno is a thread-local variable
     unsafe {
@@ -73,6 +95,19 @@ impl Errno {
         from_i32(err)
     }
 
+    /// Sets the platform-specific errno to no-error
+    ///
+    /// ```
+    /// use nix::errno::{Errno, set_errno};
+    ///
+    /// set_errno(Errno::EIO);
+    ///
+    /// Errno::clear();
+    ///
+    /// let err = Errno::last();
+    /// assert_ne!(err, Errno::EIO);
+    /// assert_eq!(err, Errno::from_i32(0));
+    /// ```
     pub fn clear() {
         clear()
     }

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -122,10 +122,7 @@ impl Errno {
     /// assert_eq!(err, Errno::from_raw(0));
     /// ```
     pub fn clear() {
-        // Safe because errno is a thread-local variable
-        unsafe {
-            *errno_location() = 0;
-        }
+        Self::set_raw(0)
     }
 
     /// Returns `Ok(value)` if it does not contain the sentinel value. This

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1109,7 +1109,7 @@ mod posix_fadvise {
         if res == 0 {
             Ok(())
         } else {
-            Err(Errno::from_i32(res))
+            Err(Errno::from_raw(res))
         }
     }
     }
@@ -1131,7 +1131,7 @@ pub fn posix_fallocate(
     match Errno::result(res) {
         Err(err) => Err(err),
         Ok(0) => Ok(()),
-        Ok(errno) => Err(Errno::from_i32(errno)),
+        Ok(errno) => Err(Errno::from_raw(errno)),
     }
 }
 }

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -158,7 +158,7 @@ impl AioCb {
         let r = unsafe { libc::aio_error(&self.aiocb().0) };
         match r {
             0 => Ok(()),
-            num if num > 0 => Err(Errno::from_i32(num)),
+            num if num > 0 => Err(Errno::from_raw(num)),
             -1 => Err(Errno::last()),
             num => panic!("unknown aio_error return value {num:?}"),
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -248,6 +248,6 @@ pub fn clock_nanosleep(
     if ret == 0 {
         Ok(remain)
     } else {
-        Err(Errno::from_i32(ret))
+        Err(Errno::from_raw(ret))
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -196,7 +196,7 @@ pub fn clock_getcpuclockid(pid: Pid) -> Result<ClockId> {
         let res = unsafe { clk_id.assume_init() };
         Ok(ClockId::from(res))
     } else {
-        Err(Errno::from_i32(ret))
+        Err(Errno::from_raw(ret))
     }
 }
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,6 +1,6 @@
 //! Safe wrappers around functions found in libc "unistd.h" header
 
-use crate::errno::{self, Errno};
+use crate::errno::Errno;
 
 #[cfg(any(
     all(feature = "fs", not(target_os = "redox")),
@@ -2148,7 +2148,7 @@ pub fn fpathconf<F: AsFd>(fd: F, var: PathconfVar) -> Result<Option<c_long>> {
         libc::fpathconf(fd.as_fd().as_raw_fd(), var as c_int)
     };
     if raw == -1 {
-        if errno::errno() == 0 {
+        if Errno::last_raw() == 0 {
             Ok(None)
         } else {
             Err(Errno::last())
@@ -2188,7 +2188,7 @@ pub fn pathconf<P: ?Sized + NixPath>(
         libc::pathconf(cstr.as_ptr(), var as c_int)
     })?;
     if raw == -1 {
-        if errno::errno() == 0 {
+        if Errno::last_raw() == 0 {
             Ok(None)
         } else {
             Err(Errno::last())
@@ -2787,7 +2787,7 @@ pub fn sysconf(var: SysconfVar) -> Result<Option<c_long>> {
         libc::sysconf(var as c_int)
     };
     if raw == -1 {
-        if errno::errno() == 0 {
+        if Errno::last_raw() == 0 {
             Ok(None)
         } else {
             Err(Errno::last())
@@ -3543,7 +3543,7 @@ pub fn ttyname<F: AsFd>(fd: F) -> Result<PathBuf> {
 
     let ret = unsafe { libc::ttyname_r(fd.as_fd().as_raw_fd(), c_buf, buf.len()) };
     if ret != 0 {
-        return Err(Errno::from_i32(ret));
+        return Err(Errno::from_raw(ret));
     }
 
     CStr::from_bytes_until_nul(&buf[..])

--- a/test/test.rs
+++ b/test/test.rs
@@ -7,6 +7,7 @@ mod common;
 mod sys;
 #[cfg(not(target_os = "redox"))]
 mod test_dir;
+mod test_errno;
 mod test_fcntl;
 #[cfg(linux_android)]
 mod test_kmod;

--- a/test/test_errno.rs
+++ b/test/test_errno.rs
@@ -1,8 +1,8 @@
-use nix::errno::{set_errno, Errno};
+use nix::errno::Errno;
 
 #[test]
 fn errno_set_and_read() {
     Errno::clear();
-    set_errno(Errno::ENFILE);
+    Errno::set(Errno::ENFILE);
     assert_eq!(Errno::last(), Errno::ENFILE);
 }

--- a/test/test_errno.rs
+++ b/test/test_errno.rs
@@ -3,6 +3,6 @@ use nix::errno::Errno;
 #[test]
 fn errno_set_and_read() {
     Errno::clear();
-    Errno::set(Errno::ENFILE);
+    Errno::ENFILE.set();
     assert_eq!(Errno::last(), Errno::ENFILE);
 }

--- a/test/test_errno.rs
+++ b/test/test_errno.rs
@@ -2,7 +2,6 @@ use nix::errno::Errno;
 
 #[test]
 fn errno_set_and_read() {
-    Errno::clear();
     Errno::ENFILE.set();
     assert_eq!(Errno::last(), Errno::ENFILE);
 }

--- a/test/test_errno.rs
+++ b/test/test_errno.rs
@@ -1,0 +1,8 @@
+use nix::errno::{set_errno, Errno};
+
+#[test]
+fn errno_set_and_read() {
+    Errno::clear();
+    set_errno(Errno::ENFILE);
+    assert_eq!(Errno::last(), Errno::ENFILE);
+}

--- a/test/test_errno.rs
+++ b/test/test_errno.rs
@@ -6,3 +6,12 @@ fn errno_set_and_read() {
     Errno::ENFILE.set();
     assert_eq!(Errno::last(), Errno::ENFILE);
 }
+
+#[test]
+fn errno_set_and_clear() {
+    Errno::ENFILE.set();
+    assert_eq!(Errno::last(), Errno::ENFILE);
+
+    Errno::clear();
+    assert_eq!(Errno::last(), Errno::from_raw(0));
+}

--- a/test/test_mount.rs
+++ b/test/test_mount.rs
@@ -49,7 +49,7 @@ exit 23";
             .mode((Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO).bits())
             .open(&test_path)
             .or_else(|e| {
-                if Errno::from_i32(e.raw_os_error().unwrap())
+                if Errno::from_raw(e.raw_os_error().unwrap())
                     == Errno::EOVERFLOW
                 {
                     // Skip tests on certain Linux kernels which have a bug


### PR DESCRIPTION
## What does this PR do

This adds a way to set errno, it makes it possible to fully drop errno crate in crates that already use nix. 

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
