### PR TITLE
feat: sockopt Ipv6Ttl for apple targets

### DIFF
--- a/changelog/2287.added.md
+++ b/changelog/2287.added.md
@@ -1,0 +1,1 @@
+Add socket option Ipv6Ttl for apple targets.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1026,7 +1026,7 @@ sockopt_impl!(
     libc::IP_TTL,
     libc::c_int
 );
-#[cfg(any(linux_android, target_os = "freebsd"))]
+#[cfg(any(apple_targets, linux_android, target_os = "freebsd"))]
 sockopt_impl!(
     /// Set the unicast hop limit for the socket.
     Ipv6Ttl,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -326,9 +326,9 @@ fn test_get_mtu() {
 }
 
 #[test]
-#[cfg(any(apple_targets, linux_android, target_os = "freebsd"))]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 fn test_ttl_opts() {
-    /* let fd4 = socket(
+    let fd4 = socket(
         AddressFamily::Inet,
         SockType::Datagram,
         SockFlag::empty(),
@@ -336,8 +336,7 @@ fn test_ttl_opts() {
     )
     .unwrap();
     setsockopt(&fd4, sockopt::Ipv4Ttl, &1)
-        .expect("setting ipv4ttl on an inet socket should succeed"); */
-
+        .expect("setting ipv4ttl on an inet socket should succeed");
     let fd6 = socket(
         AddressFamily::Inet6,
         SockType::Datagram,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -326,9 +326,9 @@ fn test_get_mtu() {
 }
 
 #[test]
-#[cfg(any(linux_android, target_os = "freebsd"))]
+#[cfg(any(apple_targets, linux_android, target_os = "freebsd"))]
 fn test_ttl_opts() {
-    let fd4 = socket(
+    /* let fd4 = socket(
         AddressFamily::Inet,
         SockType::Datagram,
         SockFlag::empty(),
@@ -336,7 +336,8 @@ fn test_ttl_opts() {
     )
     .unwrap();
     setsockopt(&fd4, sockopt::Ipv4Ttl, &1)
-        .expect("setting ipv4ttl on an inet socket should succeed");
+        .expect("setting ipv4ttl on an inet socket should succeed"); */
+
     let fd6 = socket(
         AddressFamily::Inet6,
         SockType::Datagram,


### PR DESCRIPTION
## What does this PR do

Add socket option `Ipv6Ttl` for apple targets.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments

  There is a test (`test_ttl_opts()`) for `Ipv4Ttl` and `Ipv6Ttl`, but the support of `Ipv4Ttl` for apple will be added in #2203, which means that I cannot enable that test in this PR, will do it when both of these PRs get merged.

- [x] A change log has been added if this PR modifies nix's API
