### PR TITLE
Add docs to the time and fcntl modules

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -49,14 +49,15 @@ libc_bitflags! {
     /// Flags that control how the various *at syscalls behave.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "fs", feature = "process"))))]
     pub struct AtFlags: c_int {
-        /// Used with [`unlink`](crate::unistd::unlink) to indicate that the path to remove is a
-        /// directory, and not a regular file.
+        #[allow(missing_docs)]
+        #[doc(hidden)]
+        // Should not be used by the public API, but only internally.
         AT_REMOVEDIR;
         /// Used with [`linkat`](crate::unistd::linkat`) to create a link to a symbolic link's
         /// target, instead of to the symbolic link itself.
         AT_SYMLINK_FOLLOW;
-        /// Used with [`linkat`](crate::unistd::linkat`) to create a link to a symbolic link
-        /// itself, instead of to the symbolic link's target.
+        /// Used with functions like [`fstatat`](crate::sys::stat::fstatat`) to operate on a link
+        /// itself, instead of the symbolic link's target.
         AT_SYMLINK_NOFOLLOW;
         /// Don't automount the terminal ("basename") component of pathname if it is a directory
         /// that is an automount point.
@@ -293,7 +294,7 @@ feature! {
 #![feature = "fs"]
 /// Like [`renameat`], but with an additional `flags` argument.
 ///
-/// A `renameat2` call with a zero flags argument is equivalent to `renameat`.
+/// A `renameat2` call with an empty flags argument is equivalent to `renameat`.
 ///
 /// # See Also
 /// * [`rename`](https://man7.org/linux/man-pages/man2/rename.2.html)
@@ -679,7 +680,7 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
     Errno::result(res)
 }
 
-/// Operations for use with [`flock`].
+/// Operations for use with [`Flock::lock`].
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,6 @@ feature! {
     #[deny(missing_docs)]
     pub mod features;
 }
-#[allow(missing_docs)]
 pub mod fcntl;
 feature! {
     #![feature = "net"]
@@ -164,7 +163,6 @@ feature! {
 pub mod sys;
 feature! {
     #![feature = "time"]
-    #[allow(missing_docs)]
     pub mod time;
 }
 // This can be implemented for other platforms as soon as libc

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,4 @@
-//! Sleep, query system clocks, and set system closk
+//! Sleep, query system clocks, and set system clock
 use crate::sys::time::TimeSpec;
 #[cfg(any(freebsdlike, linux_android, target_os = "emscripten"))]
 #[cfg(feature = "process")]
@@ -60,7 +60,7 @@ impl ClockId {
     /// Starts at zero when the kernel boots and increments monotonically in SI seconds while the
     /// machine is running.
     pub const CLOCK_BOOTTIME: ClockId = ClockId(libc::CLOCK_BOOTTIME);
-    /// Like [`CLOCK_BOOTTIME`](ClockId::CLOCK_BOOTTIME), but will wake the  system  if  it  is
+    /// Like [`CLOCK_BOOTTIME`](ClockId::CLOCK_BOOTTIME), but will wake the system if it is
     /// suspended..
     #[cfg(any(linux_android, target_os = "emscripten", target_os = "fuchsia"))]
     pub const CLOCK_BOOTTIME_ALARM: ClockId =
@@ -80,7 +80,7 @@ impl ClockId {
     pub const CLOCK_MONOTONIC_PRECISE: ClockId =
         ClockId(libc::CLOCK_MONOTONIC_PRECISE);
     /// Similar to [`CLOCK_MONOTONIC`](ClockId::CLOCK_MONOTONIC), but provides access to a raw
-    /// hardware-based time that  is  not subject  to  NTP adjustments.
+    /// hardware-based time that is not subject to NTP adjustments.
     #[cfg(any(linux_android, target_os = "emscripten", target_os = "fuchsia"))]
     pub const CLOCK_MONOTONIC_RAW: ClockId = ClockId(libc::CLOCK_MONOTONIC_RAW);
     #[cfg(any(
@@ -127,7 +127,7 @@ impl ClockId {
     pub const CLOCK_SGI_CYCLE: ClockId = ClockId(libc::CLOCK_SGI_CYCLE);
     /// International Atomic Time.
     ///
-    /// A  nonsettable  system-wide  clock derived from wall-clock time but ignoring leap seconds.
+    /// A nonsettable system-wide clock derived from wall-clock time but ignoring leap seconds.
     #[cfg(any(linux_android, target_os = "emscripten", target_os = "fuchsia"))]
     pub const CLOCK_TAI: ClockId = ClockId(libc::CLOCK_TAI);
     #[cfg(any(


### PR DESCRIPTION
Also, deprecate FlockArg::UnlockNonblock.  That combination of flags doesn't make sense.  And indeed, reviewing the kernel source code shows that the kernel will ignore LOCK_NB when LOCK_UN is set.
