### PR TITLE
ci: run Linux aarch64 && FreeBSD checks in parallel

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,8 +72,6 @@ task:
       arm_container:
         image: rust:1.69.0
         cpu: 1
-      depends_on:
-        - FreeBSD 14 amd64 & i686
       env:
         TARGET: aarch64-unknown-linux-gnu
   setup_script:


### PR DESCRIPTION
## What does this PR do

Make the Linux aarch64 CI no longer depend on the FreeBSD CI to reduce our CI time.

Credits:

We used 7 credits in the last month, so the usage should be fine:)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
