### PR TITLE
chore: changelog for 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,203 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 # Change Log
 
+## [0.28.0] - 2024-02-24
+
+
+### Added
+
+- Added `mkdtemp` wrapper ([#1297](https://github.com/nix-rust/nix/pull/1297))
+- Add associated constants `UTIME_OMIT` `UTIME_NOW` for `TimeSpec`
+  ([#1879](https://github.com/nix-rust/nix/pull/1879))
+- Added `EventFd` type. ([#1945](https://github.com/nix-rust/nix/pull/1945))
+- - Added `impl From<Signal> for SigSet`.
+  - Added `impl std::ops::BitOr for SigSet`.
+  - Added `impl std::ops::BitOr for Signal`.
+  - Added `impl std::ops::BitOr<Signal> for SigSet`
+
+  ([#1959](https://github.com/nix-rust/nix/pull/1959))
+- Added `TlsGetRecordType` control message type and corresponding enum for
+  linux ([#2065](https://github.com/nix-rust/nix/pull/2065))
+- Added `Ipv6HopLimit` to `::nix::sys::socket::ControlMessage` for Linux,
+  MacOS, FreeBSD, DragonflyBSD, Android, iOS and Haiku.
+  ([#2074](https://github.com/nix-rust/nix/pull/2074))
+- Added `Icmp` and `IcmpV6` to `SockProtocol`
+  ([#2103](https://github.com/nix-rust/nix/pull/2103))
+- Added rfork support for FreeBSD in `unistd`
+  ([#2121](https://github.com/nix-rust/nix/pull/2121))
+- Added `MapFlags::map_hugetlb_with_size_log2` method for Linux targets
+  ([#2125](https://github.com/nix-rust/nix/pull/2125))
+- Added `mmap_anonymous` function
+  ([#2127](https://github.com/nix-rust/nix/pull/2127))
+- Added `mips32r6` and `mips64r6` support for signal, ioctl and ptrace
+  ([#2138](https://github.com/nix-rust/nix/pull/2138))
+- Added `F_GETPATH` FcntlFlags entry on Apple/NetBSD/DragonflyBSD for
+  `::nix::fcntl`. ([#2142](https://github.com/nix-rust/nix/pull/2142))
+- Added `F_KINFO` FcntlFlags entry on FreeBSD for `::nix::fcntl`.
+  ([#2152](https://github.com/nix-rust/nix/pull/2152))
+- Added `F_GETPATH_NOFIRMLINK` and `F_BARRIERFSYNC` FcntlFlags entry
+  on Apple for `::nix::fcntl`.
+  ([#2155](https://github.com/nix-rust/nix/pull/2155))
+- Added newtype `Flock` to automatically unlock a held flock upon drop.
+  Added `Flockable` trait to represent valid types for `Flock`.
+  ([#2170](https://github.com/nix-rust/nix/pull/2170))
+- Added `SetSockOpt` impls to enable Linux Kernel TLS on a TCP socket and to
+  import TLS parameters. ([#2175](https://github.com/nix-rust/nix/pull/2175))
+- - Added the `::nix::sys::socket::SocketTimestamp` enum for configuring the
+  `TsClock` (a.k.a `SO_TS_CLOCK`) sockopt
+  - Added FreeBSD's `ScmRealtime` and `ScmMonotonic` as new options in
+  `::nix::sys::socket::ControlMessageOwned`
+
+  ([#2187](https://github.com/nix-rust/nix/pull/2187))
+- Added new fanotify API: wrappers for `fanotify_init` and `fanotify_mark`
+  ([#2194](https://github.com/nix-rust/nix/pull/2194))
+- Added `SpecialCharacterindices` support for haiku.
+  ([#2195](https://github.com/nix-rust/nix/pull/2195))
+- Added `sys::sendfile` support for solaris/illumos.
+  ([#2198](https://github.com/nix-rust/nix/pull/2198))
+- impl Display for InterfaceFlags
+  ([#2206](https://github.com/nix-rust/nix/pull/2206))
+- Added `sendfilev` in sys::sendfile for solarish
+  ([#2207](https://github.com/nix-rust/nix/pull/2207))
+- Added `fctrl::SealFlag::F_SEAL_FUTURE_WRITE`
+  ([#2213](https://github.com/nix-rust/nix/pull/2213))
+- Added `Ipv6MulticastHops` as socket option to set and read.
+  ([#2234](https://github.com/nix-rust/nix/pull/2234))
+- Enable `ControlMessageOwned::Ipv4RecvIf` and
+  `ControlMessageOwned::Ipv4RecvDstAddr` for DragonFlyBSD
+  ([#2240](https://github.com/nix-rust/nix/pull/2240))
+- `ClockId::set_time()` and `time::clock_settime()` are now enabled on macOS
+  ([#2241](https://github.com/nix-rust/nix/pull/2241))
+- Added `IpBindAddressNoPort` sockopt to support `IP_BIND_ADDRESS_NO_PORT`
+  available on linux. ([#2244](https://github.com/nix-rust/nix/pull/2244))
+- Enable `MapFlags::map_hugetlb_with_size_log2` method for Android/Fuchsia
+  ([#2245](https://github.com/nix-rust/nix/pull/2245))
+- Added `TcpFastOpenConnect` sockopt to support `TCP_FASTOPEN_CONNECT`
+  available on linux. ([#2247](https://github.com/nix-rust/nix/pull/2247))
+- Add `reboot(2)` for OpenBSD/NetBSD
+  ([#2251](https://github.com/nix-rust/nix/pull/2251))
+- Added new `MemFdCreateFlag` constants to `sys::memfd` on Linux and Android
+  related to hugetlbfs support.
+  ([#2252](https://github.com/nix-rust/nix/pull/2252))
+- Expose the inner fd of `Kqueue` through:
+
+  * impl AsFd for Kqueue
+  * impl From\<Kqueue\> for OwnedFd
+
+  ([#2258](https://github.com/nix-rust/nix/pull/2258))
+- Added `sys::eventfd` support on FreeBSD
+  ([#2259](https://github.com/nix-rust/nix/pull/2259))
+- Added `MmapFlags::MAP_FIXED` constant in `sys::mman` for netbsd and openbsd
+  ([#2260](https://github.com/nix-rust/nix/pull/2260))
+- Added the `SO_LISTENQLIMIT` sockopt.
+  ([#2263](https://github.com/nix-rust/nix/pull/2263))
+- Enable the `AT_EMPTY_PATH` flag for the `fchownat()` function
+  ([#2267](https://github.com/nix-rust/nix/pull/2267))
+- Add `AtFlags::AT_EMPTY_PATH` for FreeBSD and Hurd
+  ([#2270](https://github.com/nix-rust/nix/pull/2270))
+- Enable `OFlag::O_DIRECTORY for Solarish
+  ([#2275](https://github.com/nix-rust/nix/pull/2275))
+- Added the `Backlog` wrapper type for the `listen` call.
+  ([#2276](https://github.com/nix-rust/nix/pull/2276))
+- Add `clock_nanosleep()` ([#2277](https://github.com/nix-rust/nix/pull/2277))
+- Enabled `O_DIRECT` in `fcntl::OFlags` for solarish
+  ([#2278](https://github.com/nix-rust/nix/pull/2278))
+- Added a new API sigsuspend.
+  ([#2279](https://github.com/nix-rust/nix/pull/2279))
+- - Added `errno::Errno::set` function
+  - Added `errno::Errno::set_raw` function
+  - Added `errno::Errno::last_raw` function
+  - Added `errno::Errno::from_raw` function
+
+  ([#2283](https://github.com/nix-rust/nix/pull/2283))
+- Enable the `AT_EMPTY_PATH` flag for the `linkat()` function
+  ([#2284](https://github.com/nix-rust/nix/pull/2284))
+- Enable unistd::{sync, syncfs} for Android
+  ([#2296](https://github.com/nix-rust/nix/pull/2296))
+
+### Changed
+
+- `poll` now takes `PollTimeout` replacing `libc::c_int`.
+  ([#1876](https://github.com/nix-rust/nix/pull/1876))
+- Deprecated `sys::eventfd::eventfd`.
+  ([#1945](https://github.com/nix-rust/nix/pull/1945))
+- `mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync`, `mprotect`,
+  `munlock` and `mlock` updated to use `NonNull`.
+  ([#2000](https://github.com/nix-rust/nix/pull/2000))
+- `mmap` function now accepts `F` instead of `Option<F>`
+  ([#2127](https://github.com/nix-rust/nix/pull/2127))
+- `PollFd::new` now takes a `BorrowedFd` argument, with relaxed lifetime
+    requirements relative to the previous version.
+  ([#2134](https://github.com/nix-rust/nix/pull/2134))
+- `FdSet::{insert, remove, contains}` now take `BorrowedFd` arguments, and have
+  relaxed lifetime requirements relative to 0.27.1.
+  ([#2136](https://github.com/nix-rust/nix/pull/2136))
+- The following APIs now take an implementation of `AsFd` rather than a
+    `RawFd`:
+
+    - `unistd::tcgetpgrp`
+    - `unistd::tcsetpgrp`
+    - `unistd::fpathconf`
+    - `unistd::ttyname`
+    - `unistd::getpeereid` ([#2137](https://github.com/nix-rust/nix/pull/2137))
+- Changed `openat()` and `Dir::openat()`, now take optional `dirfd`s
+  ([#2139](https://github.com/nix-rust/nix/pull/2139))
+- The MSRV is now 1.69 ([#2144](https://github.com/nix-rust/nix/pull/2144))
+- Changed function `SockaddrIn::ip()` to return `net::Ipv4Addr` and refactored
+  `SocketAddrV6::ip()` to be `const`
+  ([#2151](https://github.com/nix-rust/nix/pull/2151))
+- The following APIs now take optional `dirfd`s:
+
+  - `readlinkat()`
+  - `fstatat()`
+  - `mknodat()`
+  - `mkdirat()`
+  - `execveat()`
+
+  ([#2157](https://github.com/nix-rust/nix/pull/2157))
+- `Epoll::wait` now takes `EpollTimeout` replacing `isize`.
+  ([#2202](https://github.com/nix-rust/nix/pull/2202))
+- - Deprecated `errno::errno()` function (use `Errno::last_raw()`)
+  - Deprecated `errno::from_i32()` function (use `Errno::from_raw()`)
+  - Deprecated `errno::Errno::from_i32()` function (use `Errno::from_raw()`)
+
+  ([#2283](https://github.com/nix-rust/nix/pull/2283))
+
+### Fixed
+
+- Fix `SigSet` incorrect implementation of `Eq`, `PartialEq` and `Hash`
+  ([#1946](https://github.com/nix-rust/nix/pull/1946))
+- Fixed `::sys::socket::sockopt::IpMulticastTtl` by fixing the value of optlen
+  passed to `libc::setsockopt` and added tests.
+  ([#2072](https://github.com/nix-rust/nix/pull/2072))
+- Fixed the function signature of `recvmmsg`, potentially causing UB
+  ([#2119](https://github.com/nix-rust/nix/pull/2119))
+- Fix `SignalFd::set_mask`.  In 0.27.0 it would actually close the file
+  descriptor. ([#2141](https://github.com/nix-rust/nix/pull/2141))
+- Fixed UnixAddr::new for haiku, it did not record the `sun_len` value as
+  needed.
+  Fixed `sys::socket::addr::from_raw_parts` and
+  `sys::socket::Sockaddrlike::len` build for solaris.
+  ([#2242](https://github.com/nix-rust/nix/pull/2242))
+- Fixed solaris build globally.
+  ([#2248](https://github.com/nix-rust/nix/pull/2248))
+- Changed the `dup3` wrapper to perform a real call to `dup3` instead of
+  emulating it via `dup2` and `fcntl` to get rid of race condition
+  ([#2268](https://github.com/nix-rust/nix/pull/2268))
+- Fixed `::unistd::Group::members` using read_unaligned to avoid crash on
+  misaligned pointers ([#2311](https://github.com/nix-rust/nix/pull/2311))
+
+### Removed
+
+- The `FchownatFlags` type has been deprecated, please use `AtFlags` instead.
+  ([#2267](https://github.com/nix-rust/nix/pull/2267))
+- Removed the `dup3` wrapper on macOS, which was emulated via `dup2` and
+  `fcntl` and could cause a race condition. The `dup3` system call is not
+  supported on macOS. ([#2268](https://github.com/nix-rust/nix/pull/2268))
+- The `LinkatFlags` type has been deprecated, please use `AtFlags` instead.
+  ([#2284](https://github.com/nix-rust/nix/pull/2284))
+
+
 ## [0.27.1] - 2023-08-28
 
 ### Fixed

--- a/changelog/1297.added.md
+++ b/changelog/1297.added.md
@@ -1,1 +1,0 @@
-Added `mkdtemp` wrapper

--- a/changelog/1876.changed.md
+++ b/changelog/1876.changed.md
@@ -1,1 +1,0 @@
-`poll` now takes `PollTimeout` replacing `libc::c_int`.

--- a/changelog/1879.added.md
+++ b/changelog/1879.added.md
@@ -1,1 +1,0 @@
-Add associated constants `UTIME_OMIT` `UTIME_NOW` for `TimeSpec`

--- a/changelog/1945.added.md
+++ b/changelog/1945.added.md
@@ -1,1 +1,0 @@
-Added `EventFd` type.

--- a/changelog/1945.changed.md
+++ b/changelog/1945.changed.md
@@ -1,1 +1,0 @@
-Deprecated `sys::eventfd::eventfd`.

--- a/changelog/1946.fixed.md
+++ b/changelog/1946.fixed.md
@@ -1,1 +1,0 @@
-Fix `SigSet` incorrect implementation of `Eq`, `PartialEq` and `Hash`

--- a/changelog/1959.added.md
+++ b/changelog/1959.added.md
@@ -1,4 +1,0 @@
-- Added `impl From<Signal> for SigSet`.
-- Added `impl std::ops::BitOr for SigSet`.
-- Added `impl std::ops::BitOr for Signal`.
-- Added `impl std::ops::BitOr<Signal> for SigSet`

--- a/changelog/2000.changed.md
+++ b/changelog/2000.changed.md
@@ -1,1 +1,0 @@
-`mmap`, `mmap_anonymous`, `munmap`, `mremap`, `madvise`, `msync`, `mprotect`, `munlock` and `mlock` updated to use `NonNull`.

--- a/changelog/2065.added.md
+++ b/changelog/2065.added.md
@@ -1,1 +1,0 @@
-Added `TlsGetRecordType` control message type and corresponding enum for linux

--- a/changelog/2072.fixed.md
+++ b/changelog/2072.fixed.md
@@ -1,1 +1,0 @@
-Fixed `::sys::socket::sockopt::IpMulticastTtl` by fixing the value of optlen passed to `libc::setsockopt` and added tests.

--- a/changelog/2074.added.md
+++ b/changelog/2074.added.md
@@ -1,2 +1,0 @@
-Added `Ipv6HopLimit` to `::nix::sys::socket::ControlMessage` for Linux,
-MacOS, FreeBSD, DragonflyBSD, Android, iOS and Haiku.

--- a/changelog/2103.added.md
+++ b/changelog/2103.added.md
@@ -1,1 +1,0 @@
-Added `Icmp` and `IcmpV6` to `SockProtocol`

--- a/changelog/2119.fixed.md
+++ b/changelog/2119.fixed.md
@@ -1,1 +1,0 @@
-Fixed the function signature of `recvmmsg`, potentially causing UB

--- a/changelog/2121.added.md
+++ b/changelog/2121.added.md
@@ -1,1 +1,0 @@
-Added rfork support for FreeBSD in `unistd`

--- a/changelog/2125.added.md
+++ b/changelog/2125.added.md
@@ -1,1 +1,0 @@
-Added `MapFlags::map_hugetlb_with_size_log2` method for Linux targets

--- a/changelog/2127.added.md
+++ b/changelog/2127.added.md
@@ -1,1 +1,0 @@
-Added `mmap_anonymous` function

--- a/changelog/2127.changed.md
+++ b/changelog/2127.changed.md
@@ -1,1 +1,0 @@
-`mmap` function now accepts `F` instead of `Option<F>`

--- a/changelog/2134.changed.md
+++ b/changelog/2134.changed.md
@@ -1,2 +1,0 @@
-`PollFd::new` now takes a `BorrowedFd` argument, with relaxed lifetime
-  requirements relative to the previous version.

--- a/changelog/2136.changed.md
+++ b/changelog/2136.changed.md
@@ -1,2 +1,0 @@
-`FdSet::{insert, remove, contains}` now take `BorrowedFd` arguments, and have
-relaxed lifetime requirements relative to 0.27.1.

--- a/changelog/2137.changed.md
+++ b/changelog/2137.changed.md
@@ -1,8 +1,0 @@
-The following APIs now take an implementation of `AsFd` rather than a
-  `RawFd`:
-
-  - `unistd::tcgetpgrp`
-  - `unistd::tcsetpgrp`
-  - `unistd::fpathconf`
-  - `unistd::ttyname`
-  - `unistd::getpeereid`

--- a/changelog/2138.added.md
+++ b/changelog/2138.added.md
@@ -1,1 +1,0 @@
-Added `mips32r6` and `mips64r6` support for signal, ioctl and ptrace

--- a/changelog/2139.changed.md
+++ b/changelog/2139.changed.md
@@ -1,1 +1,0 @@
-Changed `openat()` and `Dir::openat()`, now take optional `dirfd`s

--- a/changelog/2141.fixed.md
+++ b/changelog/2141.fixed.md
@@ -1,1 +1,0 @@
-Fix `SignalFd::set_mask`.  In 0.27.0 it would actually close the file descriptor.

--- a/changelog/2142.added.md
+++ b/changelog/2142.added.md
@@ -1,1 +1,0 @@
-Added `F_GETPATH` FcntlFlags entry on Apple/NetBSD/DragonflyBSD for `::nix::fcntl`.

--- a/changelog/2144.changed.md
+++ b/changelog/2144.changed.md
@@ -1,1 +1,0 @@
-The MSRV is now 1.69

--- a/changelog/2151.changed.md
+++ b/changelog/2151.changed.md
@@ -1,2 +1,0 @@
-Changed function `SockaddrIn::ip()` to return `net::Ipv4Addr` and refactored 
-`SocketAddrV6::ip()` to be `const` 

--- a/changelog/2152.added.md
+++ b/changelog/2152.added.md
@@ -1,1 +1,0 @@
-Added `F_KINFO` FcntlFlags entry on FreeBSD for `::nix::fcntl`.

--- a/changelog/2155.added.md
+++ b/changelog/2155.added.md
@@ -1,2 +1,0 @@
-Added `F_GETPATH_NOFIRMLINK` and `F_BARRIERFSYNC` FcntlFlags entry
-on Apple for `::nix::fcntl`.

--- a/changelog/2157.changed.md
+++ b/changelog/2157.changed.md
@@ -1,7 +1,0 @@
-The following APIs now take optional `dirfd`s:
-
-- `readlinkat()`
-- `fstatat()`
-- `mknodat()`
-- `mkdirat()`
-- `execveat()`

--- a/changelog/2170.added.md
+++ b/changelog/2170.added.md
@@ -1,2 +1,0 @@
-Added newtype `Flock` to automatically unlock a held flock upon drop.
-Added `Flockable` trait to represent valid types for `Flock`.

--- a/changelog/2175.added.md
+++ b/changelog/2175.added.md
@@ -1,1 +1,0 @@
-Added `SetSockOpt` impls to enable Linux Kernel TLS on a TCP socket and to import TLS parameters.

--- a/changelog/2187.added.md
+++ b/changelog/2187.added.md
@@ -1,2 +1,0 @@
-- Added the `::nix::sys::socket::SocketTimestamp` enum for configuring the `TsClock` (a.k.a `SO_TS_CLOCK`) sockopt
-- Added FreeBSD's `ScmRealtime` and `ScmMonotonic` as new options in `::nix::sys::socket::ControlMessageOwned`

--- a/changelog/2194.added.md
+++ b/changelog/2194.added.md
@@ -1,1 +1,0 @@
-Added new fanotify API: wrappers for `fanotify_init` and `fanotify_mark`

--- a/changelog/2195.added.md
+++ b/changelog/2195.added.md
@@ -1,1 +1,0 @@
-Added `SpecialCharacterindices` support for haiku.

--- a/changelog/2198.added.md
+++ b/changelog/2198.added.md
@@ -1,1 +1,0 @@
-Added `sys::sendfile` support for solaris/illumos.

--- a/changelog/2202.changed.md
+++ b/changelog/2202.changed.md
@@ -1,1 +1,0 @@
-`Epoll::wait` now takes `EpollTimeout` replacing `isize`.

--- a/changelog/2206.added.md
+++ b/changelog/2206.added.md
@@ -1,1 +1,0 @@
-impl Display for InterfaceFlags

--- a/changelog/2207.added.md
+++ b/changelog/2207.added.md
@@ -1,1 +1,0 @@
-Added `sendfilev` in sys::sendfile for solarish

--- a/changelog/2213.added.md
+++ b/changelog/2213.added.md
@@ -1,1 +1,0 @@
-Added `fctrl::SealFlag::F_SEAL_FUTURE_WRITE`

--- a/changelog/2234.added.md
+++ b/changelog/2234.added.md
@@ -1,1 +1,0 @@
-Added `Ipv6MulticastHops` as socket option to set and read.

--- a/changelog/2240.added.md
+++ b/changelog/2240.added.md
@@ -1,1 +1,0 @@
-Enable `ControlMessageOwned::Ipv4RecvIf` and  `ControlMessageOwned::Ipv4RecvDstAddr` for DragonFlyBSD

--- a/changelog/2241.added.md
+++ b/changelog/2241.added.md
@@ -1,1 +1,0 @@
-`ClockId::set_time()` and `time::clock_settime()` are now enabled on macOS

--- a/changelog/2242.fixed.md
+++ b/changelog/2242.fixed.md
@@ -1,2 +1,0 @@
-Fixed UnixAddr::new for haiku, it did not record the `sun_len` value as needed.
-Fixed `sys::socket::addr::from_raw_parts` and `sys::socket::Sockaddrlike::len` build for solaris.

--- a/changelog/2244.added.md
+++ b/changelog/2244.added.md
@@ -1,1 +1,0 @@
-Added `IpBindAddressNoPort` sockopt to support `IP_BIND_ADDRESS_NO_PORT` available on linux.

--- a/changelog/2245.added.md
+++ b/changelog/2245.added.md
@@ -1,1 +1,0 @@
-Enable `MapFlags::map_hugetlb_with_size_log2` method for Android/Fuchsia

--- a/changelog/2247.added.md
+++ b/changelog/2247.added.md
@@ -1,1 +1,0 @@
-Added `TcpFastOpenConnect` sockopt to support `TCP_FASTOPEN_CONNECT` available on linux.

--- a/changelog/2248.fixed.md
+++ b/changelog/2248.fixed.md
@@ -1,1 +1,0 @@
-Fixed solaris build globally.

--- a/changelog/2251.added.md
+++ b/changelog/2251.added.md
@@ -1,1 +1,0 @@
-Add `reboot(2)` for OpenBSD/NetBSD

--- a/changelog/2252.added.md
+++ b/changelog/2252.added.md
@@ -1,1 +1,0 @@
-Added new `MemFdCreateFlag` constants to `sys::memfd` on Linux and Android related to hugetlbfs support.

--- a/changelog/2258.added.md
+++ b/changelog/2258.added.md
@@ -1,4 +1,0 @@
-Expose the inner fd of `Kqueue` through:
-
-* impl AsFd for Kqueue
-* impl From\<Kqueue\> for OwnedFd

--- a/changelog/2259.added.md
+++ b/changelog/2259.added.md
@@ -1,1 +1,0 @@
-Added `sys::eventfd` support on FreeBSD

--- a/changelog/2260.added.md
+++ b/changelog/2260.added.md
@@ -1,1 +1,0 @@
-Added `MmapFlags::MAP_FIXED` constant in `sys::mman` for netbsd and openbsd

--- a/changelog/2263.added.md
+++ b/changelog/2263.added.md
@@ -1,1 +1,0 @@
-Added the `SO_LISTENQLIMIT` sockopt.

--- a/changelog/2267.added.md
+++ b/changelog/2267.added.md
@@ -1,1 +1,0 @@
-Enable the `AT_EMPTY_PATH` flag for the `fchownat()` function

--- a/changelog/2267.removed.md
+++ b/changelog/2267.removed.md
@@ -1,1 +1,0 @@
-The `FchownatFlags` type has been deprecated, please use `AtFlags` instead.

--- a/changelog/2268.fixed.md
+++ b/changelog/2268.fixed.md
@@ -1,1 +1,0 @@
-Changed the `dup3` wrapper to perform a real call to `dup3` instead of emulating it via `dup2` and `fcntl` to get rid of race condition

--- a/changelog/2268.removed.md
+++ b/changelog/2268.removed.md
@@ -1,1 +1,0 @@
-Removed the `dup3` wrapper on macOS, which was emulated via `dup2` and `fcntl` and could cause a race condition. The `dup3` system call is not supported on macOS.

--- a/changelog/2270.added.md
+++ b/changelog/2270.added.md
@@ -1,1 +1,0 @@
-Add `AtFlags::AT_EMPTY_PATH` for FreeBSD and Hurd

--- a/changelog/2275.added.md
+++ b/changelog/2275.added.md
@@ -1,1 +1,0 @@
-Enable `OFlag::O_DIRECTORY for Solarish

--- a/changelog/2276.added.md
+++ b/changelog/2276.added.md
@@ -1,1 +1,0 @@
-Added the `Backlog` wrapper type for the `listen` call.

--- a/changelog/2277.added.md
+++ b/changelog/2277.added.md
@@ -1,1 +1,0 @@
-Add `clock_nanosleep()`

--- a/changelog/2278.added.md
+++ b/changelog/2278.added.md
@@ -1,1 +1,0 @@
-Enabled `O_DIRECT` in `fcntl::OFlags` for solarish

--- a/changelog/2279.added.md
+++ b/changelog/2279.added.md
@@ -1,1 +1,0 @@
-Added a new API sigsuspend.

--- a/changelog/2283.added.md
+++ b/changelog/2283.added.md
@@ -1,4 +1,0 @@
-- Added `errno::Errno::set` function
-- Added `errno::Errno::set_raw` function
-- Added `errno::Errno::last_raw` function
-- Added `errno::Errno::from_raw` function

--- a/changelog/2283.changed.md
+++ b/changelog/2283.changed.md
@@ -1,3 +1,0 @@
-- Deprecated `errno::errno()` function (use `Errno::last_raw()`)
-- Deprecated `errno::from_i32()` function (use `Errno::from_raw()`)
-- Deprecated `errno::Errno::from_i32()` function (use `Errno::from_raw()`)

--- a/changelog/2284.added.md
+++ b/changelog/2284.added.md
@@ -1,1 +1,0 @@
-Enable the `AT_EMPTY_PATH` flag for the `linkat()` function

--- a/changelog/2284.removed.md
+++ b/changelog/2284.removed.md
@@ -1,1 +1,0 @@
-The `LinkatFlags` type has been deprecated, please use `AtFlags` instead.

--- a/changelog/2296.added.md
+++ b/changelog/2296.added.md
@@ -1,1 +1,0 @@
-Enable unistd::{sync, syncfs} for Android

--- a/changelog/2311.fixed.md
+++ b/changelog/2311.fixed.md
@@ -1,1 +1,0 @@
-Fixed `::unistd::Group::members` using read_unaligned to avoid crash on misaligned pointers


### PR DESCRIPTION
## What does this PR do

Prepare for a new release 0.28.0, and edit the changelog for it.

If a new release is allowed, then I will:

1. Update the version number in `Cargo.toml`
2. Run `cargo release`
3. Push the above changes directly to the master branch

Since this is a one-way trip, hi @asomers, is there anything you want to do before 0.28.0?

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
