### PR TITLE
test: clean clippy needless_borrow false positive issue

### DIFF
--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1180,8 +1180,6 @@ fn test_access_file_exists() {
         .expect("assertion failed");
 }
 
-//Clippy false positive https://github.com/rust-lang/rust-clippy/issues/9111
-#[allow(clippy::needless_borrow)]
 #[cfg(not(target_os = "redox"))]
 #[test]
 fn test_user_into_passwd() {


### PR DESCRIPTION
## What does this PR do

The linked [Clippy issue](https://github.com/rust-lang/rust-clippy/issues/9111) has been resolved, so let's remove this attribute.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
