### PR TITLE
Fix uninitialized memory read and associated crash.

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -326,7 +326,7 @@ pub unsafe fn forkpty<'a, 'b, T: Into<Option<&'a Winsize>>, U: Into<Option<&'b T
 ) -> Result<ForkptyResult> {
     use std::ptr;
 
-    let mut master = mem::MaybeUninit::<libc::c_int>::uninit();
+    let mut master = mem::MaybeUninit::<libc::c_int>::zeroed();
 
     let term = match termios.into() {
         Some(termios) => {


### PR DESCRIPTION
Linux doesn't set the `amaster` parameter of `forkpty()` to a valid file descriptor in the child, but we pass this value to `OwnedFd::from_raw_fd`, which panics if the passed value is `0xffff_ffff`.

A simple reproducer:

```
fn effify()
{
    let x: [u8; 1024] = [0xff; 1024];
}

fn main()
{
    effify();

    let dupped = nix::unistd::dup(1).unwrap();
    let result = unsafe { nix::pty::forkpty(None, None).unwrap() };

    match result.fork_result
    {
        nix::unistd::ForkResult::Child =>
        {
            nix::unistd::dup2(dupped, 1).unwrap();
            println!("Child is happy");
        }
        nix::unistd::ForkResult::Parent { child } =>
        {
            println!("Parent is happy");
            println!("{:?}", nix::sys::wait::waitpid(child, None).unwrap());
        }
    }
}
```

The child process panics in the above code without this patch applied.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
