### PR TITLE
System V shared memory APIs (2nd draft)

### DIFF
--- a/changelog/2313.added.md
+++ b/changelog/2313.added.md
@@ -1,0 +1,1 @@
+Add SystemV IPC support

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -668,6 +668,8 @@ impl Permissions {
         Ok(Permissions { permission: octal })
     }
 
+    /// Getter for permission
+    ///
     pub fn get_permission(&self) -> &u16 {
         &self.permission
     }
@@ -689,14 +691,15 @@ impl Permissions {
 }
 
 libc_bitflags! {
-    /// Different flags for the command `shmget`
+    /// Valid flags for the third parameter of the function [`shmget`]
     pub struct ShmgetFlag: c_int
     {
-        /// A new shared memory segment is created if key has this value
+        /// A new shared memory segment is created if key has this value.
         IPC_PRIVATE;
-        /// Create a new segment. If this flag is not used, then shmget() will
-        /// find the segment associated with key and check to see if the user
-        /// has permission to access the segment.
+        /// Create a new segment.
+        /// If this flag is not used, then shmget() will find the segment
+        /// associated with key and check to see if the user has permission
+        /// to access the segment.
         IPC_CREAT;
         /// This flag is used with IPC_CREAT to ensure that this call creates
         /// the segment.  If the segment already exists, the call fails.
@@ -706,8 +709,9 @@ libc_bitflags! {
         /// further information.
         #[cfg(any(target_os = "linux"))]
         SHM_HUGETLB;
-        // Does not exist in libc but should
+        // TODO: Does not exist in libc/linux, but should? Maybe open an issue in their repo
         // SHM_HUGE_2MB;
+        // TODO: Same for this one
         // SHM_HUGE_1GB;
         /// This flag serves the same purpose as the mmap(2) MAP_NORESERVE flag.
         /// Do not reserve swap space for this segment. When swap space is
@@ -736,10 +740,18 @@ pub fn shmget(
 }
 
 libc_bitflags! {
+    /// Valid flags for the third parameter of the function [`semget`]
     pub struct SemgetFlag: c_int
     {
+        /// A new shared memory segment is created if key has this value
         IPC_PRIVATE;
+        /// Create a new segment.
+        /// If this flag is not used, then shmget() will find the segment
+        /// associated with key and check to see if the user has permission
+        /// to access the segment.
         IPC_CREAT;
+        /// This flag is used with IPC_CREAT to ensure that this call creates
+        /// the segment. If the segment already exists, the call fails.
         IPC_EXCL;
     }
 }
@@ -760,13 +772,29 @@ pub fn semget(
 }
 
 libc_bitflags! {
+    /// Valid flags for the third parameter of the function [`shmat`]
     pub struct ShmatFlag: c_int
     {
-        SHM_EXEC;
-        SHM_RND;
-        SHM_RDONLY;
+        /// Allow the contents of the segment to be executed. The caller must
+        /// have execute permission on the segment.
         #[cfg(any(target_os = "linux"))]
+        SHM_EXEC;
+        #[cfg(any(target_os = "linux"))]
+        /// This flag specifies that the mapping of the segment should replace
+        /// any existing mapping in the range starting at shmaddr and
+        /// continuing for the size of the segment.
+        /// (Normally, an EINVAL error would result if a mapping already exists
+        /// in this address range.)
+        /// In this case, shmaddr must not be NULL.
         SHM_REMAP;
+        /// Attach the segment for read-only access. The process must have read
+        /// permission for the segment. If this flag is not specified, the
+        /// segment is attached for read and write access, and the process must
+        /// have read and write permission for the segment.
+        /// There is no notion of a write-only shared memory segment.
+        SHM_RDONLY;
+        /// TODO: I have no clue at what this does
+        SHM_RND;
     }
 }
 /// Attaches the System V shared memory segment identified by `shmid` to the
@@ -805,11 +833,45 @@ pub fn shmdt(shmaddr: *const c_void) -> Result<()> {
 }
 
 libc_bitflags! {
+    /// Valid flags for the second parameter of the function [`shmctl`]
     pub struct ShmctlFlag: c_int {
         #[cfg(any(target_os = "linux"))]
+        /// Returns the index of the highest used entry in the kernel's internal
+        /// array recording information about all shared memory segment
         IPC_INFO;
+        /// Write the values of some members of the shmid_ds structure pointed
+        /// to by buf to the kernel data structure associated with this shared
+        /// memory segment, updating also its shm_ctime member.
+        ///
+        /// The following fields are updated: shm_perm.uid,
+        /// shm_perm.gid, and (the least significant 9 bits of)
+        /// shm_perm.mode.
+        ///
+        /// The effective UID of the calling process must match the owner
+        /// (shm_perm.uid) or creator (shm_perm.cuid) of the shared memory
+        /// segment, or the caller must be privileged.
         IPC_SET;
+        /// Copy information from the kernel data structure associated with
+        /// shmid into the shmid_ds structure pointed to by buf.
+        /// The caller must have read permission on the shared memory segment.
         IPC_STAT;
+        /// Mark the segment to be destroyed. The segment will actually be
+        /// destroyed only after the last process detaches it
+        /// (i.e., when the shm_nattch member of the associated structure
+        /// shmid_ds is zero).
+        /// The caller must be the owner or creator of the segment,
+        /// or be privileged. The buf argument is ignored.
+        ///
+        /// If a segment has been marked for destruction, then the
+        /// (nonstandard) SHM_DEST flag of the shm_perm.mode field in the
+        /// associated data structure retrieved by IPC_STAT will be set.
+        ///
+        /// The caller must ensure that a segment is eventually destroyed;
+        /// otherwise its pages that were faulted in will remain in memory
+        /// or swap.
+        ///
+        /// See also the description of /proc/sys/kernel/shm_rmid_forced
+        /// in proc(5).
         IPC_RMID;
         // not available in libc/linux, but should be?
         // #[cfg(any(target_os = "linux"))]
@@ -819,8 +881,15 @@ libc_bitflags! {
         // #[cfg(any(target_os = "linux"))]
         // SHM_STAT_ANY;
         #[cfg(any(target_os = "linux"))]
+        /// Prevent swapping of the shared memory segment. The caller must
+        /// fault in any pages that are required to be present after locking is
+        /// enabled.
+        /// If a segment has been locked, then the (nonstandard) SHM_LOCKED
+        /// flag of the shm_perm.mode field in the associated data structure
+        /// retrieved by IPC_STAT will be set.
         SHM_LOCK;
         #[cfg(any(target_os = "linux"))]
+        /// Unlock the segment, allowing it to be swapped out.
         SHM_UNLOCK;
     }
 }
@@ -844,14 +913,52 @@ pub fn shmctl(
     Errno::result(unsafe { libc::shmctl(shmid, command, buf) })
 }
 
-
+#[derive(Debug)]
+/// Called as the fourth parameter of the function [`semctl`]
+/// 
+pub enum Semun {
+    /// Value for SETVAL
+    val(c_int),
+    /// Buffer for IPC_STAT, IPC_SET
+    buf(*mut semid_ds),
+    /// Array for GETALL, SETALL
+    array(*mut c_short),
+    /// Buffer for IPC_INFO
+    #[cfg(any(target_os = "linux"))]
+    __buf(*mut seminfo),
+}
 libc_bitflags! {
+    /// Valid flags for the third parameter of the function [`shmctl`]
     pub struct SemctlCmd: c_int {
+        /// Copy information from the kernel data structure associated with
+        /// shmid into the shmid_ds structure pointed to by buf.
+        /// The caller must have read permission on the shared memory segment.
         IPC_STAT;
+        /// Write the values of some members of the semid_ds structure pointed
+        /// to by arg.buf to the kernel data structure associated with this
+        /// semaphore set, updating also its sem_ctime member.
+        /// 
+        /// The following members of the structure are updated:
+        /// sem_perm.uid, sem_perm.gid, and (the least significant 9 bits of)
+        /// sem_perm.mode.
+        /// 
+        /// The effective UID of the calling process must match the owner
+        /// (sem_perm.uid) or creator (sem_perm.cuid) of the semaphore set,
+        /// or the caller must be privileged. The argument semnum is ignored.
         IPC_SET;
+        /// Immediately remove the semaphore set, awakening all processes
+        /// blocked in semop(2) calls on the set
+        /// (with an error return and errno set to EIDRM).
+        /// The effective user ID of the calling process must match the creator
+        /// or owner of the semaphore set, or the caller must be privileged.
+        /// The argument semnum is ignored.
         IPC_RMID;
         #[cfg(any(target_os = "linux"))]
+        /// Return information about system-wide semaphore limits and
+        /// parameters in the structure pointed to by arg.__buf. This structure
+        /// is of type [`seminfo`].
         IPC_INFO;
+        // TODO: None of the one following are defined in libc
         // #[cfg(any(target_os = "linux"))]
         // SEM_INFO;
         // #[cfg(any(target_os = "linux"))]
@@ -867,20 +974,6 @@ libc_bitflags! {
         // SETVAL;
     }
 }
-
-#[derive(Debug)]
-pub enum Semun {
-    /// Value for SETVAL
-    val(c_int),
-    /// Buffer for IPC_STAT, IPC_SET
-    buf(*mut semid_ds),
-    /// Array for GETALL, SETALL
-    array(*mut c_short),
-    /// Buffer for IPC_INFO
-    #[cfg(any(target_os = "linux"))]
-    __buf(*mut seminfo),
-}
-
 /// Performs control operation specified by `cmd` on the System V shared
 /// semaphore segment given by `semid`.
 ///


### PR DESCRIPTION
## What does this PR do

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API

I've seen issue #1718 and the pull request #1989 made by @arpankapoor from a year ago, that added some support for the System V API.

This is a continuation of this PR, where I tried to implement most of the change suggested by @VorpalBlade.

## What's missing

I haven't added any unit test yet, as somehow I'm getting a lot of compilation error on the test, about some missing symbol, but I've got a closed source project where I'm using this draft as a "eat your own dog food", with unit test, and it seems to work fine.

Some of the bitflags, 2 in `ShmgetFlag` and a lot in `SemctlCmd` do not exist in libc, even though they are documented.
So to merge this, there is a need to create a PR for libc that add those.

## What can be better

`Permissions`: Could maybe be moved elsewhere? I haven't found any struct already implemented that wrap the octal permission system unix use, so I threw this in 5m.

`shmat`: I'm **really** not a fan of returning a void ptr. I've tried to wrap it in a `Weak<RefCell<T>>` but I get a segfault when it gets dropped.
What would be ideal is for the user to give a generic type T that could be wrapped in a non owning smart pointer that could also be null. That's why I though Weak would be the answer, but I'm not good enough to find the problem.
Currently, the user has the cast it in unsafe themselves to be able to use the value in it, which is awkward and error prone.

I'm not too sure about the linux only bitflags compilation. We should test it for android too, but I don't know how to do that.

