### PR TITLE
docs: correct a doc comment

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -59,7 +59,7 @@ impl Dir {
         Dir::from_fd(fd.into_raw_fd())
     }
 
-    /// Converts from a file descriptor, closing it on success or failure.
+    /// Converts from a file descriptor, closing it on failure.
     #[doc(alias("fdopendir"))]
     pub fn from_fd(fd: RawFd) -> Result<Self> {
         let d = ptr::NonNull::new(unsafe { libc::fdopendir(fd) }).ok_or_else(


### PR DESCRIPTION
## What does this PR do

Corrects a wrong doc comment.

The file descriptor won't be closed if `Dir::from_fd()` succeeds, it will be closed by `closedir(3)`, which will be involved when the returned `Dir` is dropped.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
