### PR TITLE
refactor: remove redundant imports to fix CI

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -14,7 +14,6 @@
 use crate::Result;
 use cfg_if::cfg_if;
 use libc::{c_int, c_void};
-use std::convert::TryFrom;
 use std::{error, fmt, io};
 
 pub use self::consts::*;

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -2,7 +2,7 @@
 use crate::errno::Errno;
 #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))]
 use core::slice;
-use libc::{self, c_int, c_uint, size_t, ssize_t};
+use libc::{c_int, c_uint, size_t, ssize_t};
 #[cfg(any(
     target_os = "netbsd",
     apple_targets,

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -2,7 +2,6 @@
 // https://github.com/rust-lang/libc/issues/1848
 pub use libc::{suseconds_t, time_t};
 use libc::{timespec, timeval};
-use std::convert::From;
 use std::time::Duration;
 use std::{cmp, fmt, ops};
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -31,8 +31,7 @@ use crate::{Error, NixPath, Result};
 #[cfg(not(target_os = "redox"))]
 use cfg_if::cfg_if;
 use libc::{
-    self, c_char, c_int, c_long, c_uint, gid_t, mode_t, off_t, pid_t, size_t,
-    uid_t,
+    c_char, c_int, c_long, c_uint, gid_t, mode_t, off_t, pid_t, size_t, uid_t,
 };
 use std::convert::Infallible;
 #[cfg(not(target_os = "redox"))]

--- a/test/sys/test_select.rs
+++ b/test/sys/test_select.rs
@@ -68,7 +68,6 @@ macro_rules! generate_fdset_bad_fd_tests {
 
 mod test_fdset_too_large_fd {
     use super::*;
-    use std::convert::TryInto;
     generate_fdset_bad_fd_tests!(
         FD_SETSIZE.try_into().unwrap(),
         insert,

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -1,7 +1,6 @@
 use nix::errno::Errno;
 use nix::sys::signal::*;
 use nix::unistd::*;
-use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_os = "redox"))]

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::os::unix::io::{AsFd, AsRawFd};
 use tempfile::tempfile;
 


### PR DESCRIPTION
## What does this PR do

A couple imports have become redundant, let's clear them.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
