### PR TITLE
Update cfg_aliases dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ caps = "0.5.3"
 sysctl = "0.4"
 
 [build-dependencies]
-cfg_aliases = "0.1.1"
+cfg_aliases = "0.2"
 
 [[test]]
 name = "test"

--- a/changelog/2322.changed.md
+++ b/changelog/2322.changed.md
@@ -1,0 +1,1 @@
+Updated `cfg_aliases` dependency from version 0.1 to 0.2


### PR DESCRIPTION
## What does this PR do

This fixes the following notice when running `cargo update` in any project that depends on the `nix` crate.

```console
$ cargo update
    Updating crates.io index
note: pass `--verbose` to see 1 unchanged dependencies behind latest

$ cargo update --verbose
    Updating crates.io index
   Unchanged cfg_aliases v0.1.1 (latest: v0.2.0)
note: to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`

$ cargo tree --invert --package cfg_aliases
cfg_aliases v0.1.1
[build-dependencies]
└── nix v0.28.0
    └── faketty v1.0.15
```

Here is the changelog for `cfg_aliases` 0.2.0: https://github.com/katharostech/cfg_aliases/releases/tag/v0.2.0

The change related to `debug_assertions` appears to be the impetus for 0.2 to be released as a breaking change, but it does not affect `nix` as `debug_assertions` is not used in nix's build.rs.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API