### PR TITLE
feat: make SigAction repr(transparent)&From<raw>&Into<raw>

### DIFF
--- a/changelog/2326.added.md
+++ b/changelog/2326.added.md
@@ -1,0 +1,1 @@
+make SigAction repr(transparent)&From<libc::sigaction>&Into<libc::sigaction>

--- a/changelog/2326.added.md
+++ b/changelog/2326.added.md
@@ -1,1 +1,1 @@
-make SigAction repr(transparent)&From<libc::sigaction>&Into<libc::sigaction>
+make SigAction repr(transparent) & can be converted to/from the libc raw type

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -753,9 +753,23 @@ pub enum SigHandler {
 }
 
 /// Action to take on receipt of a signal. Corresponds to `sigaction`.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SigAction {
     sigaction: libc::sigaction
+}
+
+impl From<libc::sigaction> for SigAction {
+    fn from(value: libc::sigaction) -> Self {
+        Self {
+            sigaction: value
+        }
+    }
+}
+impl Into<libc::sigaction> for SigAction {
+    fn into(self) -> libc::sigaction {
+        self.sigaction
+    }
 }
 
 impl SigAction {

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -766,9 +766,9 @@ impl From<libc::sigaction> for SigAction {
         }
     }
 }
-impl Into<libc::sigaction> for SigAction {
-    fn into(self) -> libc::sigaction {
-        self.sigaction
+impl From<SigAction> for libc::sigaction {
+    fn from(value: SigAction) -> libc::sigaction {
+        value.sigaction
     }
 }
 


### PR DESCRIPTION
## What does this PR do

Make SigAction repr(transparent) & can be converted to/from the libc raw type.

This is the first PR towards the goal described in this [comment](https://github.com/nix-rust/nix/issues/2319#issuecomment-1967988916), closes #2319.

I will handle the remaining ones in the future PRs.


refe: #2327

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
