### PR TITLE
Improve ergonomics between SockaddrIn and underlying libc type

### DIFF
--- a/changelog/2328.added.md
+++ b/changelog/2328.added.md
@@ -1,0 +1,1 @@
+Add `From` trait implementation for conversions between `sockaddr_in` and `SockaddrIn`, `sockaddr_in6` and `SockaddrIn6`

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -920,6 +920,19 @@ impl From<SockaddrIn> for net::SocketAddrV4 {
 }
 
 #[cfg(feature = "net")]
+impl From<SockaddrIn> for libc::sockaddr_in {
+    fn from(sin: SockaddrIn) -> libc::sockaddr_in {
+        sin.0
+    }
+}
+#[cfg(feature = "net")]
+impl From<libc::sockaddr_in> for SockaddrIn {
+    fn from(sin: libc::sockaddr_in) -> SockaddrIn {
+        SockaddrIn(sin)
+    }
+}
+
+#[cfg(feature = "net")]
 impl std::str::FromStr for SockaddrIn {
     type Err = net::AddrParseError;
 
@@ -966,6 +979,20 @@ impl SockaddrIn6 {
     /// Returns the scope ID associated with this address.
     pub const fn scope_id(&self) -> u32 {
         self.0.sin6_scope_id
+    }
+}
+
+#[cfg(feature = "net")]
+impl From<SockaddrIn6> for libc::sockaddr_in6 {
+    fn from(sin6: SockaddrIn6) -> libc::sockaddr_in6 {
+        sin6.0
+    }
+}
+
+#[cfg(feature = "net")]
+impl From<libc::sockaddr_in6> for SockaddrIn6 {
+    fn from(sin6: libc::sockaddr_in6) -> SockaddrIn6 {
+        SockaddrIn6(sin6)
     }
 }
 


### PR DESCRIPTION
## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

- Add `Into<libc::sockaddr_in6> for SockaddrIn6`
- Add `Into<libc::sockaddr_in> for SockaddrIn`

My typical use case for these `Into` traits is when I am bridging from safe world into the world of pain (C). For example,  presently I have to go over `as_ref()` to access the underlying `sockaddr_inX` . This is a bit verbose for my liking, so I figured it would be great to have `into()` to do the job for me.  Usually `From` is preferred but I am not certain if we want that, hence I have implemented `Into` but can easily flip to `From` if that makes sense.

```diff
let addr_sa = SockaddrIn6::from(SocketAddrV6::new(addr, 0, 0, 0));
let mut req: in6_aliasreq = unsafe { mem::zeroed() };
-req.addr = *addr_sa.as_ref();
+req.addr = addr_sa.into();
```

I also noticed that `repr(transparent)` is set on these structs and naturally I thought I could use `addr_sa as sockaddr_in6` but that doesn't seem to compile.
