### PR TITLE
style: fix clippy lint clippy::mixed_attributes_style on nightly tier3

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2177,9 +2177,8 @@ mod tests {
     }
 
     #[cfg(not(any(target_os = "hurd", target_os = "redox")))]
+    #[allow(clippy::cast_ptr_alignment)]
     mod link {
-        #![allow(clippy::cast_ptr_alignment)]
-
         #[cfg(any(apple_targets, solarish))]
         use super::super::super::socklen_t;
         use super::*;


### PR DESCRIPTION
## What does this PR do

Fix a clippy lint that happens in #2329

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
