### PR TITLE
sys::socket: adding freebsd's ReusePortLb constant.

### DIFF
--- a/changelog/2332.added.md
+++ b/changelog/2332.added.md
@@ -1,0 +1,1 @@
+Add socket option ReusePortLb for FreeBSD.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -270,6 +270,16 @@ sockopt_impl!(
     libc::SO_REUSEPORT,
     bool
 );
+#[cfg(target_os = "freebsd")]
+sockopt_impl!(
+    /// Enables incoming connections to be distributed among N sockets (up to 256)
+    /// via a Load-Balancing hash based algorithm.
+    ReusePortLb,
+    Both,
+    libc::SOL_SOCKET,
+    libc::SO_REUSEPORT_LB,
+    bool
+);
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -859,3 +859,19 @@ fn test_utun_ifname() {
     let expected_name = format!("utun{}", unit - 1);
     assert_eq!(name.into_string(), Ok(expected_name));
 }
+
+#[test]
+#[cfg(target_os = "freebsd")]
+fn test_reuseport_lb() {
+    let fd = socket(
+        AddressFamily::Inet6,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+    setsockopt(&fd, sockopt::ReusePortLb, &false).unwrap();
+    assert!(!getsockopt(&fd, sockopt::ReusePortLb).unwrap());
+    setsockopt(&fd, sockopt::ReusePortLb, &true).unwrap();
+    assert!(getsockopt(&fd, sockopt::ReusePortLb).unwrap());
+}


### PR DESCRIPTION
Allows to use `SO_REUSEPORT_LB` so incoming connections can be distributed to bound (up to 256) sockets in a Load-Balanced fashion.