### PR TITLE
sys::resource update max_rss accessor doc to reflect the unit per platform

### DIFF
--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -293,7 +293,9 @@ impl Usage {
         TimeVal::from(self.0.ru_stime)
     }
 
-    /// The resident set size at its peak, in kilobytes.
+    /// The resident set size at its peak,
+    #[cfg_attr(apple_targets, doc = " in bytes.")]
+    #[cfg_attr(not(apple_targets), doc = " in kilobytes.")]
     pub fn max_rss(&self) -> c_long {
         self.0.ru_maxrss
     }


### PR DESCRIPTION
on Apple's devices. this field returns the value in byte. close #2331