### PR TITLE
ci: disable the DragonFlyBSD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-dragonfly
+          # Temporarily disable DragonFlyBSD
+          # https://github.com/nix-rust/nix/issues/2337
+          # - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
           # Temporarily disable armv7-unknown-linux-uclibceabihf
           # https://github.com/nix-rust/nix/issues/2200


### PR DESCRIPTION
## What does this PR do

Disable the tier3 DragonFlyBSD CI because the latest nightly rust toolchain is broken on it, see the upstream issue: https://github.com/rust-lang/rust/issues/122585

Nix issue: https://github.com/nix-rust/nix/issues/2337

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
