### PR TITLE
Add support for openat2.

### DIFF
--- a/changelog/2339.added.md
+++ b/changelog/2339.added.md
@@ -1,0 +1,1 @@
+Added support for openat2 on linux.


### PR DESCRIPTION
## What does this PR do

Adds support for openat2 on linux. Includes a new `ResolveFlag` struct to pass resolve flags, which is passed directly to the new `fcntl::openat2` function. `libc::open_how` isn't exposed in any way here, which will mean this API needs to change if there's an update that extends `libc::open_how` with new fields.

Given that the whole point of `libc::open_how` is that it's extensible, I'm not sure that this is the right way to go about adding this API. I could be convinced to go back and add something that looks more like the stdlib's `OpenOptions` that would allow adding more arguments to this function without a breaking change. I would love some input/direction here.

Fixes #1400.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
