### PR TITLE
style: try fixing clippy warning

### DIFF
--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -2407,7 +2407,7 @@ fn test_recvmmsg_timestampns() {
     // Receive the message
     let mut buffer = vec![0u8; message.len()];
     let cmsgspace = nix::cmsg_space!(TimeSpec);
-    let mut iov = vec![[IoSliceMut::new(&mut buffer)]];
+    let mut iov = [[IoSliceMut::new(&mut buffer)]];
     let mut data = MultiHeaders::preallocate(1, Some(cmsgspace));
     let r: Vec<RecvMsg<()>> = recvmmsg(
         in_socket.as_raw_fd(),


### PR DESCRIPTION
## What does this PR do

Fix the below clippy warning:

```sh
error: useless use of `vec!`
    --> test/sys/test_socket.rs:2410:19
     |
2410 |     let mut iov = vec![[IoSliceMut::new(&mut buffer)]];
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[[IoSliceMut::new(&mut buffer)]]`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
     = note: `-D clippy::useless-vec` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::useless_vec)]`
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
