### PR TITLE
 style: ignore false-positive lint clippy::duplicated_attributes

### DIFF
--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -71,6 +71,8 @@ type fs_type_t = libc::c_int;
 type fs_type_t = libc::__fsword_t;
 
 /// Describes the file system type as known by the operating system.
+// false positive, see: https://github.com/rust-lang/rust-clippy/issues/12537
+#[allow(clippy::duplicated_attributes)]
 #[cfg(any(
     target_os = "freebsd",
     target_os = "android",

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -12,6 +12,8 @@ const fn zero_init_timespec() -> timespec {
     unsafe { std::mem::transmute([0u8; std::mem::size_of::<timespec>()]) }
 }
 
+// false positive, see: https://github.com/rust-lang/rust-clippy/issues/12537
+#[allow(clippy::duplicated_attributes)]
 #[cfg(any(
     all(feature = "time", any(target_os = "android", target_os = "linux")),
     all(


### PR DESCRIPTION
## What does this PR do

This PR ignores the false-positive warnings introduced by clippy lint: [duplicated_attributes](https://rust-lang.github.io/rust-clippy/master/index.html#/duplicated_attributes).

There is an issue for it, see https://github.com/rust-lang/rust-clippy/issues/12537.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
