### PR TITLE
docs: document we don't alias for ONLY 1 OS[skip ci]

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -47,8 +47,12 @@ When creating newtypes, we use Rust's `CamelCase` type naming convention.
 ## cfg gates
 
 When creating operating-system-specific functionality, we gate it by
-`#[cfg(target_os = ...)]`. If more than one operating system is affected, we
+`#[cfg(target_os = ...)]`. If **MORE THAN ONE operating system** is affected, we
 prefer to use the cfg aliases defined in build.rs, like `#[cfg(bsd)]`.
+
+Please **DO NOT** use cfg aliases for **ONLY ONE** system as [they are bad][mismatched_target_os].
+
+[mismatched_target_os]: https://rust-lang.github.io/rust-clippy/master/index.html#/mismatched_target_os
 
 ## Bitflags
 

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,8 @@ fn main() {
         watchos: { target_os = "watchos" },
         tvos: { target_os = "tvos" },
 
+
+        // cfg aliases we would like to use
         apple_targets: { any(ios, macos, watchos, tvos) },
         bsd: { any(freebsd, dragonfly, netbsd, openbsd, apple_targets) },
         linux_android: { any(android, linux) },


### PR DESCRIPTION
## What does this PR do

While reviewing #2314, I found that it is easy for contributors to accidentally use cfg aliases that are ONLY for 1 operation system, this is something we don't like (see #2236 and [clippy::mismatched_target_os](https://rust-lang.github.io/rust-clippy/master/index.html#/mismatched_target_os) ), so let's document this.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
