### PR TITLE
Update bitflags to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ targets = [
 
 [dependencies]
 libc = { version = "0.2.153", features = ["extra_traits"] }
-bitflags = "2.5.0"
+bitflags = "2.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
 memoffset = { version = "0.9", optional = true }


### PR DESCRIPTION
## What does this PR do
Update dependency of `bitflags` to latest release to avoid duplicate crate versions in [serialport](https://github.com/serialport/serialport-rs).

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
