### PR TITLE
refactor: make with_opt_nix_path() a util

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,3 +362,17 @@ impl NixPath for PathBuf {
         self.as_os_str().with_nix_path(f)
     }
 }
+
+/// Like `NixPath::with_nix_path()`, but allow the `path` argument to be optional.
+///
+/// A NULL pointer will be provided if `path.is_none()`.
+pub(crate) fn with_opt_nix_path<P, T, F>(path: Option<&P>, f: F) -> Result<T>
+where
+    P: ?Sized + NixPath,
+    F: FnOnce(*const libc::c_char) -> T,
+{
+    match path {
+        Some(path) => path.with_nix_path(|p_str| f(p_str.as_ptr())),
+        None => Ok(f(ptr::null())),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,10 @@ impl NixPath for PathBuf {
 /// Like `NixPath::with_nix_path()`, but allow the `path` argument to be optional.
 ///
 /// A NULL pointer will be provided if `path.is_none()`.
+#[cfg(any(
+    all(apple_targets, feature = "mount"),
+    all(target_os = "linux", any(feature = "mount", feature = "fanotify"))
+))]
 pub(crate) fn with_opt_nix_path<P, T, F>(path: Option<&P>, f: F) -> Result<T>
 where
     P: ?Sized + NixPath,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ impl NixPath for PathBuf {
 /// A NULL pointer will be provided if `path.is_none()`.
 #[cfg(any(
     all(apple_targets, feature = "mount"),
-    all(target_os = "linux", any(feature = "mount", feature = "fanotify"))
+    all(linux_android, any(feature = "mount", feature = "fanotify"))
 ))]
 pub(crate) fn with_opt_nix_path<P, T, F>(path: Option<&P>, f: F) -> Result<T>
 where

--- a/src/mount/apple.rs
+++ b/src/mount/apple.rs
@@ -82,20 +82,9 @@ pub fn mount<
     flags: MntFlags,
     data: Option<&P3>,
 ) -> Result<()> {
-    fn with_opt_nix_path<P, T, F>(p: Option<&P>, f: F) -> Result<T>
-    where
-        P: ?Sized + NixPath,
-        F: FnOnce(*const libc::c_char) -> T,
-    {
-        match p {
-            Some(path) => path.with_nix_path(|p_str| f(p_str.as_ptr())),
-            None => Ok(f(std::ptr::null())),
-        }
-    }
-
     let res = source.with_nix_path(|s| {
         target.with_nix_path(|t| {
-            with_opt_nix_path(data, |d| unsafe {
+            crate::with_opt_nix_path(data, |d| unsafe {
                 libc::mount(
                     s.as_ptr(),
                     t.as_ptr(),

--- a/src/mount/linux.rs
+++ b/src/mount/linux.rs
@@ -113,21 +113,10 @@ pub fn mount<
     flags: MsFlags,
     data: Option<&P4>,
 ) -> Result<()> {
-    fn with_opt_nix_path<P, T, F>(p: Option<&P>, f: F) -> Result<T>
-    where
-        P: ?Sized + NixPath,
-        F: FnOnce(*const libc::c_char) -> T,
-    {
-        match p {
-            Some(path) => path.with_nix_path(|p_str| f(p_str.as_ptr())),
-            None => Ok(f(std::ptr::null())),
-        }
-    }
-
-    let res = with_opt_nix_path(source, |s| {
+    let res = crate::with_opt_nix_path(source, |s| {
         target.with_nix_path(|t| {
-            with_opt_nix_path(fstype, |ty| {
-                with_opt_nix_path(data, |d| unsafe {
+            crate::with_opt_nix_path(fstype, |ty| {
+                crate::with_opt_nix_path(data, |d| unsafe {
                     libc::mount(
                         s,
                         t.as_ptr(),

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -313,18 +313,7 @@ impl Fanotify {
         dirfd: Option<RawFd>,
         path: Option<&P>,
     ) -> Result<()> {
-        fn with_opt_nix_path<P, T, F>(p: Option<&P>, f: F) -> Result<T>
-        where
-            P: ?Sized + NixPath,
-            F: FnOnce(*const libc::c_char) -> T,
-        {
-            match p {
-                Some(path) => path.with_nix_path(|p_str| f(p_str.as_ptr())),
-                None => Ok(f(std::ptr::null())),
-            }
-        }
-
-        let res = with_opt_nix_path(path, |p| unsafe {
+        let res = crate::with_opt_nix_path(path, |p| unsafe {
             libc::fanotify_mark(
                 self.fd.as_raw_fd(),
                 flags.bits(),


### PR DESCRIPTION
## What does this PR do

`with_opt_nix_path()` has been defined multiple times in our code, which introduces duplicate code, this PR moves the implementation to `lib.rs` and makes it a utility function.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
