### PR TITLE
docs: document Errno::result() in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -135,3 +135,20 @@ If you want to add a test for a feature that is in `xxx.rs`, then the test shoul
 be put in the corresponding `test_xxx.rs` file unless you cannot do this, e.g.,
 the test involves private stuff and thus cannot be added outside of Nix, then
 it is allowed to leave the test in `xxx.rs`.
+
+## Syscall/libc function error handling
+
+Most syscall and libc functions return an [`ErrnoSentinel`][trait] value on error,
+we has a nice utility function [`Errno::result()`][util] to convert it to the 
+Rusty `Result<T, Errno>` type, e.g., here is how `dup(2)` uses it:
+
+```rs
+pub fn dup(oldfd: RawFd) -> Result<RawFd> {
+    let res = unsafe { libc::dup(oldfd) };
+
+    Errno::result(res)
+}
+```
+
+[trait]: https://docs.rs/nix/latest/nix/errno/trait.ErrnoSentinel.html
+[util]: https://docs.rs/nix/latest/nix/errno/enum.Errno.html#method.result


### PR DESCRIPTION
## What does this PR do

Document that one can use `Errno::result()` to do error handling in `CONVENTIONS.md`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
