### PR TITLE
ci: check newly-added CHANGELOGs in CI

### DIFF
--- a/.github/actions/check_changelog/action.yml
+++ b/.github/actions/check_changelog/action.yml
@@ -1,0 +1,41 @@
+name: 'Check CHANGELOG'
+description: 'Check CHANGELOG kind and PR number'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get newly added CHANGELOGs
+        id: new-changelogs
+        uses: tj-actions/changed-files@v44
+        with:
+          # Only checek the files under the `changelog` directory 
+          files: changelog/** 
+
+    - name: List added CHANGELOGs
+        if: steps.new-changelogs.outputs.added_files_count != 0
+        env:
+          NEW_CHANGELOGS: ${{ steps.new-changelogs.outputs.added_files }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          for cl in ${NEW_CHANGELOGS}; do
+            # parse it
+            IFS='.' read id kind file_extension <<< "${cl}"
+
+            # Check the kind field
+            if [ "$kind" != "added" ] && [ "$kind" != "changed" ] && [ "$kind" != "fixed" ] && [ "$kind" != "removed" ]; then
+              echo "Invalid CHANGELOG kind [${kind}] from [${cl}], available options are [added, changed, fixed, removed]";
+              exit 1;
+            fi
+
+            # Check the file extension
+            if [ "$file_extension" != "md" ]; then
+              echo "Invalid file extension [${file_extension}] from [${cl}], it should be [md]";
+              exit 1;
+            fi
+
+            # Check PR number
+            if [ "$id" != "$PR_NUMBER" ]; then
+              echo "Mismatched PR number [${id}] from [${cl}], it should be ${PR_NUMBER}";
+              exit 1;
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ env:
   MSRV: 1.69.0
 
 jobs:
+  check_changelog:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: chceck CHANGELOG
+        uses: ./.github/actions/check_changelog
 
   macos:
     runs-on: macos-13


### PR DESCRIPTION
## What does this PR do

This PR adds a new composite Github Action `check_changelog`(.github/actions/check_changelog/action.yml) and applies it in our `ci.yml`, for those newly-added changelog files under the `changelog` directory, it will check:

1. the CHANGELOG kind belongs to [added, changed, fixed, removed]
2. the PR number matches the real one
3. the file extension is `md`

Closes #2357

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
