### PR TITLE
Allow use of SignalFd through shared reference

### DIFF
--- a/changelog/2367.changed.md
+++ b/changelog/2367.changed.md
@@ -1,0 +1,5 @@
+Allow use of `SignalFd` through shared reference
+
+Like with many other file descriptors, concurrent use of signalfds is safe.
+Changing the signal mask of and reading signals from a signalfd can now be done
+with the `SignalFd` API even if other references to it exist.

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -105,11 +105,11 @@ impl SignalFd {
         Ok(SignalFd(fd))
     }
 
-    pub fn set_mask(&mut self, mask: &SigSet) -> Result<()> {
+    pub fn set_mask(&self, mask: &SigSet) -> Result<()> {
         self.update(mask, SfdFlags::empty())
     }
 
-    pub fn read_signal(&mut self) -> Result<Option<siginfo>> {
+    pub fn read_signal(&self) -> Result<Option<siginfo>> {
         let mut buffer = mem::MaybeUninit::<siginfo>::uninit();
 
         let size = mem::size_of_val(&buffer);

--- a/test/sys/test_signalfd.rs
+++ b/test/sys/test_signalfd.rs
@@ -28,7 +28,7 @@ fn read_empty_signalfd() {
     };
 
     let mask = SigSet::empty();
-    let mut fd = SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK).unwrap();
+    let fd = SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK).unwrap();
 
     let res = fd.read_signal();
     assert!(res.unwrap().is_none());
@@ -47,7 +47,7 @@ fn test_signalfd() {
     mask.add(signal::SIGUSR1);
     mask.thread_block().unwrap();
 
-    let mut fd = SignalFd::new(&mask).unwrap();
+    let fd = SignalFd::new(&mask).unwrap();
 
     // Send a SIGUSR1 signal to the current process. Note that this uses `raise` instead of `kill`
     // because `kill` with `getpid` isn't correct during multi-threaded execution like during a
@@ -72,7 +72,7 @@ fn test_signalfd_setmask() {
     // Block the SIGUSR1 signal from automatic processing for this thread
     let mut mask = SigSet::empty();
 
-    let mut fd = SignalFd::new(&mask).unwrap();
+    let fd = SignalFd::new(&mask).unwrap();
 
     mask.add(signal::SIGUSR1);
     mask.thread_block().unwrap();


### PR DESCRIPTION
Like with many other file descriptors, concurrent use of signalfds is safe. Changing the signal mask of and reading signals from a signalfd can now be done with the `SignalFd` API even if other references to it exist.

Fixes #2366.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
