### PR TITLE
ci: fix changelog checker by trimming the 'changelog/' prefix

### DIFF
--- a/.github/actions/check_new_changelog/action.yml
+++ b/.github/actions/check_new_changelog/action.yml
@@ -18,7 +18,11 @@ runs:
         NEW_CHANGELOGS: ${{ steps.new-changelogs.outputs.added_files }}
         PR_NUMBER: ${{ github.event.number }}
       run: |
+        # `cl` will be something like "changelog/1.added.md"
         for cl in ${NEW_CHANGELOGS}; do
+          # Trim the directory name
+          prefix="changelog/"; trimmed_cl=${cl/#$prefix}; cl="${trimmed_cl}";
+
           # parse it
           IFS='.' read id kind file_extension <<< "${cl}"
 


### PR DESCRIPTION
## What does this PR do

Fix changelog checker by trimming the 'changelog/' prefix

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
