### PR TITLE
ci: only run changelog checker in PR

### DIFF
--- a/.github/workflows/check_new_changelog.yml
+++ b/.github/workflows/check_new_changelog.yml
@@ -1,0 +1,18 @@
+name: Check new CHANGELOGs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read 
+
+jobs:
+  check_new_changelog:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: check new CHANGELOG
+        uses: ./.github/actions/check_new_changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,6 @@ env:
   MSRV: 1.69.0
 
 jobs:
-  check_new_changelog:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: check new CHANGELOG
-        uses: ./.github/actions/check_new_changelog
-
   macos:
     runs-on: macos-13
     env: 


### PR DESCRIPTION
## What does this PR do

The changelog checker only works with PRs, so we should only execute it in PRs.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
