### PR TITLE
test: skip test_utun_ifname if unprivileged

### DIFF
--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -832,6 +832,8 @@ fn test_ktls() {
 #[test]
 #[cfg(apple_targets)]
 fn test_utun_ifname() {
+    skip_if_not_root!("test_utun_ifname");
+
     use nix::sys::socket::connect;
     use nix::sys::socket::SysControlAddr;
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -3,6 +3,7 @@ extern crate cfg_if;
 #[cfg_attr(not(any(target_os = "redox", target_os = "haiku")), macro_use)]
 extern crate nix;
 
+#[macro_use]
 mod common;
 mod mount;
 mod sys;


### PR DESCRIPTION
## What does this PR do

From this [post](https://forums.developer.apple.com/forums/thread/85473), the `utun` interface requires privilege, and this is exactly what happens on my mac:

```sh
$ cargo t --all-features test_utun_ifname -q

running 1 test
F
failures:

---- sys::test_sockopt::test_utun_ifname stdout ----
thread 'sys::test_sockopt::test_utun_ifname' panicked at test/sys/test_sockopt.rs:854:36:
called `Result::unwrap()` on an `Err` value: EPERM
```

This PR skips the test if the process is not privileged.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
