### PR TITLE
test: use parking_lot::Mutex for FORK_MTX

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -59,7 +59,7 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
 
 /// Any test that creates child processes must grab this mutex, regardless
 /// of what it does with those children.
-pub static FORK_MTX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub static FORK_MTX: Mutex<()> = Mutex::new(());
 /// Any test that changes the process's current working directory must grab
 /// the RwLock exclusively.  Any process that cares about the current
 /// working directory must grab it shared.


### PR DESCRIPTION
## What does this PR do

For `FORK_MTX` use the `Mutex` type from `parking_lot` rather than the std one for the feature of no poisoning.

Closes #2363

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
