### PR TITLE
sys::prctl: Adding set_vma_anon_name.

### DIFF
--- a/changelog/2378.added.md
+++ b/changelog/2378.added.md
@@ -1,0 +1,1 @@
+Add prctl function `prctl_set_vma_anon_name` for Linux/Android.


### PR DESCRIPTION
to set a name for an `anonymous` region for Linux/Android.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
