### PR TITLE
unistd: fdatasync support for apple.

### DIFF
--- a/changelog/2380.added.md
+++ b/changelog/2380.added.md
@@ -1,0 +1,1 @@
+Add fdatasync support for Apple targets.


### PR DESCRIPTION
is not present in system headers, however the syscall is actually implemented.
