### PR TITLE
test: grab the SIGNAL_MTX lock in test_sigaction

### DIFF
--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -283,6 +283,7 @@ fn test_from_and_into_iterator() {
 #[test]
 #[cfg(not(target_os = "redox"))]
 fn test_sigaction() {
+    let _m = crate::SIGNAL_MTX.lock();
     thread::spawn(|| {
         extern "C" fn test_sigaction_handler(_: libc::c_int) {}
         extern "C" fn test_sigaction_action(


### PR DESCRIPTION
## What does this PR do

This test changes the process-wide signal handler so we should use a lock to serialize it with other tests.

cc @TheJonny

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
