### PR TITLE
feat: OFlag::O_PATH for FreeBSD and Fuchsia

### DIFF
--- a/changelog/2382.added.md
+++ b/changelog/2382.added.md
@@ -1,0 +1,1 @@
+Add `fcntl::OFlag::O_PATH` for FreeBSD and Fuchsia

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -151,7 +151,7 @@ libc_bitflags!(
         /// Obtain a file descriptor for low-level access.
         ///
         /// The file itself is not opened and other file operations will fail.
-        #[cfg(any(linux_android, target_os = "redox"))]
+        #[cfg(any(linux_android, target_os = "redox", target_os = "freebsd", target_os = "fuchsia"))]
         O_PATH;
         /// Only allow reading.
         ///


### PR DESCRIPTION
## What does this PR do

Add `fcntl::OFlag::O_PATH` for FreeBSD and Fuchsia.

Closes #2361

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
