### PR TITLE
test: initgroups: compare result group lists without order

### DIFF
--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -313,12 +313,15 @@ fn test_initgroups() {
     // groups that the user belongs to are also set.
     let user = CString::new("root").unwrap();
     let group = Gid::from_raw(123);
-    let group_list = getgrouplist(&user, group).unwrap();
+    let mut group_list = getgrouplist(&user, group).unwrap();
     assert!(group_list.contains(&group));
 
     initgroups(&user, group).unwrap();
 
-    let new_groups = getgroups().unwrap();
+    let mut new_groups = getgroups().unwrap();
+
+    new_groups.sort_by_key(|gid| gid.as_raw());
+    group_list.sort_by_key(|gid| gid.as_raw());
     assert_eq!(new_groups, group_list);
 
     // Revert back to the old groups


### PR DESCRIPTION
Fixes issue #2384

- [ ] Review that the order of the getgroups() return value does not matter