### PR TITLE
test: Grab FORK_MTX when unmounting or forking in the mount tests

### DIFF
--- a/test/mount/test_mount.rs
+++ b/test/mount/test_mount.rs
@@ -53,6 +53,8 @@ fn test_mount_tmpfs_without_flags_allows_rwx() {
         .unwrap_or_else(|e| panic!("read failed: {e}"));
     assert_eq!(buf, SCRIPT_CONTENTS);
 
+    // while forking and unmounting prevent other child processes
+    let _m = FORK_MTX.lock();
     // Verify execute.
     assert_eq!(
         EXPECTED_STATUS,
@@ -89,6 +91,8 @@ fn test_mount_rdonly_disallows_write() {
             .unwrap()
     );
 
+    // wait for child processes to prevent EBUSY
+    let _m = FORK_MTX.lock();
     umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
 }
 
@@ -129,6 +133,8 @@ fn test_mount_noexec_disallows_exec() {
         &test_path
     );
 
+    // while forking and unmounting prevent other child processes
+    let _m = FORK_MTX.lock();
     // EACCES: Permission denied
     assert_eq!(
         EACCES,
@@ -168,6 +174,8 @@ fn test_mount_bind() {
             .and_then(|mut f| f.write(SCRIPT_CONTENTS))
             .unwrap_or_else(|e| panic!("write failed: {e}"));
 
+        // wait for child processes to prevent EBUSY
+        let _m = FORK_MTX.lock();
         umount(mount_point.path())
             .unwrap_or_else(|e| panic!("umount failed: {e}"));
     }

--- a/test/mount/test_mount.rs
+++ b/test/mount/test_mount.rs
@@ -91,8 +91,6 @@ fn test_mount_rdonly_disallows_write() {
             .unwrap()
     );
 
-    // wait for child processes to prevent EBUSY
-    let _m = FORK_MTX.lock();
     umount(tempdir.path()).unwrap_or_else(|e| panic!("umount failed: {e}"));
 }
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -58,7 +58,8 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
 }
 
 /// Any test that creates child processes must grab this mutex, regardless
-/// of what it does with those children.
+/// of what it does with those children. It must hold the mutex until the
+/// child processes are waited upon.
 pub static FORK_MTX: Mutex<()> = Mutex::new(());
 /// Any test that changes the process's current working directory must grab
 /// the RwLock exclusively.  Any process that cares about the current

--- a/test/test.rs
+++ b/test/test.rs
@@ -57,7 +57,7 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     }
 }
 
-/// Any test that creates child processes must grab this mutex, regardless
+/// Any test that creates child processes or can be affected by child processes must grab this mutex, regardless
 /// of what it does with those children. It must hold the mutex until the
 /// child processes are waited upon.
 pub static FORK_MTX: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
fork() duplicates all open file descriptors, which then could prevent a successful umount().

So either when creating file descriptors or when requiring a file descriptor to be closed, we must make sure that no child processes have copies. since wile descriptors are created all over the place, It is more practical to wait for all child processes before unlock.

# TODO:
 - [x] verify the semantic of FORK_MTX: how long must it be held? This PR assumes that the mutex is locked until all child processes have exited.