### PR TITLE
feat: MIN_HOLE_SIZE for apple targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.153", features = ["extra_traits"] }
+libc = { git = "https://github.com/rust-lang/libc", branch = "libc-0.2", features = ["extra_traits"] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2388.added.md
+++ b/changelog/2388.added.md
@@ -1,0 +1,1 @@
+Added `PathconfVar::MIN_HOLE_SIZE` for apple_targets.

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2046,6 +2046,7 @@ pub enum PathconfVar {
     /// may require to be typed as input before reading them.
     MAX_INPUT = libc::_PC_MAX_INPUT,
     #[cfg(any(
+        apple_targets,
         solarish,
         freebsdlike,
         target_os = "netbsd",


### PR DESCRIPTION
## What does this PR do

Added `PathconfVar::MIN_HOLE_SIZE` for apple_targets.


Ref #2349

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
