### PR TITLE
feat: Add VisionOS to apple_targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,10 +14,11 @@ fn main() {
         solaris: { target_os = "solaris" },
         watchos: { target_os = "watchos" },
         tvos: { target_os = "tvos" },
+        visionos: { target_os = "visionos" },
 
 
         // cfg aliases we would like to use
-        apple_targets: { any(ios, macos, watchos, tvos) },
+        apple_targets: { any(ios, macos, watchos, tvos, visionos) },
         bsd: { any(freebsd, dragonfly, netbsd, openbsd, apple_targets) },
         bsd_without_apple: { any(freebsd, dragonfly, netbsd, openbsd) },
         linux_android: { any(android, linux) },


### PR DESCRIPTION
## What does this PR do

Support VisionOS, closes #2298.

target: https://doc.rust-lang.org/nightly/rustc/platform-support/apple-visionos.html

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
