### PR TITLE
refactor: use zero-variants enum for types that are RegisterSet

### DIFF
--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -236,7 +236,7 @@ pub mod regset {
 
     #[derive(Debug, Clone, Copy)]
     /// General-purpose registers.
-    pub struct NT_PRSTATUS;
+    pub enum NT_PRSTATUS {}
 
     unsafe impl RegisterSet for NT_PRSTATUS {
         const VALUE: RegisterSetValue = RegisterSetValue::NT_PRSTATUS;
@@ -245,7 +245,7 @@ pub mod regset {
 
     #[derive(Debug, Clone, Copy)]
     /// Floating-point registers.
-    pub struct NT_PRFPREG;
+    pub enum NT_PRFPREG {}
 
     unsafe impl RegisterSet for NT_PRFPREG {
         const VALUE: RegisterSetValue = RegisterSetValue::NT_PRFPREG;


### PR DESCRIPTION
## What does this PR do

For those types implementing `trait RegisterSet`, defining them with zero-variants enum rather than unit struct as we don't want our users to construct them, and an enum with 0 variants will never be constructed, so using it is more suitable than using unit struct here.

For more discussion, see this [thread](https://github.com/nix-rust/nix/pull/2373#discussion_r1573538488).

This is not an API change unless users are constructing those unit struct types, which should have no use cases, so no CHANGELOG needed.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
