### PR TITLE
Add `From<libc::sockaddr_ll> for LinkAddr`

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1864,6 +1864,12 @@ mod datalink {
         }
     }
 
+    impl From<libc::sockaddr_ll> for LinkAddr {
+        fn from(sll: libc::sockaddr_ll) -> Self {
+            Self(sll)
+        }
+    }
+
     impl fmt::Display for LinkAddr {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(addr) = self.addr() {


### PR DESCRIPTION
## What does this PR do

This PR adds a `impl From<libc::sockaddr_ll> for LinkAddr` to help users of nix avoid `unsafe` code. See https://github.com/nix-rust/nix/issues/2059#issuecomment-1878463448 for reference.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- ~~[ ] I have written necessary tests and rustdoc comments~~
- ~~[ ] A change log has been added if this PR modifies nix's API~~