### PR TITLE
fix: only close `fanotify` events with a valid fd

### DIFF
--- a/changelog/2399.fixed.md
+++ b/changelog/2399.fixed.md
@@ -1,0 +1,1 @@
+No longer panics when the `fanotify` queue overflows.

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -236,6 +236,9 @@ impl FanotifyEvent {
 
 impl Drop for FanotifyEvent {
     fn drop(&mut self) {
+        if self.0.fd == libc::FAN_NOFD {
+            return;
+        }
         let e = close(self.0.fd);
         if !std::thread::panicking() && e == Err(Errno::EBADF) {
             panic!("Closing an invalid file descriptor!");

--- a/test/sys/test_fanotify.rs
+++ b/test/sys/test_fanotify.rs
@@ -1,9 +1,10 @@
 use crate::*;
+use nix::errno::Errno;
 use nix::sys::fanotify::{
     EventFFlags, Fanotify, FanotifyResponse, InitFlags, MarkFlags, MaskFlags,
     Response,
 };
-use std::fs::{read_link, File, OpenOptions};
+use std::fs::{read_link, read_to_string, File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::{Read, Write};
 use std::os::fd::AsRawFd;
@@ -16,6 +17,7 @@ pub fn test_fanotify() {
 
     test_fanotify_notifications();
     test_fanotify_responses();
+    test_fanotify_overflow();
 }
 
 fn test_fanotify_notifications() {
@@ -146,4 +148,73 @@ fn test_fanotify_responses() {
         .unwrap();
 
     file_thread.join().unwrap();
+}
+
+fn test_fanotify_overflow() {
+    let max_events: usize =
+        read_to_string("/proc/sys/fs/fanotify/max_queued_events")
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+
+    // make sure the kernel is configured with the default value,
+    // just so this test doesn't run forever
+    assert_eq!(max_events, 16384);
+
+    let group = Fanotify::init(
+        InitFlags::FAN_CLASS_NOTIF
+            | InitFlags::FAN_REPORT_TID
+            | InitFlags::FAN_NONBLOCK,
+        EventFFlags::O_RDONLY,
+    )
+    .unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempfile = tempdir.path().join("test");
+
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tempfile)
+        .unwrap();
+
+    group
+        .mark(
+            MarkFlags::FAN_MARK_ADD,
+            MaskFlags::FAN_OPEN,
+            None,
+            Some(&tempfile),
+        )
+        .unwrap();
+
+    // perform 10 more events to demonstrate some will be dropped
+    for _ in 0..(max_events + 10) {
+        let tempfile = tempfile.clone();
+        thread::spawn(move || {
+            File::open(&tempfile).unwrap();
+        })
+        .join()
+        .unwrap();
+    }
+
+    // flush the queue until it's empty
+    let mut n = 0;
+    let mut last_event = None;
+    loop {
+        match group.read_events() {
+            Ok(events) => {
+                n += events.len();
+                if let Some(event) = events.last() {
+                    last_event = Some(event.mask());
+                }
+            }
+            Err(e) if e == Errno::EWOULDBLOCK => break,
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    // make sure we read all we expected.
+    // the +1 is for the overflow event.
+    assert_eq!(n, max_events + 1);
+    assert_eq!(last_event, Some(MaskFlags::FAN_Q_OVERFLOW));
 }

--- a/test/sys/test_fanotify.rs
+++ b/test/sys/test_fanotify.rs
@@ -187,15 +187,14 @@ fn test_fanotify_overflow() {
         )
         .unwrap();
 
-    // perform 10 more events to demonstrate some will be dropped
-    for _ in 0..(max_events + 10) {
-        let tempfile = tempfile.clone();
-        thread::spawn(move || {
-            File::open(&tempfile).unwrap();
-        })
-        .join()
-        .unwrap();
-    }
+    thread::scope(|s| {
+        // perform 10 more events to demonstrate some will be dropped
+        for _ in 0..(max_events + 10) {
+            s.spawn(|| {
+                File::open(&tempfile).unwrap();
+            });
+        }
+    });
 
     // flush the queue until it's empty
     let mut n = 0;


### PR DESCRIPTION
## What does this PR do

`fanotify` returns events with the fd set to `FAN_NOFD` when the queue overflows. 
Trying to close it panics with `EBADF`, so don't bother.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
