### PR TITLE
Added I/O safety to sys::aio

### DIFF
--- a/changelog/2401.changed.md
+++ b/changelog/2401.changed.md
@@ -1,0 +1,2 @@
+Added I/O safety to the sys/aio module.  Most functions that previously
+accepted a `AsRawFd` argument now accept an `AsFd` instead.

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -30,7 +30,7 @@ use std::{
     fmt::{self, Debug},
     marker::{PhantomData, PhantomPinned},
     mem,
-    os::unix::io::RawFd,
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd},
     pin::Pin,
     ptr, thread,
 };
@@ -102,7 +102,7 @@ unsafe impl Sync for LibcAiocb {}
 // provide polymorphism at the wrong level.  Instead, the best place for
 // polymorphism is at the level of `Futures`.
 #[repr(C)]
-struct AioCb {
+struct AioCb<'a> {
     aiocb: LibcAiocb,
     /// Could this `AioCb` potentially have any in-kernel state?
     // It would be really nice to perform the in-progress check entirely at
@@ -112,9 +112,10 @@ struct AioCb {
     //   that there's no way to write an AioCb constructor that neither boxes
     //   the object itself, nor moves it during return.
     in_progress: bool,
+    _fd: PhantomData<BorrowedFd<'a>>,
 }
 
-impl AioCb {
+impl<'a> AioCb<'a> {
     pin_utils::unsafe_unpinned!(aiocb: LibcAiocb);
 
     fn aio_return(mut self: Pin<&mut Self>) -> Result<usize> {
@@ -139,18 +140,23 @@ impl AioCb {
         }
     }
 
-    fn common_init(fd: RawFd, prio: i32, sigev_notify: SigevNotify) -> Self {
+    fn common_init(
+        fd: BorrowedFd<'a>,
+        prio: i32,
+        sigev_notify: SigevNotify,
+    ) -> Self {
         // Use mem::zeroed instead of explicitly zeroing each field, because the
         // number and name of reserved fields is OS-dependent.  On some OSes,
         // some reserved fields are used the kernel for state, and must be
         // explicitly zeroed when allocated.
         let mut a = unsafe { mem::zeroed::<libc::aiocb>() };
-        a.aio_fildes = fd;
+        a.aio_fildes = fd.as_raw_fd();
         a.aio_reqprio = prio;
         a.aio_sigevent = SigEvent::new(sigev_notify).sigevent();
         AioCb {
             aiocb: LibcAiocb(a),
             in_progress: false,
+            _fd: PhantomData,
         }
     }
 
@@ -186,7 +192,7 @@ impl AioCb {
     }
 }
 
-impl Debug for AioCb {
+impl<'a> Debug for AioCb<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("AioCb")
             .field("aiocb", &self.aiocb.0)
@@ -195,7 +201,7 @@ impl Debug for AioCb {
     }
 }
 
-impl Drop for AioCb {
+impl<'a> Drop for AioCb<'a> {
     /// If the `AioCb` has no remaining state in the kernel, just drop it.
     /// Otherwise, dropping constitutes a resource leak, which is an error
     fn drop(&mut self) {
@@ -243,11 +249,11 @@ pub trait Aio {
     /// # use nix::sys::signal::SigevNotify;
     /// # use std::{thread, time};
     /// # use std::io::Write;
-    /// # use std::os::unix::io::AsRawFd;
+    /// # use std::os::unix::io::AsFd;
     /// # use tempfile::tempfile;
     /// let wbuf = b"CDEF";
     /// let mut f = tempfile().unwrap();
-    /// let mut aiocb = Box::pin(AioWrite::new(f.as_raw_fd(),
+    /// let mut aiocb = Box::pin(AioWrite::new(f.as_fd(),
     ///     2,   //offset
     ///     &wbuf[..],
     ///     0,   //priority
@@ -284,11 +290,11 @@ pub trait Aio {
     /// # use nix::sys::aio::*;
     /// # use nix::sys::signal::SigevNotify;
     /// # use std::{thread, time};
-    /// # use std::os::unix::io::AsRawFd;
+    /// # use std::os::unix::io::AsFd;
     /// # use tempfile::tempfile;
     /// const WBUF: &[u8] = b"abcdef123456";
     /// let mut f = tempfile().unwrap();
-    /// let mut aiocb = Box::pin(AioWrite::new(f.as_raw_fd(),
+    /// let mut aiocb = Box::pin(AioWrite::new(f.as_fd(),
     ///     2,   //offset
     ///     WBUF,
     ///     0,   //priority
@@ -306,7 +312,7 @@ pub trait Aio {
     fn error(self: Pin<&mut Self>) -> Result<()>;
 
     /// Returns the underlying file descriptor associated with the operation.
-    fn fd(&self) -> RawFd;
+    fn fd(&self) -> BorrowedFd;
 
     /// Does this operation currently have any in-kernel state?
     ///
@@ -321,10 +327,10 @@ pub trait Aio {
     /// # use nix::sys::aio::*;
     /// # use nix::sys::signal::SigevNotify::SigevNone;
     /// # use std::{thread, time};
-    /// # use std::os::unix::io::AsRawFd;
+    /// # use std::os::unix::io::AsFd;
     /// # use tempfile::tempfile;
     /// let f = tempfile().unwrap();
-    /// let mut aiof = Box::pin(AioFsync::new(f.as_raw_fd(), AioFsyncMode::O_SYNC,
+    /// let mut aiof = Box::pin(AioFsync::new(f.as_fd(), AioFsyncMode::O_SYNC,
     ///     0, SigevNone));
     /// assert!(!aiof.as_mut().in_progress());
     /// aiof.as_mut().submit().expect("aio_fsync failed early");
@@ -364,8 +370,10 @@ macro_rules! aio_methods {
             self.aiocb().error()
         }
 
-        fn fd(&self) -> RawFd {
-            self.aiocb.aiocb.0.aio_fildes
+        fn fd(&self) -> BorrowedFd<'a> {
+            // safe because self's lifetime is the same as the original file
+            // descriptor.
+            unsafe { BorrowedFd::borrow_raw(self.aiocb.aiocb.0.aio_fildes) }
         }
 
         fn in_progress(&self) -> bool {
@@ -413,10 +421,10 @@ macro_rules! aio_methods {
 /// # use nix::sys::aio::*;
 /// # use nix::sys::signal::SigevNotify::SigevNone;
 /// # use std::{thread, time};
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// let f = tempfile().unwrap();
-/// let mut aiof = Box::pin(AioFsync::new(f.as_raw_fd(), AioFsyncMode::O_SYNC,
+/// let mut aiof = Box::pin(AioFsync::new(f.as_fd(), AioFsyncMode::O_SYNC,
 ///     0, SigevNone));
 /// aiof.as_mut().submit().expect("aio_fsync failed early");
 /// while (aiof.as_mut().error() == Err(Errno::EINPROGRESS)) {
@@ -426,13 +434,13 @@ macro_rules! aio_methods {
 /// ```
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct AioFsync {
-    aiocb: AioCb,
+pub struct AioFsync<'a> {
+    aiocb: AioCb<'a>,
     _pin: PhantomPinned,
 }
 
-impl AioFsync {
-    unsafe_pinned!(aiocb: AioCb);
+impl<'a> AioFsync<'a> {
+    unsafe_pinned!(aiocb: AioCb<'a>);
 
     /// Returns the operation's fsync mode: data and metadata or data only?
     pub fn mode(&self) -> AioFsyncMode {
@@ -451,7 +459,7 @@ impl AioFsync {
     /// * `sigev_notify`: Determines how you will be notified of event
     ///                   completion.
     pub fn new(
-        fd: RawFd,
+        fd: BorrowedFd<'a>,
         mode: AioFsyncMode,
         prio: i32,
         sigev_notify: SigevNotify,
@@ -469,7 +477,7 @@ impl AioFsync {
     }
 }
 
-impl Aio for AioFsync {
+impl<'a> Aio for AioFsync<'a> {
     type Output = ();
 
     aio_methods!();
@@ -490,7 +498,7 @@ impl Aio for AioFsync {
 
 // AioFsync does not need AsMut, since it can't be used with lio_listio
 
-impl AsRef<libc::aiocb> for AioFsync {
+impl<'a> AsRef<libc::aiocb> for AioFsync<'a> {
     fn as_ref(&self) -> &libc::aiocb {
         &self.aiocb.aiocb.0
     }
@@ -512,7 +520,7 @@ impl AsRef<libc::aiocb> for AioFsync {
 /// # use nix::sys::signal::SigevNotify;
 /// # use std::{thread, time};
 /// # use std::io::Write;
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// const INITIAL: &[u8] = b"abcdef123456";
 /// const LEN: usize = 4;
@@ -522,7 +530,7 @@ impl AsRef<libc::aiocb> for AioFsync {
 /// {
 ///     let mut aior = Box::pin(
 ///         AioRead::new(
-///             f.as_raw_fd(),
+///             f.as_fd(),
 ///             2,   //offset
 ///             &mut rbuf,
 ///             0,   //priority
@@ -540,13 +548,13 @@ impl AsRef<libc::aiocb> for AioFsync {
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct AioRead<'a> {
-    aiocb: AioCb,
+    aiocb: AioCb<'a>,
     _data: PhantomData<&'a [u8]>,
     _pin: PhantomPinned,
 }
 
 impl<'a> AioRead<'a> {
-    unsafe_pinned!(aiocb: AioCb);
+    unsafe_pinned!(aiocb: AioCb<'a>);
 
     /// Returns the requested length of the aio operation in bytes
     ///
@@ -570,7 +578,7 @@ impl<'a> AioRead<'a> {
     /// * `sigev_notify`: Determines how you will be notified of event
     ///                   completion.
     pub fn new(
-        fd: RawFd,
+        fd: BorrowedFd<'a>,
         offs: off_t,
         buf: &'a mut [u8],
         prio: i32,
@@ -629,7 +637,7 @@ impl<'a> AsRef<libc::aiocb> for AioRead<'a> {
 /// # use nix::sys::signal::SigevNotify;
 /// # use std::{thread, time};
 /// # use std::io::{IoSliceMut, Write};
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// const INITIAL: &[u8] = b"abcdef123456";
 /// let mut rbuf0 = vec![0; 4];
@@ -641,7 +649,7 @@ impl<'a> AsRef<libc::aiocb> for AioRead<'a> {
 /// {
 ///     let mut aior = Box::pin(
 ///         AioReadv::new(
-///             f.as_raw_fd(),
+///             f.as_fd(),
 ///             2,   //offset
 ///             &mut rbufs,
 ///             0,   //priority
@@ -661,14 +669,14 @@ impl<'a> AsRef<libc::aiocb> for AioRead<'a> {
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct AioReadv<'a> {
-    aiocb: AioCb,
+    aiocb: AioCb<'a>,
     _data: PhantomData<&'a [&'a [u8]]>,
     _pin: PhantomPinned,
 }
 
 #[cfg(target_os = "freebsd")]
 impl<'a> AioReadv<'a> {
-    unsafe_pinned!(aiocb: AioCb);
+    unsafe_pinned!(aiocb: AioCb<'a>);
 
     /// Returns the number of buffers the operation will read into.
     pub fn iovlen(&self) -> usize {
@@ -689,7 +697,7 @@ impl<'a> AioReadv<'a> {
     /// * `sigev_notify`: Determines how you will be notified of event
     ///                   completion.
     pub fn new(
-        fd: RawFd,
+        fd: BorrowedFd<'a>,
         offs: off_t,
         bufs: &mut [IoSliceMut<'a>],
         prio: i32,
@@ -750,13 +758,13 @@ impl<'a> AsRef<libc::aiocb> for AioReadv<'a> {
 /// # use nix::sys::aio::*;
 /// # use nix::sys::signal::SigevNotify;
 /// # use std::{thread, time};
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// const WBUF: &[u8] = b"abcdef123456";
 /// let mut f = tempfile().unwrap();
 /// let mut aiow = Box::pin(
 ///     AioWrite::new(
-///         f.as_raw_fd(),
+///         f.as_fd(),
 ///         2,   //offset
 ///         WBUF,
 ///         0,   //priority
@@ -772,13 +780,13 @@ impl<'a> AsRef<libc::aiocb> for AioReadv<'a> {
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct AioWrite<'a> {
-    aiocb: AioCb,
+    aiocb: AioCb<'a>,
     _data: PhantomData<&'a [u8]>,
     _pin: PhantomPinned,
 }
 
 impl<'a> AioWrite<'a> {
-    unsafe_pinned!(aiocb: AioCb);
+    unsafe_pinned!(aiocb: AioCb<'a>);
 
     /// Returns the requested length of the aio operation in bytes
     ///
@@ -802,7 +810,7 @@ impl<'a> AioWrite<'a> {
     /// * `sigev_notify`: Determines how you will be notified of event
     ///                   completion.
     pub fn new(
-        fd: RawFd,
+        fd: BorrowedFd<'a>,
         offs: off_t,
         buf: &'a [u8],
         prio: i32,
@@ -864,7 +872,7 @@ impl<'a> AsRef<libc::aiocb> for AioWrite<'a> {
 /// # use nix::sys::signal::SigevNotify;
 /// # use std::{thread, time};
 /// # use std::io::IoSlice;
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// const wbuf0: &[u8] = b"abcdef";
 /// const wbuf1: &[u8] = b"123456";
@@ -873,7 +881,7 @@ impl<'a> AsRef<libc::aiocb> for AioWrite<'a> {
 /// let mut f = tempfile().unwrap();
 /// let mut aiow = Box::pin(
 ///     AioWritev::new(
-///         f.as_raw_fd(),
+///         f.as_fd(),
 ///         2,   //offset
 ///         &wbufs,
 ///         0,   //priority
@@ -890,14 +898,14 @@ impl<'a> AsRef<libc::aiocb> for AioWrite<'a> {
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct AioWritev<'a> {
-    aiocb: AioCb,
+    aiocb: AioCb<'a>,
     _data: PhantomData<&'a [&'a [u8]]>,
     _pin: PhantomPinned,
 }
 
 #[cfg(target_os = "freebsd")]
 impl<'a> AioWritev<'a> {
-    unsafe_pinned!(aiocb: AioCb);
+    unsafe_pinned!(aiocb: AioCb<'a>);
 
     /// Returns the number of buffers the operation will read into.
     pub fn iovlen(&self) -> usize {
@@ -918,7 +926,7 @@ impl<'a> AioWritev<'a> {
     /// * `sigev_notify`: Determines how you will be notified of event
     ///                   completion.
     pub fn new(
-        fd: RawFd,
+        fd: BorrowedFd<'a>,
         offs: off_t,
         bufs: &[IoSlice<'a>],
         prio: i32,
@@ -983,17 +991,17 @@ impl<'a> AsRef<libc::aiocb> for AioWritev<'a> {
 /// # use nix::sys::signal::SigevNotify;
 /// # use std::{thread, time};
 /// # use std::io::Write;
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// let wbuf = b"CDEF";
 /// let mut f = tempfile().unwrap();
-/// let mut aiocb = Box::pin(AioWrite::new(f.as_raw_fd(),
+/// let mut aiocb = Box::pin(AioWrite::new(f.as_fd(),
 ///     2,   //offset
 ///     &wbuf[..],
 ///     0,   //priority
 ///     SigevNotify::SigevNone));
 /// aiocb.as_mut().submit().unwrap();
-/// let cs = aio_cancel_all(f.as_raw_fd()).unwrap();
+/// let cs = aio_cancel_all(f.as_fd()).unwrap();
 /// if cs == AioCancelStat::AioNotCanceled {
 ///     while (aiocb.as_mut().error() == Err(Errno::EINPROGRESS)) {
 ///         thread::sleep(time::Duration::from_millis(10));
@@ -1006,8 +1014,8 @@ impl<'a> AsRef<libc::aiocb> for AioWritev<'a> {
 /// # References
 ///
 /// [`aio_cancel`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/aio_cancel.html)
-pub fn aio_cancel_all(fd: RawFd) -> Result<AioCancelStat> {
-    match unsafe { libc::aio_cancel(fd, ptr::null_mut()) } {
+pub fn aio_cancel_all<F: AsFd>(fd: F) -> Result<AioCancelStat> {
+    match unsafe { libc::aio_cancel(fd.as_fd().as_raw_fd(), ptr::null_mut()) } {
         libc::AIO_CANCELED => Ok(AioCancelStat::AioCanceled),
         libc::AIO_NOTCANCELED => Ok(AioCancelStat::AioNotCanceled),
         libc::AIO_ALLDONE => Ok(AioCancelStat::AioAllDone),
@@ -1028,11 +1036,11 @@ pub fn aio_cancel_all(fd: RawFd) -> Result<AioCancelStat> {
 /// ```
 /// # use nix::sys::aio::*;
 /// # use nix::sys::signal::SigevNotify;
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use tempfile::tempfile;
 /// const WBUF: &[u8] = b"abcdef123456";
 /// let mut f = tempfile().unwrap();
-/// let mut aiocb = Box::pin(AioWrite::new(f.as_raw_fd(),
+/// let mut aiocb = Box::pin(AioWrite::new(f.as_fd(),
 ///     2,   //offset
 ///     WBUF,
 ///     0,   //priority
@@ -1078,14 +1086,14 @@ pub fn aio_suspend(
 /// This mode is useful for otherwise-synchronous programs that want to execute
 /// a handful of I/O operations in parallel.
 /// ```
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use nix::sys::aio::*;
 /// # use nix::sys::signal::SigevNotify;
 /// # use tempfile::tempfile;
 /// const WBUF: &[u8] = b"abcdef123456";
 /// let mut f = tempfile().unwrap();
 /// let mut aiow = Box::pin(AioWrite::new(
-///     f.as_raw_fd(),
+///     f.as_fd(),
 ///     2,      // offset
 ///     WBUF,
 ///     0,      // priority
@@ -1102,7 +1110,7 @@ pub fn aio_suspend(
 /// technique for reducing overall context-switch overhead, especially when
 /// combined with kqueue.
 /// ```
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use std::thread;
 /// # use std::time;
 /// # use nix::errno::Errno;
@@ -1112,7 +1120,7 @@ pub fn aio_suspend(
 /// const WBUF: &[u8] = b"abcdef123456";
 /// let mut f = tempfile().unwrap();
 /// let mut aiow = Box::pin(AioWrite::new(
-///     f.as_raw_fd(),
+///     f.as_fd(),
 ///     2,      // offset
 ///     WBUF,
 ///     0,      // priority
@@ -1136,7 +1144,7 @@ pub fn aio_suspend(
 /// possibly resubmit some.
 /// ```
 /// # use libc::c_int;
-/// # use std::os::unix::io::AsRawFd;
+/// # use std::os::unix::io::AsFd;
 /// # use std::sync::atomic::{AtomicBool, Ordering};
 /// # use std::thread;
 /// # use std::time;
@@ -1158,7 +1166,7 @@ pub fn aio_suspend(
 /// const WBUF: &[u8] = b"abcdef123456";
 /// let mut f = tempfile().unwrap();
 /// let mut aiow = Box::pin(AioWrite::new(
-///     f.as_raw_fd(),
+///     f.as_fd(),
 ///     2,      // offset
 ///     WBUF,
 ///     0,      // priority

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -16,7 +16,7 @@
 fn test_drop() {
     use nix::sys::aio::*;
     use nix::sys::signal::*;
-    use std::os::unix::io::AsRawFd;
+    use std::os::unix::io::AsFd;
     use tempfile::tempfile;
 
     const WBUF: &[u8] = b"CDEF";
@@ -24,7 +24,7 @@ fn test_drop() {
     let f = tempfile().unwrap();
     f.set_len(6).unwrap();
     let mut aiocb = Box::pin(AioWrite::new(
-        f.as_raw_fd(),
+        f.as_fd(),
         2, //offset
         WBUF,
         0, //priority


### PR DESCRIPTION
## What does this PR do

Adds I/O safety to the sys/aio module.  Those methods now take `AsFd` arguments instead of `RawFd`.  And `struct Aiocb` now has a lifetime argument.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
