### PR TITLE
Enable O_DSYNC on FreeBSD with fcntl and aio_fsync

### DIFF
--- a/changelog/2404.added.md
+++ b/changelog/2404.added.md
@@ -1,0 +1,1 @@
+`O_DSYNC` may now be used with `aio_fsync` and `fcntl` on FreeBSD.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -114,7 +114,7 @@ libc_bitflags!(
         /// If the specified path isn't a directory, fail.
         O_DIRECTORY;
         /// Implicitly follow each `write()` with an `fdatasync()`.
-        #[cfg(any(linux_android, apple_targets, netbsdlike))]
+        #[cfg(any(linux_android, apple_targets, target_os = "freebsd", netbsdlike))]
         O_DSYNC;
         /// Error out if a file was not created.
         O_EXCL;

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -55,6 +55,7 @@ libc_enum! {
         /// on supported operating systems only, do it like `fdatasync`
         #[cfg(any(apple_targets,
                   target_os = "linux",
+                  target_os = "freebsd",
                   netbsdlike))]
         O_DSYNC
     }


### PR DESCRIPTION
It first appeared in FreeBSD 13.0.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
