### PR TITLE
Remove an unnecessary cast from aio_suspend's doc test

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1047,7 +1047,7 @@ pub fn aio_cancel_all<F: AsFd>(fd: F) -> Result<AioCancelStat> {
 ///     SigevNotify::SigevNone));
 /// aiocb.as_mut().submit().unwrap();
 /// aio_suspend(&[&*aiocb], None).expect("aio_suspend failed");
-/// assert_eq!(aiocb.as_mut().aio_return().unwrap() as usize, WBUF.len());
+/// assert_eq!(aiocb.as_mut().aio_return().unwrap(), WBUF.len());
 /// ```
 /// # References
 ///


### PR DESCRIPTION
Reported by: @stevelauc

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
