### PR TITLE
docs: correct limit value of FAN_UNLIMITED_QUEUE and FAN_UNLIMITED_MARKS

### DIFF
--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -96,9 +96,22 @@ libc_bitflags! {
         /// final data.
         FAN_CLASS_PRE_CONTENT;
 
-        /// Remove the limit of 16384 events for the event queue.
+        /// Remove the limit on the number of events in the event queue.
+        ///
+        /// Prior to Linux kernel 5.13, this limit was hardcoded to 16384. After
+        /// 5.13, one can change it via file `/proc/sys/fs/fanotify/max_queued_events`.
+        ///
+        /// See `fanotify(7)` for details about this limit. Use of this flag
+        /// requires the `CAP_SYS_ADMIN` capability.
         FAN_UNLIMITED_QUEUE;
-        /// Remove the limit of 8192 marks.
+        /// Remove the limit on the number of fanotify marks per user.
+        ///
+        /// Prior to Linux kernel 5.13, this limit was hardcoded to 8192 (per
+        /// group, not per user). After 5.13, one can change it via file
+        /// `/proc/sys/fs/fanotify/max_user_marks`.
+        ///
+        /// See `fanotify(7)` for details about this limit. Use of this flag
+        /// requires the `CAP_SYS_ADMIN` capability.
         FAN_UNLIMITED_MARKS;
 
         /// Make `FanotifyEvent::pid` return pidfd. Since Linux 5.15.


### PR DESCRIPTION
## What does this PR do

Correct the docs for 2 fanotify init limit flags, they only have hardcoded limit values before Linux kernel 5.13, after that, they can be changed via config file.

ref: [man 7 fanotify](https://man7.org/linux/man-pages/man7/fanotify.7.html)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
