### PR TITLE
chore: bump libc to 0.2.155

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.154", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 bitflags = "2.3.1"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }


### PR DESCRIPTION
## What does this PR do

libc 0.2.154 has been yanked, so we have to bump it to 0.2.155.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
