### PR TITLE
revert: impl From<sigaction> for SigAction

### DIFF
--- a/changelog/2326.added.md
+++ b/changelog/2326.added.md
@@ -1,1 +1,1 @@
-make SigAction repr(transparent) & can be converted to/from the libc raw type
+make SigAction repr(transparent) & can be converted to the libc raw type

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -759,13 +759,6 @@ pub struct SigAction {
     sigaction: libc::sigaction
 }
 
-impl From<libc::sigaction> for SigAction {
-    fn from(value: libc::sigaction) -> Self {
-        Self {
-            sigaction: value
-        }
-    }
-}
 impl From<SigAction> for libc::sigaction {
     fn from(value: SigAction) -> libc::sigaction {
         value.sigaction


### PR DESCRIPTION
## What does this PR do

`impl From<libc::sigaction> for SigAction` is unsafe since there is no guarantee on the values stored in `libc::sigaction`, revert the implementation added in #2326.

Issue #2327 still needs to be resolved, some thoughts on it:

1. impl TryFrom and check the values to ensure they are valid
2. Define unsafe traits like `unsafe trait UnsafeFrom/UnsafeInto`

cc @AzariasB


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
