### PR TITLE
refactor: fix clippy & unused imports/helper type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub type Result<T> = result::Result<T, Errno>;
 /// * `Eq`
 /// * Small size
 /// * Represents all of the system's errnos, instead of just the most common
-/// ones.
+///   ones.
 pub type Error = Errno;
 
 /// Common trait used to represent file system paths by many Nix functions.

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -120,7 +120,10 @@ mod sched_linux_like {
             let ptr = stack.as_mut_ptr().add(stack.len());
             let ptr_aligned = ptr.sub(ptr as usize % 16);
             libc::clone(
-                mem::transmute(
+                mem::transmute::<
+                    extern "C" fn(*mut Box<dyn FnMut() -> isize>) -> i32,
+                    extern "C" fn(*mut libc::c_void) -> i32,
+                >(
                     callback
                         as extern "C" fn(*mut Box<dyn FnMut() -> isize>) -> i32,
                 ),

--- a/src/sys/timer.rs
+++ b/src/sys/timer.rs
@@ -95,7 +95,7 @@ impl Timer {
     /// There are 3 types of alarms you can set:
     ///
     ///   - one shot: the alarm will trigger once after the specified amount of
-    /// time.
+    ///     time.
     ///     Example: I want an alarm to go off in 60s and then disable itself.
     ///
     ///   - interval: the alarm will trigger every specified interval of time.

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -113,7 +113,7 @@ impl TimerFd {
     /// There are 3 types of alarms you can set:
     ///
     ///   - one shot: the alarm will trigger once after the specified amount of
-    /// time.
+    ///     time.
     ///     Example: I want an alarm to go off in 60s and then disable itself.
     ///
     ///   - interval: the alarm will trigger every specified interval of time.


### PR DESCRIPTION
## What does this PR do

This PR

1. Fixes documents identification issue
2. Adds type annotations for one usage of `std::mem::transmute()`
3. Dead code analysis of the latest nightly toolchain has become smarter, there are some unused helper SetXXX/GetXXX types in `src/sys/socket/sockopt.rs`, this PR gates them with target and feature.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
