### PR TITLE
ci: bump GitHub action runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
   # Use cross for QEMU-based testing
   # cross needs to execute Docker, GitHub Action already has it installed
   cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [rustfmt, minver, macos, linux_native_builds, rust_stable]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo rm -rf $CARGO_HOME/registry/index
 
   macos-aarch64:
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       TARGET: aarch64-apple-darwin
     steps:
@@ -73,7 +73,7 @@ jobs:
   # Use cross for QEMU-based testing
   # cross needs to execute Docker, GitHub Action already has it installed
   cross:
-    runs-on: ubuntu-20.04 
+    runs-on: ubuntu-latest
     needs: [rustfmt, minver, macos, linux_native_builds, rust_stable]
     strategy:
       fail-fast: false
@@ -129,7 +129,7 @@ jobs:
   # Tasks for Linux native builds
   # Only test x86_64 targets on GitHub Action, leave aarch64 one in Cirrus CI.
   linux_native_builds:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
         run: sudo rm -rf $CARGO_HOME/registry/index;
 
   rust_stable:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: 
       TARGET: x86_64-unknown-linux-gnu
     steps:
@@ -194,7 +194,7 @@ jobs:
 
   # Tasks for cross-compiling, but no testing
   cross_compiling:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [rustfmt, minver, macos, linux_native_builds, rust_stable]
     env:
       BUILD: check
@@ -249,7 +249,7 @@ jobs:
   
 
   redox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [rustfmt, minver, macos, linux_native_builds, rust_stable]
     env: 
       TARGET: x86_64-unknown-redox
@@ -282,7 +282,7 @@ jobs:
 
   # Rust Tier 3 targets can't use Rustup
   tier3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: 
       BUILD: check
       ZFLAGS: -Zbuild-std
@@ -328,7 +328,7 @@ jobs:
   # "cargo test" doesn't work because some of our dev-dependencies, like
   # rand, can't build with their own minimal dependencies.
   minver:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: 
       TARGET: x86_64-unknown-linux-gnu
     steps:
@@ -349,7 +349,7 @@ jobs:
 
   # Tasks that checks if the code is formatted right using `cargo fmt` tool
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
   # Use cross for QEMU-based testing
   # cross needs to execute Docker, GitHub Action already has it installed
   cross:
-    runs-on: ubuntu-24.04
+    # Still use 20.04 for this CI step as test `test_prctl::test_set_vma_anon_name`
+    # would fail on 22.04 and 24.04 (at least for now)
+    # https://github.com/nix-rust/nix/issues/2418
+    runs-on: ubuntu-20.04
     needs: [rustfmt, minver, macos, linux_native_builds, rust_stable]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What does this PR do

Bump GitHub action runner:

* `macos-14` -> `macos-latest`
   
   Currently, `macos-latest` is `macos-14`, so no changes for now.

* `ubuntu-20.04` -> `ubuntu-latest`

Update:

For `cross` test, we would still use Ubuntu 20.04 due to this issue: #2418.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
