### PR TITLE
chore: ignore lint unsafe_op_in_unsafe_fn for usage of env::remove_var

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -49,6 +49,8 @@ pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
         } else {
             use std::env;
             for (name, _) in env::vars_os() {
+                // Ignore the lint due to Rust bug: https://github.com/rust-lang/rust/issues/125875
+                #[allow(unsafe_op_in_unsafe_fn)]
                 env::remove_var(name);
             }
             let ret = 0;


### PR DESCRIPTION
## What does this PR do

~~[`std::env::remove_var` has been made unsafe](https://github.com/rust-lang/rust/pull/124636). Due to lint `unsafe_op_in_unsafe_fn`, we need to wrap it in an unsafe block.~~

This PR is for the following CI failure (full log [here](https://github.com/nix-rust/nix/actions/runs/9330193674/job/25683513633?pr=2417)):

```rs
error[E0133]: call to unsafe function `std::env::remove_var` is unsafe and requires unsafe block
  --> src/env.rs:52:17
   |
52 |                 env::remove_var(name);
   |                 ^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
   |
   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
   = note: consult the function's documentation for information on how to avoid undefined behavior
note: an unsafe function restricts its caller, but its body is safe by default
  --> src/env.rs:41:1
   |
41 | pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: the lint level is defined here
  --> src/lib.rs:94:9
   |
94 | #![deny(unsafe_op_in_unsafe_fn)]
   |         ^^^^^^^^^^^^^^^^^^^^^^
```

`std::env::remove_var()` will become unsafe ONLY in Rust 2024, Nix is using Rust 2021, so the above issue should not happen. I have filed an [issue](https://github.com/rust-lang/rust/issues/125875) for this bug, before it gets fixed, ignore the lint `unsafe_op_in_unsafe_fn` here.



## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
