### PR TITLE
Don't `deny(warnings)` outside of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ permissions:
 
 env: 
   MSRV: 1.69.0
+  RUSTFLAGS: -Dwarnings
 
 jobs:
   macos:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![allow(non_camel_case_types)]
-#![cfg_attr(test, deny(warnings))]
 #![recursion_limit = "500"]
 #![deny(unused)]
 #![allow(unused_macros)]


### PR DESCRIPTION
This allows the tests to continue compiling in new Rust versions, even if new warnings are added.

Fixes #2423.