### PR TITLE
docs: document signalfd::siginfo[skip ci]

### DIFF
--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -18,6 +18,8 @@
 use crate::errno::Errno;
 pub use crate::sys::signal::{self, SigSet};
 use crate::Result;
+
+/// Information of a received signal, the return type of [`SignalFd::read_signal()`].
 pub use libc::signalfd_siginfo as siginfo;
 
 use std::mem;


### PR DESCRIPTION
## What does this PR do

As requested by #2426, document `signalfd::siginfo`. Though I didn't explicitly say something like "this is not the siginfo_t type", the current document should make that pretty obvious.

Closes #2426 

cc @lolbinarycat

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
