### PR TITLE
revert: PR 2421 since the Rust issue has been fixed

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -49,8 +49,6 @@ pub unsafe fn clearenv() -> std::result::Result<(), ClearEnvError> {
         } else {
             use std::env;
             for (name, _) in env::vars_os() {
-                // Ignore the lint due to Rust bug: https://github.com/rust-lang/rust/issues/125875
-                #[allow(unsafe_op_in_unsafe_fn)]
                 env::remove_var(name);
             }
             let ret = 0;


### PR DESCRIPTION
## What does this PR do

Revert #2421 since the Rust issue has been fixed, and the fix should be available in the latest nightly, I guess?

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
