### PR TITLE
test: test memfd_create() on FreeBSD

### DIFF
--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -82,3 +82,13 @@ mod test_statfs;
     target_os = "haiku"
 )))]
 mod test_resource;
+
+// This test module should be enabled for both linux_android and freebsd, but
+// the `memfd_create(2)` symbol is not available under Linux QEMU,
+//
+// https://github.com/nix-rust/nix/actions/runs/9427112650/job/25970870477
+//
+// and I haven't found a way to stop the linker from linking that symbol, so
+// only enable this for FreeBSD for now.
+#[cfg(target_os = "freebsd")]
+mod test_memfd;

--- a/test/sys/test_memfd.rs
+++ b/test/sys/test_memfd.rs
@@ -1,0 +1,22 @@
+#[test]
+fn test_memfd_create() {
+    use nix::sys::memfd::memfd_create;
+    use nix::sys::memfd::MemFdCreateFlag;
+    use nix::unistd::lseek;
+    use nix::unistd::read;
+    use nix::unistd::{write, Whence};
+    use std::os::fd::{AsFd, AsRawFd};
+
+    let fd =
+        memfd_create("test_memfd_create_name", MemFdCreateFlag::MFD_CLOEXEC)
+            .unwrap();
+    let contents = b"hello";
+    assert_eq!(write(fd.as_fd(), contents).unwrap(), 5);
+
+    lseek(fd.as_raw_fd(), 0, Whence::SeekSet).unwrap();
+
+    let mut buf = vec![0_u8; contents.len()];
+    assert_eq!(read(fd.as_raw_fd(), &mut buf).unwrap(), 5);
+
+    assert_eq!(contents, buf.as_slice());
+}


### PR DESCRIPTION
## What does this PR do

Following #2431, even though we cannot resolve the linking issue under QEMU, we can still test this syscall on FreeBSD.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
