### PR TITLE
refactor: I/O safety for modules fcntl and dir

### DIFF
--- a/changelog/2434.changed.md
+++ b/changelog/2434.changed.md
@@ -1,0 +1,1 @@
+Public interfaces in `fcntl.rs` and `dir.rs` now use I/O-safe types.

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -74,9 +74,9 @@ impl Dir {
     /// Converts from a file descriptor, closing it on failure.
     #[doc(alias("fdopendir"))]
     pub fn from_fd(fd: std::os::fd::OwnedFd) -> Result<Self> {
-        use std::os::fd::AsRawFd;
-
-        let d = ptr::NonNull::new(unsafe { libc::fdopendir(fd.as_raw_fd()) }).ok_or(Errno::last())?;
+        // take the ownership as the constructed `Dir` is now the owner
+        let raw_fd = fd.into_raw_fd();
+        let d = ptr::NonNull::new(unsafe { libc::fdopendir(raw_fd) }).ok_or(Errno::last())?;
         Ok(Dir(d))
     }
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -59,7 +59,10 @@ impl Dir {
     ///
     /// It is only safe if `fd` is an owned file descriptor.
     #[inline]
-    #[deprecated(since = "0.30.0", note = "Deprecate this since it is not I/O-safe, use from_fd instead.")]
+    #[deprecated(
+        since = "0.30.0",
+        note = "Deprecate this since it is not I/O-safe, use from_fd instead."
+    )]
     pub unsafe fn from<F: IntoRawFd>(fd: F) -> Result<Self> {
         use std::os::fd::FromRawFd;
         use std::os::fd::OwnedFd;
@@ -76,7 +79,8 @@ impl Dir {
     pub fn from_fd(fd: std::os::fd::OwnedFd) -> Result<Self> {
         // take the ownership as the constructed `Dir` is now the owner
         let raw_fd = fd.into_raw_fd();
-        let d = ptr::NonNull::new(unsafe { libc::fdopendir(raw_fd) }).ok_or(Errno::last())?;
+        let d = ptr::NonNull::new(unsafe { libc::fdopendir(raw_fd) })
+            .ok_or(Errno::last())?;
         Ok(Dir(d))
     }
 
@@ -102,9 +106,7 @@ impl std::os::fd::AsFd for Dir {
         //
         // `raw_fd` should be open and valid for the lifetime of the returned
         // `BorrowedFd` as it is extracted from `&self`.
-        unsafe {
-            std::os::fd::BorrowedFd::borrow_raw(raw_fd)
-        }
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(raw_fd) }
     }
 }
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -44,6 +44,32 @@ use crate::{sys::stat::Mode, NixPath, Result};
 pub use self::posix_fadvise::{posix_fadvise, PosixFadviseAdvice};
 
 /// A file descriptor referring to the working directory of the current process.
+///
+/// # Examples
+///
+/// Use it in [`openat()`]:
+///
+/// ```no_run
+/// use nix::fcntl::AT_FDCWD;
+/// use nix::fcntl::openat;
+/// use nix::fcntl::OFlag;
+/// use nix::sys::stat::Mode;
+///
+/// let fd = openat(AT_FDCWD, "foo", OFlag::O_RDONLY | OFlag::O_CLOEXEC, Mode::empty()).unwrap();
+/// ```
+///
+/// # WARNING
+///
+/// Do NOT pass this symbol to non-`xxat()` functions, it won't work:
+///
+/// ```should_panic
+/// use nix::errno::Errno;
+/// use nix::fcntl::AT_FDCWD;
+/// use nix::sys::stat::fstat;
+/// use std::os::fd::AsRawFd;
+///
+/// let never = fstat(AT_FDCWD.as_raw_fd()).unwrap();
+/// ```
 //
 // SAFETY:
 // 1. `AT_FDCWD` is usable for the whole process life, so it is `'static`.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -53,6 +53,7 @@ pub use self::posix_fadvise::{posix_fadvise, PosixFadviseAdvice};
 // 1. `AT_FDCWD` is usable for the whole process life, so it is `'static`.
 // 2. It is not a valid file descriptor, but OS will handle it for us when passed
 //    to `xxat(2)` calls.
+#[cfg(not(target_os = "redox"))] // Redox does not have this
 pub const AT_FDCWD: BorrowedFd<'static> =
     unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1358,6 +1358,8 @@ impl SpacectlRange {
 #[cfg(target_os = "freebsd")]
 #[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
 pub fn fspacectl<Fd: std::os::fd::AsFd>(fd: Fd, range: SpacectlRange) -> Result<SpacectlRange> {
+    use std::os::fd::AsRawFd;
+
     let mut rqsr = libc::spacectl_range {
         r_offset: range.0,
         r_len: range.1,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -13,12 +13,13 @@ use std::ffi::CStr;
 use std::ffi::OsString;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 use std::ops::{Deref, DerefMut};
+use std::os::fd::BorrowedFd;
 #[cfg(not(target_os = "redox"))]
 use std::os::raw;
 use std::os::unix::ffi::OsStringExt;
-use std::os::unix::io::RawFd;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 use std::os::unix::io::OwnedFd;
+use std::os::unix::io::RawFd;
 #[cfg(any(
     target_os = "netbsd",
     apple_targets,
@@ -28,7 +29,6 @@ use std::os::unix::io::OwnedFd;
 use std::path::PathBuf;
 #[cfg(any(linux_android, target_os = "freebsd"))]
 use std::ptr;
-use std::os::fd::BorrowedFd;
 
 #[cfg(feature = "fs")]
 use std::os::fd::FromRawFd;
@@ -53,7 +53,8 @@ pub use self::posix_fadvise::{posix_fadvise, PosixFadviseAdvice};
 // 1. `AT_FDCWD` is usable for the whole process life, so it is `'static`.
 // 2. It is not a valid file descriptor, but OS will handle it for us when passed
 //    to `xxat(2)` calls.
-pub const AT_FDCWD: BorrowedFd<'static> = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
+pub const AT_FDCWD: BorrowedFd<'static> =
+    unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
 
 #[cfg(not(target_os = "redox"))]
 #[cfg(any(feature = "fs", feature = "process", feature = "user"))]

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -18,7 +18,7 @@ use std::os::raw;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::RawFd;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
-use std::os::unix::io::{AsRawFd, OwnedFd};
+use std::os::unix::io::OwnedFd;
 #[cfg(any(
     target_os = "netbsd",
     apple_targets,
@@ -27,7 +27,11 @@ use std::os::unix::io::{AsRawFd, OwnedFd};
 ))]
 use std::path::PathBuf;
 #[cfg(any(linux_android, target_os = "freebsd"))]
-use std::{os::unix::io::AsFd, ptr};
+use std::ptr;
+use std::os::fd::BorrowedFd;
+
+#[cfg(feature = "fs")]
+use std::os::fd::FromRawFd;
 
 #[cfg(feature = "fs")]
 use crate::{sys::stat::Mode, NixPath, Result};
@@ -42,6 +46,14 @@ use crate::{sys::stat::Mode, NixPath, Result};
 ))]
 #[cfg(feature = "fs")]
 pub use self::posix_fadvise::{posix_fadvise, PosixFadviseAdvice};
+
+/// A file descriptor referring to the working directory of the current process.
+//
+// SAFETY:
+// 1. `AT_FDCWD` is usable for the whole process life, so it is `'static`.
+// 2. It is not a valid file descriptor, but OS will handle it for us when passed
+//    to `xxat(2)` calls.
+pub const AT_FDCWD: BorrowedFd<'static> = unsafe { BorrowedFd::borrow_raw(libc::AT_FDCWD) };
 
 #[cfg(not(target_os = "redox"))]
 #[cfg(any(feature = "fs", feature = "process", feature = "user"))]
@@ -221,12 +233,16 @@ pub fn open<P: ?Sized + NixPath>(
     path: &P,
     oflag: OFlag,
     mode: Mode,
-) -> Result<RawFd> {
+) -> Result<OwnedFd> {
     let fd = path.with_nix_path(|cstr| unsafe {
         libc::open(cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint)
     })?;
+    Errno::result(fd)?;
 
-    Errno::result(fd)
+    // SAFETY:
+    //
+    // `open(2)` should return a valid owned fd on success
+    Ok( unsafe { OwnedFd::from_raw_fd(fd)  } )
 }
 
 /// open or create a file for reading, writing or executing
@@ -240,16 +256,23 @@ pub fn open<P: ?Sized + NixPath>(
 // The conversion is not identical on all operating systems.
 #[allow(clippy::useless_conversion)]
 #[cfg(not(target_os = "redox"))]
-pub fn openat<P: ?Sized + NixPath>(
-    dirfd: Option<RawFd>,
+pub fn openat<P: ?Sized + NixPath, Fd: std::os::fd::AsFd>(
+    dirfd: Fd,
     path: &P,
     oflag: OFlag,
     mode: Mode,
-) -> Result<RawFd> {
+) -> Result<OwnedFd> {
+    use std::os::fd::AsRawFd;
+
     let fd = path.with_nix_path(|cstr| unsafe {
-        libc::openat(at_rawfd(dirfd), cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint)
+        libc::openat(dirfd.as_fd().as_raw_fd(), cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint)
     })?;
-    Errno::result(fd)
+    Errno::result(fd)?;
+
+    // SAFETY:
+    //
+    // `openat(2)` should return a valid owned fd on success
+    Ok( unsafe { OwnedFd::from_raw_fd(fd)  } )
 }
 
 cfg_if::cfg_if! {
@@ -345,22 +368,29 @@ cfg_if::cfg_if! {
         /// # See also
         ///
         /// [openat2](https://man7.org/linux/man-pages/man2/openat2.2.html)
-        pub fn openat2<P: ?Sized + NixPath>(
-            dirfd: RawFd,
+        pub fn openat2<P: ?Sized + NixPath, Fd: std::os::fd::AsFd>(
+            dirfd: Fd,
             path: &P,
             mut how: OpenHow,
-        ) -> Result<RawFd> {
+        ) -> Result<OwnedFd> {
+            use std::os::fd::AsRawFd;
+            use std::os::fd::FromRawFd;
+
             let fd = path.with_nix_path(|cstr| unsafe {
                 libc::syscall(
                     libc::SYS_openat2,
-                    dirfd,
+                    dirfd.as_fd().as_raw_fd(),
                     cstr.as_ptr(),
                     &mut how as *mut OpenHow,
                     std::mem::size_of::<libc::open_how>(),
                 )
-            })?;
+            })? as RawFd;
+            Errno::result(fd)?;
 
-            Errno::result(fd as RawFd)
+            // SAFETY:
+            //
+            // `openat2(2)` should return a valid owned fd on success
+            Ok( unsafe { OwnedFd::from_raw_fd(fd)  } )
         }
     }
 }
@@ -374,18 +404,20 @@ cfg_if::cfg_if! {
 /// # See Also
 /// [`renameat`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html)
 #[cfg(not(target_os = "redox"))]
-pub fn renameat<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
-    old_dirfd: Option<RawFd>,
+pub fn renameat<P1: ?Sized + NixPath, P2: ?Sized + NixPath, Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
+    old_dirfd: Fd1,
     old_path: &P1,
-    new_dirfd: Option<RawFd>,
+    new_dirfd: Fd2,
     new_path: &P2,
 ) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
     let res = old_path.with_nix_path(|old_cstr| {
         new_path.with_nix_path(|new_cstr| unsafe {
             libc::renameat(
-                at_rawfd(old_dirfd),
+                old_dirfd.as_fd().as_raw_fd(),
                 old_cstr.as_ptr(),
-                at_rawfd(new_dirfd),
+                new_dirfd.as_fd().as_raw_fd(),
                 new_cstr.as_ptr(),
             )
         })
@@ -422,19 +454,21 @@ feature! {
 /// # See Also
 /// * [`rename`](https://man7.org/linux/man-pages/man2/rename.2.html)
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-pub fn renameat2<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
-    old_dirfd: Option<RawFd>,
+pub fn renameat2<P1: ?Sized + NixPath, P2: ?Sized + NixPath, Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
+    old_dirfd: Fd1,
     old_path: &P1,
-    new_dirfd: Option<RawFd>,
+    new_dirfd: Fd2,
     new_path: &P2,
     flags: RenameFlags,
 ) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
     let res = old_path.with_nix_path(|old_cstr| {
         new_path.with_nix_path(|new_cstr| unsafe {
             libc::renameat2(
-                at_rawfd(old_dirfd),
+                old_dirfd.as_fd().as_raw_fd(),
                 old_cstr.as_ptr(),
-                at_rawfd(new_dirfd),
+                new_dirfd.as_fd().as_raw_fd(),
                 new_cstr.as_ptr(),
                 flags.bits(),
             )
@@ -449,7 +483,16 @@ fn wrap_readlink_result(mut v: Vec<u8>, len: ssize_t) -> Result<OsString> {
     Ok(OsString::from_vec(v.to_vec()))
 }
 
-fn readlink_maybe_at<P: ?Sized + NixPath>(
+/// Read the symlink specified by `path` and `dirfd` and put the contents in `v`.
+/// Return the number of bytes placed in `v`.
+///
+/// This function can call `readlink(2)` or `readlinkat(2)` depending on if `dirfd`
+/// is some, if it is, then `readlinkat(2)` is called, otherwise, call `readlink(2)`.
+///
+/// # Safety
+///
+/// This function is not I/O-safe considering it employs the `RawFd` type.
+unsafe fn readlink_maybe_at<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
     v: &mut Vec<u8>,
@@ -457,7 +500,7 @@ fn readlink_maybe_at<P: ?Sized + NixPath>(
     path.with_nix_path(|cstr| unsafe {
         match dirfd {
             #[cfg(target_os = "redox")]
-            Some(_) => unreachable!(),
+            Some(_) => unreachable!("redox does not have readlinkat(2)"),
             #[cfg(not(target_os = "redox"))]
             Some(dirfd) => libc::readlinkat(
                 dirfd,
@@ -474,7 +517,15 @@ fn readlink_maybe_at<P: ?Sized + NixPath>(
     })
 }
 
-fn inner_readlink<P: ?Sized + NixPath>(
+/// The actual implementation of [`readlink(2)`] or [`readlinkat(2)`].
+///
+/// This function can call `readlink(2)` or `readlinkat(2)` depending on if `dirfd`
+/// is some, if it is, then `readlinkat(2)` is called, otherwise, call `readlink(2)`.
+///
+/// # Safety
+///
+/// This function is marked unsafe because it uses `RawFd`.
+unsafe fn inner_readlink<P: ?Sized + NixPath>(
     dirfd: Option<RawFd>,
     path: &P,
 ) -> Result<OsString> {
@@ -486,7 +537,12 @@ fn inner_readlink<P: ?Sized + NixPath>(
 
     {
         // simple case: result is strictly less than `PATH_MAX`
-        let res = readlink_maybe_at(dirfd, path, &mut v)?;
+
+        // SAFETY:
+        //
+        // If this call of `readlink_maybe_at()` is safe or not depends on the
+        // usage of `unsafe fn inner_readlink()`.
+        let res = unsafe { readlink_maybe_at(dirfd, path, &mut v)? };
         let len = Errno::result(res)?;
         debug_assert!(len >= 0);
         if (len as usize) < v.capacity() {
@@ -499,7 +555,7 @@ fn inner_readlink<P: ?Sized + NixPath>(
     let mut try_size = {
         let reported_size = match dirfd {
             #[cfg(target_os = "redox")]
-            Some(_) => unreachable!(),
+            Some(_) => unreachable!("redox does not have readlinkat(2)"),
             #[cfg(any(linux_android, target_os = "freebsd", target_os = "hurd"))]
             Some(dirfd) => {
                 let flags = if path.is_empty() {
@@ -543,7 +599,11 @@ fn inner_readlink<P: ?Sized + NixPath>(
     loop {
         {
             v.reserve_exact(try_size);
-            let res = readlink_maybe_at(dirfd, path, &mut v)?;
+            // SAFETY:
+            //
+            // If this call of `readlink_maybe_at()` is safe or not depends on the
+            // usage of `unsafe fn inner_readlink()`.
+            let res = unsafe { readlink_maybe_at(dirfd, path, &mut v)? };
             let len = Errno::result(res)?;
             debug_assert!(len >= 0);
             if (len as usize) < v.capacity() {
@@ -566,7 +626,16 @@ fn inner_readlink<P: ?Sized + NixPath>(
 /// # See Also
 /// * [`readlink`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlink.html)
 pub fn readlink<P: ?Sized + NixPath>(path: &P) -> Result<OsString> {
-    inner_readlink(None, path)
+    // argument `dirfd` should be `None` since we call it from `readlink()`
+    //
+    // Do NOT call it with `Some(AT_CWD)` as in that way, we are emulating
+    // `readlink(2)` with `readlinkat(2)`, which will make us lose `readlink(2)`
+    // on Redox.
+    //
+    // SAFETY:
+    //
+    // It is definitely safe because the argument involving `RawFd` is `None`
+    unsafe { inner_readlink(None, path) }
 }
 
 /// Read value of a symbolic link.
@@ -577,12 +646,18 @@ pub fn readlink<P: ?Sized + NixPath>(path: &P) -> Result<OsString> {
 /// # See Also
 /// * [`readlink`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/readlink.html)
 #[cfg(not(target_os = "redox"))]
-pub fn readlinkat<P: ?Sized + NixPath>(
-    dirfd: Option<RawFd>,
+pub fn readlinkat<Fd: std::os::fd::AsFd,P: ?Sized + NixPath>(
+    dirfd: Fd,
     path: &P,
 ) -> Result<OsString> {
-    let dirfd = at_rawfd(dirfd);
-    inner_readlink(Some(dirfd), path)
+    use std::os::fd::AsRawFd;
+
+    // argument `dirfd` should be `Some` since we call it from `readlinkat()`
+    //
+    // SAFETY:
+    //
+    // The passed `RawFd` should be valid since it is borrowed from `Fd: AsFd`.
+    unsafe { inner_readlink(Some(dirfd.as_fd().as_raw_fd()), path) }
 }
 }
 
@@ -720,7 +795,10 @@ pub use self::FcntlArg::*;
 /// # See Also
 /// * [`fcntl`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html)
 // TODO: Figure out how to handle value fcntl returns
-pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
+pub fn fcntl<Fd: std::os::fd::AsFd>(fd: Fd, arg: FcntlArg) -> Result<c_int> {
+    use std::os::fd::AsRawFd;
+
+    let fd = fd.as_fd().as_raw_fd();
     let res = unsafe {
         match arg {
             F_DUPFD(rawfd) => libc::fcntl(fd, libc::F_DUPFD, rawfd),
@@ -853,7 +931,7 @@ pub fn flock(fd: RawFd, arg: FlockArg) -> Result<()> {
 /// # Safety
 /// Types implementing this must not be `Clone`.
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
-pub unsafe trait Flockable: AsRawFd {}
+pub unsafe trait Flockable: std::os::fd::AsRawFd {}
 
 /// Represents an owned flock, which unlocks on drop.
 ///
@@ -1037,13 +1115,15 @@ feature! {
 // define it as "loff_t".  But on both OSes, on all supported platforms, those
 // are 64 bits.  So Nix uses i64 to make the docs simple and consistent.
 #[cfg(any(linux_android, target_os = "freebsd"))]
-pub fn copy_file_range<Fd1: AsFd, Fd2: AsFd>(
+pub fn copy_file_range<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
     fd_in: Fd1,
     off_in: Option<&mut i64>,
     fd_out: Fd2,
     off_out: Option<&mut i64>,
     len: usize,
 ) -> Result<usize> {
+    use std::os::fd::AsRawFd;
+
     let off_in = off_in
         .map(|offset| offset as *mut i64)
         .unwrap_or(ptr::null_mut());
@@ -1087,7 +1167,7 @@ pub fn copy_file_range<Fd1: AsFd, Fd2: AsFd>(
 /// # See Also
 /// *[`splice`](https://man7.org/linux/man-pages/man2/splice.2.html)
 #[cfg(linux_android)]
-pub fn splice<Fd1: AsFd, Fd2: AsFd>(
+pub fn splice<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
     fd_in: Fd1,
     off_in: Option<&mut libc::loff_t>,
     fd_out: Fd2,
@@ -1095,6 +1175,8 @@ pub fn splice<Fd1: AsFd, Fd2: AsFd>(
     len: usize,
     flags: SpliceFFlags,
 ) -> Result<usize> {
+    use std::os::fd::AsRawFd;
+
     let off_in = off_in
         .map(|offset| offset as *mut libc::loff_t)
         .unwrap_or(ptr::null_mut());
@@ -1113,12 +1195,14 @@ pub fn splice<Fd1: AsFd, Fd2: AsFd>(
 /// # See Also
 /// *[`tee`](https://man7.org/linux/man-pages/man2/tee.2.html)
 #[cfg(linux_android)]
-pub fn tee<Fd1: AsFd, Fd2: AsFd>(
+pub fn tee<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
     fd_in: Fd1,
     fd_out: Fd2,
     len: usize,
     flags: SpliceFFlags,
 ) -> Result<usize> {
+    use std::os::fd::AsRawFd;
+
     let ret = unsafe { libc::tee(fd_in.as_fd().as_raw_fd(), fd_out.as_fd().as_raw_fd(), len, flags.bits()) };
     Errno::result(ret).map(|r| r as usize)
 }
@@ -1128,11 +1212,13 @@ pub fn tee<Fd1: AsFd, Fd2: AsFd>(
 /// # See Also
 /// *[`vmsplice`](https://man7.org/linux/man-pages/man2/vmsplice.2.html)
 #[cfg(linux_android)]
-pub fn vmsplice<F: AsFd>(
+pub fn vmsplice<F: std::os::fd::AsFd>(
     fd: F,
     iov: &[std::io::IoSlice<'_>],
     flags: SpliceFFlags,
 ) -> Result<usize> {
+    use std::os::fd::AsRawFd;
+
     let ret = unsafe {
         libc::vmsplice(
             fd.as_fd().as_raw_fd(),
@@ -1187,13 +1273,15 @@ feature! {
 /// file referred to by fd.
 #[cfg(target_os = "linux")]
 #[cfg(feature = "fs")]
-pub fn fallocate(
-    fd: RawFd,
+pub fn fallocate<Fd: std::os::fd::AsFd>(
+    fd: Fd,
     mode: FallocateFlags,
     offset: libc::off_t,
     len: libc::off_t,
 ) -> Result<()> {
-    let res = unsafe { libc::fallocate(fd, mode.bits(), offset, len) };
+    use std::os::fd::AsRawFd;
+
+    let res = unsafe { libc::fallocate(fd.as_fd().as_raw_fd(), mode.bits(), offset, len) };
     Errno::result(res).map(drop)
 }
 
@@ -1268,14 +1356,14 @@ impl SpacectlRange {
 /// ```
 #[cfg(target_os = "freebsd")]
 #[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
-pub fn fspacectl(fd: RawFd, range: SpacectlRange) -> Result<SpacectlRange> {
+pub fn fspacectl<Fd: std::os::fd::AsFd>(fd: Fd, range: SpacectlRange) -> Result<SpacectlRange> {
     let mut rqsr = libc::spacectl_range {
         r_offset: range.0,
         r_len: range.1,
     };
     let res = unsafe {
         libc::fspacectl(
-            fd,
+            fd.as_fd().as_raw_fd(),
             libc::SPACECTL_DEALLOC, // Only one command is supported ATM
             &rqsr,
             0, // No flags are currently supported
@@ -1317,11 +1405,13 @@ pub fn fspacectl(fd: RawFd, range: SpacectlRange) -> Result<SpacectlRange> {
 /// ```
 #[cfg(target_os = "freebsd")]
 #[inline] // Delays codegen, preventing linker errors with dylibs and --no-allow-shlib-undefined
-pub fn fspacectl_all(
-    fd: RawFd,
+pub fn fspacectl_all<Fd: std::os::fd::AsFd>(
+    fd: Fd,
     offset: libc::off_t,
     len: libc::off_t,
 ) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
     let mut rqsr = libc::spacectl_range {
         r_offset: offset,
         r_len: len,
@@ -1329,7 +1419,7 @@ pub fn fspacectl_all(
     while rqsr.r_len > 0 {
         let res = unsafe {
             libc::fspacectl(
-                fd,
+                fd.as_fd().as_raw_fd(),
                 libc::SPACECTL_DEALLOC, // Only one command is supported ATM
                 &rqsr,
                 0, // No flags are currently supported
@@ -1352,7 +1442,6 @@ pub fn fspacectl_all(
 mod posix_fadvise {
     use crate::errno::Errno;
     use crate::Result;
-    use std::os::unix::io::RawFd;
 
     #[cfg(feature = "fs")]
     libc_enum! {
@@ -1384,13 +1473,15 @@ mod posix_fadvise {
     ///
     /// # See Also
     /// * [`posix_fadvise`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_fadvise.html)
-    pub fn posix_fadvise(
-        fd: RawFd,
+    pub fn posix_fadvise<Fd: std::os::fd::AsFd>(
+        fd: Fd,
         offset: libc::off_t,
         len: libc::off_t,
         advice: PosixFadviseAdvice,
     ) -> Result<()> {
-        let res = unsafe { libc::posix_fadvise(fd, offset, len, advice as libc::c_int) };
+        use std::os::fd::AsRawFd;
+
+        let res = unsafe { libc::posix_fadvise(fd.as_fd().as_raw_fd(), offset, len, advice as libc::c_int) };
 
         if res == 0 {
             Ok(())
@@ -1412,12 +1503,14 @@ mod posix_fadvise {
     target_os = "fuchsia",
     target_os = "wasi",
 ))]
-pub fn posix_fallocate(
-    fd: RawFd,
+pub fn posix_fallocate<Fd: std::os::fd::AsFd>(
+    fd: Fd,
     offset: libc::off_t,
     len: libc::off_t,
 ) -> Result<()> {
-    let res = unsafe { libc::posix_fallocate(fd, offset, len) };
+    use std::os::fd::AsRawFd;
+
+    let res = unsafe { libc::posix_fallocate(fd.as_fd().as_raw_fd(), offset, len) };
     match Errno::result(res) {
         Err(err) => Err(err),
         Ok(0) => Ok(()),

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1401,7 +1401,7 @@ pub fn fspacectl<Fd: std::os::fd::AsFd>(fd: Fd, range: SpacectlRange) -> Result<
 /// const INITIAL: &[u8] = b"0123456789abcdef";
 /// let mut f = tempfile().unwrap();
 /// f.write_all(INITIAL).unwrap();
-/// fspacectl_all(&f., 3, 6).unwrap();
+/// fspacectl_all(&f, 3, 6).unwrap();
 /// let mut buf = vec![0; INITIAL.len()];
 /// f.read_exact_at(&mut buf, 0).unwrap();
 /// assert_eq!(buf, b"012\0\0\0\0\0\09abcdef");

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1127,7 +1127,8 @@ pub fn test_af_alg_aead() {
     //
     // `session_socket` will be valid for the lifetime of this test
     // TODO: remove this workaround when accept(2) becomes I/O-safe.
-    let borrowed_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
+    let borrowed_fd =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     fcntl(borrowed_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
         .expect("fcntl non_blocking");
     let num_bytes =

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1122,7 +1122,13 @@ pub fn test_af_alg_aead() {
     // authentication tag memory is only needed in the output buffer for encryption
     // and in the input buffer for decryption.
     // Do not block on read, as we may have fewer bytes than buffer size
-    fcntl(session_socket, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
+
+    // SAFETY:
+    //
+    // `session_socket` will be valid for the lifetime of this test
+    // TODO: remove this workaround when accept(2) becomes I/O-safe.
+    let borrowed_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
+    fcntl(borrowed_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
         .expect("fcntl non_blocking");
     let num_bytes =
         read(session_socket.as_raw_fd(), &mut decrypted).expect("read decrypt");

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -100,10 +100,10 @@ fn test_local_flags() {
     let pty = openpty(None, &termios).unwrap();
 
     // Set the master is in nonblocking mode or reading will never return.
-    let flags = fcntl::fcntl(pty.master.as_raw_fd(), fcntl::F_GETFL).unwrap();
+    let flags = fcntl::fcntl(pty.master.as_fd(), fcntl::F_GETFL).unwrap();
     let new_flags =
         fcntl::OFlag::from_bits_truncate(flags) | fcntl::OFlag::O_NONBLOCK;
-    fcntl::fcntl(pty.master.as_raw_fd(), fcntl::F_SETFL(new_flags)).unwrap();
+    fcntl::fcntl(pty.master.as_fd(), fcntl::F_SETFL(new_flags)).unwrap();
 
     // Write into the master
     let string = "foofoofoo\r";

--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -56,9 +56,3 @@ fn rewind() {
     assert_eq!(entries1, entries2);
     assert_eq!(entries2, entries3);
 }
-
-#[cfg(not(target_os = "haiku"))]
-#[test]
-fn ebadf() {
-    assert_eq!(Dir::from_fd(-1).unwrap_err(), nix::Error::EBADF);
-}

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -584,7 +584,7 @@ mod test_posix_fallocate {
 #[test]
 fn test_f_get_path() {
     use nix::fcntl::*;
-    use std::{os::unix::io::AsRawFd, path::PathBuf};
+    use std::path::PathBuf;
 
     let tmp = NamedTempFile::new().unwrap();
     let mut path = PathBuf::new();
@@ -601,7 +601,7 @@ fn test_f_get_path() {
 #[test]
 fn test_f_get_path_nofirmlink() {
     use nix::fcntl::*;
-    use std::{os::unix::io::AsRawFd, path::PathBuf};
+    use std::path::PathBuf;
 
     let tmp = NamedTempFile::new().unwrap();
     let mut path = PathBuf::new();

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -154,23 +154,11 @@ fn test_renameat2_behaves_like_renameat_with_no_flags() {
     let new_dir = tempfile::tempdir().unwrap();
     let new_dirfd =
         open(new_dir.path(), OFlag::empty(), Mode::empty()).unwrap();
-    renameat2(
-        &old_dirfd,
-        "old",
-        &new_dirfd,
-        "new",
-        RenameFlags::empty(),
-    )
-    .unwrap();
+    renameat2(&old_dirfd, "old", &new_dirfd, "new", RenameFlags::empty())
+        .unwrap();
     assert_eq!(
-        renameat2(
-            &old_dirfd,
-            "old",
-            &new_dirfd,
-            "new",
-            RenameFlags::empty()
-        )
-        .unwrap_err(),
+        renameat2(&old_dirfd, "old", &new_dirfd, "new", RenameFlags::empty())
+            .unwrap_err(),
         Errno::ENOENT
     );
     assert!(new_dir.path().join("new").exists());
@@ -301,14 +289,7 @@ fn test_copy_file_range() {
     tmp1.flush().unwrap();
 
     let mut from_offset: i64 = 3;
-    copy_file_range(
-        &tmp1,
-        Some(&mut from_offset),
-        &tmp2,
-        None,
-        3,
-    )
-    .unwrap();
+    copy_file_range(&tmp1, Some(&mut from_offset), &tmp2, None, 3).unwrap();
 
     let mut res: String = String::new();
     tmp2.rewind().unwrap();
@@ -435,7 +416,8 @@ mod linux_android {
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(tmp.as_raw_fd()).expect("fstat failed").st_ino as usize;
+        let inode =
+            fstat(tmp.as_raw_fd()).expect("fstat failed").st_ino as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips
@@ -452,7 +434,8 @@ mod linux_android {
         );
 
         flock.l_type = libc::F_UNLCK as libc::c_short;
-        fcntl(&tmp, FcntlArg::F_OFD_SETLKW(&flock)).expect("write unlock failed");
+        fcntl(&tmp, FcntlArg::F_OFD_SETLKW(&flock))
+            .expect("write unlock failed");
         assert_eq!(None, lock_info(inode));
     }
 
@@ -473,7 +456,8 @@ mod linux_android {
             // skip the test.
             skip!("/proc/locks does not work on overlayfs");
         }
-        let inode = fstat(tmp.as_raw_fd()).expect("fstat failed").st_ino as usize;
+        let inode =
+            fstat(tmp.as_raw_fd()).expect("fstat failed").st_ino as usize;
 
         let mut flock: libc::flock = unsafe {
             mem::zeroed() // required for Linux/mips
@@ -490,7 +474,8 @@ mod linux_android {
         );
 
         flock.l_type = libc::F_UNLCK as libc::c_short;
-        fcntl(&tmp, FcntlArg::F_OFD_SETLKW(&flock)).expect("read unlock failed");
+        fcntl(&tmp, FcntlArg::F_OFD_SETLKW(&flock))
+            .expect("read unlock failed");
         assert_eq!(None, lock_info(inode));
     }
 
@@ -540,12 +525,8 @@ mod test_posix_fadvise {
     #[test]
     fn test_errno() {
         let (rd, _wr) = pipe().unwrap();
-        let res = posix_fadvise(
-            &rd,
-            0,
-            100,
-            PosixFadviseAdvice::POSIX_FADV_WILLNEED,
-        );
+        let res =
+            posix_fadvise(&rd, 0, 100, PosixFadviseAdvice::POSIX_FADV_WILLNEED);
         assert_eq!(res, Err(Errno::ESPIPE));
     }
 }
@@ -660,7 +641,8 @@ fn test_f_kinfo() {
     // to pass.
     let tmp2 = File::open(tmp.path()).unwrap();
     let mut path = PathBuf::new();
-    let res = fcntl(&tmp2, FcntlArg::F_KINFO(&mut path)).expect("get path failed");
+    let res =
+        fcntl(&tmp2, FcntlArg::F_KINFO(&mut path)).expect("get path failed");
     assert_ne!(res, -1);
     assert_eq!(path, tmp.path());
 }

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -632,7 +632,7 @@ fn test_f_get_path_nofirmlink() {
 #[test]
 fn test_f_kinfo() {
     use nix::fcntl::*;
-    use std::{os::unix::io::AsRawFd, path::PathBuf};
+    use std::path::PathBuf;
 
     let tmp = NamedTempFile::new().unwrap();
     // With TMPDIR set with UFS, the vnode name is not entered

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -103,7 +103,6 @@ fn open_ptty_pair() -> (PtyMaster, File) {
     #[allow(clippy::comparison_chain)]
     {
         use libc::{ioctl, I_FIND, I_PUSH};
-        use std::os::fd::AsRawFd;
 
         // On illumos systems, as per pts(7D), one must push STREAMS modules
         // after opening a device path returned from ptsname().

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -103,19 +103,23 @@ fn open_ptty_pair() -> (PtyMaster, File) {
     #[allow(clippy::comparison_chain)]
     {
         use libc::{ioctl, I_FIND, I_PUSH};
+        use std::os::fd::AsRawFd;
 
         // On illumos systems, as per pts(7D), one must push STREAMS modules
         // after opening a device path returned from ptsname().
         let ptem = b"ptem\0";
         let ldterm = b"ldterm\0";
-        let r = unsafe { ioctl(slave_fd, I_FIND, ldterm.as_ptr()) };
+        let r = unsafe { ioctl(slave_fd.as_raw_fd(), I_FIND, ldterm.as_ptr()) };
         if r < 0 {
             panic!("I_FIND failure");
         } else if r == 0 {
-            if unsafe { ioctl(slave_fd, I_PUSH, ptem.as_ptr()) } < 0 {
+            if unsafe { ioctl(slave_fd.as_raw_fd(), I_PUSH, ptem.as_ptr()) } < 0
+            {
                 panic!("I_PUSH ptem failure");
             }
-            if unsafe { ioctl(slave_fd, I_PUSH, ldterm.as_ptr()) } < 0 {
+            if unsafe { ioctl(slave_fd.as_raw_fd(), I_PUSH, ldterm.as_ptr()) }
+                < 0
+            {
                 panic!("I_PUSH ldterm failure");
             }
         }

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -121,7 +121,7 @@ fn open_ptty_pair() -> (PtyMaster, File) {
         }
     }
 
-    let slave = unsafe { File::from_raw_fd(slave_fd) };
+    let slave = File::from(slave_fd);
 
     (master, slave)
 }

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -110,15 +110,19 @@ fn test_stat_and_fstat() {
 #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
 fn test_fstatat() {
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempfile::tempdir().unwrap();
     let filename = tempdir.path().join("foo.txt");
     File::create(&filename).unwrap();
     let dirfd =
-        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty()).unwrap();
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+            .unwrap();
 
-    let result =
-        stat::fstatat(Some(dirfd.as_raw_fd()), &filename, fcntl::AtFlags::empty());
+    let result = stat::fstatat(
+        Some(dirfd.as_raw_fd()),
+        &filename,
+        fcntl::AtFlags::empty(),
+    );
     assert_stat_results(result);
 }
 
@@ -173,7 +177,7 @@ fn test_fchmod() {
 #[cfg(not(target_os = "redox"))]
 fn test_fchmodat() {
     use std::os::fd::AsRawFd;
-    
+
     let _dr = crate::DirRestore::new();
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "foo.txt";
@@ -187,8 +191,13 @@ fn test_fchmodat() {
     let mut mode1 = Mode::empty();
     mode1.insert(Mode::S_IRUSR);
     mode1.insert(Mode::S_IWUSR);
-    fchmodat(Some(dirfd.as_raw_fd()), filename, mode1, FchmodatFlags::FollowSymlink)
-        .unwrap();
+    fchmodat(
+        Some(dirfd.as_raw_fd()),
+        filename,
+        mode1,
+        FchmodatFlags::FollowSymlink,
+    )
+    .unwrap();
 
     let file_stat1 = stat(&fullpath).unwrap();
     assert_eq!(file_stat1.st_mode as mode_t & 0o7777, mode1.bits());
@@ -271,7 +280,7 @@ fn test_lutimes() {
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_futimens() {
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempfile::tempdir().unwrap();
     let fullpath = tempdir.path().join("file");
     drop(File::create(&fullpath).unwrap());
@@ -279,7 +288,12 @@ fn test_futimens() {
     let fd = fcntl::open(&fullpath, fcntl::OFlag::empty(), stat::Mode::empty())
         .unwrap();
 
-    futimens(fd.as_raw_fd(), &TimeSpec::seconds(10), &TimeSpec::seconds(20)).unwrap();
+    futimens(
+        fd.as_raw_fd(),
+        &TimeSpec::seconds(10),
+        &TimeSpec::seconds(20),
+    )
+    .unwrap();
     assert_times_eq(10, 20, &fs::metadata(&fullpath).unwrap());
 }
 
@@ -287,7 +301,7 @@ fn test_futimens() {
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_utimensat() {
     use std::os::fd::AsRawFd;
-    
+
     let _dr = crate::DirRestore::new();
     let tempdir = tempfile::tempdir().unwrap();
     let filename = "foo.txt";
@@ -329,7 +343,8 @@ fn test_mkdirat_success_path() {
     let dirfd =
         fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
             .unwrap();
-    mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU)
+        .expect("mkdirat failed");
     assert!(Path::exists(&tempdir.path().join(filename)));
 }
 
@@ -337,7 +352,7 @@ fn test_mkdirat_success_path() {
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_mkdirat_success_mode() {
     use std::os::fd::AsRawFd;
-    
+
     let expected_bits =
         stat::SFlag::S_IFDIR.bits() | stat::Mode::S_IRWXU.bits();
     let tempdir = tempfile::tempdir().unwrap();
@@ -345,7 +360,8 @@ fn test_mkdirat_success_mode() {
     let dirfd =
         fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
             .unwrap();
-    mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU).expect("mkdirat failed");
+    mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU)
+        .expect("mkdirat failed");
     let permissions = fs::metadata(tempdir.path().join(filename))
         .unwrap()
         .permissions();
@@ -367,7 +383,8 @@ fn test_mkdirat_fail() {
         stat::Mode::empty(),
     )
     .unwrap();
-    let result = mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU).unwrap_err();
+    let result =
+        mkdirat(Some(dirfd.as_raw_fd()), filename, Mode::S_IRWXU).unwrap_err();
     assert_eq!(result, Errno::ENOTDIR);
 }
 
@@ -446,7 +463,8 @@ fn test_futimens_unchanged() {
         .modified()
         .unwrap();
 
-    futimens(fd.as_raw_fd(), &TimeSpec::UTIME_OMIT, &TimeSpec::UTIME_OMIT).unwrap();
+    futimens(fd.as_raw_fd(), &TimeSpec::UTIME_OMIT, &TimeSpec::UTIME_OMIT)
+        .unwrap();
 
     let new_atime = fs::metadata(fullpath.as_path())
         .unwrap()

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -192,9 +192,12 @@ fn test_mkfifoat() {
 
     mkfifoat(Some(dirfd.as_raw_fd()), mkfifoat_name, Mode::S_IRUSR).unwrap();
 
-    let stats =
-        stat::fstatat(Some(dirfd.as_raw_fd()), mkfifoat_name, fcntl::AtFlags::empty())
-            .unwrap();
+    let stats = stat::fstatat(
+        Some(dirfd.as_raw_fd()),
+        mkfifoat_name,
+        fcntl::AtFlags::empty(),
+    )
+    .unwrap();
     let typ = stat::SFlag::from_bits_truncate(stats.st_mode);
     assert_eq!(typ, SFlag::S_IFIFO);
 }
@@ -228,7 +231,8 @@ fn test_mkfifoat_directory() {
     let tempdir = tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let mkfifoat_dir = "mkfifoat_dir";
-    stat::mkdirat(Some(dirfd.as_raw_fd()), mkfifoat_dir, Mode::S_IRUSR).unwrap();
+    stat::mkdirat(Some(dirfd.as_raw_fd()), mkfifoat_dir, Mode::S_IRUSR)
+        .unwrap();
 
     mkfifoat(Some(dirfd.as_raw_fd()), mkfifoat_dir, Mode::S_IRUSR)
         .expect_err("assertion failed");
@@ -573,7 +577,8 @@ fn test_fchownat() {
 
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
 
-    fchownat(Some(dirfd.as_raw_fd()), "file", uid, gid, AtFlags::empty()).unwrap();
+    fchownat(Some(dirfd.as_raw_fd()), "file", uid, gid, AtFlags::empty())
+        .unwrap();
 
     chdir(tempdir.path()).unwrap();
     fchownat(None, "file", uid, gid, AtFlags::empty()).unwrap();
@@ -762,13 +767,11 @@ fn test_pipe2() {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag};
 
     let (fd0, fd1) = pipe2(OFlag::O_CLOEXEC).unwrap();
-    let f0 = FdFlag::from_bits_truncate(
-        fcntl(&fd0, FcntlArg::F_GETFD).unwrap(),
-    );
+    let f0 =
+        FdFlag::from_bits_truncate(fcntl(&fd0, FcntlArg::F_GETFD).unwrap());
     assert!(f0.contains(FdFlag::FD_CLOEXEC));
-    let f1 = FdFlag::from_bits_truncate(
-        fcntl(&fd1, FcntlArg::F_GETFD).unwrap(),
-    );
+    let f1 =
+        FdFlag::from_bits_truncate(fcntl(&fd1, FcntlArg::F_GETFD).unwrap());
     assert!(f1.contains(FdFlag::FD_CLOEXEC));
 }
 
@@ -877,7 +880,7 @@ fn test_canceling_alarm() {
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_symlinkat() {
     use std::os::fd::AsRawFd;
-    
+
     let _m = crate::CWD_LOCK.read();
 
     let tempdir = tempdir().unwrap();
@@ -1117,7 +1120,7 @@ fn test_linkat_follow_symlink() {
 #[cfg(not(target_os = "redox"))]
 fn test_unlinkat_dir_noremovedir() {
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempdir().unwrap();
     let dirname = "foo_dir";
     let dirpath = tempdir.path().join(dirname);
@@ -1132,7 +1135,8 @@ fn test_unlinkat_dir_noremovedir() {
 
     // Attempt unlink dir at relative path without proper flag
     let err_result =
-        unlinkat(Some(dirfd.as_raw_fd()), dirname, UnlinkatFlags::NoRemoveDir).unwrap_err();
+        unlinkat(Some(dirfd.as_raw_fd()), dirname, UnlinkatFlags::NoRemoveDir)
+            .unwrap_err();
     assert!(err_result == Errno::EISDIR || err_result == Errno::EPERM);
 }
 
@@ -1140,7 +1144,7 @@ fn test_unlinkat_dir_noremovedir() {
 #[cfg(not(target_os = "redox"))]
 fn test_unlinkat_dir_removedir() {
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempdir().unwrap();
     let dirname = "foo_dir";
     let dirpath = tempdir.path().join(dirname);
@@ -1154,7 +1158,8 @@ fn test_unlinkat_dir_removedir() {
             .unwrap();
 
     // Attempt unlink dir at relative path with proper flag
-    unlinkat(Some(dirfd.as_raw_fd()), dirname, UnlinkatFlags::RemoveDir).unwrap();
+    unlinkat(Some(dirfd.as_raw_fd()), dirname, UnlinkatFlags::RemoveDir)
+        .unwrap();
     assert!(!dirpath.exists());
 }
 
@@ -1162,7 +1167,7 @@ fn test_unlinkat_dir_removedir() {
 #[cfg(not(target_os = "redox"))]
 fn test_unlinkat_file() {
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempdir().unwrap();
     let filename = "foo.txt";
     let filepath = tempdir.path().join(filename);
@@ -1176,7 +1181,12 @@ fn test_unlinkat_file() {
             .unwrap();
 
     // Attempt unlink file at relative path
-    unlinkat(Some(dirfd.as_raw_fd()), filename, UnlinkatFlags::NoRemoveDir).unwrap();
+    unlinkat(
+        Some(dirfd.as_raw_fd()),
+        filename,
+        UnlinkatFlags::NoRemoveDir,
+    )
+    .unwrap();
     assert!(!filepath.exists());
 }
 
@@ -1322,7 +1332,7 @@ fn test_faccessat_none_not_existing() {
 fn test_faccessat_not_existing() {
     use nix::fcntl::AtFlags;
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempfile::tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let not_exist_file = "does_not_exist.txt";
@@ -1360,7 +1370,7 @@ fn test_faccessat_none_file_exists() {
 fn test_faccessat_file_exists() {
     use nix::fcntl::AtFlags;
     use std::os::fd::AsRawFd;
-    
+
     let tempdir = tempfile::tempdir().unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let exist_file = "does_exist.txt";


### PR DESCRIPTION
## What does this PR do

This PR adds I/O safety to `fcntl.rs` and `dir.rs`.

Ref: #1750 

## xxat() interfaces

For those `xxat()` interfaces, I didn't introduce a new trait to represent directory file descriptors, instead, I took the way how rustix implements it:

1. Define `AT_FDCWD: BorrowedFd<'static>`
2. Change the signature to `xxat<Fd: AsFd>(dirfd: Fd, ...)`

 because:

1. rustix has been using this interface for a long time, which means it would work pretty well.
3. It is indeed unfortunate that we cannot catch some errors at compile time, but we will eventually get notified at runtime, e.g., when passing a fd that is not a directory to `dirfd`, or using `AT_FDCWD` with non-`xxat()` functions.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
