### PR TITLE
chore: clear a fixed false positive lint

### DIFF
--- a/test/test_dir.rs
+++ b/test/test_dir.rs
@@ -16,7 +16,6 @@ fn flags() -> OFlag {
 }
 
 #[test]
-#[allow(clippy::unnecessary_sort_by)] // False positive
 fn read() {
     let tmp = tempdir().unwrap();
     File::create(tmp.path().join("foo")).unwrap();


### PR DESCRIPTION
## What does this PR do

Clear a fixed false positive lint `clippy::unnecessary_sort_by`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
