### PR TITLE
refactor: I/O safety for unistd.rs

### DIFF
--- a/changelog/2440.changed.md
+++ b/changelog/2440.changed.md
@@ -1,0 +1,1 @@
+Module unistd now adopts I/O safety.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -13,8 +13,6 @@ use std::ffi::CStr;
 use std::ffi::OsString;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 use std::ops::{Deref, DerefMut};
-#[cfg(not(target_os = "redox"))]
-use std::os::raw;
 use std::os::unix::ffi::OsStringExt;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 use std::os::unix::io::OwnedFd;
@@ -234,12 +232,8 @@ libc_bitflags!(
 );
 
 /// Computes the raw fd consumed by a function of the form `*at`.
-#[cfg(any(
-    all(feature = "fs", not(target_os = "redox")),
-    all(feature = "process", linux_android),
-    all(feature = "fanotify", target_os = "linux")
-))]
-pub(crate) fn at_rawfd(fd: Option<RawFd>) -> raw::c_int {
+#[cfg(all(feature = "fanotify", target_os = "linux"))]
+pub(crate) fn at_rawfd(fd: Option<RawFd>) -> RawFd {
     fd.unwrap_or(libc::AT_FDCWD)
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -36,7 +36,7 @@ impl<'fd> PollFd<'fd> {
     /// let mut fds = [pfd];
     /// poll(&mut fds, PollTimeout::NONE).unwrap();
     /// let mut buf = [0u8; 80];
-    /// read(r.as_raw_fd(), &mut buf[..]);
+    /// read(&r, &mut buf[..]);
     /// ```
     // Unlike I/O functions, constructors like this must take `BorrowedFd`
     // instead of AsFd or &AsFd.  Otherwise, an `OwnedFd` argument would be

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -73,7 +73,7 @@ impl IntoRawFd for PtyMaster {
 
 impl io::Read for PtyMaster {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        unistd::read(self.0.as_raw_fd(), buf).map_err(io::Error::from)
+        unistd::read(&self.0, buf).map_err(io::Error::from)
     }
 }
 
@@ -88,7 +88,7 @@ impl io::Write for PtyMaster {
 
 impl io::Read for &PtyMaster {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        unistd::read(self.0.as_raw_fd(), buf).map_err(io::Error::from)
+        unistd::read(&self.0, buf).map_err(io::Error::from)
     }
 }
 

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -252,7 +252,11 @@ impl Drop for FanotifyEvent {
         if self.0.fd == libc::FAN_NOFD {
             return;
         }
-        let e = close(self.0.fd);
+        // SAFETY:
+        //
+        // If this fd is not `FAN_NOFD`, then it should be a valid, owned file
+        // descriptor, which means we can safely close it.
+        let e = unsafe { close(self.0.fd) };
         if !std::thread::panicking() && e == Err(Errno::EBADF) {
             panic!("Closing an invalid file descriptor!");
         };
@@ -362,7 +366,7 @@ impl Fanotify {
         let mut events = Vec::new();
         let mut offset = 0;
 
-        let nread = read(self.fd.as_raw_fd(), &mut buffer)?;
+        let nread = read(&self.fd, &mut buffer)?;
 
         while (nread - offset) >= metadata_size {
             let metadata = unsafe {

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -201,7 +201,7 @@ impl Inotify {
         let mut events = Vec::new();
         let mut offset = 0;
 
-        let nread = read(self.fd.as_raw_fd(), &mut buffer)?;
+        let nread = read(&self.fd, &mut buffer)?;
 
         while (nread - offset) >= header_size {
             let event = unsafe {

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -208,7 +208,7 @@ impl TimerFd {
     ///
     /// Note: If the alarm is unset, then you will wait forever.
     pub fn wait(&self) -> Result<()> {
-        while let Err(e) = read(self.fd.as_fd().as_raw_fd(), &mut [0u8; 8]) {
+        while let Err(e) = read(&self.fd, &mut [0u8; 8]) {
             if e == Errno::ECANCELED {
                 break;
             }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -429,7 +429,6 @@ feature! {
 /// * [`dup2()`]
 /// * [`dup2_raw()`]
 /// * [`dup3()`]
-/// * [`dup3_raw()`]
 #[inline]
 pub fn dup<Fd: std::os::fd::AsFd>(oldfd: Fd) -> Result<std::os::fd::OwnedFd> {
     use std::os::fd::AsRawFd;
@@ -445,6 +444,7 @@ pub fn dup<Fd: std::os::fd::AsFd>(oldfd: Fd) -> Result<std::os::fd::OwnedFd> {
 }
 
 /// Duplicate `fd` with stdin.
+#[inline]
 pub fn dup2_stdin<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
     use std::os::fd::AsRawFd;
     use libc::STDIN_FILENO;
@@ -454,6 +454,7 @@ pub fn dup2_stdin<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
 }
 
 /// Duplicate `fd` with stdout.
+#[inline]
 pub fn dup2_stdout<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
     use std::os::fd::AsRawFd;
     use libc::STDOUT_FILENO;
@@ -463,6 +464,7 @@ pub fn dup2_stdout<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
 }
 
 /// Duplicate `fd` with stderr.
+#[inline]
 pub fn dup2_stderr<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
     use std::os::fd::AsRawFd;
     use libc::STDERR_FILENO;
@@ -478,7 +480,8 @@ pub fn dup2_stderr<Fd: std::os::fd::AsFd>(fd: Fd) -> Result<()> {
 /// more detail on the exact behavior of this function.
 ///
 /// This function does not allow you to duplicate `oldfd` with any file descriptor
-/// you want, to do that, use [`dup2_raw()`].
+/// you want, to do that, use [`dup2_raw()`]#[inline]
+.
 ///
 /// # Reference
 ///

--- a/test/sys/test_memfd.rs
+++ b/test/sys/test_memfd.rs
@@ -5,7 +5,6 @@ fn test_memfd_create() {
     use nix::unistd::lseek;
     use nix::unistd::read;
     use nix::unistd::{write, Whence};
-    use std::os::fd::{AsFd, AsRawFd};
 
     let fd =
         memfd_create("test_memfd_create_name", MemFdCreateFlag::MFD_CLOEXEC)

--- a/test/sys/test_memfd.rs
+++ b/test/sys/test_memfd.rs
@@ -11,12 +11,12 @@ fn test_memfd_create() {
         memfd_create("test_memfd_create_name", MemFdCreateFlag::MFD_CLOEXEC)
             .unwrap();
     let contents = b"hello";
-    assert_eq!(write(fd.as_fd(), contents).unwrap(), 5);
+    assert_eq!(write(&fd, contents).unwrap(), 5);
 
-    lseek(fd.as_raw_fd(), 0, Whence::SeekSet).unwrap();
+    lseek(&fd, 0, Whence::SeekSet).unwrap();
 
     let mut buf = vec![0_u8; contents.len()];
-    assert_eq!(read(fd.as_raw_fd(), &mut buf).unwrap(), 5);
+    assert_eq!(read(&fd, &mut buf).unwrap(), 5);
 
     assert_eq!(contents, buf.as_slice());
 }

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1693,7 +1693,7 @@ pub fn test_named_unixdomain() {
     // It should be safe considering that s3 will be open within this test
     let s3 = unsafe { std::os::fd::BorrowedFd::borrow_raw(s3) };
     let mut buf = [0; 5];
-    read(&s3, &mut buf).unwrap();
+    read(s3, &mut buf).unwrap();
     thr.join().unwrap();
 
     assert_eq!(&buf[..], b"hello");

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -321,7 +321,7 @@ pub fn test_socketpair() {
     .unwrap();
     write(&fd1, b"hello").unwrap();
     let mut buf = [0; 5];
-    read(fd2.as_raw_fd(), &mut buf).unwrap();
+    read(&fd2, &mut buf).unwrap();
 
     assert_eq!(&buf[..], b"hello");
 }
@@ -908,9 +908,15 @@ pub fn test_scm_rights() {
     // Ensure that the received file descriptor works
     write(&w, b"world").unwrap();
     let mut buf = [0u8; 5];
-    read(received_r.as_raw_fd(), &mut buf).unwrap();
+    // SAFETY:
+    // should be safe since we don't use it after close
+    let borrowed_received_r =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(received_r) };
+    read(borrowed_received_r, &mut buf).unwrap();
     assert_eq!(&buf[..], b"world");
-    close(received_r).unwrap();
+    // SAFETY:
+    // there shouldn't be double close
+    unsafe { close(received_r).unwrap() };
 }
 
 // Disable the test on emulated platforms due to not enabled support of AF_ALG in QEMU from rust cross
@@ -975,8 +981,12 @@ pub fn test_af_alg_cipher() {
 
     // allocate buffer for encrypted data
     let mut encrypted = vec![0u8; payload_len];
+    // SAFETY:
+    // should be safe since session_socket won't be closed before the use of this borrowed one
+    let borrowed_session_socket =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(session_socket.as_raw_fd(), &mut encrypted).expect("read encrypt");
+        read(borrowed_session_socket, &mut encrypted).expect("read encrypt");
     assert_eq!(num_bytes, payload_len);
 
     let iov = IoSlice::new(&encrypted);
@@ -998,8 +1008,12 @@ pub fn test_af_alg_cipher() {
 
     // allocate buffer for decrypted data
     let mut decrypted = vec![0u8; payload_len];
+    // SAFETY:
+    // should be safe since session_socket won't be closed before the use of this borrowed one
+    let borrowed_session_socket =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(session_socket.as_raw_fd(), &mut decrypted).expect("read decrypt");
+        read(borrowed_session_socket, &mut decrypted).expect("read decrypt");
 
     assert_eq!(num_bytes, payload_len);
     assert_eq!(decrypted, payload);
@@ -1087,8 +1101,12 @@ pub fn test_af_alg_aead() {
     // allocate buffer for encrypted data
     let mut encrypted =
         vec![0u8; (assoc_size as usize) + payload_len + auth_size];
+    // SAFETY:
+    // should be safe since session_socket won't be closed before the use of this borrowed one
+    let borrowed_session_socket =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(session_socket.as_raw_fd(), &mut encrypted).expect("read encrypt");
+        read(borrowed_session_socket, &mut encrypted).expect("read encrypt");
     assert_eq!(num_bytes, payload_len + auth_size + (assoc_size as usize));
 
     for i in 0..assoc_size {
@@ -1131,8 +1149,7 @@ pub fn test_af_alg_aead() {
         unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     fcntl(borrowed_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
         .expect("fcntl non_blocking");
-    let num_bytes =
-        read(session_socket.as_raw_fd(), &mut decrypted).expect("read decrypt");
+    let num_bytes = read(borrowed_fd, &mut decrypted).expect("read decrypt");
 
     assert!(num_bytes >= payload_len + (assoc_size as usize));
     assert_eq!(
@@ -1622,9 +1639,15 @@ fn test_impl_scm_credentials_and_rights(
     // Ensure that the received file descriptor works
     write(&w, b"world").unwrap();
     let mut buf = [0u8; 5];
-    read(received_r.as_raw_fd(), &mut buf).unwrap();
+    // SAFETY:
+    // It should be safe if we don't use this BorrowedFd after close.
+    let received_r_borrowed =
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(received_r) };
+    read(received_r_borrowed, &mut buf).unwrap();
     assert_eq!(&buf[..], b"world");
-    close(received_r).unwrap();
+    // SAFETY:
+    // double-close won't happen
+    unsafe { close(received_r).unwrap() };
 
     Ok(())
 }
@@ -1666,8 +1689,11 @@ pub fn test_named_unixdomain() {
 
     let s3 = accept(s1.as_raw_fd()).expect("accept failed");
 
+    // SAFETY:
+    // It should be safe considering that s3 will be open within this test
+    let s3 = unsafe { std::os::fd::BorrowedFd::borrow_raw(s3) };
     let mut buf = [0; 5];
-    read(s3.as_raw_fd(), &mut buf).unwrap();
+    read(&s3, &mut buf).unwrap();
     thr.join().unwrap();
 
     assert_eq!(&buf[..], b"hello");

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,4 +1,4 @@
-use std::os::unix::io::{AsFd, AsRawFd};
+use std::os::unix::io::AsFd;
 use tempfile::tempfile;
 
 use nix::errno::Errno;
@@ -100,7 +100,7 @@ fn test_local_flags() {
     let pty = openpty(None, &termios).unwrap();
 
     // Set the master is in nonblocking mode or reading will never return.
-    let flags = fcntl::fcntl(pty.master.as_fd(), fcntl::F_GETFL).unwrap();
+    let flags = fcntl::fcntl(&pty.master, fcntl::F_GETFL).unwrap();
     let new_flags =
         fcntl::OFlag::from_bits_truncate(flags) | fcntl::OFlag::O_NONBLOCK;
     fcntl::fcntl(pty.master.as_fd(), fcntl::F_SETFL(new_flags)).unwrap();
@@ -111,6 +111,6 @@ fn test_local_flags() {
 
     // Try to read from the master, which should not have anything as echoing was disabled.
     let mut buf = [0u8; 10];
-    let read = read(pty.master.as_raw_fd(), &mut buf).unwrap_err();
+    let read = read(&pty.master, &mut buf).unwrap_err();
     assert_eq!(read, Errno::EAGAIN);
 }

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -4,7 +4,6 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::fs::OpenOptions;
 use std::io::IoSlice;
-use std::os::unix::io::AsRawFd;
 use std::{cmp, iter};
 
 #[cfg(not(target_os = "redox"))]
@@ -49,7 +48,7 @@ fn test_writev() {
     let written = write_res.expect("couldn't write");
     // Check whether we written all data
     assert_eq!(to_write.len(), written);
-    let read_res = read(reader.as_raw_fd(), &mut read_buf[..]);
+    let read_res = read(&reader, &mut read_buf[..]);
     let read = read_res.expect("couldn't read");
     // Check we have read as much as we written
     assert_eq!(read, written);
@@ -228,7 +227,6 @@ fn test_process_vm_readv() {
     use nix::sys::signal::*;
     use nix::sys::wait::*;
     use nix::unistd::ForkResult::*;
-    use std::os::unix::io::AsRawFd;
 
     require_capability!("test_process_vm_readv", CAP_SYS_PTRACE);
     let _m = crate::FORK_MTX.lock();
@@ -242,7 +240,7 @@ fn test_process_vm_readv() {
         Parent { child } => {
             drop(w);
             // wait for child
-            read(r.as_raw_fd(), &mut [0u8]).unwrap();
+            read(&r, &mut [0u8]).unwrap();
             drop(r);
 
             let ptr = vector.as_ptr() as usize;

--- a/test/test.rs
+++ b/test/test.rs
@@ -38,7 +38,7 @@ mod test_unistd;
 
 use nix::unistd::{chdir, getcwd, read};
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
-use std::os::unix::io::{AsFd, AsRawFd};
+use std::os::unix::io::AsFd;
 use std::path::PathBuf;
 
 /// Helper function analogous to `std::io::Read::read_exact`, but for `Fd`s
@@ -47,7 +47,7 @@ fn read_exact<Fd: AsFd>(f: Fd, buf: &mut [u8]) {
     while len < buf.len() {
         // get_mut would be better than split_at_mut, but it requires nightly
         let (_, remaining) = buf.split_at_mut(len);
-        len += read(f.as_fd().as_raw_fd(), remaining).unwrap();
+        len += read(&f, remaining).unwrap();
     }
 }
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -37,8 +37,6 @@ use tempfile::NamedTempFile;
 // https://gitlab.com/qemu-project/qemu/-/issues/829
 #[cfg_attr(qemu, ignore)]
 fn test_openat() {
-    use std::os::fd::AsRawFd;
-
     const CONTENTS: &[u8] = b"abcd";
     let mut tmp = NamedTempFile::new().unwrap();
     tmp.write_all(CONTENTS).unwrap();
@@ -55,7 +53,7 @@ fn test_openat() {
     .unwrap();
 
     let mut buf = [0u8; 1024];
-    assert_eq!(4, read(fd.as_raw_fd(), &mut buf).unwrap());
+    assert_eq!(4, read(&fd, &mut buf).unwrap());
     assert_eq!(CONTENTS, &buf[0..4]);
 }
 
@@ -65,8 +63,6 @@ fn test_openat() {
 // https://gitlab.com/qemu-project/qemu/-/issues/829
 #[cfg_attr(qemu, ignore)]
 fn test_openat2() {
-    use std::os::fd::AsRawFd;
-
     const CONTENTS: &[u8] = b"abcd";
     let mut tmp = NamedTempFile::new().unwrap();
     tmp.write_all(CONTENTS).unwrap();
@@ -86,7 +82,7 @@ fn test_openat2() {
     .unwrap();
 
     let mut buf = [0u8; 1024];
-    assert_eq!(4, read(fd.as_raw_fd(), &mut buf).unwrap());
+    assert_eq!(4, read(&fd, &mut buf).unwrap());
     assert_eq!(CONTENTS, &buf[0..4]);
 }
 
@@ -316,8 +312,6 @@ mod linux_android {
 
     #[test]
     fn test_splice() {
-        use std::os::fd::AsRawFd;
-
         const CONTENTS: &[u8] = b"abcdef123456";
         let mut tmp = tempfile().unwrap();
         tmp.write_all(CONTENTS).unwrap();
@@ -331,15 +325,13 @@ mod linux_android {
         assert_eq!(2, res);
 
         let mut buf = [0u8; 1024];
-        assert_eq!(2, read(rd.as_raw_fd(), &mut buf).unwrap());
+        assert_eq!(2, read(&rd, &mut buf).unwrap());
         assert_eq!(b"f1", &buf[0..2]);
         assert_eq!(7, offset);
     }
 
     #[test]
     fn test_tee() {
-        use std::os::fd::AsRawFd;
-
         let (rd1, wr1) = pipe().unwrap();
         let (rd2, wr2) = pipe().unwrap();
 
@@ -352,18 +344,16 @@ mod linux_android {
         let mut buf = [0u8; 1024];
 
         // Check the tee'd bytes are at rd2.
-        assert_eq!(2, read(rd2.as_raw_fd(), &mut buf).unwrap());
+        assert_eq!(2, read(&rd2, &mut buf).unwrap());
         assert_eq!(b"ab", &buf[0..2]);
 
         // Check all the bytes are still at rd1.
-        assert_eq!(3, read(rd1.as_raw_fd(), &mut buf).unwrap());
+        assert_eq!(3, read(&rd1, &mut buf).unwrap());
         assert_eq!(b"abc", &buf[0..3]);
     }
 
     #[test]
     fn test_vmsplice() {
-        use std::os::fd::AsRawFd;
-
         let (rd, wr) = pipe().unwrap();
 
         let buf1 = b"abcdef";
@@ -376,22 +366,20 @@ mod linux_android {
 
         // Check the bytes can be read at rd.
         let mut buf = [0u8; 32];
-        assert_eq!(6, read(rd.as_raw_fd(), &mut buf).unwrap());
+        assert_eq!(6, read(&rd, &mut buf).unwrap());
         assert_eq!(b"abcdef", &buf[0..6]);
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn test_fallocate() {
-        use std::os::fd::AsRawFd;
-
         let tmp = NamedTempFile::new().unwrap();
 
         fallocate(&tmp, FallocateFlags::empty(), 0, 100).unwrap();
 
         // Check if we read exactly 100 bytes
         let mut buf = [0u8; 200];
-        assert_eq!(100, read(tmp.as_raw_fd(), &mut buf).unwrap());
+        assert_eq!(100, read(&tmp, &mut buf).unwrap());
     }
 
     // The tests below are disabled for the listed targets

--- a/test/test_sendfile.rs
+++ b/test/test_sendfile.rs
@@ -7,7 +7,6 @@ use tempfile::tempfile;
 cfg_if! {
     if #[cfg(linux_android)] {
         use nix::unistd::{pipe, read};
-        use std::os::unix::io::AsRawFd;
     } else if #[cfg(any(freebsdlike, apple_targets, solarish))] {
         use std::net::Shutdown;
         use std::os::unix::net::UnixStream;
@@ -28,7 +27,7 @@ fn test_sendfile_linux() {
     assert_eq!(2, res);
 
     let mut buf = [0u8; 1024];
-    assert_eq!(2, read(rd.as_raw_fd(), &mut buf).unwrap());
+    assert_eq!(2, read(&rd, &mut buf).unwrap());
     assert_eq!(b"f1", &buf[0..2]);
     assert_eq!(7, offset);
 }
@@ -47,7 +46,7 @@ fn test_sendfile64_linux() {
     assert_eq!(2, res);
 
     let mut buf = [0u8; 1024];
-    assert_eq!(2, read(rd.as_raw_fd(), &mut buf).unwrap());
+    assert_eq!(2, read(&rd, &mut buf).unwrap());
     assert_eq!(b"f1", &buf[0..2]);
     assert_eq!(7, offset);
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -26,7 +26,6 @@ use std::ffi::CString;
 use std::fs::DirBuilder;
 use std::fs::{self, File};
 use std::io::Write;
-use std::os::unix::prelude::*;
 #[cfg(not(any(
     target_os = "fuchsia",
     target_os = "redox",
@@ -434,7 +433,7 @@ macro_rules! execve_test_factory (
 cfg_if! {
     if #[cfg(target_os = "android")] {
         execve_test_factory!(test_execve, execve, CString::new("/system/bin/sh").unwrap().as_c_str());
-        execve_test_factory!(test_fexecve, fexecve, File::open("/system/bin/sh").unwrap().into_raw_fd());
+        execve_test_factory!(test_fexecve, fexecve, &File::open("/system/bin/sh").unwrap());
     } else if #[cfg(any(freebsdlike, target_os = "linux", target_os = "hurd"))] {
         // These tests frequently fail on musl, probably due to
         // https://github.com/nix-rust/nix/issues/555
@@ -1246,6 +1245,8 @@ fn test_setfsuid() {
     target_os = "haiku"
 )))]
 fn test_ttyname() {
+    use std::os::fd::AsRawFd;
+
     let fd = posix_openpt(OFlag::O_RDWR).expect("posix_openpt failed");
     assert!(fd.as_raw_fd() > 0);
 


### PR DESCRIPTION
## What does this PR do

Add I/O safety to module unistd.

## File descriptor duplication

The safe interface for `dup2()` proposed in this PR looks like this:

```rs
pub fn dup2<Fd: AsFd>(oldfd: Fd, newfd: &mut OwnedFd) -> Result<()>
```

We take `newfd` by mutable reference so that we can ensure we have exclusive access. This interface stops users from specifying `newfd` with arbitrary fd values, `unsafe fn dup2_raw()` comes as a remedy:

```rs
pub unsafe fn dup2_raw<Fd1: AsFd, Fd2: IntoRawFd>(
    oldfd: Fd1,
    newfd: Fd2,
) -> Result<OwnedFd>
```

`dup2_raw()` is unsafe because when specifying a fd that is open, one has to ensure the returned `OwnedFd` is the ONLY owner of this fd, or a double close will happen.

![image](https://github.com/nix-rust/nix/assets/96880612/3ddf840e-546c-4943-bfa2-3c832efeabba)
 

Using the above `dup2()` interface for stdin/stdout/stderr redirection is troublesome, one has to construct an `OwnedFd` from stdin/stdout/stderr, then `mem::forget()` it. We provide 3 helper functions to make this easier:

```rs
pub fn dup2_stdin<Fd: AsFd>(fd: Fd) -> Result<()>
pub fn dup2_stdout<Fd: AsFd>(fd: Fd) -> Result<()>
pub fn dup2_stderr<Fd: AsFd>(fd: Fd) -> Result<()>
```

Since the only flag that can be used with `dup3()` is `O_CLOEXEC`, which does not make much sense to stdin/stdout/stderr, I didn't provide the dup3 versions of these utilities.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
