### PR TITLE
ci: disable Haiku

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,10 @@ jobs:
           # Temporarily disable armv7-unknown-linux-uclibceabihf
           # https://github.com/nix-rust/nix/issues/2200
           #- target: armv7-unknown-linux-uclibceabihf
-          - target: x86_64-unknown-haiku
+
+          # https://github.com/nix-rust/nix/issues/2441
+          # - target: x86_64-unknown-haiku
+
           # Disable hurd due to
           # https://github.com/nix-rust/nix/issues/2306
           # - target: i686-unknown-hurd-gnu


### PR DESCRIPTION
## What does this PR do

Rust std is broken on Haiku, we have to disable the Haiku CI until the issue is fixed.

Ref: #2441

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
