### PR TITLE
Add sigaction() versions that allow specify the signal by its number

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -945,8 +945,8 @@ pub unsafe fn sigaction_noretrieve(signal: libc::c_int, sigaction: &SigAction) -
                               std::ptr::null_mut()) };
 
     match Errno::result(res) {
-       Ok(_) => { return Ok(()); }
-       Err(e) => { return Err(e); }
+       Ok(_) => { Ok(()) }
+       Err(e) => { Err(e) }
     }
     
 }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -948,7 +948,7 @@ pub unsafe fn sigaction_noretrieve(signal: libc::c_int, sigaction: &SigAction) -
        Ok(_) => { Ok(()) }
        Err(e) => { Err(e) }
     }
-    
+
 }
 
 /// Signal management (see [signal(3p)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html))


### PR DESCRIPTION
Currently, the ```nix::sys::signal::sigaction()``` function uses the ```Signal``` enum, which only covers standard signals, but not real-time signals. Using real-time signals with ```nix``` requires using the ```std::mem::transmute()``` function to assign an impossible value to the ```Signal``` enum, which is [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html).

## What does this PR do

In this PR, I add two new functions: ```nix::sys::signal::sigaction_numeric()```, that uses signal numbers instead of the enum, and ```nix::sys::signal::sigaction_noretrieve()```, which also doesn't retrieve the old signal handler by supplying the null pointer as the ```oldact``` argument (to avoid trouble if the handler has been installed by the C code).

## Checklist:

- [yes] I have read `CONTRIBUTING.md`
- [yes] I have written necessary tests and rustdoc comments
- [?] A change log has been added if this PR modifies nix's API
