### PR TITLE
Making signal API real-time signal aware

### DIFF
--- a/changelog/2449.changed.md
+++ b/changelog/2449.changed.md
@@ -1,0 +1,4 @@
+This pull request adds a new enum **SignalValue** that allows specifying both standard signals and real-time signals. For most functions, a new "real-time signal aware" version was added (for instance, for **sigaction()**, the new function is called **rt_sigaction()**). However, there are two significant changes:
+
+* Turning **SigSet** into iterator now returns real-time signal aware **SignalSetIter** instead of the old **SigSetIter**
+* The **signal** field of the **SigevSignal** and **SigevThreadId** structs is now of real-time signal aware type **SignalValue** instead of the old **Signal** type

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1173,7 +1173,7 @@ pub fn aio_suspend(
 ///     0,      // priority
 ///     SigevNotify::SigevNone
 /// ));
-/// let sev = SigevNotify::SigevSignal { signal: Signal::SIGUSR2, si_value: 0 };
+/// let sev = SigevNotify::SigevSignal { signal: SignalValue::Standard(Signal::SIGUSR2), si_value: 0 };
 /// lio_listio(LioMode::LIO_NOWAIT, &mut[aiow.as_mut()], sev).unwrap();
 /// while !SIGNALED.load(Ordering::Relaxed) {
 ///     thread::sleep(time::Duration::from_millis(10));

--- a/src/sys/timer.rs
+++ b/src/sys/timer.rs
@@ -12,7 +12,7 @@
 //! Create an interval timer that signals SIGALARM every 250 milliseconds.
 //!
 //! ```no_run
-//! use nix::sys::signal::{self, SigEvent, SigHandler, SigevNotify, Signal};
+//! use nix::sys::signal::{self, SigEvent, SigHandler, SigevNotify, Signal, SignalValue};
 //! use nix::sys::timer::{Expiration, Timer, TimerSetTimeFlags};
 //! use nix::time::ClockId;
 //! use std::convert::TryFrom;
@@ -33,7 +33,7 @@
 //! fn main() {
 //!     let clockid = ClockId::CLOCK_MONOTONIC;
 //!     let sigevent = SigEvent::new(SigevNotify::SigevSignal {
-//!         signal: SIG,
+//!         signal: SignalValue::Standard(SIG),
 //!         si_value: 0,
 //!     });
 //!

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -14,7 +14,7 @@ use nix::{
         aio::*,
         signal::{
             sigaction, SaFlags, SigAction, SigHandler, SigSet, SigevNotify,
-            Signal,
+            Signal, SignalValue,
         },
         time::{TimeSpec, TimeValLike},
     },
@@ -51,7 +51,7 @@ mod aio_fsync {
             AioFsyncMode::O_SYNC,
             42,
             SigevNotify::SigevSignal {
-                signal: Signal::SIGUSR2,
+                signal: SignalValue::Standard(Signal::SIGUSR2),
                 si_value: 99,
             },
         );
@@ -114,7 +114,7 @@ mod aio_read {
             &mut rbuf,
             42, //priority
             SigevNotify::SigevSignal {
-                signal: Signal::SIGUSR2,
+                signal: SignalValue::Standard(Signal::SIGUSR2),
                 si_value: 99,
             },
         );
@@ -303,7 +303,7 @@ mod aio_write {
             &wbuf,
             42, //priority
             SigevNotify::SigevSignal {
-                signal: Signal::SIGUSR2,
+                signal: SignalValue::Standard(Signal::SIGUSR2),
                 si_value: 99,
             },
         );
@@ -536,7 +536,7 @@ fn sigev_signal() {
             WBUF,
             0, //priority
             SigevNotify::SigevSignal {
-                signal: Signal::SIGUSR2,
+                signal: SignalValue::Standard(Signal::SIGUSR2),
                 si_value: 0, //TODO: validate in sigfunc
             },
         ));

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -146,7 +146,7 @@ fn test_signal() {
 #[test]
 fn test_contains() {
     let mut mask = SigSet::empty();
-    mask.add(SIGUSR1);
+    mask.rt_add(SignalValue::Standard(SIGUSR1)).unwrap();
 
     assert!(mask.contains(SIGUSR1));
     assert!(!mask.contains(SIGUSR2));
@@ -154,6 +154,19 @@ fn test_contains() {
     let all = SigSet::all();
     assert!(all.contains(SIGUSR1));
     assert!(all.contains(SIGUSR2));
+}
+
+#[test]
+fn test_rt_contains() {
+    let mut mask = SigSet::empty();
+    mask.add(SIGUSR1);
+
+    assert!(mask.rt_contains(SignalValue::Standard(SIGUSR1)));
+    assert!(!mask.rt_contains(SignalValue::Standard(SIGUSR2)));
+
+    let all = SigSet::all();
+    assert!(mask.rt_contains(SignalValue::Standard(SIGUSR1)));
+    assert!(all.rt_contains(SignalValue::Standard(SIGUSR2)));
 }
 
 #[test]
@@ -188,6 +201,19 @@ fn test_extend() {
 
     let mut two_signals = SigSet::empty();
     two_signals.add(SIGUSR2);
+    two_signals.extend(&one_signal);
+
+    assert!(two_signals.contains(SIGUSR1));
+    assert!(two_signals.contains(SIGUSR2));
+}
+
+#[test]
+fn test_extend_rt() {
+    let mut one_signal = SigSet::empty();
+    one_signal.rt_add(SignalValue::Standard(SIGUSR1)).unwrap();
+
+    let mut two_signals = SigSet::empty();
+    one_signal.rt_add(SignalValue::Standard(SIGUSR2)).unwrap();
     two_signals.extend(&one_signal);
 
     assert!(two_signals.contains(SIGUSR1));
@@ -275,9 +301,18 @@ fn test_thread_signal_swap() {
 
 #[test]
 fn test_from_and_into_iterator() {
-    let sigset = SigSet::from_iter(vec![Signal::SIGUSR1, Signal::SIGUSR2]);
-    let signals = sigset.into_iter().collect::<Vec<Signal>>();
-    assert_eq!(signals, [Signal::SIGUSR1, Signal::SIGUSR2]);
+    let sigset = SigSet::from_iter(vec![
+        SignalValue::Standard(Signal::SIGUSR1),
+        SignalValue::Standard(Signal::SIGUSR2),
+    ]);
+    let signals = sigset.into_iter().collect::<Vec<SignalValue>>();
+    assert_eq!(
+        signals,
+        [
+            SignalValue::Standard(Signal::SIGUSR1),
+            SignalValue::Standard(Signal::SIGUSR2)
+        ]
+    );
 }
 
 #[test]
@@ -338,6 +373,22 @@ fn test_sigwait() {
 
         raise(SIGUSR1).unwrap();
         assert_eq!(mask.wait().unwrap(), SIGUSR1);
+    })
+    .join()
+    .unwrap();
+}
+
+#[test]
+#[cfg(not(target_os = "redox"))]
+fn test_rt_sigwait() {
+    thread::spawn(|| {
+        let mut mask = SigSet::empty();
+        mask.rt_add(SignalValue::Standard(SIGUSR1)).unwrap();
+        mask.rt_add(SignalValue::Standard(SIGUSR2)).unwrap();
+        mask.thread_block().unwrap();
+
+        raise_signal(SignalValue::Standard(SIGUSR1)).unwrap();
+        assert_eq!(mask.rt_wait().unwrap(), SignalValue::Standard(SIGUSR1));
     })
     .join()
     .unwrap();

--- a/test/sys/test_timer.rs
+++ b/test/sys/test_timer.rs
@@ -1,6 +1,6 @@
 use nix::sys::signal::{
-    sigaction, SaFlags, SigAction, SigEvent, SigHandler, SigSet, SigevNotify,
-    Signal,
+    rt_sigaction, sigaction, SaFlags, SigAction, SigEvent, SigHandler, SigSet,
+    SigevNotify, Signal, SignalValue,
 };
 use nix::sys::timer::{Expiration, Timer, TimerSetTimeFlags};
 use nix::time::ClockId;
@@ -9,12 +9,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
-const SIG: Signal = Signal::SIGALRM;
+const SIG: SignalValue = SignalValue::Standard(Signal::SIGALRM);
 static ALARM_CALLED: AtomicBool = AtomicBool::new(false);
 
 pub extern "C" fn handle_sigalarm(raw_signal: libc::c_int) {
     let signal = Signal::try_from(raw_signal).unwrap();
-    if signal == SIG {
+    if SignalValue::Standard(signal) == SIG {
         ALARM_CALLED.store(true, Ordering::Release);
     }
 }
@@ -36,7 +36,7 @@ fn alarm_fires() {
     let signal_action =
         SigAction::new(handler, SaFlags::SA_RESTART, SigSet::empty());
     let old_handler = unsafe {
-        sigaction(SIG, &signal_action)
+        rt_sigaction(SIG, &signal_action)
             .expect("unable to set signal handler for alarm")
     };
 
@@ -97,6 +97,7 @@ fn alarm_fires() {
     drop(timer);
     thread::sleep(TIMER_PERIOD);
     unsafe {
-        sigaction(SIG, &old_handler).expect("unable to reset signal handler");
+        rt_sigaction(SIG, &old_handler)
+            .expect("unable to reset signal handler");
     }
 }


### PR DESCRIPTION
Currently, the ```nix::sys::signal::sigaction()``` function uses the ```Signal``` enum, which only covers standard signals, but not real-time signals. Using real-time signals with ```nix``` requires using the ```std::mem::transmute()``` function to assign an impossible value to the ```Signal``` enum, which is [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html) (and is unsafe for any other use than passing to ```nix``` functions, and possible even then).

## What does this PR do

In this PR, the ```nix::sys::signal``` API is made real-time signal aware by adding the new enum ```SignalValue``` that has two variants: ```Standard``` that takes ```Signal``` values, and ```Realtime```, that takes real-time signal numbers ```SIGRTMIN+n```, where ```n``` is the passed number. Most of the functions are left untouched, instead, real-time signal aware versions of the were added with the ```rt_``` prefix (similar to the real-time signal aware system calls in the Linux kernel that glibc uses instead of the old system calls). However, two significant changes have been made: turning ```SigSet``` into iterator returns a ```SignalSetIter``` instead of real-time signal unaware ```SigSetIter```, and the ```signal``` field of structs ```SigevSignal``` and ```SigevThreadId``` takes the new enum instead of the old one.

## Checklist:

- [yes] I have read `CONTRIBUTING.md`
- [yes] I have written necessary tests and rustdoc comments
- [yes] A change log has been added if this PR modifies nix's API
