### PR TITLE
refactor: remove EventFd::defuse() and EventFd::arm()

### DIFF
--- a/changelog/2452.removed.md
+++ b/changelog/2452.removed.md
@@ -1,0 +1,1 @@
+`EventFd::defuse()` is removed because it does nothing, `EventFd::arm()` is also removed for symmetry reasons.

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -88,7 +88,7 @@ impl EpollEvent {
 /// epoll.add(&eventfd, EpollEvent::new(EpollFlags::EPOLLIN,DATA))?;
 ///
 /// // Arm eventfd & Time wait
-/// eventfd.arm()?;
+/// eventfd.write(1)?;
 /// let now = Instant::now();
 ///
 /// // Wait on event

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -58,20 +58,6 @@ impl EventFd {
         Self::from_value_and_flags(init_val, EfdFlags::empty())
     }
 
-    /// Arms `self`, a following call to `poll`, `select` or `epoll` will return immediately.
-    ///
-    /// [`EventFd::write`] with `1`.
-    pub fn arm(&self) -> Result<usize> {
-        self.write(1)
-    }
-
-    /// Defuses `self`, a following call to `poll`, `select` or `epoll` will block.
-    ///
-    /// [`EventFd::write`] with `0`.
-    pub fn defuse(&self) -> Result<usize> {
-        self.write(0)
-    }
-
     /// Enqueues `value` triggers, i.e., adds the integer value supplied in `value`
     /// to the counter.
     ///


### PR DESCRIPTION
## What does this PR do

1. Remove `EventFd::defuse()` because it is a no-op, `write(0)`ing to an event fd does nothing. While in the documentation, it says:
   
    > a following call to `poll`, `select` or `epoll` will block.

    which means that this method should reset the kernel counter to 0, but it won't.    

2. Remove `EventFd::arm()` for symmetry reasons.

Having `read()/write()` is already sufficient for usage. 


Closes #2422

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
