### PR TITLE
Fix the build with -Zdirect-minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: setup 
-        run: cargo update -Zminimal-versions
+        run: cargo update -Zdirect-minimal-versions
 
       - name: check
         run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ targets = [
 
 [dependencies]
 libc = { version = "0.2.155", features = ["extra_traits"] }
-bitflags = "2.3.1"
+bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
 memoffset = { version = "0.9", optional = true }


### PR DESCRIPTION
The difference between -Zminimal-versions and -Zdirect-minimal-versions is subtle.  But the important point is that with the former, a new release published by one of our dependencies can cause our CI to fail. With the latter, it cannot.  That's why I think it's better to test with the latter.