### PR TITLE
Disable unsupported signals on sparc-linux

### DIFF
--- a/changelog/2454.fixed.md
+++ b/changelog/2454.fixed.md
@@ -1,0 +1,1 @@
+Disable unsupported signals on sparc-linux

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -67,6 +67,7 @@ libc_enum! {
                           target_arch = "mips32r6",
                           target_arch = "mips64",
                           target_arch = "mips64r6",
+                          target_arch = "sparc",
                           target_arch = "sparc64"))))]
         SIGSTKFLT,
         /// To parent on child stop or exit
@@ -147,6 +148,7 @@ impl FromStr for Signal {
                     target_arch = "mips32r6",
                     target_arch = "mips64",
                     target_arch = "mips64r6",
+                    target_arch = "sparc",
                     target_arch = "sparc64"
                 ))
             ))]
@@ -229,6 +231,7 @@ impl Signal {
                     target_arch = "mips32r6",
                     target_arch = "mips64",
                     target_arch = "mips64r6",
+                    target_arch = "sparc",
                     target_arch = "sparc64"
                 ))
             ))]
@@ -316,6 +319,7 @@ const SIGNALS: [Signal; 28] = [
         target_arch = "mips32r6",
         target_arch = "mips64",
         target_arch = "mips64r6",
+        target_arch = "sparc",
         target_arch = "sparc64"
     ))
 ))]
@@ -333,6 +337,7 @@ const SIGNALS: [Signal; 31] = [
         target_arch = "mips32r6",
         target_arch = "mips64",
         target_arch = "mips64r6",
+        target_arch = "sparc",
         target_arch = "sparc64"
     )
 ))]


### PR DESCRIPTION
This PR fixes building `nix` on sparc-linux by disabling unsupported signals.

The unsupported signals match those of sparc64-linux.