### PR TITLE
Fix cmsg_len() return type on OpenHarmony

### DIFF
--- a/changelog/2456.fixed.md
+++ b/changelog/2456.fixed.md
@@ -1,0 +1,1 @@
+Fix cmsg_len() return type on OpenHarmony

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1169,13 +1169,13 @@ impl<'a> ControlMessage<'a> {
     /// The value of CMSG_LEN on this message.
     /// Safe because CMSG_LEN is always safe
     #[cfg(any(target_os = "android",
-              all(target_os = "linux", not(target_env = "musl"))))]
+              all(target_os = "linux", not(any(target_env = "musl", target_env = "ohos")))))]
     fn cmsg_len(&self) -> usize {
         unsafe{CMSG_LEN(self.len() as libc::c_uint) as usize}
     }
 
     #[cfg(not(any(target_os = "android",
-                  all(target_os = "linux", not(target_env = "musl")))))]
+              all(target_os = "linux", not(any(target_env = "musl", target_env = "ohos"))))))]
     fn cmsg_len(&self) -> libc::c_uint {
         unsafe{CMSG_LEN(self.len() as libc::c_uint)}
     }


### PR DESCRIPTION
## What does this PR do

`target_env = "ohos"` (OpenHarmony) uses a musl based libc. Fixes a compilation failure when targeting `aarch64-unknown-linux-ohos`:

```
error[E0308]: mismatched types
    --> /home/jschwender/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.29.0/src/sys/socket/mod.rs:1415:32
     |
1415 |             (*cmsg).cmsg_len = self.cmsg_len();
     |             ----------------   ^^^^^^^^^^^^^^^ expected `u32`, found `usize`
     |             |
     |             expected due to the type of this binding
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
