### PR TITLE
Change: api revisions for zero-alloc sendmmsg and recvmmsg

### DIFF
--- a/changelog/2459.changed.md
+++ b/changelog/2459.changed.md
@@ -1,0 +1,1 @@
+Change generics on `recvmmsg` and `sendmmsg` to support memory reuse.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1506,7 +1506,7 @@ pub fn sendmmsg<'a, XS, AS, C, I, S>(
     flags: MsgFlags
 ) -> crate::Result<MultiResults<'a, S>>
     where
-        XS: IntoIterator<Item = &'a I>,
+        XS: IntoIterator<Item = I>,
         AS: AsRef<[Option<S>]>,
         I: AsRef<[IoSlice<'a>]> + 'a,
         C: AsRef<[ControlMessage<'a>]> + 'a,
@@ -1657,11 +1657,11 @@ pub fn recvmmsg<'a, XS, S, I>(
     mut timeout: Option<crate::sys::time::TimeSpec>,
 ) -> crate::Result<MultiResults<'a, S>>
 where
-    XS: IntoIterator<Item = &'a mut I>,
+    XS: IntoIterator<Item = I>,
     I: AsMut<[IoSliceMut<'a>]> + 'a,
 {
     let mut count = 0;
-    for (i, (slice, mmsghdr)) in slices.into_iter().zip(data.items.iter_mut()).enumerate() {
+    for (i, (mut slice, mmsghdr)) in slices.into_iter().zip(data.items.iter_mut()).enumerate() {
         let p = &mut mmsghdr.msg_hdr;
         p.msg_iov = slice.as_mut().as_mut_ptr().cast();
         p.msg_iovlen = slice.as_mut().len() as _;


### PR DESCRIPTION
## Change *mmsg to support memory reuse

In short, these changes adjust the generics on `sendmmsg` and `recvmmsg` so that both can be used in a loop without requiring new heap allocations from the caller on each iteration.

### Motivation 
First, thanks much to the maintainers of this library. It's very solid, and I use it heavily. However, with some frustration, I've been unable to find a way to use `sendmmsg` and `recvmmsg` in a loop without making any heap allocations. If someone knows how to with the current API, please just show me a compiling example and I'll close this PR. Otherwise, here's the issue as I understand it. I'll use `sendmmsg` for analysis, but both have the same issue:

Current:
```rust
pub fn sendmmsg<'a, XS, AS, C, I, S>(
..
    slices: XS,
..
) -> crate::Result<MultiResults<'a, S>>
    where
        XS: IntoIterator<Item = &'a I>,
..
        I: AsRef<[IoSlice<'a>]> + 'a,
..
{
```

Proposed:
```rust
pub fn sendmmsg<'a, XS, AS, C, I, S>(
..
    slices: XS,
..
) -> crate::Result<MultiResults<'a, S>>
    where
        XS: IntoIterator<Item = I>,
..
        I: AsRef<[IoSlice<'a>]> + 'a,
..
{
```

`sendmmsg` requires its buffers to be wrapped in an `IoSlice`. Because `IoSlice` takes the lifetime of the buffer it wraps, the underlying buffer cannot be mutated until the `IoSlice` is dropped. So, if the buffer allocation is reused between calls to `sendmmsg`, then the `IoSlice` needs to be dropped. If there's a non-constant number of `IoSlices`, then they need to be in an iterator or some dynamic collection. 

Because `I` is borrowed in the signature, the `IoSlice` cannot be produced by an iterator because a reference cannot be returned to an `IoSlice` created within the same iterator. That basically mandates that  the`IoSlice` instances are collected into a `Vec` before `sendmmsg` is called. 

However, I don't think a reference is actually needed here. Making `I` an `&'a AsRef<_>` is redundant because we use `AsRef` to borrow the data anyway. My changes remove the borrow over `I` from `sendmmsg` and `recvmmsg`. This allows the `IoSlice` and `IoSliceMut` instances to be yielded from an iterator instead of a heap-allocated collection, which gives a meaningful performance boost to my code using these functions.

Also, I noticed someone else recently made an issue related to this. Perhaps this would satisfy them as well? #2457 

### Validation

I made a small repo to demo my use case and how these changes help. It can be found here: https://github.com/cfzimmerman/nix-alloc-demo/blob/main/src/lib.rs

The important part is this comparison in extension of the example above.

Using the current API:
```rust
    pub fn send(
        fd: i32,
        hdrs: &mut MultiHeaders<SockaddrStorage>,
        bufs: &[([u8; 32], Vec<u8>)],
        addrs: &[Option<SockaddrStorage>],
    ) -> anyhow::Result<usize> {
        let slices: Vec<_> = bufs
            .iter()
            .map(|(buf1, buf2)| [IoSlice::new(buf1), IoSlice::new(buf2)])
            .collect();
        Ok(sendmmsg(fd, hdrs, &slices, addrs, [], MsgFlags::empty())?.count())
    }
```

Using the proposed API:
```rust
    pub fn send(
        fd: i32,
        hdrs: &mut MultiHeaders<SockaddrStorage>,
        bufs: &[([u8; 32], Vec<u8>)],
        addrs: &[Option<SockaddrStorage>],
    ) -> anyhow::Result<usize> {
        let slices = bufs
            .iter()
            .map(|(buf1, buf2)| [IoSlice::new(buf1), IoSlice::new(buf2)]);
        Ok(sendmmsg(fd, hdrs, slices, addrs, [], MsgFlags::empty())?.count())
    }
```

I do not know if this is a breaking API change. From the limited examples I've tried, it doesn't seem to be. However, I can't guarantee that and would appreciate input from someone with more experience.

Also, I encountered a test that seems flaky, but maybe there are issues on my side. Both before and after my changes, the test `test_recvmm2` failed for me occasionally. Is this expected? Here's a demo of failure before I made any changes. If this is a reason not to merge, please let me know and I'll try to debug first.

<img width="1219" alt="Screenshot 2024-07-06 at 20 14 26" src="https://github.com/nix-rust/nix/assets/70831620/1087ce1b-3443-4e63-8d23-35b4897e20e2">


Thanks for considering these changes!

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
    - Is this desired/necessary for a change this small?
- [x] A change log has been added if this PR modifies nix's API
