### PR TITLE
Update ci.yml to add support for loongarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,6 @@ jobs:
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-netbsd
-          - target: loongarch64-unknown-linux-gnu
-
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-netbsd
+-
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read 
 
 env: 
-  MSRV: 1.69.0
+  MSRV: 1.71.0
   RUSTFLAGS: -Dwarnings
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-netbsd
--
+
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           mips64el-unknown-linux-gnuabi64,
           mipsel-unknown-linux-gnu,
           powerpc64le-unknown-linux-gnu,
+          loongarch64-unknown-linux-gnu,
         ]
 
     steps:
@@ -227,6 +228,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-netbsd
+          - target: loongarch64-unknown-linux-gnu
 
     steps:
       - name: checkout

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,5 +4,5 @@ passthrough = [
 	"RUST_TEST_THREADS"
 ]
 [target.loongarch64-unknown-linux-gnu]
-image = "ghcr.io/loongarchlinux/archlinux:latest"
+image.name = "ghcr.io/loongarchlinux/archlinux:latest"
 image.toolchain = ["loongarch64-unknown-linux-gnu"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,5 @@ passthrough = [
 	"RUSTFLAGS",
 	"RUST_TEST_THREADS"
 ]
+[target.loongarch64-unknown-linux-gnu]
+image = "ghcr.io/loongarchlinux/archlinux:latest"

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,3 +5,4 @@ passthrough = [
 ]
 [target.loongarch64-unknown-linux-gnu]
 image = "ghcr.io/loongarchlinux/archlinux:latest"
+image.toolchain = ["loongarch64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The following targets are supported by `nix`:
     <li>x86_64-linux-android</li>
     <li>x86_64-unknown-illumos</li>
     <li>x86_64-unknown-netbsd</li>
+    <li>loongarch64-unknown-linux-gnu</li>
    </td>
    <td>
     <li>armv7-unknown-linux-uclibceabihf</li>


### PR DESCRIPTION
## What does this PR do
Add CI support for loongarch64 (re-implementation of #2023 ). Ioctl has been implemented in #2045 .

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
