### PR TITLE
feat: add socket option IP_TOS/IPV6_TCLASS on Android/FreeBSD

### DIFF
--- a/changelog/2464.added.md
+++ b/changelog/2464.added.md
@@ -1,0 +1,1 @@
+Add socket option IP_TOS (nix::sys::socket::sockopt::IpTos) IPV6_TCLASS (nix::sys::socket::sockopt::Ipv6TClass) on Android/FreeBSD

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -402,7 +402,7 @@ sockopt_impl!(
     libc::SO_PRIORITY,
     libc::c_int
 );
-#[cfg(target_os = "linux")]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -414,7 +414,7 @@ sockopt_impl!(
     libc::IP_TOS,
     libc::c_int
 );
-#[cfg(target_os = "linux")]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -469,7 +469,7 @@ fn test_so_priority() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 fn test_ip_tos() {
     let fd = socket(
         AddressFamily::Inet,
@@ -484,7 +484,7 @@ fn test_ip_tos() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(any(linux_android, target_os = "freebsd"))]
 // Disable the test under emulation because it fails in Cirrus-CI.  Lack
 // of QEMU support is suspected.
 #[cfg_attr(qemu, ignore)]


### PR DESCRIPTION
## What does this PR do

add socket option IP_TOS (`nix::sys::socket::sockopt::IpTos`) IPV6_TCLASS (`nix::sys::socket::sockopt::Ipv6TClass`) on Android/FreeBSD

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
