### PR TITLE
chore: deprecate `IpTos` in favor of `Ipv4Tos`

### DIFF
--- a/changelog/2465.changed.md
+++ b/changelog/2465.changed.md
@@ -1,0 +1,1 @@
+Socket option `IpTos` has been renamed to `Ipv4Tos`, the old symbol is deprecated since 0.30.0

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -409,6 +409,7 @@ sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set or receive the Type-Of-Service (TOS) field that is
     /// sent with every IP packet originating from this socket
+    #[allow(deprecated)]
     IpTos,
     Both,
     libc::IPPROTO_IP,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -44,6 +44,7 @@ const TCP_CA_NAME_MAX: usize = 16;
 ///    `bool`, `SetUsize` for `usize`, etc.).
 macro_rules! setsockopt_impl {
     ($name:ident, $level:expr, $flag:path, $ty:ty, $setter:ty) => {
+        #[allow(deprecated)] // to allow we have deprecated socket option
         impl SetSockOpt for $name {
             type Val = $ty;
 
@@ -89,6 +90,7 @@ macro_rules! setsockopt_impl {
 ///    `bool`, `GetUsize` for `usize`, etc.).
 macro_rules! getsockopt_impl {
     ($name:ident, $level:expr, $flag:path, $ty:ty, $getter:ty) => {
+        #[allow(deprecated)] // to allow we have deprecated socket option
         impl GetSockOpt for $name {
             type Val = $ty;
 
@@ -404,7 +406,6 @@ sockopt_impl!(
 );
 #[cfg(any(linux_android, target_os = "freebsd"))]
 #[cfg(feature = "net")]
-#[allow(deprecated)]
 sockopt_impl!(
     #[deprecated(since = "0.30.0", note = "Use Ipv4Tos instead")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -404,12 +404,12 @@ sockopt_impl!(
 );
 #[cfg(any(linux_android, target_os = "freebsd"))]
 #[cfg(feature = "net")]
+#[allow(deprecated)]
 sockopt_impl!(
     #[deprecated(since = "0.30.0", note = "Use Ipv4Tos instead")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set or receive the Type-Of-Service (TOS) field that is
     /// sent with every IP packet originating from this socket
-    #[allow(deprecated)]
     IpTos,
     Both,
     libc::IPPROTO_IP,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -405,6 +405,19 @@ sockopt_impl!(
 #[cfg(any(linux_android, target_os = "freebsd"))]
 #[cfg(feature = "net")]
 sockopt_impl!(
+    #[deprecated(since = "0.30.0", note = "Use Ipv4Tos instead")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Set or receive the Type-Of-Service (TOS) field that is
+    /// sent with every IP packet originating from this socket
+    IpTos,
+    Both,
+    libc::IPPROTO_IP,
+    libc::IP_TOS,
+    libc::c_int
+);
+#[cfg(any(linux_android, target_os = "freebsd"))]
+#[cfg(feature = "net")]
+sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Set or receive the Type-Of-Service (TOS) field that is
     /// sent with every IP packet originating from this socket


### PR DESCRIPTION
## What does this PR do

In #2425, we renamed `IpTos` to `Ipv4Tos`, this is a breaking change, to help our users migrate, let's add `IpTos` back and mark it deprecated.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
