### PR TITLE
Add `SeekData` and `SeekHole` to `Whence` for hurd/apple targets

### DIFF
--- a/changelog/2473.added.md
+++ b/changelog/2473.added.md
@@ -1,0 +1,1 @@
+Add `SeekData` and `SeekHole` to `Whence` for hurd and apple targets

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1426,8 +1426,10 @@ pub enum Whence {
     /// equal to offset that contains some data. If offset points to
     /// some data, then the file offset is set to offset.
     #[cfg(any(
+        apple_targets,
         freebsdlike,
         solarish,
+        target_os = "hurd",
         target_os = "linux",
     ))]
     SeekData = libc::SEEK_DATA,
@@ -1437,8 +1439,10 @@ pub enum Whence {
     /// then the file offset should be adjusted to the end of the file (i.e., there
     /// is an implicit hole at the end of any file).
     #[cfg(any(
+        apple_targets,
         freebsdlike,
         solarish,
+        target_os = "hurd",
         target_os = "linux",
     ))]
     SeekHole = libc::SEEK_HOLE,


### PR DESCRIPTION
## What does this PR do

This PR adds `SeekData` and `SeekHole` to `Whence` for hurd and apple targets.

Corresponding constants were added to the `libc` crate in:
- Apple: https://github.com/rust-lang/libc/pull/2886, released `v0.2.133` (September 2022)
- Hurd: https://github.com/rust-lang/libc/pull/3325, released `v0.2.149` (October 2023)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
