### PR TITLE
Add direct conversion from SockAddrIn(6) to SocketAddr

### DIFF
--- a/changelog/2474.added.md
+++ b/changelog/2474.added.md
@@ -1,0 +1,1 @@
+Add `From` trait implementation between `SocketAddr` and `Sockaddr`, `Sockaddr6`

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -920,6 +920,13 @@ impl From<SockaddrIn> for net::SocketAddrV4 {
 }
 
 #[cfg(feature = "net")]
+impl From<SockaddrIn> for net::SocketAddr {
+    fn from(addr: SockaddrIn) -> Self {
+        net::SocketAddr::from(net::SocketAddrV4::from(addr))
+    }
+}
+
+#[cfg(feature = "net")]
 impl From<SockaddrIn> for libc::sockaddr_in {
     fn from(sin: SockaddrIn) -> libc::sockaddr_in {
         sin.0
@@ -1072,6 +1079,13 @@ impl From<SockaddrIn6> for net::SocketAddrV6 {
             addr.0.sin6_flowinfo,
             addr.0.sin6_scope_id,
         )
+    }
+}
+
+#[cfg(feature = "net")]
+impl From<SockaddrIn6> for net::SocketAddr {
+    fn from(addr: SockaddrIn6) -> Self {
+        net::SocketAddr::from(net::SocketAddrV6::from(addr))
     }
 }
 


### PR DESCRIPTION
## What does this PR do

At the moment nix only offers conversions between `SockaddrIn` -> `SocketAddrV4` and `SockaddrIn6` -> `SocketAddrV6` but no conversions to the container type, `SocketAddr` itself.

While it's trivial to wrap either `SocketAddrV4` or `SocketAddrV6` into `SocketAddr`, I think having a shortcut would improve ergonomics and essentially align nix with std, which supports `From` conversions from `SocketAddrV{4,6}` to `SocketAddr`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
