### PR TITLE
fcntl adding F_RDAHEAD for apple targets.

### DIFF
--- a/changelog/2482.added.md
+++ b/changelog/2482.added.md
@@ -1,0 +1,1 @@
+Add fcntl constant `F_RDAHEAD` for Apple target

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -800,6 +800,9 @@ pub enum FcntlArg<'a> {
     /// Issue an advisory read async with no copy to user
     #[cfg(apple_targets)]
     F_RDADVISE(libc::radvisory),
+    /// Turn read ahead off/on
+    #[cfg(apple_targets)]
+    F_RDAHEAD(bool)
     // TODO: Rest of flags
 }
 
@@ -911,6 +914,11 @@ pub fn fcntl<Fd: std::os::fd::AsFd>(fd: Fd, arg: FcntlArg) -> Result<c_int> {
             #[cfg(apple_targets)]
             F_RDADVISE(rad) => {
                 libc::fcntl(fd, libc::F_RDADVISE, &rad)
+            }
+            #[cfg(apple_targets)]
+            F_RDAHEAD(on) => {
+                let val = if on { 1 } else { 0 };
+                libc::fcntl(fd, libc::F_RDAHEAD, val)
             }
         }
     };


### PR DESCRIPTION
Enable/disable read ahead globally on the file descriptor. When on,
 the os preemptively reads data in cache to anticipate future read
operations.