### PR TITLE
fcntl adding F_LOG2PHYS* flags.

### DIFF
--- a/changelog/2483.added.md
+++ b/changelog/2483.added.md
@@ -1,0 +1,1 @@
+Add `F_LOG2PHYS` and `F_LOG2PHYS_EXT` for Apple target


### PR DESCRIPTION
to get the current device address, in practice its current offset only.