### PR TITLE
ci: enable armv7-unknown-linux-uclibceabihf CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,10 +298,7 @@ jobs:
           - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
           - target: x86_64-unknown-haiku
-
-          # Temporarily disable armv7-unknown-linux-uclibceabihf
-          # https://github.com/nix-rust/nix/issues/2200
-          #- target: armv7-unknown-linux-uclibceabihf
+          - target: armv7-unknown-linux-uclibceabihf
 
           # Disable hurd due to
           # https://github.com/nix-rust/nix/issues/2306


### PR DESCRIPTION
## What does this PR do

Re-enable the CI for `armv7-unknown-linux-uclibceabihf` as the upstream issue is possibly fixed.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
