### PR TITLE
style: allow clippy::too_long_first_doc_paragraph

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![allow(non_camel_case_types)]
+// A clear document is a good document no matter if it has a summary in its 
+// first paragraph or not.
+#![allow(clippy::too_long_first_doc_paragraph)]
 #![recursion_limit = "500"]
 #![deny(unused)]
 #![allow(unused_macros)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #![crate_name = "nix"]
 #![cfg(unix)]
 #![allow(non_camel_case_types)]
-// A clear document is a good document no matter if it has a summary in its 
+// A clear document is a good document no matter if it has a summary in its
 // first paragraph or not.
 #![allow(clippy::too_long_first_doc_paragraph)]
 #![recursion_limit = "500"]


### PR DESCRIPTION
## What does this PR do

`#![allow(clippy::too_long_first_doc_paragraph)]` as I don't think it really matters.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
