### PR TITLE
Use cfg_aliases 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ caps = "0.5.3"
 sysctl = "0.4"
 
 [build-dependencies]
-cfg_aliases = "0.2"
+cfg_aliases = "0.2.1"
 
 [[test]]
 name = "test"

--- a/build.rs
+++ b/build.rs
@@ -27,14 +27,7 @@ fn main() {
         solarish: { any(illumos, solaris) },
     }
 
-    // Below are Nix's custom cfg values that we need to let the compiler know
-    println!("cargo:rustc-check-cfg=cfg(apple_targets)");
-    println!("cargo:rustc-check-cfg=cfg(bsd)");
-    println!("cargo:rustc-check-cfg=cfg(bsd_without_apple)");
-    println!("cargo:rustc-check-cfg=cfg(linux_android)");
-    println!("cargo:rustc-check-cfg=cfg(freebsdlike)");
-    println!("cargo:rustc-check-cfg=cfg(netbsdlike)");
-    println!("cargo:rustc-check-cfg=cfg(solarish)");
+    // Below are custom cfg values set during some CI steps.
     println!("cargo:rustc-check-cfg=cfg(fbsd14)");
     println!("cargo:rustc-check-cfg=cfg(qemu)");
 }


### PR DESCRIPTION
With 0.2.1, there's no need to manually write rustc-check-cfg statements.
