### PR TITLE
style: deny(unexpected_cfgs)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 #![allow(clippy::too_long_first_doc_paragraph)]
 #![recursion_limit = "500"]
 #![deny(unused)]
+#![deny(unexpected_cfgs)]
 #![allow(unused_macros)]
 #![cfg_attr(
     not(all(


### PR DESCRIPTION
## What does this PR do

The default level for this lint is `warn`, let's deny it. Though I am not sure if this is only available since Rust 1.80, let's verify this in our CI.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
