### PR TITLE
Feature `user` for emscripten

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -1,7 +1,7 @@
 //! Feature tests for OS functionality
 pub use self::os::*;
 
-#[cfg(linux_android)]
+#[cfg(any(linux_android, target_os = "emscripten"))]
 mod os {
     use crate::sys::utsname::uname;
     use crate::Result;

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1986,7 +1986,8 @@ pub fn setgroups(groups: &[Gid]) -> Result<()> {
     target_os = "aix",
     solarish,
     apple_targets,
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "emscripten",
 )))]
 pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
     let ngroups_max = match sysconf(SysconfVar::NGROUPS_MAX) {
@@ -2070,7 +2071,8 @@ pub fn getgrouplist(user: &CStr, group: Gid) -> Result<Vec<Gid>> {
 #[cfg(not(any(
     apple_targets,
     target_os = "redox",
-    target_os = "haiku"
+    target_os = "haiku",
+    target_os = "emscripten",
 )))]
 pub fn initgroups(user: &CStr, group: Gid) -> Result<()> {
     cfg_if! {
@@ -3492,6 +3494,7 @@ pub struct User {
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "emscripten",
     )))]
     pub class: CString,
     /// Last password change
@@ -3502,6 +3505,7 @@ pub struct User {
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "emscripten",
     )))]
     pub change: libc::time_t,
     /// Expiration time of account
@@ -3512,6 +3516,7 @@ pub struct User {
         target_os = "fuchsia",
         target_os = "haiku",
         target_os = "hurd",
+        target_os = "emscripten",
     )))]
     pub expire: libc::time_t,
 }
@@ -3565,6 +3570,7 @@ impl From<&libc::passwd> for User {
                     target_os = "fuchsia",
                     target_os = "haiku",
                     target_os = "hurd",
+                    target_os = "emscripten",
                 )))]
                 class: CString::new(CStr::from_ptr(pw.pw_class).to_bytes())
                     .unwrap(),
@@ -3575,6 +3581,7 @@ impl From<&libc::passwd> for User {
                     target_os = "fuchsia",
                     target_os = "haiku",
                     target_os = "hurd",
+                    target_os = "emscripten",
                 )))]
                 change: pw.pw_change,
                 #[cfg(not(any(
@@ -3584,6 +3591,7 @@ impl From<&libc::passwd> for User {
                     target_os = "fuchsia",
                     target_os = "haiku",
                     target_os = "hurd",
+                    target_os = "emscripten",
                 )))]
                 expire: pw.pw_expire,
             }
@@ -3625,6 +3633,7 @@ impl From<User> for libc::passwd {
                 target_os = "fuchsia",
                 target_os = "haiku",
                 target_os = "hurd",
+                target_os = "emscripten",
             )))]
             pw_class: u.class.into_raw(),
             #[cfg(not(any(
@@ -3634,6 +3643,7 @@ impl From<User> for libc::passwd {
                 target_os = "fuchsia",
                 target_os = "haiku",
                 target_os = "hurd",
+                target_os = "emscripten",
             )))]
             pw_change: u.change,
             #[cfg(not(any(
@@ -3643,6 +3653,7 @@ impl From<User> for libc::passwd {
                 target_os = "fuchsia",
                 target_os = "haiku",
                 target_os = "hurd",
+                target_os = "emscripten",
             )))]
             pw_expire: u.expire,
             #[cfg(solarish)]


### PR DESCRIPTION
## What does this PR do
Fix failed to build for target `wasm32-unknown-emscripten` with `--features user` with this error:
```
error[E0432]: unresolved import `self::os`
 --> src/features.rs:2:15
  |
2 | pub use self::os::*;
  |               ^^ could not find `os` in `self`

error[E0609]: no field `pw_class` on type `&passwd`
    --> src/unistd.rs:3569:55
     |
3569 |                 class: CString::new(CStr::from_ptr(pw.pw_class).to_bytes())
     |                                                       ^^^^^^^^ unknown field
     |
     = note: available fields are: `pw_name`, `pw_passwd`, `pw_uid`, `pw_gid`, `pw_gecos` ... and 2 others

error[E0609]: no field `pw_change` on type `&passwd`
    --> src/unistd.rs:3579:28
     |
3579 |                 change: pw.pw_change,
     |                            ^^^^^^^^^ unknown field
     |
     = note: available fields are: `pw_name`, `pw_passwd`, `pw_uid`, `pw_gid`, `pw_gecos` ... and 2 others

error[E0609]: no field `pw_expire` on type `&passwd`
    --> src/unistd.rs:3588:28
     |
3588 |                 expire: pw.pw_expire,
     |                            ^^^^^^^^^ unknown field
     |
     = note: available fields are: `pw_name`, `pw_passwd`, `pw_uid`, `pw_gid`, `pw_gecos` ... and 2 others

error[E0560]: struct `passwd` has no field named `pw_class`
    --> src/unistd.rs:3629:13
     |
3629 |             pw_class: u.class.into_raw(),
     |             ^^^^^^^^ `passwd` does not have this field
     |
     = note: all struct fields are already assigned

error[E0560]: struct `passwd` has no field named `pw_change`
    --> src/unistd.rs:3638:13
     |
3638 |             pw_change: u.change,
     |             ^^^^^^^^^ `passwd` does not have this field
     |
     = note: all struct fields are already assigned

error[E0560]: struct `passwd` has no field named `pw_expire`
    --> src/unistd.rs:3647:13
     |
3647 |             pw_expire: u.expire,
     |             ^^^^^^^^^ `passwd` does not have this field
     |
     = note: all struct fields are already assigned

Some errors have detailed explanations: E0432, E0560, E0609.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `nix` (lib) due to 7 previous errors
```
- struct `passwd` for emscripten not have some fields, so disabled it.

Even if this error is resolved, full support for emscripten will not be possible because libc does not provide some functions for emscripten like `libc::getpwuid_r`. but this change will be useful in the future.
## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
