### PR TITLE
Add MAP_SHARED_VALIDATE & MAP_SYNC

### DIFF
--- a/changelog/2499.added.md
+++ b/changelog/2499.added.md
@@ -1,0 +1,1 @@
+Added `MAP_SHARED_VALIDATE` & `MAP_SYNC` for x86.

--- a/changelog/2499.added.md
+++ b/changelog/2499.added.md
@@ -1,1 +1,1 @@
-Added `MAP_SHARED_VALIDATE` & `MAP_SYNC` for x86.
+`MAP_SHARED_VALIDATE` was added for all linux targets. & `MAP_SYNC` was added for linux with the exclusion of mips architecures, and uclibc

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -42,7 +42,7 @@ libc_bitflags! {
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
         /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
-        #[cfg(any(target_os = "linux"), not(linux_android))]
+        #[cfg(all(any(target_arch = "x86"), not(linux_android)))]
         MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
@@ -146,7 +146,7 @@ libc_bitflags! {
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems. 
-        #[cfg(any(target_arch = "x86"), not(linux_android))]
+        #[cfg(all(any(target_arch = "x86"), not(linux_android)))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -42,7 +42,7 @@ libc_bitflags! {
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
         /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
-        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc")))]
+        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc"), not(freebsdlike)))]
         MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
@@ -146,7 +146,7 @@ libc_bitflags! {
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems.
-        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc")))]
+        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc"), not(freebsdlike)))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -42,7 +42,7 @@ libc_bitflags! {
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
         /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
-        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc"), not(freebsdlike)))]
+        #[cfg(target_os = "linux")]
         MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
@@ -146,7 +146,8 @@ libc_bitflags! {
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems.
-        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc"), not(freebsdlike)))]
+        // Available on Linux glibc and musl, MIPS* target excluded.
+        #[cfg(all(target_os = "linux", not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mipsel", target_arch = "mips64el")), not(target_env = "uclibc")))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -41,6 +41,9 @@ libc_bitflags! {
         MAP_FILE;
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
+        /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
+        #[cfg(any(linux_android, target_os = "linux"))]
+        MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
         /// Place the mapping at exactly the address specified in `addr`.
@@ -142,6 +145,9 @@ libc_bitflags! {
         /// Region grows down, like a stack.
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
+        /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems. 
+        #[cfg(any(linux_android, target_os = "linux"))]
+        MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]
         MAP_NOCACHE;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -147,7 +147,7 @@ libc_bitflags! {
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems.
         // Available on Linux glibc and musl, MIPS* target excluded.
-        #[cfg(all(target_os = "linux", not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mipsel", target_arch = "mips64el")), not(target_env = "uclibc")))]
+        #[cfg(all(target_os = "linux", not(any(target_arch = "mips", target_arch = "mips64", target_arch = "mips32r6", target_arch = "mips64r6")), not(target_env = "uclibc")))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -42,7 +42,7 @@ libc_bitflags! {
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
         /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
-        #[cfg(any(linux_android, target_os = "linux"))]
+        #[cfg(any(target_os = "linux"), not(linux_android))]
         MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
@@ -146,7 +146,7 @@ libc_bitflags! {
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems. 
-        #[cfg(any(linux_android, target_os = "linux"))]
+        #[cfg(any(target_arch = "x86"), not(linux_android))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -42,7 +42,7 @@ libc_bitflags! {
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;
         /// Force mmap to check and fail on unknown flags. This also enables `MAP_SYNC`.
-        #[cfg(all(any(target_arch = "x86"), not(linux_android)))]
+        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc")))]
         MAP_SHARED_VALIDATE;
         /// Create a private copy-on-write mapping. Mutually exclusive with `MAP_SHARED`.
         MAP_PRIVATE;
@@ -145,8 +145,8 @@ libc_bitflags! {
         /// Region grows down, like a stack.
         #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
         MAP_STACK;
-        /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems. 
-        #[cfg(all(any(target_arch = "x86"), not(linux_android)))]
+        /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems.
+        #[cfg(all(any(target_arch = "x86"), not(linux_android), not(target_os = "hurd"), not(target_env = "uclibc")))]
         MAP_SYNC;
         /// Pages in this mapping are not retained in the kernel's memory cache.
         #[cfg(apple_targets)]


### PR DESCRIPTION
This pull adds two flags: MAP_SHARED_VALIDATE & MAP_SYNC implemented on https://github.com/rust-lang/libc

The MAP_SHARED_VALIDATE flag was added to linux since 4.15, its a flag that does two things: provide backwards compatibility with old mmap implementations that don't check for unknown flags, and allow new flags to be added.

MAP_SYNC, on the other hand, was added to allow mmap to utilize Direct Accses (DAX) on hardware that support it (non-volatile memory devices) or in general: any ram-shaped filesystem.

both flags are available on both linux and android. (Edit: The android kernel does not support the flags)

Notice:
mmap always returns ENOTSUPP when MAP_SYNC is used on filesystems that are not mounted with DAX enabled (normal everyday filesystems), this means that this kind of test would not be possible on github CI.
 
## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
