### PR TITLE
fix off-by-one error in range check of Backlog::new

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -2190,7 +2190,7 @@ impl Backlog {
 
         let val = val.into();
 
-        if !(MIN..Self::MAXCONN.0).contains(&val) {
+        if !(MIN..=Self::MAXCONN.0).contains(&val) {
             return Err(Errno::EINVAL);
         }
 

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1696,6 +1696,13 @@ pub fn test_named_unixdomain() {
 }
 
 #[test]
+pub fn test_listen_maxbacklog() {
+    use nix::sys::socket::Backlog;
+
+    assert!(Backlog::new(libc::SOMAXCONN).is_ok());
+}
+
+#[test]
 pub fn test_listen_wrongbacklog() {
     use nix::sys::socket::Backlog;
 


### PR DESCRIPTION
## What does this PR do

Makes it possible to call `Backlog::new(libc::SOMAXCONN)` without error.

In the case where I encountered this, a constant is passed to `Backlog::new`
and it just happens to be equal to `SOMAXCONN` on some platforms.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
