### PR TITLE
refactor: make test_parsing_kernel_version() private

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -92,7 +92,7 @@ mod os {
     }
 
     #[test]
-    pub fn test_parsing_kernel_version() {
+    fn test_parsing_kernel_version() {
         assert!(kernel_version().unwrap() > 0);
     }
 }


### PR DESCRIPTION
## What does this PR do

The test function `test_parsing_kernel_version()` is public, which is unnecessary since it is under attribute `#[test]`. Also, it causes the CI failure in PR #2500:

```
error: missing documentation for a function
   --> src/features.rs:95:5
    |
95  |     pub fn test_parsing_kernel_version() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:121:12
    |
121 |     #[deny(missing_docs)]
    |            ^^^^^^^^^^^^

error: could not compile `nix` (lib test) due to 1 previous error
```

so let's make it private.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
