### PR TITLE
Add `getregs()`/`setregs()`/`getregset()`/`setregset()` for Linux/musl/aarch64

### DIFF
--- a/changelog/2502.added.md
+++ b/changelog/2502.added.md
@@ -1,0 +1,1 @@
+Add `getregset()` for Linux/musl/aarch64

--- a/changelog/2502.added.md
+++ b/changelog/2502.added.md
@@ -1,1 +1,1 @@
-Add `getregset()` for Linux/musl/aarch64
+Add `getregs()`/`getregset()`/`setregset()` for Linux/musl/aarch64

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -348,12 +348,17 @@ pub fn getregs(pid: Pid) -> Result<user_regs_struct> {
 /// Get a particular set of user registers, as with `ptrace(PTRACE_GETREGSET, ...)`
 #[cfg(all(
     target_os = "linux",
-    target_env = "gnu",
     any(
-        target_arch = "x86_64",
-        target_arch = "x86",
-        target_arch = "aarch64",
-        target_arch = "riscv64",
+        all(
+            target_env = "gnu",
+            any(
+                target_arch = "x86_64",
+                target_arch = "x86",
+                target_arch = "aarch64",
+                target_arch = "riscv64"
+            )
+        ),
+        all(target_env = "musl", any(target_arch = "aarch64"))
     )
 ))]
 pub fn getregset<S: RegisterSet>(pid: Pid) -> Result<S::Regs> {
@@ -412,8 +417,13 @@ pub fn setregs(pid: Pid, regs: user_regs_struct) -> Result<()> {
 /// [ptrace(2)]: https://www.man7.org/linux/man-pages/man2/ptrace.2.html
 #[cfg(all(
     target_os = "linux",
-    target_env = "gnu",
-    any(target_arch = "aarch64", target_arch = "riscv64")
+    any(
+        all(
+            target_env = "gnu",
+            any(target_arch = "aarch64", target_arch = "riscv64")
+        ),
+        all(target_env = "musl", target_arch = "aarch64")
+    )
 ))]
 pub fn setregs(pid: Pid, regs: user_regs_struct) -> Result<()> {
     setregset::<regset::NT_PRSTATUS>(pid, regs)
@@ -422,12 +432,17 @@ pub fn setregs(pid: Pid, regs: user_regs_struct) -> Result<()> {
 /// Set a particular set of user registers, as with `ptrace(PTRACE_SETREGSET, ...)`
 #[cfg(all(
     target_os = "linux",
-    target_env = "gnu",
     any(
-        target_arch = "x86_64",
-        target_arch = "x86",
-        target_arch = "aarch64",
-        target_arch = "riscv64",
+        all(
+            target_env = "gnu",
+            any(
+                target_arch = "x86_64",
+                target_arch = "x86",
+                target_arch = "aarch64",
+                target_arch = "riscv64"
+            )
+        ),
+        all(target_env = "musl", target_arch = "aarch64")
     )
 ))]
 pub fn setregset<S: RegisterSet>(pid: Pid, mut regs: S::Regs) -> Result<()> {

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -14,11 +14,10 @@ pub type AddressType = *mut ::libc::c_void;
     target_os = "linux",
     any(
         all(
-            target_arch = "x86_64",
+            any(target_arch = "x86_64", target_arch = "aarch64"),
             any(target_env = "gnu", target_env = "musl")
         ),
         all(target_arch = "x86", target_env = "gnu"),
-        all(target_arch = "aarch64", target_env = "gnu"),
         all(target_arch = "riscv64", target_env = "gnu"),
     ),
 ))]
@@ -334,8 +333,13 @@ pub fn getregs(pid: Pid) -> Result<user_regs_struct> {
 /// [ptrace(2)]: https://www.man7.org/linux/man-pages/man2/ptrace.2.html
 #[cfg(all(
     target_os = "linux",
-    target_env = "gnu",
-    any(target_arch = "aarch64", target_arch = "riscv64")
+    any(
+        all(
+            target_arch = "aarch64",
+            any(target_env = "gnu", target_env = "musl")
+        ),
+        all(target_arch = "riscv64", target_env = "gnu")
+    )
 ))]
 pub fn getregs(pid: Pid) -> Result<user_regs_struct> {
     getregset::<regset::NT_PRSTATUS>(pid)

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -358,7 +358,7 @@ pub fn getregs(pid: Pid) -> Result<user_regs_struct> {
                 target_arch = "riscv64"
             )
         ),
-        all(target_env = "musl", any(target_arch = "aarch64"))
+        all(target_env = "musl", target_arch = "aarch64")
     )
 ))]
 pub fn getregset<S: RegisterSet>(pid: Pid) -> Result<S::Regs> {

--- a/test/sys/test_ptrace.rs
+++ b/test/sys/test_ptrace.rs
@@ -292,12 +292,17 @@ fn test_ptrace_syscall() {
 
 #[cfg(all(
     target_os = "linux",
-    target_env = "gnu",
     any(
-        target_arch = "x86_64",
-        target_arch = "x86",
-        target_arch = "aarch64",
-        target_arch = "riscv64",
+        all(
+            target_env = "gnu",
+            any(
+                target_arch = "x86_64",
+                target_arch = "x86",
+                target_arch = "aarch64",
+                target_arch = "riscv64"
+            )
+        ),
+        all(target_env = "musl", target_arch = "aarch64")
     )
 ))]
 #[test]


### PR DESCRIPTION
## What does this PR do

I needed this specific API for packaging my project for Alpine Linux distribution:

- https://github.com/JakWai01/lurk/issues/4
- https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/71833
- https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/71875

I added support for `aarch64-unknown-linux-musl` for `getregs()` function and it builds fine now, but I don't have a way to test it.
Also, I'm not sure if this is the correct way to add support for this architecture - but should be fine!

Let me know what you think and I can try adding support for other functions (such as `setregs()`) as well.

BTW this is my first PR to the `nix` crate so please let me know if I'm doing something wrong :bear:

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
