### PR TITLE
fix: correct arg type of prctl::set_timerslack

### DIFF
--- a/changelog/2505.fixed.md
+++ b/changelog/2505.fixed.md
@@ -1,0 +1,1 @@
+The `ns` argument of `sys::prctl::set_timerslack()` should be of type `c_ulong`

--- a/src/sys/prctl.rs
+++ b/src/sys/prctl.rs
@@ -166,7 +166,7 @@ pub fn get_name() -> Result<CString> {
 
 /// Sets the timer slack value for the calling thread. Timer slack is used by the kernel to group
 /// timer expirations and make them the supplied amount of nanoseconds late.
-pub fn set_timerslack(ns: u64) -> Result<()> {
+pub fn set_timerslack(ns: c_ulong) -> Result<()> {
     let res = unsafe { libc::prctl(libc::PR_SET_TIMERSLACK, ns, 0, 0, 0) };
 
     Errno::result(res).map(drop)

--- a/test/sys/test_prctl.rs
+++ b/test/sys/test_prctl.rs
@@ -89,14 +89,14 @@ mod test_prctl {
     #[cfg_attr(qemu, ignore)]
     #[test]
     fn test_get_set_timerslack() {
-        let original = prctl::get_timerslack().unwrap();
+        let original = prctl::get_timerslack().unwrap() as libc::c_ulong;
 
         let slack = 60_000;
         prctl::set_timerslack(slack).unwrap();
-        let res = prctl::get_timerslack().unwrap();
-        assert_eq!(slack, res as u64);
+        let res = prctl::get_timerslack().unwrap() as libc::c_ulong;
+        assert_eq!(slack, res);
 
-        prctl::set_timerslack(original as u64).unwrap();
+        prctl::set_timerslack(original).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do

The `ns` argument of function `nix::sys::prctl::set_timerslack()` [should have type `c_ulong`](https://man7.org/linux/man-pages/man2/PR_SET_TIMERSLACK.2const.html), before this PR, we are using an `u64`, which causes issue #2497.

This PR changes the type to `c_ulong`.

Closes #2497

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
