### PR TITLE
Enable CI for Loongarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ permissions:
 
 env: 
   MSRV: 1.69.0
+  # Rust's Loongarch support merged in 1.71.0
+  MSRV_LOONGARCH: 1.71.0
   RUSTFLAGS: -Dwarnings
 
 jobs:
@@ -92,6 +94,7 @@ jobs:
           mips64el-unknown-linux-gnuabi64,
           mipsel-unknown-linux-gnu,
           powerpc64le-unknown-linux-gnu,
+          loongarch64-unknown-linux-gnu,
         ]
 
     steps:
@@ -101,7 +104,8 @@ jobs:
       - name: setup Rust
         uses: dtolnay/rust-toolchain@master
         with: 
-          toolchain: '${{ env.MSRV }}'
+          # Use a newer version rustc if the target is Loongarch, remove this workaround after MSRV is newer than 1.71.0
+          toolchain: "${{ matrix.target == 'loongarch64-unknown-linux-gnu' && env.MSRV_LOONGARCH || env.MSRV }}"
           components: clippy
 
       # cross relies on docker or podman, GitHub Acton already has it installed.

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,6 @@ passthrough = [
 	"RUSTFLAGS",
 	"RUST_TEST_THREADS"
 ]
+
+[target.loongarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/loongarch64-unknown-linux-gnu:edge"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following targets are supported by `nix`:
     <li>arm-unknown-linux-musleabi</li>
     <li>armv7-linux-androideabi</li>
     <li>i686-linux-android</li>
+    <li>loongarch64-unknown-linux-gnu</li>
     <li>s390x-unknown-linux-gnu</li>
     <li>x86_64-linux-android</li>
     <li>x86_64-unknown-illumos</li>

--- a/test/sys/test_prctl.rs
+++ b/test/sys/test_prctl.rs
@@ -99,6 +99,10 @@ mod test_prctl {
         prctl::set_timerslack(original).unwrap();
     }
 
+    // Loongarch need to use a newer QEMU that disabled these PRCTL subcodes/methods.
+    // https://github.com/qemu/qemu/commit/220717a6f46a99031a5b1af964bbf4dec1310440
+    // So we should ignore them when testing in QEMU environments.
+    #[cfg_attr(all(qemu, target_arch = "loongarch64"), ignore)]
     #[test]
     fn test_disable_enable_perf_events() {
         prctl::task_perf_events_disable().unwrap();
@@ -112,6 +116,10 @@ mod test_prctl {
         assert!(no_new_privs);
     }
 
+    // Loongarch need to use a newer QEMU that disabled these PRCTL subcodes/methods
+    // https://github.com/qemu/qemu/commit/220717a6f46a99031a5b1af964bbf4dec1310440
+    // So we should ignore them when testing in QEMU environments.
+    #[cfg_attr(all(qemu, target_arch = "loongarch64"), ignore)]
     #[test]
     fn test_get_set_thp_disable() {
         let original = prctl::get_thp_disable().unwrap();


### PR DESCRIPTION
## What does this PR do

This PR is the reimplementation of PR #2461. That will enable CI testing for `loongarch64-unknown-linux-gnu`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
