### PR TITLE
ci: add CI for Linux/aarch64/musl

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,12 +68,18 @@ task:
 # Tasks for Linux aarch64 native builds 
 task:
   matrix:
-    - name: Linux aarch64
+    - name: Linux aarch64 gnu
       arm_container:
         image: rust:1.69.0
         cpu: 1
       env:
         TARGET: aarch64-unknown-linux-gnu
+    - name: Linux aarch64 musl
+      arm_container:
+        image: rust:1.69.0
+        cpu: 1
+      env:
+        TARGET: aarch64-unknown-linux-musl
   setup_script:
     - rustup target add $TARGET
     - rustup component add clippy


### PR DESCRIPTION
## What does this PR do

Adds CI for target `aarch64-unknown-linux-musl`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
