### PR TITLE
chore: employ just to run commonly used long cmds[skip ci]

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,8 @@
+# If no sub-command is given, simply list all the available options
+_default:
+    just --list
+
+# Build the doc
+doc *args='':
+    RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --all-features --no-deps {{args}}
+


### PR DESCRIPTION
## What does this PR do

Closes #2271

I found myself repeatedly opening that issue to copy the command to build the doc:

> RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --all-features --no-deps --open

Let's wrap these commonly-used commands in a justfile.

This PR adds that doc command, now, to build the doc, one can simply run:

```sh
$ just doc
```

It passes the arguments to the underlying `cargo doc` as well (`*args=''`), so wen can use `just doc --open` to open the doc.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
