### PR TITLE
fix: the build with feature 'socket' on macOS

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1697,12 +1697,14 @@ impl<'a> Set<'a, OsString> for SetOsString<'a> {
 
 /// Getter for a `CString` value.
 #[cfg(apple_targets)]
+#[cfg(feature = "net")]
 struct GetCString<T: AsMut<[u8]>> {
     len: socklen_t,
     val: MaybeUninit<T>,
 }
 
 #[cfg(apple_targets)]
+#[cfg(feature = "net")]
 impl<T: AsMut<[u8]>> Get<CString> for GetCString<T> {
     fn uninit() -> Self {
         GetCString {


### PR DESCRIPTION
## What does this PR do

Before this PR, I could not build Nix with feature `socket` enabled on macOS:

```sh
$ cargo b --features socket -q
error: struct `GetCString` is never constructed
    --> src/sys/socket/sockopt.rs:1700:8
     |
1700 | struct GetCString<T: AsMut<[u8]>> {
     |        ^^^^^^^^^^
     |
note: the lint level is defined here
    --> src/lib.rs:50:9
     |
50   | #![deny(unused)]
     |         ^^^^^^
     = note: `#[deny(dead_code)]` implied by `#[deny(unused)]`

error: could not compile `nix` (lib) due to 1 previous error
```

I am using Rust 1.81, this was not caught in our CI because it won't happen with Rust 1.69:

```sh
$ cargo +1.69 b --features socket -q

$ echo $?
0
```


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
