### PR TITLE
P_PIDFD is supported on linux

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -340,7 +340,7 @@ pub enum Id<'fd> {
     /// If the PID is zero, the caller's process group is used since Linux 5.4.
     PGid(Pid),
     /// Wait for the child referred to by the given PID file descriptor
-    #[cfg(linux_android)]
+    #[cfg(any(linux_android, target_os = "linux"))]
     PIDFd(BorrowedFd<'fd>),
     /// A helper variant to resolve the unused parameter (`'fd`) problem on platforms
     /// other than Linux and Android.
@@ -362,7 +362,7 @@ pub fn waitid(id: Id, flags: WaitPidFlag) -> Result<WaitStatus> {
         Id::All => (libc::P_ALL, 0),
         Id::Pid(pid) => (libc::P_PID, pid.as_raw() as libc::id_t),
         Id::PGid(pid) => (libc::P_PGID, pid.as_raw() as libc::id_t),
-        #[cfg(linux_android)]
+        #[cfg(any(linux_android, target_os = "linux"))]
         Id::PIDFd(fd) => (libc::P_PIDFD, fd.as_raw_fd() as libc::id_t),
         Id::_Unreachable(_) => {
             unreachable!("This variant could never be constructed")


### PR DESCRIPTION
Hello, The id_type flag: `P_PIDFD` is currently configured to only compile for `linux_android` target, but it's also supported on linux and is available on libc.

This pull adds linux as a target os.

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
