### PR TITLE
Developer experience - enable all the features when running tests by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ test: &TEST
   << : *BUILD
   test_script:
     - . $HOME/.cargo/env || true
-    - $TOOL test --target $TARGET --all-features
+    - $TOOL test --target $TARGET
 
 # Test FreeBSD in a full VM.  Test the i686 target too, in the
 # same VM.  The binary will be built in 32-bit mode, but will execute on a
@@ -59,7 +59,7 @@ task:
     - . $HOME/.cargo/env
     - cargo build --target i686-unknown-freebsd --all-features
     - cargo doc --no-deps --target i686-unknown-freebsd --all-features
-    - cargo test --target i686-unknown-freebsd --all-features
+    - cargo test --target i686-unknown-freebsd
   i386_feature_script:
     - . $HOME/.cargo/env
     - if [ -z "$NOHACK" ]; then cargo hack check --each-feature --target i686-unknown-freebsd; fi

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -29,4 +29,4 @@ runs:
 
     - name: test
       shell: bash
-      run: ${{ inputs.SUDO }} $(which ${{ inputs.TOOL }}) test --target ${{ inputs.TARGET }} --all-features
+      run: ${{ inputs.SUDO }} $(which ${{ inputs.TOOL }}) test --target ${{ inputs.TARGET }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ And having multiple change logs for one PR is allowed.
 
 ## Testing
 
-nix has a test suite that you can run with `cargo test --all-features`. Ideally, we'd like pull
+nix has a test suite that you can run with `cargo test`. Ideally, we'd like pull
 requests to include tests where they make sense. For example, when fixing a bug,
 add a test that would have failed without the fix.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,11 @@ parking_lot = "0.12"
 rand = "0.8"
 tempfile = "3.7.1"
 semver = "1.0.7"
+nix = { path = ".", features = ["acct", "aio", "dir", "env", "event", "fanotify",
+    "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
+    "net", "personality", "poll", "pthread", "ptrace", "quota", "process", "reboot",
+    "resource", "sched", "signal", "socket", "term", "time", "ucontext", "uio",
+    "user", "zerocopy"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.5.3"


### PR DESCRIPTION
## What does this PR do

https://github.com/nix-rust/nix/pull/2091 left developer experience in a bad state: as far as tools are concerned by default - the project is broken. `cargo test` fails with lots of bogus errors, `rust-analyzer` ignores majority of the code, etc. 

This PR tries to address this problem by explicitly enabling all the features for the `nix` crate in dev mode and making sure they will be added manually to the list by removing explicit `--all-features` from a few places.

According to [cargo docs](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) path-only dev dependencies are allowed and will be ignored when publishing the crate.

With this change in place I can run tests with usual `cargo test`, `rust-analyzer` and other tools work as expected.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
