### PR TITLE
style: make clippy happy

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1797,11 +1797,9 @@ impl<S> MultiHeaders<S> {
 /// call to recvmmsg(). In the current implementation, however, the error code can be
 /// overwritten in the meantime by an unrelated network event on a socket, for example an
 /// incoming ICMP packet.
-
 // On aarch64 linux using recvmmsg and trying to get hardware/kernel timestamps might not
 // always produce the desired results - see https://github.com/nix-rust/nix/pull/1744 for more
 // details
-
 #[cfg(any(linux_android, target_os = "freebsd", target_os = "netbsd"))]
 pub fn recvmmsg<'a, XS, S, I>(
     fd: RawFd,


### PR DESCRIPTION
## What does this PR do

Fixes the Clippy error that happened in this PR: https://github.com/nix-rust/nix/actions/runs/11051131303/job/30700376034

```
error: empty lines after outer attribute
    --> src/sys/socket/mod.rs:1799:1
     |
1799 | / /// incoming ICMP packet.
1800 | |
1801 | | // On aarch64 linux using recvmmsg and trying to get hardware/kernel timestamps might not
1802 | | // always produce the desired results - see https://github.com/nix-rust/nix/pull/1744 for more
1803 | | // details
1804 | |
     | |_
1805 |   #[cfg(any(linux_android, target_os = "freebsd", target_os = "netbsd"))]
1806 | / pub fn recvmmsg<'a, XS, S, I>(
1807 | |     fd: RawFd,
1808 | |     data: &'a mut MultiHeaders<S>,
1809 | |     slices: XS,
...    |
1814 | |     XS: IntoIterator<Item = &'a mut I>,
1815 | |     I: AsMut<[IoSliceMut<'a>]> + 'a,
     | |____________________________________- the attribute applies to this function
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_outer_attr
     = note: `-D clippy::empty-line-after-outer-attr` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_outer_attr)]`
     = help: if the empty lines are unintentional remove them
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
