### PR TITLE
Make fields in UnknownCmsg public

### DIFF
--- a/changelog/2520.changed.md
+++ b/changelog/2520.changed.md
@@ -1,0 +1,1 @@
+Made fields in `nix::sys::socket::UnknownCmsg` public

--- a/changelog/2520.changed.md
+++ b/changelog/2520.changed.md
@@ -1,1 +1,1 @@
-Made fields in `nix::sys::socket::UnknownCmsg` public
+Made `nix::sys::socket::UnknownCmsg` public and more readable

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -39,20 +39,10 @@ pub use self::addr::{SockaddrLike, SockaddrStorage};
 pub use self::addr::{AddressFamily, UnixAddr};
 #[cfg(not(solarish))]
 pub use self::addr::{AddressFamily, UnixAddr};
-#[cfg(not(any(
-    solarish,
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "redox"
-)))]
+#[cfg(not(any(solarish, target_os = "haiku", target_os = "hurd", target_os = "redox")))]
 #[cfg(feature = "net")]
 pub use self::addr::{LinkAddr, SockaddrIn, SockaddrIn6};
-#[cfg(any(
-    solarish,
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "redox"
-))]
+#[cfg(any(solarish, target_os = "haiku", target_os = "hurd", target_os = "redox"))]
 #[cfg(feature = "net")]
 pub use self::addr::{SockaddrIn, SockaddrIn6};
 
@@ -804,17 +794,17 @@ pub enum ControlMessageOwned {
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv6HopLimit(i32),
 
-    /// Retrieve the DSCP (ToS) header field of the incoming IPv4 packet.
+    /// Retrieve the DSCP (ToS) header field of the incoming IPv4 packet. 
     #[cfg(any(linux_android, target_os = "freebsd"))]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv4Tos(u8),
 
-    /// Retrieve the DSCP (Traffic Class) header field of the incoming IPv6 packet.
+    /// Retrieve the DSCP (Traffic Class) header field of the incoming IPv6 packet. 
     #[cfg(any(linux_android, target_os = "freebsd"))]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
-    Ipv6TClass(i32),
+    Ipv6TClass(i32), 
 
     /// UDP Generic Receive Offload (GRO) allows receiving multiple UDP
     /// packets from a single sender.
@@ -2313,7 +2303,8 @@ pub fn recvfrom<T: SockaddrLike>(
             0,
             addr.as_mut_ptr().cast(),
             &mut len as *mut socklen_t,
-        ))? as usize;
+        ))? as:q
+ usize;
 
         Ok((ret, T::from_raw(addr.assume_init().as_ptr(), Some(len))))
     }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -2303,8 +2303,7 @@ pub fn recvfrom<T: SockaddrLike>(
             0,
             addr.as_mut_ptr().cast(),
             &mut len as *mut socklen_t,
-        ))? as:q
- usize;
+        ))? as usize;
 
         Ok((ret, T::from_raw(addr.assume_init().as_ptr(), Some(len))))
     }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -39,10 +39,20 @@ pub use self::addr::{SockaddrLike, SockaddrStorage};
 pub use self::addr::{AddressFamily, UnixAddr};
 #[cfg(not(solarish))]
 pub use self::addr::{AddressFamily, UnixAddr};
-#[cfg(not(any(solarish, target_os = "haiku", target_os = "hurd", target_os = "redox")))]
+#[cfg(not(any(
+    solarish,
+    target_os = "haiku",
+    target_os = "hurd",
+    target_os = "redox"
+)))]
 #[cfg(feature = "net")]
 pub use self::addr::{LinkAddr, SockaddrIn, SockaddrIn6};
-#[cfg(any(solarish, target_os = "haiku", target_os = "hurd", target_os = "redox"))]
+#[cfg(any(
+    solarish,
+    target_os = "haiku",
+    target_os = "hurd",
+    target_os = "redox"
+))]
 #[cfg(feature = "net")]
 pub use self::addr::{SockaddrIn, SockaddrIn6};
 
@@ -794,17 +804,17 @@ pub enum ControlMessageOwned {
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv6HopLimit(i32),
 
-    /// Retrieve the DSCP (ToS) header field of the incoming IPv4 packet. 
+    /// Retrieve the DSCP (ToS) header field of the incoming IPv4 packet.
     #[cfg(any(linux_android, target_os = "freebsd"))]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     Ipv4Tos(u8),
 
-    /// Retrieve the DSCP (Traffic Class) header field of the incoming IPv6 packet. 
+    /// Retrieve the DSCP (Traffic Class) header field of the incoming IPv6 packet.
     #[cfg(any(linux_android, target_os = "freebsd"))]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
-    Ipv6TClass(i32), 
+    Ipv6TClass(i32),
 
     /// UDP Generic Receive Offload (GRO) allows receiving multiple UDP
     /// packets from a single sender.
@@ -1258,7 +1268,7 @@ pub enum ControlMessage<'a> {
 // An opaque structure used to prevent cmsghdr from being a public type
 #[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UnknownCmsg(cmsghdr, Vec<u8>);
+pub struct UnknownCmsg(pub cmsghdr, pub Vec<u8>);
 
 impl ControlMessage<'_> {
     /// The value of CMSG_SPACE on this message.
@@ -2454,4 +2464,3 @@ pub fn shutdown(df: RawFd, how: Shutdown) -> Result<()> {
         Errno::result(shutdown(df, how)).map(drop)
     }
 }
-


### PR DESCRIPTION
## What does this PR do
Made fields in `nix::sys::socket::UnknownCmsg` public.   
This change will allow user to implement custom parsing for unsupported message, such as `SOL_IP, IP_RECVORIGDSTADDR`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] A change log has been added if this PR modifies nix's API
