### PR TITLE
recvmsg: take slice for cmsg_buffer

### DIFF
--- a/changelog/2524.changed.md
+++ b/changelog/2524.changed.md
@@ -1,0 +1,1 @@
+recvmsg: take slice for cmsg_buffer instead of Vec

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -573,7 +573,7 @@ macro_rules! cmsg_space {
     ( $( $x:ty ),* ) => {
         {
             let space = 0 $(+ $crate::sys::socket::cmsg_space::<$x>())*;
-            Vec::<u8>::with_capacity(space)
+            vec![0u8; space]
         }
     }
 }
@@ -2081,7 +2081,7 @@ fn pack_mhdr_to_send<'a, I, C, S>(
 /// # References
 /// [recvmsg(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html)
 pub fn recvmsg<'a, 'outer, 'inner, S>(fd: RawFd, iov: &'outer mut [IoSliceMut<'inner>],
-                   mut cmsg_buffer: Option<&'a mut Vec<u8>>,
+                   mut cmsg_buffer: Option<&'a mut [u8]>,
                    flags: MsgFlags) -> Result<RecvMsg<'a, 'outer, S>>
     where S: SockaddrLike + 'a,
     'inner: 'outer
@@ -2089,7 +2089,7 @@ pub fn recvmsg<'a, 'outer, 'inner, S>(fd: RawFd, iov: &'outer mut [IoSliceMut<'i
     let mut address = mem::MaybeUninit::uninit();
 
     let (msg_control, msg_controllen) = cmsg_buffer.as_mut()
-        .map(|v| (v.as_mut_ptr(), v.capacity()))
+        .map(|v| (v.as_mut_ptr(), v.len()))
         .unwrap_or((ptr::null_mut(), 0));
     let mut mhdr = unsafe {
         pack_mhdr_to_receive(iov.as_mut().as_mut_ptr(), iov.len(), msg_control, msg_controllen, address.as_mut_ptr())


### PR DESCRIPTION
Instead of a Vec, to avoid forcing an allocation.

`cmsg_space!` now creates a zero initialized vec (instead of a zero-len vec with capacity): this way callsites do not need to be changed.

I tried to change `cmsg_space!` to create a fixed sized array (instead of a Vec) but run into:

```
error: constant expression depends on a generic parameter
    --> test/sys/test_socket.rs:2907:26
     |
2907 |         let mut cspace = cmsg_space!(libc::sock_extended_err, SA);
     |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Fixes #2523
