### PR TITLE
sys::mman: enables MAP_STACK flag for netbsd too.

### DIFF
--- a/changelog/2526.added.md
+++ b/changelog/2526.added.md
@@ -1,0 +1,1 @@
+Add `MapFlags::MAP_STACK` in `sys::man` for netbsd

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -143,7 +143,7 @@ libc_bitflags! {
         #[cfg(any(freebsdlike, netbsdlike))]
         MAP_HASSEMAPHORE;
         /// Region grows down, like a stack.
-        #[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
+        #[cfg(any(linux_android, freebsdlike, netbsdlike))]
         MAP_STACK;
         /// Do not write through the page caches, write directly to the file. Used for Direct Access (DAX) enabled file systems.
         // Available on Linux glibc and musl, MIPS* target excluded.


### PR DESCRIPTION
Same status as Linux, a no-op, but in the future can be useful for architectures which need this feature.