### PR TITLE
Developer experience, cargo fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![deny(clippy::cast_ptr_alignment)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
@@ -105,68 +105,52 @@ mod macros;
 
 // Public crates
 #[cfg(not(target_os = "redox"))]
-feature! {
-    #![feature = "dir"]
-    pub mod dir;
-}
-feature! {
-    #![feature = "env"]
-    pub mod env;
-}
+#[cfg(feature = "dir")]
+pub mod dir;
+
+#[cfg(feature = "env")]
+pub mod env;
+
 #[allow(missing_docs)]
 pub mod errno;
-feature! {
-    #![feature = "feature"]
 
-    #[deny(missing_docs)]
-    pub mod features;
-}
+#[cfg(feature = "feature")]
+#[deny(missing_docs)]
+pub mod features;
+
 pub mod fcntl;
-feature! {
-    #![feature = "net"]
 
-    #[cfg(any(linux_android,
-              bsd,
-              solarish))]
-    #[deny(missing_docs)]
-    pub mod ifaddrs;
-    #[cfg(not(target_os = "redox"))]
-    #[deny(missing_docs)]
-    pub mod net;
-}
+#[cfg(feature = "net")]
+#[cfg(any(linux_android, bsd, solarish))]
+#[deny(missing_docs)]
+pub mod ifaddrs;
+
+#[cfg(feature = "net")]
+#[cfg(not(target_os = "redox"))]
+#[deny(missing_docs)]
+pub mod net;
+
 #[cfg(linux_android)]
-feature! {
-    #![feature = "kmod"]
-    pub mod kmod;
-}
-feature! {
-    #![feature = "mount"]
-    pub mod mount;
-}
+#[cfg(feature = "kmod")]
+pub mod kmod;
+
+#[cfg(feature = "mount")]
+pub mod mount;
+
 #[cfg(any(freebsdlike, target_os = "linux", target_os = "netbsd"))]
-feature! {
-    #![feature = "mqueue"]
-    pub mod mqueue;
-}
-feature! {
-    #![feature = "poll"]
-    pub mod poll;
-}
+#[cfg(feature = "mqueue")]
+pub mod mqueue;
+#[cfg(feature = "poll")]
+pub mod poll;
 #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
-feature! {
-    #![feature = "term"]
-    #[deny(missing_docs)]
-    pub mod pty;
-}
-feature! {
-    #![feature = "sched"]
-    pub mod sched;
-}
+#[cfg(feature = "term")]
+#[deny(missing_docs)]
+pub mod pty;
+#[cfg(feature = "sched")]
+pub mod sched;
 pub mod sys;
-feature! {
-    #![feature = "time"]
-    pub mod time;
-}
+#[cfg(feature = "time")]
+pub mod time;
 // This can be implemented for other platforms as soon as libc
 // provides bindings for them.
 #[cfg(all(
@@ -178,11 +162,9 @@ feature! {
         target_arch = "x86_64"
     )
 ))]
-feature! {
-    #![feature = "ucontext"]
-    #[allow(missing_docs)]
-    pub mod ucontext;
-}
+#[cfg(feature = "ucontext")]
+#[allow(missing_docs)]
+pub mod ucontext;
 pub mod unistd;
 
 #[cfg(any(feature = "poll", feature = "event"))]
@@ -195,10 +177,8 @@ mod poll_timeout;
     target_os = "netbsd",
     apple_targets
 ))]
-feature! {
-    #![feature = "process"]
-    pub mod spawn;
-}
+#[cfg(feature = "process")]
+pub mod spawn;
 
 use std::ffi::{CStr, CString, OsStr};
 use std::mem::MaybeUninit;

--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -3,9 +3,12 @@
 //! Uses Linux and/or POSIX functions to resolve interface names like "eth0"
 //! or "socan1" into device numbers.
 
-use std::{ffi::{CStr, CString}, fmt};
 use crate::{errno::Errno, Error, NixPath, Result};
 use libc::{c_uint, IF_NAMESIZE};
+use std::{
+    ffi::{CStr, CString},
+    fmt,
+};
 
 #[cfg(not(solarish))]
 /// type alias for InterfaceFlags
@@ -31,18 +34,19 @@ pub fn if_indextoname(index: c_uint) -> Result<CString> {
     // We need to allocate this anyway, so doing it directly is faster.
     let mut buf = vec![0u8; IF_NAMESIZE];
 
-    let return_buf = unsafe {
-        libc::if_indextoname(index, buf.as_mut_ptr().cast())
-    };
+    let return_buf =
+        unsafe { libc::if_indextoname(index, buf.as_mut_ptr().cast()) };
 
     Errno::result(return_buf.cast())?;
-    Ok(CStr::from_bytes_until_nul(buf.as_slice()).unwrap().to_owned())
+    Ok(CStr::from_bytes_until_nul(buf.as_slice())
+        .unwrap()
+        .to_owned())
 }
 
 libc_bitflags!(
     /// Standard interface flags, used by `getifaddrs`
     pub struct InterfaceFlags: IflagsType {
-    
+
         /// Interface is running. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_UP as IflagsType;
@@ -264,13 +268,7 @@ impl fmt::Display for InterfaceFlags {
     }
 }
 
-
-#[cfg(any(
-    bsd,
-    target_os = "fuchsia",
-    target_os = "linux",
-    solarish,
-))]
+#[cfg(any(bsd, target_os = "fuchsia", target_os = "linux", solarish,))]
 mod if_nameindex {
     use super::*;
 
@@ -392,10 +390,5 @@ mod if_nameindex {
         }
     }
 }
-#[cfg(any(
-    bsd,
-    target_os = "fuchsia",
-    target_os = "linux",
-    solarish,
-))]
+#[cfg(any(bsd, target_os = "fuchsia", target_os = "linux", solarish,))]
 pub use if_nameindex::*;


### PR DESCRIPTION
## What does this PR do

Right now `cargo fmt` is broken, CI admits it calling format on each individual file: `cargo fmt --all -- --check **/*.rs`. Second commit shows that CI was not actually enforcing formatting across all the files. This breaks workflow of writing code as is and letting your editor to deal with formatting on save or hotkey.

The problem is caused by the `feature!` macro. `rustfmt` does not perform any macro expansion and ignores everything inside of any unknown macro, in fact nothing inside of the `feature!` macro blocks is formatted. This includes scanning for child modules. `feature!` macro is used to lock some parts of the library behind features as well as explicitly document that in rustdoc using nightly feature `doc_cfg`.

This PR proposes a potential alternative - I replaced some of the `feature!`  macro invocation with plain `#[cfg(feature ...)]` invocation and implicit feature documentation using a different nightly feature: `doc_auto_cfg`. Downside (or an upside) is that documentation will contain the actual combination of feature flags and target platforms, for example features for `dir` from `dir` becomes `Non-Redox and dir`.

If we agree that this is a way forward - I'll remove all the remaining uses of `feature!` macro and remove it. It might cause some merge conflicts.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
