### PR TITLE
MacOS socket audit token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.158", features = ["extra_traits"] }
+libc = { version = "0.2.160", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2529.added.md
+++ b/changelog/2529.added.md
@@ -1,0 +1,1 @@
+Add support for `libc::LOCAL_PEERTOKEN` in `getsockopt`.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -499,6 +499,63 @@ cfg_if! {
     }
 }
 
+cfg_if! {
+    if #[cfg(apple_targets)] {
+        use std::fmt;
+
+        /// Return type of [`LocalPeerToken`].
+        ///
+        /// The audit token is an opaque token which identifies Mach tasks and
+        /// senders of Mach messages as subjects to the BSM audit system. Only
+        /// the appropriate BSM library routines should be used to interpret
+        /// the contents of the audit token as the representation of the
+        /// subject identity within the token may change over time.
+        ///
+        /// Starting with macOS 11, almost all audit functions have been
+        /// deprecated (see the system header `bsm/libbsm.h`), do not use them
+        /// if your program target more recent versions of macOS.
+        ///
+        /// [`LocalPeerToken`]: crate::sys::socket::sockopt::LocalPeerToken
+        #[repr(C)]
+        #[derive(Default, Copy, Clone, PartialEq, Eq, Hash)]
+        pub struct audit_token_t {
+            /// Value of the token.
+            ///
+            /// This is considered an opaque value, do not rely on its format.
+            pub val: [libc::c_uint; 8],
+        }
+
+        // Make the debug representation a hex string to make it shorter and clearer.
+        impl fmt::Debug for audit_token_t {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_tuple("audit_token_t")
+                    .field(&format!("0x{:08X}", self))
+                    .finish()
+            }
+        }
+
+        impl fmt::LowerHex for audit_token_t {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                for v in self.val {
+                    fmt::LowerHex::fmt(&v, f)?;
+                }
+
+                Ok(())
+            }
+        }
+
+        impl fmt::UpperHex for audit_token_t {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                for v in self.val {
+                    fmt::UpperHex::fmt(&v, f)?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
 feature! {
 #![feature = "net"]
 /// Request for multicast socket operations

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -563,7 +563,7 @@ sockopt_impl!(
     libc::SO_KEEPALIVE,
     bool
 );
-#[cfg(any(freebsdlike, apple_targets))]
+#[cfg(freebsdlike)]
 sockopt_impl!(
     /// Get the credentials of the peer process of a connected unix domain
     /// socket.
@@ -575,10 +575,20 @@ sockopt_impl!(
 );
 #[cfg(apple_targets)]
 sockopt_impl!(
+    /// Get the credentials of the peer process of a connected unix domain
+    /// socket.
+    LocalPeerCred,
+    GetOnly,
+    libc::SOL_LOCAL,
+    libc::LOCAL_PEERCRED,
+    super::XuCred
+);
+#[cfg(apple_targets)]
+sockopt_impl!(
     /// Get the PID of the peer process of a connected unix domain socket.
     LocalPeerPid,
     GetOnly,
-    0,
+    libc::SOL_LOCAL,
     libc::LOCAL_PEERPID,
     libc::c_int
 );

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -592,6 +592,16 @@ sockopt_impl!(
     libc::LOCAL_PEERPID,
     libc::c_int
 );
+#[cfg(apple_targets)]
+sockopt_impl!(
+    /// Get the audit token of the peer process of a connected unix domain
+    /// socket.
+    LocalPeerToken,
+    GetOnly,
+    libc::SOL_LOCAL,
+    libc::LOCAL_PEERTOKEN,
+    super::audit_token_t
+);
 #[cfg(linux_android)]
 sockopt_impl!(
     /// Return the credentials of the foreign process connected to this socket.


### PR DESCRIPTION
## What does this PR do

This adds a new API for `getsockopt` around `libc::LOCAL_PEERTOKEN` following https://github.com/rust-lang/libc/pull/3929. The return type definition is the low-level [`audit_token_t`](https://developer.apple.com/documentation/kernel/audit_token_t) as defined in [`osfmk/mach/message.h`](https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/osfmk/mach/message.h#L741) and taken from [`endpoint-sec-sys`](https://crates.io/crates/endpoint-sec-sys). A small test was added for it.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
