### PR TITLE
docs: correct epoll_ctl deprecation message

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -205,7 +205,10 @@ pub fn epoll_create1(flags: EpollCreateFlags) -> Result<RawFd> {
     Errno::result(res)
 }
 
-#[deprecated(since = "0.27.0", note = "Use Epoll::epoll_ctl() instead")]
+#[deprecated(
+    since = "0.27.0",
+    note = "Use corresponding Epoll methods instead"
+)]
 #[inline]
 pub fn epoll_ctl<'a, T>(
     epfd: RawFd,


### PR DESCRIPTION
## What does this PR do

Corrects the deprecation message of `epoll_ctl()`, and closes #2531.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
