### PR TITLE
Add the TCP_FUNCTION_BLK socket option, on FreeBSD

### DIFF
--- a/changelog/2539.added.md
+++ b/changelog/2539.added.md
@@ -1,0 +1,1 @@
+Add the `TCP_FUNCTION_BLK` sockopt, on FreeBSD.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -300,7 +300,18 @@ sockopt_impl!(
     libc::SO_REUSEPORT_LB,
     bool
 );
+#[cfg(target_os = "freebsd")]
 #[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Select or query the set of functions that TCP will use for this connection.  This allows a
+    /// user to select an alternate TCP stack.
+    TcpFunctionBlk,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_FUNCTION_BLK,
+    libc::tcp_function_set
+);
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Used to disable Nagle's algorithm.

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -282,6 +282,28 @@ fn test_tcp_congestion() {
 }
 
 #[test]
+#[cfg(target_os = "freebsd")]
+fn test_tcp_function_blk() {
+    use std::ffi::CStr;
+
+    let fd = socket(
+        AddressFamily::Inet,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .unwrap();
+
+    let tfs = getsockopt(&fd, sockopt::TcpFunctionBlk).unwrap();
+    let name = unsafe { CStr::from_ptr(tfs.function_set_name.as_ptr()) };
+    assert!(!name.to_bytes().is_empty());
+
+    // We can't know at compile time what options are available.  So just test the setter by a
+    // no-op set.
+    setsockopt(&fd, sockopt::TcpFunctionBlk, &tfs).unwrap();
+}
+
+#[test]
 #[cfg(linux_android)]
 fn test_bindtodevice() {
     skip_if_not_root!("test_bindtodevice");


### PR DESCRIPTION
## What does this PR do

Adds the `TCP_FUNCTION_BLK` socket option, used to set or query a socket's TCP stack, on FreeBSD only

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
