### PR TITLE
Solaris: fixes build and tests, adds CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,27 @@ jobs:
       - name: before_cache_script
         run: rm -rf $CARGO_HOME/registry/index
 
+  solaris:
+    name: solaris (x86_64-pc-solaris)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build and test
+        uses: vmactions/solaris-vm@v1
+        with:
+          release: "11.4-gcc"
+          usesh: true
+          mem: 4096
+          copyback: false
+          prepare: |
+            source <(curl -s https://raw.githubusercontent.com/psumbera/solaris-rust/refs/heads/main/sh.rust-web-install)
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ Solaris-version ~~~~"
+            uname -a
+          run: |
+            export PATH=$HOME/.rust_solaris/bin:$PATH
+            cargo build --target x86_64-pc-solaris --all-targets --all-features && sudo cargo test
 
   # Test that we can build with the lowest version of all dependencies.
   # "cargo test" doesn't work because some of our dev-dependencies, like

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.164", features = ["extra_traits"] }
+libc = { version = "0.2.166", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -46,7 +46,7 @@ use libc::{dirent, readdir_r};
 /// let mut cwd = Dir::open(".", OFlag::O_RDONLY | OFlag::O_CLOEXEC, Mode::empty()).unwrap();
 /// for res_entry in cwd.iter() {
 ///     let entry = res_entry.unwrap();
-///     println!("File name: {}", entry.file_name().to_str().unwrap());
+///     println!("File name: {}", entry.file_name().to_string_lossy());
 /// }
 /// ```
 #[derive(Debug, Eq, Hash, PartialEq)]

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -14,7 +14,7 @@ use std::ffi::OsString;
 #[cfg(not(any(target_os = "redox", target_os = "solaris")))]
 use std::ops::{Deref, DerefMut};
 use std::os::unix::ffi::OsStringExt;
-#[cfg(not(any(target_os = "redox", target_os = "solaris")))]
+#[cfg(not(target_os = "redox"))]
 use std::os::unix::io::OwnedFd;
 use std::os::unix::io::RawFd;
 #[cfg(any(
@@ -141,7 +141,7 @@ libc_bitflags!(
         #[cfg(any(
             freebsdlike,
             linux_android,
-            solarish,
+            target_os = "illumos",
             target_os = "netbsd"
         ))]
         O_DIRECT;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -38,6 +38,7 @@ libc_bitflags! {
     /// Additional parameters for [`mmap`].
     pub struct MapFlags: c_int {
         /// Compatibility flag. Ignored.
+        #[cfg(not(target_os = "solaris"))]
         MAP_FILE;
         /// Share this mapping. Mutually exclusive with `MAP_PRIVATE`.
         MAP_SHARED;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -110,7 +110,8 @@ libc_enum! {
         SIGEMT,
         #[cfg(not(any(linux_android, target_os = "emscripten",
                       target_os = "fuchsia", target_os = "redox",
-                      target_os = "haiku", target_os = "aix")))]
+                      target_os = "haiku", target_os = "aix",
+                      target_os = "solaris")))]
         /// Information request
         SIGINFO,
     }
@@ -188,7 +189,8 @@ impl FromStr for Signal {
                 target_os = "fuchsia",
                 target_os = "redox",
                 target_os = "aix",
-                target_os = "haiku"
+                target_os = "haiku",
+                target_os = "solaris"
             )))]
             "SIGINFO" => Signal::SIGINFO,
             _ => return Err(Errno::EINVAL),
@@ -272,7 +274,8 @@ impl Signal {
                 target_os = "fuchsia",
                 target_os = "redox",
                 target_os = "aix",
-                target_os = "haiku"
+                target_os = "haiku",
+                target_os = "solaris"
             )))]
             Signal::SIGINFO => "SIGINFO",
         }
@@ -356,13 +359,22 @@ const SIGNALS: [Signal; 30] = [
     SIGURG, SIGPOLL, SIGIO, SIGSTOP, SIGTSTP, SIGCONT, SIGTTIN, SIGTTOU,
     SIGVTALRM, SIGPROF, SIGXCPU, SIGXFSZ, SIGTRAP,
 ];
+#[cfg(target_os = "solaris")]
+#[cfg(feature = "signal")]
+const SIGNALS: [Signal; 30] = [
+    SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE, SIGKILL,
+    SIGUSR1, SIGSEGV, SIGUSR2, SIGPIPE, SIGALRM, SIGTERM, SIGCHLD, SIGCONT,
+    SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU, SIGURG, SIGXCPU, SIGXFSZ, SIGVTALRM,
+    SIGPROF, SIGWINCH, SIGIO, SIGSYS, SIGEMT,
+];
 #[cfg(not(any(
     linux_android,
     target_os = "fuchsia",
     target_os = "emscripten",
     target_os = "aix",
     target_os = "redox",
-    target_os = "haiku"
+    target_os = "haiku",
+    target_os = "solaris"
 )))]
 #[cfg(feature = "signal")]
 const SIGNALS: [Signal; 31] = [

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1670,6 +1670,7 @@ impl ControlMessage<'_> {
 /// sendmsg::<()>(fd1.as_raw_fd(), &iov, &[cmsg], MsgFlags::empty(), None).unwrap();
 /// ```
 /// When directing to a specific address, the generic type will be inferred.
+/// Note that SCM_RIGHTS ancillary data are valid only for AF_UNIX sockets on Solaris.
 /// ```
 /// # use nix::sys::socket::*;
 /// # use nix::unistd::pipe;
@@ -1684,6 +1685,7 @@ impl ControlMessage<'_> {
 /// let iov = [IoSlice::new(b"hello")];
 /// let fds = [r.as_raw_fd()];
 /// let cmsg = ControlMessage::ScmRights(&fds);
+/// #[cfg(not(target_os = "solaris"))]
 /// sendmsg(fd.as_raw_fd(), &iov, &[cmsg], MsgFlags::empty(), Some(&localhost)).unwrap();
 /// ```
 pub fn sendmsg<S>(fd: RawFd, iov: &[IoSlice<'_>], cmsgs: &[ControlMessage],

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -418,7 +418,7 @@ libc_enum! {
         VEOL,
         VEOL2,
         VERASE,
-        #[cfg(any(freebsdlike, solarish))]
+        #[cfg(any(freebsdlike, target_os = "illumos"))]
         VERASE2,
         VINTR,
         VKILL,
@@ -431,7 +431,7 @@ libc_enum! {
         #[cfg(not(target_os = "haiku"))]
         VREPRINT,
         VSTART,
-        #[cfg(any(bsd, solarish))]
+        #[cfg(any(bsd, target_os = "illumos"))]
         VSTATUS,
         VSTOP,
         VSUSP,
@@ -461,7 +461,7 @@ impl SpecialCharacterIndices {
 }
 
 pub use libc::NCCS;
-#[cfg(any(linux_android, target_os = "aix", bsd))]
+#[cfg(any(bsd, linux_android, target_os = "aix", target_os = "solaris"))]
 pub use libc::_POSIX_VDISABLE;
 
 libc_bitflags! {

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -138,7 +138,7 @@ libc_bitflags! {
         /// which file descriptors are allocated.
         LOG_NDELAY;
         /// Write the message to standard error output as well to the system log.
-        #[cfg(not(any(target_os = "redox", target_os = "illumos")))]
+        #[cfg(not(any(solarish, target_os = "redox")))]
         LOG_PERROR;
     }
 }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -2157,7 +2157,9 @@ pub mod alarm {
     //! sigset.add(Signal::SIGALRM);
     //! sigset.wait();
     //!
-    //! assert!(start.elapsed() >= Duration::from_secs(1));
+    //! // On Solaris, the signal can arrive before the full second.
+    //! const TOLERANCE: Duration = Duration::from_millis(10);
+    //! assert!(start.elapsed() + TOLERANCE >= Duration::from_secs(1));
     //! ```
     //!
     //! # References

--- a/test/sys/test_stat.rs
+++ b/test/sys/test_stat.rs
@@ -368,7 +368,8 @@ fn test_mkdirat_fail() {
     freebsdlike,
     apple_targets,
     target_os = "haiku",
-    target_os = "redox"
+    target_os = "redox",
+    target_os = "solaris"
 )))]
 fn test_mknod() {
     use stat::{lstat, mknod, SFlag};

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -80,6 +80,7 @@ fn test_output_flags() {
 
 // Test modifying local flags
 #[test]
+#[cfg(not(target_os = "solaris"))]
 fn test_local_flags() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -148,6 +148,7 @@ fn make_raw<Fd: AsFd>(fd: Fd) {
 
 /// Test `io::Read` on the PTTY master
 #[test]
+#[cfg(not(target_os = "solaris"))]
 fn test_read_ptty_pair() {
     let (mut master, mut slave) = open_ptty_pair();
     make_raw(&slave);


### PR DESCRIPTION
Disables some tests for Solaris.

test/test_sendfile.rs:

Solaris, sendfilev() doesn't support AF_UNIX sockets. Instead, it expects an AF_INET or AF_INET6 sockets.