### PR TITLE
Clippy cleanup: needless as_bytes

### DIFF
--- a/test/test_sendfile.rs
+++ b/test/test_sendfile.rs
@@ -94,7 +94,7 @@ fn test_sendfile_freebsd() {
         + &trailer_strings.concat();
 
     // Verify the message that was sent
-    assert_eq!(bytes_written as usize, expected_string.as_bytes().len());
+    assert_eq!(bytes_written as usize, expected_string.len());
 
     let mut read_string = String::new();
     let bytes_read = rd.read_to_string(&mut read_string).unwrap();


### PR DESCRIPTION
Fixes a clippy warning on the latest nightly
