### PR TITLE
feat: impl Into<OwnedFd> for owned fd types

### DIFF
--- a/changelog/2548.added.md
+++ b/changelog/2548.added.md
@@ -1,0 +1,1 @@
+Implements `Into<OwnedFd>` for `PtyMaster/Fanotify/Inotify/SignalFd/TimerFd`

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -64,6 +64,12 @@ impl AsFd for PtyMaster {
     }
 }
 
+impl From<PtyMaster> for OwnedFd {
+    fn from(value: PtyMaster) -> Self {
+        value.0
+    }
+}
+
 impl IntoRawFd for PtyMaster {
     fn into_raw_fd(self) -> RawFd {
         let fd = self.0;

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -101,8 +101,9 @@ impl AsRawFd for EventFd {
         self.0.as_raw_fd()
     }
 }
+
 impl From<EventFd> for OwnedFd {
-    fn from(x: EventFd) -> OwnedFd {
-        x.0
+    fn from(value: EventFd) -> Self {
+        value.0
     }
 }

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -418,3 +418,9 @@ impl AsFd for Fanotify {
         self.fd.as_fd()
     }
 }
+
+impl From<Fanotify> for OwnedFd {
+    fn from(value: Fanotify) -> Self {
+        value.fd
+    }
+}

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -254,3 +254,9 @@ impl AsFd for Inotify {
         self.fd.as_fd()
     }
 }
+
+impl From<Inotify> for OwnedFd {
+    fn from(value: Inotify) -> Self {
+        value.fd
+    }
+}

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -147,6 +147,12 @@ impl AsRawFd for SignalFd {
     }
 }
 
+impl From<SignalFd> for OwnedFd {
+    fn from(value: SignalFd) -> Self {
+        value.0 
+    }
+}
+
 impl Iterator for SignalFd {
     type Item = siginfo;
 

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -58,6 +58,12 @@ impl FromRawFd for TimerFd {
     }
 }
 
+impl From<TimerFd> for OwnedFd {
+    fn from(value: TimerFd) -> Self {
+        value.fd  
+    }
+}
+
 libc_enum! {
     /// The type of the clock used to mark the progress of the timer. For more
     /// details on each kind of clock, please refer to [timerfd_create(2)](https://man7.org/linux/man-pages/man2/timerfd_create.2.html).


### PR DESCRIPTION
## What does this PR do

Implements `Into<OwnedFd> for x` (Actually, it is `From<x> for OwnedFd` due to the clippy rule [clippy::from_over_into](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into)) for types that are **simply owned file descriptors**.

Types like [Dir](https://docs.rs/nix/latest/nix/dir/struct.Dir.html), do not only contain a file descriptor, so they are not included in this PR.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
