### PR TITLE
Add missing Fanotify APIs from the libc crate into Nix.

### DIFF
--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -251,7 +251,7 @@ impl FanotifyFidRecord {
     /// differs depending on the host system. Please read the statfs(2) documentation
     /// for more information:
     /// https://man7.org/linux/man-pages/man2/statfs.2.html#VERSIONS
-    pub fn fsid(&self) -> libc::__kernel_fsid_t {
+    pub fn filesystem_id(&self) -> libc::__kernel_fsid_t {
         self.0.fsid
     }
 
@@ -595,7 +595,14 @@ impl Fanotify {
                     );
 
                 let info_record = match header.info_type {
-                    libc::FAN_EVENT_INFO_TYPE_FID => {
+                    // FanotifyFidRecord can be returned for any of the following info_type.
+                    // This isn't found in the fanotify(7) documentation, but the fanotify_init(2) documentation
+                    // https://man7.org/linux/man-pages/man2/fanotify_init.2.html
+                    libc::FAN_EVENT_INFO_TYPE_FID
+                    | libc::FAN_EVENT_INFO_TYPE_DFID
+                    | libc::FAN_EVENT_INFO_TYPE_DFID_NAME
+                    | libc::FAN_EVENT_INFO_TYPE_NEW_DFID_NAME
+                    | libc::FAN_EVENT_INFO_TYPE_OLD_DFID_NAME => {
                         let record = self
                             .get_struct::<libc::fanotify_event_info_fid>(
                                 &buffer,

--- a/test/sys/test_fanotify.rs
+++ b/test/sys/test_fanotify.rs
@@ -3,7 +3,7 @@ use nix::errno::Errno;
 use nix::fcntl::AT_FDCWD;
 use nix::sys::fanotify::{
     EventFFlags, Fanotify, FanotifyResponse, InitFlags, MarkFlags, MaskFlags,
-    Response,
+    Response, FanotifyInfoRecord
 };
 use std::fs::{read_link, read_to_string, File, OpenOptions};
 use std::io::ErrorKind;
@@ -18,6 +18,7 @@ pub fn test_fanotify() {
 
     test_fanotify_notifications();
     test_fanotify_responses();
+    test_fanotify_notifications_with_info_records();
     test_fanotify_overflow();
 }
 
@@ -82,6 +83,65 @@ fn test_fanotify_notifications() {
     let fd = fd_opt.as_ref().unwrap();
     let path = read_link(format!("/proc/self/fd/{}", fd.as_raw_fd())).unwrap();
     assert_eq!(path, tempfile);
+}
+
+fn test_fanotify_notifications_with_info_records() {
+    let group =
+        Fanotify::init(InitFlags::FAN_CLASS_NOTIF | InitFlags::FAN_REPORT_FID, EventFFlags::O_RDONLY)
+            .unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempfile = tempdir.path().join("test");
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tempfile)
+        .unwrap();
+
+    group
+        .mark(
+            MarkFlags::FAN_MARK_ADD,
+            MaskFlags::FAN_OPEN | MaskFlags::FAN_MODIFY | MaskFlags::FAN_CLOSE,
+            AT_FDCWD,
+            Some(&tempfile),
+        )
+        .unwrap();
+
+    // modify test file
+    {
+        let mut f = OpenOptions::new().write(true).open(&tempfile).unwrap();
+        f.write_all(b"hello").unwrap();
+    }
+
+    let mut events = group.read_events_with_info_records().unwrap();
+    assert_eq!(events.len(), 1, "should have read exactly one event");
+    let (event, info_records) = events.pop().unwrap();
+    assert_eq!(info_records.len(), 1, "should have read exactly one info record");
+    assert!(event.check_version());
+    assert_eq!(
+        event.mask(),
+        MaskFlags::FAN_OPEN
+            | MaskFlags::FAN_MODIFY
+            | MaskFlags::FAN_CLOSE_WRITE
+    );
+
+    assert!(matches!(info_records[0], FanotifyInfoRecord::Fid { .. }), "info record should be an fid record");
+
+    // read test file
+    {
+        let mut f = File::open(&tempfile).unwrap();
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+    }
+
+    let mut events = group.read_events_with_info_records().unwrap();
+    assert_eq!(events.len(), 1, "should have read exactly one event");
+    let (event, info_records) = events.pop().unwrap();
+    assert_eq!(info_records.len(), 1, "should have read exactly one info record");
+    assert!(event.check_version());
+    assert_eq!(
+        event.mask(),
+        MaskFlags::FAN_OPEN | MaskFlags::FAN_CLOSE_NOWRITE
+    );
 }
 
 fn test_fanotify_responses() {


### PR DESCRIPTION
## What does this PR do
Adds support for nix to receive additional Fanotify information records (such as `libc::fanotify_event_info_fid`, `libc::fanotify_event_info_error` and `libc::fanotify_event_info_pidfd`)
Adds abstractions over the new fanotify structs.
Adds new `InitFlags` to allow receiving these new information records.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
