### PR TITLE
sys::mman: adding `MREMAP_DONTUNMAP` flag for mremap on Linux.

### DIFF
--- a/changelog/2555.added.md
+++ b/changelog/2555.added.md
@@ -1,0 +1,1 @@
+Add `MremapFlags::MREMAP_DONTUNMAP` to `sys::mman::mremap` for linux target.

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -205,6 +205,10 @@ libc_bitflags! {
         /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "linux")]
         MREMAP_FIXED;
+        /// Works in conjunction with `MREMAP_MAYMOVE` but does not unmap `old_address`.
+        /// Note that, in this case, `old_size` and `new_size` must be the same.
+        #[cfg(target_os = "linux")]
+        MREMAP_DONTUNMAP;
         /// Place the mapping at exactly the address specified in `new_address`.
         #[cfg(target_os = "netbsd")]
         MAP_FIXED;


### PR DESCRIPTION
Is meant to be used with `MREMAP_MAYMOVE` and allow to not unmapping `old_address`.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
