### PR TITLE
Make sockopt_impl! public

### DIFF
--- a/changelog/2556.added.md
+++ b/changelog/2556.added.md
@@ -1,0 +1,2 @@
+Added `sockopt_impl!` to the public API.  It's now possible for users to define
+their own sockopts without needing to make a PR to Nix.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -6,6 +6,7 @@ use crate::sys::time::TimeVal;
 use crate::{errno::Errno, Result};
 use cfg_if::cfg_if;
 use libc::{self, c_int, c_void, socklen_t};
+#[cfg(apple_targets)]
 use std::ffi::{CStr, CString};
 use std::ffi::{OsStr, OsString};
 use std::mem::{self, MaybeUninit};
@@ -1774,14 +1775,13 @@ impl<'a> Set<'a, OsString> for SetOsString<'a> {
 }
 
 /// Getter for a `CString` value.
-// Hide the docs, because it's an implementation detail of `sockopt_impl!`
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct GetCString<T: AsMut<[u8]>> {
+#[cfg(apple_targets)]
+struct GetCString<T: AsMut<[u8]>> {
     len: socklen_t,
     val: MaybeUninit<T>,
 }
 
+#[cfg(apple_targets)]
 impl<T: AsMut<[u8]>> Get<CString> for GetCString<T> {
     fn uninit() -> Self {
         GetCString {

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -11,8 +11,7 @@ use std::ffi::{OsStr, OsString};
 use std::mem::{self, MaybeUninit};
 use std::os::unix::ffi::OsStrExt;
 #[cfg(linux_android)]
-use std::os::unix::io::AsFd;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsFd, AsRawFd};
 
 // Constants
 // TCP_CA_NAME_MAX isn't defined in user space include files
@@ -54,9 +53,9 @@ macro_rules! setsockopt_impl {
                 fd: &F,
                 val: &$ty,
             ) -> $crate::Result<()> {
+                use std::os::fd::AsRawFd;
                 use $crate::sys::socket::sockopt::Set;
-                let setter: $setter =
-                    $crate::sys::socket::sockopt::Set::new(val);
+                let setter: $setter = Set::new(val);
                 let level = $level;
                 let flag = $flag;
                 let res = unsafe {
@@ -107,9 +106,9 @@ macro_rules! getsockopt_impl {
                 &self,
                 fd: &F,
             ) -> $crate::Result<$ty> {
+                use std::os::fd::AsRawFd;
                 use $crate::sys::socket::sockopt::Get;
-                let mut getter: $getter =
-                    $crate::sys::socket::sockopt::Get::uninit();
+                let mut getter: $getter = Get::uninit();
                 let level = $level;
                 let flag = $flag;
                 let res = unsafe {

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1054,7 +1054,6 @@ mod sockopt_impl {
         getsockopt, setsockopt, socket, AddressFamily, SockFlag, SockProtocol,
         SockType,
     };
-    use std::os::unix::io::AsRawFd;
 
     sockopt_impl!(
         Linger,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1047,3 +1047,54 @@ fn test_ipv6_recv_traffic_class_opts() {
         "unsetting IPV6_RECVTCLASS on an inet6 datagram socket should succeed",
     );
 }
+
+/// Users should be able to define their own sockopts.
+mod sockopt_impl {
+    use nix::sys::socket::{
+        getsockopt, setsockopt, socket, AddressFamily, SockFlag, SockProtocol,
+        SockType,
+    };
+    use std::os::unix::io::AsRawFd;
+
+    sockopt_impl!(
+        Linger,
+        Both,
+        libc::SOL_SOCKET,
+        libc::SO_LINGER,
+        libc::linger
+    );
+    #[test]
+    fn test_linger() {
+        let fd = socket(
+            AddressFamily::Inet,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        )
+        .unwrap();
+
+        let set_linger = libc::linger {
+            l_onoff: 1,
+            l_linger: 42,
+        };
+        setsockopt(&fd, Linger, &set_linger).unwrap();
+
+        let get_linger = getsockopt(&fd, Linger).unwrap();
+        assert_eq!(get_linger.l_linger, set_linger.l_linger);
+    }
+
+    sockopt_impl!(KeepAlive, Both, libc::SOL_SOCKET, libc::SO_KEEPALIVE, bool);
+
+    #[test]
+    fn test_so_tcp_keepalive() {
+        let fd = socket(
+            AddressFamily::Inet,
+            SockType::Stream,
+            SockFlag::empty(),
+            SockProtocol::Tcp,
+        )
+        .unwrap();
+        setsockopt(&fd, KeepAlive, &true).unwrap();
+        assert!(getsockopt(&fd, KeepAlive).unwrap());
+    }
+}

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate cfg_if;
-#[cfg_attr(not(any(target_os = "redox", target_os = "haiku")), macro_use)]
+#[cfg_attr(not(any(target_os = "redox")), macro_use)]
 extern crate nix;
 
 #[macro_use]


### PR DESCRIPTION
This allows users to define their own sockopts, instead of needing to make a PR to Nix for every single one.

Fixes #577

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
