### PR TITLE
Exclude NUL characters from OSStrings returned by getsockopt

### DIFF
--- a/changelog/2557.fixed.md
+++ b/changelog/2557.fixed.md
@@ -1,0 +1,1 @@
+Properly exclude NUL characters from `OSString`s returned by `getsockopt`.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1746,9 +1746,11 @@ impl<T: AsMut<[u8]>> Get<OsString> for GetOsString<T> {
         let len = self.len as usize;
         let mut v = unsafe { self.val.assume_init() };
         if let Ok(cs) = CStr::from_bytes_until_nul(&v.as_mut()[0..len]) {
+            // It's legal for the kernel to return any number of NULs at the
+            // end of the string.  C applications don't care, after all.
             OsStr::from_bytes(cs.to_bytes())
         } else {
-            // The OS returned a non-NUL-terminated string
+            // Even zero NULs is possible.
             OsStr::from_bytes(&v.as_mut()[0..len])
         }
         .to_owned()

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -258,6 +258,7 @@ fn test_so_type_unknown() {
 #[cfg_attr(qemu, ignore)]
 fn test_tcp_congestion() {
     use std::ffi::OsString;
+    use std::os::unix::ffi::OsStrExt;
 
     let fd = socket(
         AddressFamily::Inet,
@@ -268,7 +269,7 @@ fn test_tcp_congestion() {
     .unwrap();
 
     let val = getsockopt(&fd, sockopt::TcpCongestion).unwrap();
-    let bytes = val.as_os_str().as_encoded_bytes();
+    let bytes = val.as_os_str().as_bytes();
     for b in bytes.iter() {
         assert_ne!(
             *b, 0,

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -249,14 +249,13 @@ fn test_so_type_unknown() {
 }
 
 // The CI doesn't supported getsockopt and setsockopt on emulated processors.
-// It's believed that a QEMU issue, the tests run ok on a fully emulated system.
-// Current CI just run the binary with QEMU but the Kernel remains the same as the host.
+// It's believed to be a QEMU issue; the tests run ok on a fully emulated
+// system.  Current CI just runs the binary with QEMU but the kernel remains the
+// same as the host.
 // So the syscall doesn't work properly unless the kernel is also emulated.
 #[test]
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    any(target_os = "freebsd", target_os = "linux")
-))]
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+#[cfg_attr(qemu, ignore)]
 fn test_tcp_congestion() {
     use std::ffi::OsString;
 
@@ -269,6 +268,14 @@ fn test_tcp_congestion() {
     .unwrap();
 
     let val = getsockopt(&fd, sockopt::TcpCongestion).unwrap();
+    let bytes = val.as_os_str().as_encoded_bytes();
+    for b in bytes.iter() {
+        assert_ne!(
+            *b, 0,
+            "OsString should contain no embedded NULs: {:?}",
+            val
+        );
+    }
     setsockopt(&fd, sockopt::TcpCongestion, &val).unwrap();
 
     setsockopt(


### PR DESCRIPTION
On FreeBSD, getsockopt appends a single NUL to the returned string.  On Linux, it pads the entire buffer with NULs.  But both of those behaviors may be version-dependent.  Adjust GetOsString to handle any number of NUL characters.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
