### PR TITLE
sys::socket adding GetOnly `TCP_FUNCTION_ALIAS` for freebsd.

### DIFF
--- a/changelog/2558.added.md
+++ b/changelog/2558.added.md
@@ -1,0 +1,1 @@
+Add the `TCP_FUNCTION_ALIAS` sockopt, on FreeBSD.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -330,6 +330,19 @@ sockopt_impl!(
     libc::TCP_FUNCTION_BLK,
     libc::tcp_function_set
 );
+#[cfg(target_os = "freebsd")]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Query the alias name of the set of function of the socket's TCP stack.
+    /// Uses the same field for the main name when getting from TCP_FUNCTION_BLK.
+    /// Empty if no alias.
+    TcpFunctionAlias,
+    GetOnly,
+    libc::IPPROTO_TCP,
+    libc::TCP_FUNCTION_ALIAS,
+    libc::tcp_function_set
+);
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     /// Used to disable Nagle's algorithm.

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -283,7 +283,7 @@ fn test_tcp_congestion() {
 
 #[test]
 #[cfg(target_os = "freebsd")]
-fn test_tcp_function_blk() {
+fn test_tcp_function_blk_alias() {
     use std::ffi::CStr;
 
     let fd = socket(
@@ -298,8 +298,15 @@ fn test_tcp_function_blk() {
     let name = unsafe { CStr::from_ptr(tfs.function_set_name.as_ptr()) };
     assert!(!name.to_bytes().is_empty());
 
+    let aliastfs = getsockopt(&fd, sockopt::TcpFunctionAlias).unwrap();
+    let aliasname =
+        unsafe { CStr::from_ptr(aliastfs.function_set_name.as_ptr()) };
+    // freebsd default tcp stack has no alias.
+    assert!(aliasname.to_bytes().is_empty());
+
     // We can't know at compile time what options are available.  So just test the setter by a
     // no-op set.
+    // TODO: test if we can load for example BBR tcp stack kernel module.
     setsockopt(&fd, sockopt::TcpFunctionBlk, &tfs).unwrap();
 }
 


### PR DESCRIPTION
to complete `TCP_FUNCTION_BLK` as to get the alias name, if existent, of the TCP stack.