### PR TITLE
sys::mman: adding few madvise flags.

### DIFF
--- a/changelog/2559.added.md
+++ b/changelog/2559.added.md
@@ -1,1 +1,1 @@
-Add `sys::mman::MmapAdvise` `MADV_PAGEOUT`, `MADV_COLD`, `MADV_WIPEONFORK`, `MADV_KEEPONFORK` for Linux target
+Add `sys::mman::MmapAdvise` `MADV_PAGEOUT`, `MADV_COLD`, `MADV_WIPEONFORK`, `MADV_KEEPONFORK` for Linux and Android targets

--- a/changelog/2559.added.md
+++ b/changelog/2559.added.md
@@ -1,0 +1,1 @@
+Add `sys::mman::MmapAdvise` `MADV_PAGEOUT`, `MADV_COLD`, `MADV_WIPEONFORK`, `MADV_KEEPONFORK` for Linux target

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -316,6 +316,18 @@ libc_enum! {
         #[cfg(apple_targets)]
         #[allow(missing_docs)]
         MADV_CAN_REUSE,
+        /// Reclaim the address range when applicable.
+        #[cfg(linux_android)]
+        MADV_PAGEOUT,
+        /// Deactivate the address range when applicable.
+        #[cfg(linux_android)]
+        MADV_COLD,
+        /// After fork, the adress range is zero filled.
+        #[cfg(linux_android)]
+        MADV_WIPEONFORK,
+        /// Undo `MADV_WIPEONFORK` when it applied.
+        #[cfg(linux_android)]
+        MADV_KEEPONFORK,
     }
 }
 


### PR DESCRIPTION
- `MADV_PAGEOUT` which reclaim the address range, swapping it out if the page is anonymous or written back to disk if it's backed up by a file.
- `MADV_COLD` which deactivate the address range but as a hint.
- `MADV_WIPEONFORK` after `fork()`, the address range is wiped out to avoid sharing sensible data between processes.
- `MADV_KEEPONFORK` disables `MADV_WIPEONFORK` workflow.
