### PR TITLE
Add doc aliases for `getpw{nam,uid}`

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -3732,6 +3732,7 @@ impl User {
     /// let res = User::from_uid(Uid::from_raw(0)).unwrap().unwrap();
     /// assert_eq!(res.name, "root");
     /// ```
+    #[doc(alias("getpwuid", "getpwuid_r"))]
     pub fn from_uid(uid: Uid) -> Result<Option<Self>> {
         // SAFETY: `getpwuid_r` will write to `res` if it initializes the value
         // at `pwd`.
@@ -3755,6 +3756,7 @@ impl User {
     /// let res = User::from_name("root").unwrap().unwrap();
     /// assert_eq!(res.name, "root");
     /// ```
+    #[doc(alias("getpwnam", "getpwnam_r"))]
     pub fn from_name(name: &str) -> Result<Option<Self>> {
         let name = match CString::new(name) {
             Ok(c_str) => c_str,


### PR DESCRIPTION
I was reviewing some unsafe code using libc directly for these functions, and it took me some time to figure out what nix actually has wrappers from them so we can avoid using unsafe. These aliases would have made it much easier for me to discover these functions.