### PR TITLE
Add Sctp protocol and MSG_NOTIFICATION

### DIFF
--- a/changelog/2562.added.md
+++ b/changelog/2562.added.md
@@ -1,0 +1,1 @@
+Add socket protocol `Sctp`, as well as `MSG_NOTIFICATION` for non-Android Linux targets.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -213,6 +213,14 @@ pub enum SockProtocol {
     Icmp = libc::IPPROTO_ICMP,
     /// ICMPv6 protocol (ICMP over IPv6)
     IcmpV6 = libc::IPPROTO_ICMPV6,
+    /// SCTP ([sctp(7)](https://man7.org/linux/man-pages/man7/sctp.7.html))
+    #[cfg(any(
+        apple_targets,
+        linux_android,
+        target_os = "freebsd",
+        target_os = "netbsd"
+    ))]
+    Sctp = libc::IPPROTO_SCTP,
 }
 
 impl SockProtocol {
@@ -356,6 +364,9 @@ libc_bitflags! {
                   target_os = "fuchsia",
                   target_os = "freebsd"))]
         MSG_WAITFORONE;
+        /// Indicates that this message is not a user message but an SCTP notification.
+        #[cfg(target_os = "linux")]
+        MSG_NOTIFICATION;
     }
 }
 


### PR DESCRIPTION
## What does this PR do
 - Adds the `Sctp` variant to the `SockProtocol` enum, allowing the user to create SCTP sockets with either `SockType::Stream` or `SockType::SeqPacket`.
 - (Linux Only) Expose `MSG_NOTIFICATION` through `MsgFlags` so that it won't be truncated when converting from `i32`.

`IPPROTO_SCTP` is defined in [RFC-6458](https://datatracker.ietf.org/doc/html/rfc6458), but it is not supported by all OSs.
I've cfg'd-out targets that failed in CI.

`MSG_NOTIFICATION` is Linux-specific, as far as I can tell, but is not exposed through Android's libc, so I've limited it to `linux` and not `linux_android`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
