### PR TITLE
Add from_owned_fd constructor to EventFd

### DIFF
--- a/changelog/2563.added.md
+++ b/changelog/2563.added.md
@@ -1,0 +1,1 @@
+Added `from_owned_fd` constructor to `EventFd`

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -58,6 +58,13 @@ impl EventFd {
         Self::from_value_and_flags(init_val, EfdFlags::empty())
     }
 
+    /// Constructs an `EventFd` wrapping an existing `OwnedFd`.
+    ///
+    /// Safety: `OwnedFd` is a valid eventfd.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self(fd)
+    }
+
     /// Enqueues `value` triggers, i.e., adds the integer value supplied in `value`
     /// to the counter.
     ///

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -60,7 +60,9 @@ impl EventFd {
 
     /// Constructs an `EventFd` wrapping an existing `OwnedFd`.
     ///
-    /// Safety: `OwnedFd` is a valid eventfd.
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid eventfd.
     pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
         Self(fd)
     }


### PR DESCRIPTION
Allow creating an `EventFd` from an `OwnedFd` acquired from another process.

Fixes #2561 