### PR TITLE
Parse unix address from sockaddr without length

### DIFF
--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1189,6 +1189,9 @@ impl SockaddrLike for SockaddrStorage {
                 libc::AF_ALG => unsafe {
                     AlgAddr::from_raw(addr, l).map(|alg| Self { alg })
                 },
+                libc::AF_UNIX => unsafe {
+                    UnixAddr::from_raw(addr, l).map(|su| Self { su })
+                },
                 #[cfg(feature = "net")]
                 libc::AF_INET => unsafe {
                     SockaddrIn::from_raw(addr, l).map(|sin| Self { sin })

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2392,6 +2392,19 @@ mod tests {
             assert_eq!(ss.len(), ua.len());
         }
 
+        #[test]
+        fn from_sockaddr_un_named_no_length() {
+            let ua = UnixAddr::new("/var/run/mysock").unwrap();
+            assert!(
+                UnixAddr::size()
+                    <= mem::size_of::<libc::sockaddr_storage>()
+                        as libc::socklen_t
+            );
+            let ptr = ua.as_ptr().cast();
+            let ss = unsafe { SockaddrStorage::from_raw(ptr, None) }.unwrap();
+            assert_eq!(ss.len(), ua.len());
+        }
+
         #[cfg(linux_android)]
         #[test]
         fn from_sockaddr_un_abstract_named() {


### PR DESCRIPTION
## What does this PR do

I noticed that feeding `*const sockaddr_un` into `SockaddrStorage` without length returns `None`. I had impression that it should actually work.

However extracting `sa_len` manually and feeding it into `SockaddrStrorage` works as expected and I am able to cast it to `UnixAddr` later on by calling `SockaddrStorage::as_unix_addr()`.

```rs
 SockaddrStorage::from_raw(sa_ptr, Some((*sa_ptr).sa_len.into()))
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

