### PR TITLE
sys::man adding `MADV_POPULATE_READ` and `MAP_POPULATE_WRITE`.

### DIFF
--- a/changelog/2565.added.md
+++ b/changelog/2565.added.md
@@ -1,0 +1,2 @@
+Add `sys::mman::MmapAdvise` `MADV_POPULATE_READ`, `MADV_POPULATE_WRITE` for Linux and Android targets
+

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -328,6 +328,13 @@ libc_enum! {
         /// Undo `MADV_WIPEONFORK` when it applied.
         #[cfg(linux_android)]
         MADV_KEEPONFORK,
+        /// Pre-load the address range for reading to reduce page-fault latency.
+        #[cfg(linux_android)]
+        MADV_POPULATE_READ,
+        /// Pre-fault the address range for writing to reduce page-fault
+        /// latency on subsequent writes.
+        #[cfg(linux_android)]
+        MADV_POPULATE_WRITE,
     }
 }
 


### PR DESCRIPTION
More specialised than MmapFlags::MAP_POPULATE, another difference being it does not silently fail.

- `MADV_POPULATE_READ` to pre-populate pages ahead of read accesses.
- `MADV_POPULATE_WRITE` to pre-populate pages ahead of subsequent writes.
