### PR TITLE
feat: add unsafe fn from_owned_fd() for owne fd wrapper types

### DIFF
--- a/changelog/2566.added.md
+++ b/changelog/2566.added.md
@@ -1,0 +1,1 @@
+Added `from_owned_fd` constructor to `PtyMaster/Fanotify/Inotify/SignalFd/TimerFd`

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -52,6 +52,17 @@ pub enum ForkptyResult {
 #[derive(Debug)]
 pub struct PtyMaster(OwnedFd);
 
+impl PtyMaster {
+    /// Constructs a `PytMaster` wrapping an existing `OwnedFd`.
+    ///
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid `PtyMaster`.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self(fd)
+    }
+}
+
 impl AsRawFd for PtyMaster {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -424,3 +424,16 @@ impl From<Fanotify> for OwnedFd {
         value.fd
     }
 }
+
+impl Fanotify {
+    /// Constructs a `Fanotify` wrapping an existing `OwnedFd`.
+    ///
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid `Fanotify`.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self {
+            fd
+        }
+    }
+}

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -239,6 +239,17 @@ impl Inotify {
 
         Ok(events)
     }
+
+    /// Constructs an `Inotify` wrapping an existing `OwnedFd`.
+    ///
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid `Inotify`.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self {
+            fd
+        }
+    }
 }
 
 impl FromRawFd for Inotify {

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -127,6 +127,15 @@ impl SignalFd {
         }
     }
 
+    /// Constructs a `SignalFd` wrapping an existing `OwnedFd`.
+    ///
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid `SignalFd`.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self(fd)
+    }
+
     fn update(&self, mask: &SigSet, flags: SfdFlags) -> Result<()> {
         let raw_fd = self.0.as_raw_fd();
         unsafe {

--- a/src/sys/timerfd.rs
+++ b/src/sys/timerfd.rs
@@ -225,4 +225,16 @@ impl TimerFd {
 
         Ok(())
     }
+
+
+    /// Constructs a `TimerFd` wrapping an existing `OwnedFd`.
+    ///
+    /// # Safety
+    ///
+    /// `OwnedFd` is a valid `TimerFd`.
+    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self {
+        Self {
+            fd
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do

A PR that follows #2563, add:

```
impl Wrapper {
    pub unsafe fn from_owned_fd(fd: OwnedFd) -> Self
}
```

For all the remaining `OwnedFd` wrapper types.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
