### PR TITLE
Fix the build issue of undefined import self::consts on the loongarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.26.5] - 2024-12-20
+
+### Fixed
+
+- Fixed the build issue of undefined import self::consts on the loongarch64.
+  ([#2568](https://github.com/nix-rust/nix/pull/2568))
+
 ## [0.26.4] - 2023-08-28
 
 ### Fixed

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -19,7 +19,8 @@ pub const TYPEBITS: ioctl_num_type = 8;
     target_arch = "mips64",
     target_arch = "powerpc",
     target_arch = "powerpc64",
-    target_arch = "sparc64"
+    target_arch = "sparc64",
+    target_arch = "loongarch64"
 ))]
 mod consts {
     #[doc(hidden)]


### PR DESCRIPTION
## What does this PR do
Fix failed to build for target loongarch64(similar to MIPS) with this error:
```c
error[E0432]: unresolved import `self::consts`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.26.4/src/sys/ioctl/linux.rs:60:15
   |
60 | pub use self::consts::*;
   |               ^^^^^^ could not find `consts` in `self`
```



## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
