### PR TITLE
nix::fcntl add FcntlArg::F_READAHEAD for freebsd.

### DIFF
--- a/changelog/2569.added.md
+++ b/changelog/2569.added.md
@@ -1,0 +1,1 @@
+Added `FcntlArg::F_READAHEAD` for FreeBSD target

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -825,6 +825,11 @@ pub enum FcntlArg<'a> {
     /// Both descriptors must reference regular files in the same volume.
     #[cfg(apple_targets)]
     F_TRANSFEREXTENTS(RawFd),
+    /// Set or clear the read ahead (pre-fetch) amount for sequential access or
+    /// disable it with 0 or to system default for any value < 0.
+    /// It manages how the kernel caches file data.
+    #[cfg(target_os = "freebsd")]
+    F_READAHEAD(c_int),
     // TODO: Rest of flags
 }
 
@@ -961,6 +966,10 @@ pub fn fcntl<Fd: std::os::fd::AsFd>(fd: Fd, arg: FcntlArg) -> Result<c_int> {
             #[cfg(apple_targets)]
             F_TRANSFEREXTENTS(rawfd) => {
                 libc::fcntl(fd, libc::F_TRANSFEREXTENTS, rawfd)
+            },
+            #[cfg(target_os = "freebsd")]
+            F_READAHEAD(val) => {
+                libc::fcntl(fd, libc::F_READAHEAD, val)
             },
         }
     };

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -805,3 +805,16 @@ fn test_f_transferextents() {
         .expect("transferextents failed");
     assert_ne!(res, -1);
 }
+
+#[cfg(target_os = "freebsd")]
+#[test]
+fn test_f_readahead() {
+    use nix::fcntl::*;
+
+    let tmp = NamedTempFile::new().unwrap();
+    let mut res = fcntl(&tmp, FcntlArg::F_READAHEAD(1_000_000))
+        .expect("read ahead failed");
+    assert_ne!(res, -1);
+    res = fcntl(&tmp, FcntlArg::F_READAHEAD(-1024)).expect("read ahead failed");
+    assert_ne!(res, -1);
+}


### PR DESCRIPTION
Set/clear the amount of read ahead for the file descriptor.