### PR TITLE
Don't use `Cow::<str>::to_string`

### DIFF
--- a/src/ifaddrs.rs
+++ b/src/ifaddrs.rs
@@ -93,7 +93,7 @@ impl InterfaceAddress {
         let netmask =
             unsafe { SockaddrStorage::from_raw(info.ifa_netmask, None) };
         let mut addr = InterfaceAddress {
-            interface_name: ifname.to_string_lossy().to_string(),
+            interface_name: ifname.to_string_lossy().into_owned(),
             flags: InterfaceFlags::from_bits_truncate(
                 info.ifa_flags as IflagsType,
             ),


### PR DESCRIPTION
## What does this PR do

The existing code accidentally dropped the possibly already existing owned value.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
