### PR TITLE
sys::socket adding sockopt::LingerSec for Apple targets.

### DIFF
--- a/changelog/2572.added.md
+++ b/changelog/2572.added.md
@@ -1,0 +1,1 @@
+Added `sockopt::LingerSec` for Apple targets

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -372,6 +372,15 @@ sockopt_impl!(
     libc::SO_LINGER,
     libc::linger
 );
+#[cfg(apple_targets)]
+sockopt_impl!(
+    /// Same as `SO_LINGER`, but the duration is in seconds rather than kernel ticks.
+    LingerSec,
+    Both,
+    libc::SOL_SOCKET,
+    libc::SO_LINGER_SEC,
+    libc::linger
+);
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]


### PR DESCRIPTION
```c
#define SO_LINGER 0x0080 /* linger on close if data present (in ticks) */
#define SO_LINGER_SEC 0x1080 /* linger on close if data present (in seconds) */
```

