### PR TITLE
sys::socket::sockopt, adding `ExclBind` for solarish systems.

### DIFF
--- a/changelog/2573.added.md
+++ b/changelog/2573.added.md
@@ -1,0 +1,1 @@
+Added `sockopt::EsclBind` for solarish targets

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1257,6 +1257,18 @@ sockopt_impl!(
     GetCString<[u8; libc::IFNAMSIZ]>
 );
 
+#[cfg(solarish)]
+sockopt_impl!(
+    /// Enable/disable exclusive binding.
+    /// Prevent multiple sockets to bind to the same
+    /// address:port, neutralizing `SO_REUSEADDR` effect.
+    ExclBind,
+    Both,
+    libc::SOL_SOCKET,
+    libc::SO_EXCLBIND,
+    bool
+);
+
 #[allow(missing_docs)]
 // Not documented by Linux!
 #[cfg(linux_android)]


### PR DESCRIPTION
Disallow multiple sockets to bind to an address/port combination.
