### PR TITLE
ci: re-enable hurd CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,8 +303,7 @@ jobs:
           - target: x86_64-unknown-openbsd
           - target: x86_64-unknown-haiku
           - target: armv7-unknown-linux-uclibceabihf
-          # Disable it due to: https://github.com/nix-rust/nix/issues/2549
-          # - target: i686-unknown-hurd-gnu
+          - target: i686-unknown-hurd-gnu
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What does this PR do

Re-enable the Hurd CI as the Rust issue has been fixed. Closes #2549

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
