### PR TITLE
Add ioctl support for Fuchsia

### DIFF
--- a/changelog/2580.added.md
+++ b/changelog/2580.added.md
@@ -1,0 +1,1 @@
+Added Fuchsia support for `ioctl`.

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -1,10 +1,14 @@
 use cfg_if::cfg_if;
 
 /// The datatype used for the ioctl number
-#[cfg(any(target_os = "android", target_env = "musl"))]
+#[cfg(any(target_os = "android", target_os = "fuchsia", target_env = "musl"))]
 #[doc(hidden)]
 pub type ioctl_num_type = ::libc::c_int;
-#[cfg(not(any(target_os = "android", target_env = "musl")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "fuchsia",
+    target_env = "musl"
+)))]
 #[doc(hidden)]
 pub type ioctl_num_type = ::libc::c_ulong;
 /// The datatype used for the 3rd argument

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -227,11 +227,11 @@
 //! ```
 use cfg_if::cfg_if;
 
-#[cfg(any(linux_android, target_os = "redox"))]
+#[cfg(any(linux_android, target_os = "fuchsia", target_os = "redox"))]
 #[macro_use]
 mod linux;
 
-#[cfg(any(linux_android, target_os = "redox"))]
+#[cfg(any(linux_android, target_os = "fuchsia", target_os = "redox"))]
 pub use self::linux::*;
 
 #[cfg(any(bsd, solarish, target_os = "haiku",))]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -31,7 +31,13 @@ feature! {
     pub mod fanotify;
 }
 
-#[cfg(any(bsd, linux_android, target_os = "redox", solarish))]
+#[cfg(any(
+    bsd,
+    linux_android,
+    solarish,
+    target_os = "fuchsia",
+    target_os = "redox",
+))]
 #[cfg(feature = "ioctl")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
 #[macro_use]


### PR DESCRIPTION
## What does this PR do

Fuchsia now supports the linux-style ioctl api.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
