### PR TITLE
unistd: allow `linkat` to take multiple path types

### DIFF
--- a/changelog/2582.changed.md
+++ b/changelog/2582.changed.md
@@ -1,0 +1,1 @@
+linkat: allow distinct types for path arguments

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1577,11 +1577,11 @@ impl LinkatFlags {
 /// # References
 /// See also [linkat(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/linkat.html)
 #[cfg(not(target_os = "redox"))] // Redox does not have this yet
-pub fn linkat<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd, P: ?Sized + NixPath>(
+pub fn linkat<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd, P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
     olddirfd: Fd1,
-    oldpath: &P,
+    oldpath: &P1,
     newdirfd: Fd2,
-    newpath: &P,
+    newpath: &P2,
     flag: AtFlags,
 ) -> Result<()> {
     use std::os::fd::AsRawFd;

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -929,6 +929,40 @@ fn test_linkat_file() {
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+/// This test is the same as [test_linkat_file], but ensures that two different types can be used
+/// as the path arguments.
+fn test_linkat_pathtypes() {
+    use nix::fcntl::AtFlags;
+
+    let tempdir = tempdir().unwrap();
+    let oldfilename = "foo.txt";
+    let oldfilepath = tempdir.path().join(oldfilename);
+
+    let newfilename = "bar.txt";
+    let newfilepath = tempdir.path().join(newfilename);
+
+    // Create file
+    File::create(oldfilepath).unwrap();
+
+    // Get file descriptor for base directory
+    let dirfd =
+        fcntl::open(tempdir.path(), fcntl::OFlag::empty(), stat::Mode::empty())
+            .unwrap();
+
+    // Attempt hard link file at relative path
+    linkat(
+        &dirfd,
+        PathBuf::from(oldfilename).as_path(),
+        &dirfd,
+        newfilename,
+        AtFlags::AT_SYMLINK_FOLLOW,
+    )
+    .unwrap();
+    assert!(newfilepath.exists());
+}
+
+#[test]
+#[cfg(not(any(target_os = "redox", target_os = "haiku")))]
 fn test_linkat_olddirfd_none() {
     use nix::fcntl::AtFlags;
     use nix::fcntl::AT_FDCWD;


### PR DESCRIPTION
## What does this PR do

Add a second type parameter to `linkat` to allow the two paths to have different backing types.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

----

I'm unsure if this warrants additional tests, or if it qualifies as an API change. (I guess it technically is, but it doesn't change the usage in any way.)

LMK if I need to add either, or if there are other instances of this (unintentional(?) type parameter re-use) that I can clean up.