### PR TITLE
feat(ohos): fix some compilation errors and add some features

### DIFF
--- a/changelog/2587.fixed.md
+++ b/changelog/2587.fixed.md
@@ -1,0 +1,1 @@
+Fixes the build on OpenHarmony

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,11 +145,11 @@ feature! {
     #![feature = "mount"]
     pub mod mount;
 }
-#[cfg(all(any(
+#[cfg(any(
     freebsdlike,
     all(target_os = "linux", not(target_env = "ohos")),
     target_os = "netbsd"
-)))]
+))]
 feature! {
     #![feature = "mqueue"]
     pub mod mqueue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,11 @@ feature! {
     #![feature = "mount"]
     pub mod mount;
 }
-#[cfg(any(freebsdlike, target_os = "linux", target_os = "netbsd"))]
+#[cfg(all(any(
+    freebsdlike,
+    all(target_os = "linux", not(target_env = "ohos")),
+    target_os = "netbsd"
+)))]
 feature! {
     #![feature = "mqueue"]
     pub mod mqueue;

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -1,13 +1,19 @@
 use cfg_if::cfg_if;
 
 /// The datatype used for the ioctl number
-#[cfg(any(target_os = "android", target_os = "fuchsia", target_env = "musl"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "fuchsia",
+    target_env = "musl",
+    target_env = "ohos"
+))]
 #[doc(hidden)]
 pub type ioctl_num_type = ::libc::c_int;
 #[cfg(not(any(
     target_os = "android",
     target_os = "fuchsia",
-    target_env = "musl"
+    target_env = "musl",
+    target_env = "ohos"
 )))]
 #[doc(hidden)]
 pub type ioctl_num_type = ::libc::c_ulong;

--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -37,6 +37,18 @@ libc_bitflags!(
         /// [`memfd_create(2)`]: https://man7.org/linux/man-pages/man2/memfd_create.2.html
         #[cfg(linux_android)]
         MFD_HUGETLB;
+        /// Shift to get the huge page size.
+        #[cfg(target_env = "ohos")]
+        MFD_HUGE_SHIFT;
+        /// Mask to get the huge page size.
+        #[cfg(target_env = "ohos")]
+        MFD_HUGE_MASK;
+        /// hugetlb size of 64KB.
+        #[cfg(target_env = "ohos")]
+        MFD_HUGE_64KB;
+        /// hugetlb size of 512KB.
+        #[cfg(target_env = "ohos")]
+        MFD_HUGE_512KB;
         /// Following are to be used with [`MFD_HUGETLB`], indicating the desired hugetlb size.
         ///
         /// See also the hugetlb filesystem in [`memfd_create(2)`].
@@ -99,9 +111,10 @@ pub fn memfd_create<P: NixPath + ?Sized>(
                 not(target_os = "android"),
                 any(
                     target_os = "freebsd",
-                    // If the OS is Linux, gnu and musl expose a memfd_create symbol but not uclibc
+                    // If the OS is Linux, gnu/musl/ohos expose a memfd_create symbol but not uclibc
                     target_env = "gnu",
                     target_env = "musl",
+                    target_env = "ohos"
                 )))]
             {
                 libc::memfd_create(cstr.as_ptr(), flags.bits())

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -64,6 +64,7 @@ libc_bitflags! {
         #[cfg(any(all(linux_android,
                       any(target_arch = "x86", target_arch = "x86_64")),
                   all(target_os = "linux", target_env = "musl", any(target_arch = "x86", target_arch = "x86_64")),
+                  all(target_os = "linux", target_env = "ohos", target_arch = "x86_64"),
                   all(target_os = "freebsd", target_pointer_width = "64")))]
         MAP_32BIT;
         /// Used for stacks; indicates to the kernel that the mapping should extend downward in memory.

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,7 +1,10 @@
 //! Mostly platform-specific functionality
 #[cfg(any(
     freebsdlike,
-    all(target_os = "linux", not(target_env = "uclibc")),
+    all(
+        target_os = "linux",
+        not(any(target_env = "uclibc", target_env = "ohos"))
+    ),
     apple_targets,
     target_os = "netbsd"
 ))]

--- a/src/sys/personality.rs
+++ b/src/sys/personality.rs
@@ -20,7 +20,7 @@ libc_bitflags! {
         /// [`mmap(2)`]: https://man7.org/linux/man-pages/man2/mmap.2.html
         ADDR_LIMIT_3GB;
         /// User-space function pointers to signal handlers point to descriptors.
-        #[cfg(not(any(target_env = "musl", target_env = "uclibc")))]
+        #[cfg(not(any(target_env = "musl", target_env = "uclibc", target_env = "ohos")))]
         FDPIC_FUNCPTRS;
         /// Map page 0 as read-only.
         MMAP_PAGE_ZERO;
@@ -41,7 +41,7 @@ libc_bitflags! {
         /// version number.
         ///
         /// [`uname(2)`]: https://man7.org/linux/man-pages/man2/uname.2.html
-        #[cfg(not(any(target_env = "musl", target_env = "uclibc")))]
+        #[cfg(not(any(target_env = "musl", target_env = "uclibc", target_env = "ohos")))]
         UNAME26;
         /// No effects.
         WHOLE_SECONDS;

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -36,8 +36,8 @@ cfg_if! {
 }
 
 libc_enum! {
-    #[cfg_attr(not(any(target_env = "musl", target_env = "uclibc", target_os = "android")), repr(u32))]
-    #[cfg_attr(any(target_env = "musl", target_env = "uclibc", target_os = "android"), repr(i32))]
+    #[cfg_attr(not(any(target_env = "musl", target_env = "uclibc", target_os = "android", target_env = "ohos")), repr(u32))]
+    #[cfg_attr(any(target_env = "musl", target_env = "uclibc", target_os = "android", target_env = "ohos"), repr(i32))]
     /// Ptrace Request enum defining the action to be taken.
     #[non_exhaustive]
     pub enum Request {
@@ -53,6 +53,7 @@ libc_enum! {
         PTRACE_SINGLESTEP,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
+                                               target_env = "ohos",
                                                target_arch = "mips",
                                                target_arch = "mips32r6",
                                                target_arch = "mips64",
@@ -62,6 +63,7 @@ libc_enum! {
         PTRACE_GETREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
+                                               target_env = "ohos",
                                                target_arch = "mips",
                                                target_arch = "mips32r6",
                                                target_arch = "mips64",
@@ -71,6 +73,7 @@ libc_enum! {
         PTRACE_SETREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
+                                               target_env = "ohos",
                                                target_arch = "mips",
                                                target_arch = "mips32r6",
                                                target_arch = "mips64",
@@ -80,6 +83,7 @@ libc_enum! {
         PTRACE_GETFPREGS,
         #[cfg(any(all(target_os = "android", target_pointer_width = "32"),
                   all(target_os = "linux", any(target_env = "musl",
+                                               target_env = "ohos",
                                                target_arch = "mips",
                                                target_arch = "mips32r6",
                                                target_arch = "mips64",
@@ -90,6 +94,7 @@ libc_enum! {
         PTRACE_ATTACH,
         PTRACE_DETACH,
         #[cfg(all(target_os = "linux", any(target_env = "musl",
+                                           target_env = "ohos",
                                            target_arch = "mips",
                                            target_arch = "mips32r6",
                                            target_arch = "mips64",
@@ -98,6 +103,7 @@ libc_enum! {
                                            target_arch = "x86_64")))]
         PTRACE_GETFPXREGS,
         #[cfg(all(target_os = "linux", any(target_env = "musl",
+                                           target_env = "ohos",
                                            target_arch = "mips",
                                            target_arch = "mips32r6",
                                            target_arch = "mips64",

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -51,11 +51,13 @@ pub struct Statfs(type_of_statfs);
 type fs_type_t = u32;
 #[cfg(target_os = "android")]
 type fs_type_t = libc::c_ulong;
-#[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
+#[cfg(all(
+    target_os = "linux",
+    target_arch = "s390x",
+    not(target_env = "musl")
+))]
 type fs_type_t = libc::c_uint;
-#[cfg(all(target_os = "linux", target_env = "musl"))]
-type fs_type_t = libc::c_ulong;
-#[cfg(all(target_os = "linux", target_env = "ohos"))]
+#[cfg(all(target_os = "linux", any(target_env = "musl", target_env = "ohos")))]
 type fs_type_t = libc::c_ulong;
 #[cfg(all(target_os = "linux", target_env = "uclibc"))]
 type fs_type_t = libc::c_int;
@@ -318,7 +320,11 @@ impl Statfs {
     }
 
     /// Optimal transfer block size
-    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
+    #[cfg(all(
+        target_os = "linux",
+        target_arch = "s390x",
+        not(target_env = "musl")
+    ))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -373,7 +379,11 @@ impl Statfs {
 
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
-    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
+    #[cfg(all(
+        target_os = "linux",
+        target_arch = "s390x",
+        not(target_env = "musl")
+    ))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
     }
@@ -454,7 +464,11 @@ impl Statfs {
     }
 
     /// Maximum length of filenames
-    #[cfg(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl")))]
+    #[cfg(all(
+        target_os = "linux",
+        target_arch = "s390x",
+        not(target_env = "musl")
+    ))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namelen
     }

--- a/src/sys/time.rs
+++ b/src/sys/time.rs
@@ -1,4 +1,7 @@
-#[cfg_attr(target_env = "musl", allow(deprecated))]
+#[cfg_attr(
+    any(target_env = "musl", target_env = "ohos"),
+    allow(deprecated)
+)]
 // https://github.com/rust-lang/libc/issues/1848
 pub use libc::{suseconds_t, time_t};
 use libc::{timespec, timeval};
@@ -253,7 +256,10 @@ impl PartialOrd for TimeSpec {
 
 impl TimeValLike for TimeSpec {
     #[inline]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )]
     // https://github.com/rust-lang/libc/issues/1848
     fn seconds(seconds: i64) -> TimeSpec {
         assert!(
@@ -286,7 +292,10 @@ impl TimeValLike for TimeSpec {
 
     /// Makes a new `TimeSpec` with given number of nanoseconds.
     #[inline]
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )]
     // https://github.com/rust-lang/libc/issues/1848
     fn nanoseconds(nanoseconds: i64) -> TimeSpec {
         let (secs, nanos) = div_mod_floor_64(nanoseconds, NANOS_PER_SEC);
@@ -340,7 +349,10 @@ impl TimeSpec {
         TimeSpec::new(0, libc::UTIME_NOW as timespec_tv_nsec_t);
 
     /// Construct a new `TimeSpec` from its components
-    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )] // https://github.com/rust-lang/libc/issues/1848
     pub const fn new(seconds: time_t, nanoseconds: timespec_tv_nsec_t) -> Self {
         let mut ts = zero_init_timespec();
         ts.tv_sec = seconds;
@@ -356,7 +368,10 @@ impl TimeSpec {
         }
     }
 
-    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )] // https://github.com/rust-lang/libc/issues/1848
     pub const fn tv_sec(&self) -> time_t {
         self.0.tv_sec
     }
@@ -365,7 +380,10 @@ impl TimeSpec {
         self.0.tv_nsec
     }
 
-    #[cfg_attr(target_env = "musl", allow(deprecated))]
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )]
     // https://github.com/rust-lang/libc/issues/1848
     pub const fn from_duration(duration: Duration) -> Self {
         let mut ts = zero_init_timespec();
@@ -506,7 +524,10 @@ impl TimeValLike for TimeVal {
             (TV_MIN_SECONDS..=TV_MAX_SECONDS).contains(&seconds),
             "TimeVal out of bounds; seconds={seconds}"
         );
-        #[cfg_attr(target_env = "musl", allow(deprecated))]
+        #[cfg_attr(
+            any(target_env = "musl", target_env = "ohos"),
+            allow(deprecated)
+        )]
         // https://github.com/rust-lang/libc/issues/1848
         TimeVal(timeval {
             tv_sec: seconds as time_t,
@@ -531,7 +552,10 @@ impl TimeValLike for TimeVal {
             (TV_MIN_SECONDS..=TV_MAX_SECONDS).contains(&secs),
             "TimeVal out of bounds"
         );
-        #[cfg_attr(target_env = "musl", allow(deprecated))]
+        #[cfg_attr(
+            any(target_env = "musl", target_env = "ohos"),
+            allow(deprecated)
+        )]
         // https://github.com/rust-lang/libc/issues/1848
         TimeVal(timeval {
             tv_sec: secs as time_t,
@@ -549,7 +573,10 @@ impl TimeValLike for TimeVal {
             (TV_MIN_SECONDS..=TV_MAX_SECONDS).contains(&secs),
             "TimeVal out of bounds"
         );
-        #[cfg_attr(target_env = "musl", allow(deprecated))]
+        #[cfg_attr(
+            any(target_env = "musl", target_env = "ohos"),
+            allow(deprecated)
+        )]
         // https://github.com/rust-lang/libc/issues/1848
         TimeVal(timeval {
             tv_sec: secs as time_t,
@@ -586,7 +613,10 @@ impl TimeValLike for TimeVal {
 
 impl TimeVal {
     /// Construct a new `TimeVal` from its components
-    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )] // https://github.com/rust-lang/libc/issues/1848
     pub const fn new(seconds: time_t, microseconds: suseconds_t) -> Self {
         Self(timeval {
             tv_sec: seconds,
@@ -602,7 +632,10 @@ impl TimeVal {
         }
     }
 
-    #[cfg_attr(target_env = "musl", allow(deprecated))] // https://github.com/rust-lang/libc/issues/1848
+    #[cfg_attr(
+        any(target_env = "musl", target_env = "ohos"),
+        allow(deprecated)
+    )] // https://github.com/rust-lang/libc/issues/1848
     pub const fn tv_sec(&self) -> time_t {
         self.0.tv_sec
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -122,7 +122,10 @@ impl ClockId {
     #[cfg(any(
         target_os = "emscripten",
         target_os = "fuchsia",
-        all(target_os = "linux", target_env = "musl")
+        all(
+            target_os = "linux",
+            any(target_env = "musl", target_env = "ohos")
+        )
     ))]
     pub const CLOCK_SGI_CYCLE: ClockId = ClockId(libc::CLOCK_SGI_CYCLE);
     /// International Atomic Time.

--- a/src/ucontext.rs
+++ b/src/ucontext.rs
@@ -1,9 +1,9 @@
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(any(target_env = "musl", target_env = "ohos")))]
 use crate::errno::Errno;
 use crate::sys::signal::SigSet;
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(any(target_env = "musl", target_env = "ohos")))]
 use crate::Result;
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(any(target_env = "musl", target_env = "ohos")))]
 use std::mem;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -12,7 +12,7 @@ pub struct UContext {
 }
 
 impl UContext {
-    #[cfg(not(target_env = "musl"))]
+    #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
     pub fn get() -> Result<UContext> {
         let mut context = mem::MaybeUninit::<libc::ucontext_t>::uninit();
         let res = unsafe { libc::getcontext(context.as_mut_ptr()) };
@@ -23,7 +23,7 @@ impl UContext {
         })
     }
 
-    #[cfg(not(target_env = "musl"))]
+    #[cfg(not(any(target_env = "musl", target_env = "ohos")))]
     pub fn set(&self) -> Result<()> {
         let res = unsafe {
             libc::setcontext(&self.context as *const libc::ucontext_t)

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -8,7 +8,10 @@ mod test_signal;
 #[cfg(any(
     target_os = "freebsd",
     apple_targets,
-    all(target_os = "linux", not(target_env = "uclibc")),
+    all(
+        target_os = "linux",
+        not(any(target_env = "uclibc", target_env = "ohos"))
+    ),
     target_os = "netbsd"
 ))]
 mod test_aio;

--- a/test/sys/test_aio_drop.rs
+++ b/test/sys/test_aio_drop.rs
@@ -6,6 +6,7 @@
 #[cfg(all(
     not(target_env = "musl"),
     not(target_env = "uclibc"),
+    not(target_env = "ohos"),
     any(
         target_os = "linux",
         apple_targets,

--- a/test/sys/test_pthread.rs
+++ b/test/sys/test_pthread.rs
@@ -1,13 +1,17 @@
 use nix::sys::pthread::*;
 
-#[cfg(any(target_env = "musl", target_os = "redox"))]
+#[cfg(any(target_env = "musl", target_os = "redox", target_env = "ohos"))]
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();
     assert!(!tid.is_null());
 }
 
-#[cfg(not(any(target_env = "musl", target_os = "redox")))]
+#[cfg(not(any(
+    target_env = "musl",
+    target_os = "redox",
+    target_env = "ohos"
+)))]
 #[test]
 fn test_pthread_self() {
     let tid = pthread_self();

--- a/test/test.rs
+++ b/test/test.rs
@@ -13,7 +13,11 @@ mod test_errno;
 mod test_fcntl;
 #[cfg(linux_android)]
 mod test_kmod;
-#[cfg(any(freebsdlike, target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(
+    freebsdlike,
+    all(target_os = "linux", not(target_env = "ohos")),
+    target_os = "netbsd"
+))]
 mod test_mq;
 #[cfg(not(target_os = "redox"))]
 mod test_net;


### PR DESCRIPTION
## What does this PR do

This PR fix some compilation errors for OpenHarmony. I'll try to explain the following changes.
1. The basic c library for OpenHarmony is forked from musl(1.25), so it's reasonable for us to follow the musl condition compilation.
2. According to the [document](https://developer.huawei.com/consumer/en/doc/harmonyos-references-V5/musl-peculiar-symbol-V5), some symbols don't export. So `aio` and `mqueue` should be hidden for OpenHarmony.
3. OpenHarmony support more enum for `memfd`, the following code is the content of `memfd.h`:   
```c
 /****************************************************************************
 ****************************************************************************
 ***
 ***   This header was automatically generated from a Linux kernel header
 ***   of the same name, to make information necessary for userspace to
 ***   call into the kernel available to libc.  It contains only constants,
 ***   structures, and macros generated from the original header, and thus,
 ***   contains no copyrightable information.
 ***
 ***   To edit the content of this header, modify the corresponding
 ***   source file (e.g. under external/kernel-headers/original/) then
 ***   run bionic/libc/kernel/tools/update_all.py
 ***
 ***   Any manual change here will be lost the next time this script will
 ***   be run. You've been warned!
 ***
 ****************************************************************************
 ****************************************************************************/
#ifndef _UAPI_LINUX_MEMFD_H
#define _UAPI_LINUX_MEMFD_H
#include <asm-generic/hugetlb_encode.h>
#define MFD_CLOEXEC 0x0001U
#define MFD_ALLOW_SEALING 0x0002U
#define MFD_HUGETLB 0x0004U
#define MFD_HUGE_SHIFT HUGETLB_FLAG_ENCODE_SHIFT
#define MFD_HUGE_MASK HUGETLB_FLAG_ENCODE_MASK
#define MFD_HUGE_64KB HUGETLB_FLAG_ENCODE_64KB
#define MFD_HUGE_512KB HUGETLB_FLAG_ENCODE_512KB
#define MFD_HUGE_1MB HUGETLB_FLAG_ENCODE_1MB
#define MFD_HUGE_2MB HUGETLB_FLAG_ENCODE_2MB
#define MFD_HUGE_8MB HUGETLB_FLAG_ENCODE_8MB
#define MFD_HUGE_16MB HUGETLB_FLAG_ENCODE_16MB
#define MFD_HUGE_32MB HUGETLB_FLAG_ENCODE_32MB
#define MFD_HUGE_256MB HUGETLB_FLAG_ENCODE_256MB
#define MFD_HUGE_512MB HUGETLB_FLAG_ENCODE_512MB
#define MFD_HUGE_1GB HUGETLB_FLAG_ENCODE_1GB
#define MFD_HUGE_2GB HUGETLB_FLAG_ENCODE_2GB
#define MFD_HUGE_16GB HUGETLB_FLAG_ENCODE_16GB
#endif
```
4. NDK include the `epoll.h` and `eventfd.h` file, so i think `epoll` and `eventfd` can be used for OHOS

This PR don't change any nix's API, so i think i don't need to add a changelog right? Hope you can give me some suggestion thanks.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix