### PR TITLE
feat: dynamically-sized CpuSet

### DIFF
--- a/test/test_sched.rs
+++ b/test/test_sched.rs
@@ -2,6 +2,19 @@ use nix::sched::{sched_getaffinity, sched_getcpu, sched_setaffinity, CpuSet};
 use nix::unistd::Pid;
 
 #[test]
+fn tset_dynamic_cpu_set() {
+    let mut dyn_cpu_set = CpuSet::new_dynamic();
+
+    for i in 0..4096 {
+        assert!(!dyn_cpu_set.is_set(i).unwrap());
+        dyn_cpu_set.set(i).unwrap();
+        assert!(dyn_cpu_set.is_set(i).unwrap());
+        dyn_cpu_set.unset(i).unwrap();
+        assert!(!dyn_cpu_set.is_set(i).unwrap());
+    }
+}
+
+#[test]
 fn test_sched_affinity() {
     // If pid is zero, then the mask of the calling process is returned.
     let initial_affinity = sched_getaffinity(Pid::from_raw(0)).unwrap();


### PR DESCRIPTION
## What does this PR do

Before this PR, our `CpuSet` type used only 1 libc `cpuset` structure, which can only hold 64 bits on both FreeBSD-like and Linux-like systems. With this limitation, it won't work on systems with more than 64 cores, as reported by #2589.

This PR changes the `CpuSet` type to an enum, which has 2 variants, a sized variant that is same as the previous definition, a dynamic variant that is dynamically allocated, which will extend itself when needed.

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
