### PR TITLE
docs: doc that signal-unsafe fns can be called after execve

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -334,9 +334,9 @@ feature! {
 /// # Safety
 ///
 /// In a multithreaded program, only [async-signal-safe] functions like `pause`
-/// and `_exit` may be called by the child (the parent isn't restricted). Note
-/// that memory allocation may **not** be async-signal-safe and thus must be
-/// prevented.
+/// and `_exit` may be called by the child (the parent isn't restricted) until
+/// a call of `execve(2)`. Note that memory allocation may **not** be 
+/// async-signal-safe and thus must be prevented.
 ///
 /// Those functions are only a small subset of your operating system's API, so
 /// special care must be taken to only invoke code you can control and audit.

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -335,7 +335,7 @@ feature! {
 ///
 /// In a multithreaded program, only [async-signal-safe] functions like `pause`
 /// and `_exit` may be called by the child (the parent isn't restricted) until
-/// a call of `execve(2)`. Note that memory allocation may **not** be 
+/// a call of `execve(2)`. Note that memory allocation may **not** be
 /// async-signal-safe and thus must be prevented.
 ///
 /// Those functions are only a small subset of your operating system's API, so

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -265,9 +265,9 @@ impl ForkResult {
 /// # Safety
 ///
 /// In a multithreaded program, only [async-signal-safe] functions like `pause`
-/// and `_exit` may be called by the child (the parent isn't restricted). Note
-/// that memory allocation may **not** be async-signal-safe and thus must be
-/// prevented.
+/// and `_exit` may be called by the child (the parent isn't restricted) until
+/// a call of `execve(2)`. Note that memory allocation may **not** be
+/// async-signal-safe and thus must be prevented.
 ///
 /// Those functions are only a small subset of your operating system's API, so
 /// special care must be taken to only invoke code you can control and audit.


### PR DESCRIPTION
## What does this PR do

Resolves the issue reported in [this comment](https://github.com/nix-rust/nix/issues/586#issuecomment-2620124046)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
