### PR TITLE
refactor: clippy cleanup doc_overindented_list_items and macro_metavars_in_unsafe

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -455,10 +455,9 @@ impl<'a> AioFsync<'a> {
     /// * `fd`:           File descriptor to sync.
     /// * `mode`:         Whether to sync file metadata too, or just data.
     /// * `prio`:         If POSIX Prioritized IO is supported, then the
-    ///                   operation will be prioritized at the process's
-    ///                   priority level minus `prio`.
-    /// * `sigev_notify`: Determines how you will be notified of event
-    ///                   completion.
+    ///   operation will be prioritized at the process's priority level minus 
+    ///   `prio`.
+    /// * `sigev_notify`: Determines how you will be notified of event completion.
     pub fn new(
         fd: BorrowedFd<'a>,
         mode: AioFsyncMode,
@@ -573,11 +572,9 @@ impl<'a> AioRead<'a> {
     /// * `fd`:           File descriptor to read from
     /// * `offs`:         File offset
     /// * `buf`:          A memory buffer.  It must outlive the `AioRead`.
-    /// * `prio`:         If POSIX Prioritized IO is supported, then the
-    ///                   operation will be prioritized at the process's
-    ///                   priority level minus `prio`
-    /// * `sigev_notify`: Determines how you will be notified of event
-    ///                   completion.
+    /// * `prio`:         If POSIX Prioritized IO is supported, then the operation
+    ///   will be prioritized at the process's priority level minus `prio`
+    /// * `sigev_notify`: Determines how you will be notified of event completion.
     pub fn new(
         fd: BorrowedFd<'a>,
         offs: off_t,
@@ -805,11 +802,9 @@ impl<'a> AioWrite<'a> {
     /// * `fd`:           File descriptor to write to
     /// * `offs`:         File offset
     /// * `buf`:          A memory buffer.  It must outlive the `AioWrite`.
-    /// * `prio`:         If POSIX Prioritized IO is supported, then the
-    ///                   operation will be prioritized at the process's
-    ///                   priority level minus `prio`
-    /// * `sigev_notify`: Determines how you will be notified of event
-    ///                   completion.
+    /// * `prio`:         If POSIX Prioritized IO is supported, then the operation
+    ///   will be prioritized at the process's priority level minus `prio`
+    /// * `sigev_notify`: Determines how you will be notified of event completion.
     pub fn new(
         fd: BorrowedFd<'a>,
         offs: off_t,

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -655,8 +655,10 @@ macro_rules! ioctl_readwrite {
         pub unsafe fn $name(fd: $crate::libc::c_int,
                             data: *mut $ty)
                             -> $crate::Result<$crate::libc::c_int> {
+            let ioty = $ioty;
+            let nr = $nr;
             unsafe {
-                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
+                convert_ioctl_res!($crate::libc::ioctl(fd, request_code_readwrite!(ioty, nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::ioctl_num_type, data))
             }
         }
     )

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -655,15 +655,13 @@ pub trait SockaddrLike: private::SockaddrLikePriv {
     ///
     /// # Arguments
     ///
-    /// - `addr`:   raw pointer to something that can be cast to a
-    ///             `libc::sockaddr`. For example, `libc::sockaddr_in`,
-    ///             `libc::sockaddr_in6`, etc.
-    /// - `len`:    For fixed-width types like `sockaddr_in`, it will be
-    ///             validated if present and ignored if not.  For variable-width
-    ///             types it is required and must be the total length of valid
-    ///             data.  For example, if `addr` points to a
-    ///             named `sockaddr_un`, then `len` must be the length of the
-    ///             structure up to but not including the trailing NUL.
+    /// - `addr`:   raw pointer to something that can be cast to a `libc::sockaddr`.
+    ///   For example, `libc::sockaddr_in`, `libc::sockaddr_in6`, etc.
+    /// - `len`:    For fixed-width types like `sockaddr_in`, it will be validated
+    ///   if present and ignored if not. For variable-width types it is required 
+    ///   and must be the total length of valid data. For example, if `addr` 
+    ///   points to a named `sockaddr_un`, then `len` must be the length of the
+    ///   structure up to but not including the trailing NUL.
     ///
     /// # Safety
     ///

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -33,15 +33,15 @@ const TCP_CA_NAME_MAX: usize = 16;
 ///
 /// * `$name:ident`: name of the type you want to implement `SetSockOpt` for.
 /// * `$level:expr` : socket layer, or a `protocol level`: could be *raw sockets*
-///    (`libc::SOL_SOCKET`), *ip protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),
-///    and more. Please refer to your system manual for more options. Will be passed as the second
-///    argument (`level`) to the `setsockopt` call.
+///   (`libc::SOL_SOCKET`), *ip protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),
+///   and more. Please refer to your system manual for more options. Will be passed as the second
+///   argument (`level`) to the `setsockopt` call.
 /// * `$flag:path`: a flag name to set. Some examples: `libc::SO_REUSEADDR`, `libc::TCP_NODELAY`,
-///    `libc::IP_ADD_MEMBERSHIP` and others. Will be passed as the third argument (`option_name`)
-///    to the `setsockopt` call.
+///   `libc::IP_ADD_MEMBERSHIP` and others. Will be passed as the third argument (`option_name`)
+///   to the `setsockopt` call.
 /// * Type of the value that you are going to set.
-/// * Type that implements the `Set` trait for the type from the previous item (like `SetBool` for
-///    `bool`, `SetUsize` for `usize`, etc.).
+/// * Type that implements the `Set` trait for the type from the previous item 
+///   (like `SetBool` for `bool`, `SetUsize` for `usize`, etc.).
 #[macro_export]
 macro_rules! setsockopt_impl {
     ($name:ident, $level:expr, $flag:path, $ty:ty, $setter:ty) => {
@@ -87,15 +87,15 @@ macro_rules! setsockopt_impl {
 ///
 /// * Name of the type you want to implement `GetSockOpt` for.
 /// * Socket layer, or a `protocol level`: could be *raw sockets* (`lic::SOL_SOCKET`),  *ip
-///    protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),  and more. Please refer
-///    to your system manual for more options. Will be passed as the second argument (`level`) to
-///    the `getsockopt` call.
+///   protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),  and more. Please refer
+///   to your system manual for more options. Will be passed as the second argument (`level`) to
+///   the `getsockopt` call.
 /// * A flag to set. Some examples: `libc::SO_REUSEADDR`, `libc::TCP_NODELAY`,
-///    `libc::SO_ORIGINAL_DST` and others. Will be passed as the third argument (`option_name`) to
-///    the `getsockopt` call.
+///   `libc::SO_ORIGINAL_DST` and others. Will be passed as the third argument (`option_name`) to
+///   the `getsockopt` call.
 /// * Type of the value that you are going to get.
 /// * Type that implements the `Get` trait for the type from the previous item (`GetBool` for
-///    `bool`, `GetUsize` for `usize`, etc.).
+///   `bool`, `GetUsize` for `usize`, etc.).
 #[macro_export]
 macro_rules! getsockopt_impl {
     ($name:ident, $level:expr, $flag:path, $ty:ty, $getter:ty) => {
@@ -161,15 +161,15 @@ macro_rules! getsockopt_impl {
 /// # Arguments
 ///
 /// * `GetOnly`, `SetOnly` or `Both`: whether you want to implement only getter, only setter or
-///    both of them.
+///   both of them.
 /// * `$name:ident`: name of type `GetSockOpt`/`SetSockOpt` will be implemented for.
 /// * `$level:expr` : socket layer, or a `protocol level`: could be *raw sockets*
-///    (`libc::SOL_SOCKET`), *ip protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),
-///    and more. Please refer to your system manual for more options. Will be passed as the second
-///    argument (`level`) to the `getsockopt`/`setsockopt` call.
+///   (`libc::SOL_SOCKET`), *ip protocol* (libc::IPPROTO_IP), *tcp protocol* (`libc::IPPROTO_TCP`),
+///   and more. Please refer to your system manual for more options. Will be passed as the second
+///   argument (`level`) to the `getsockopt`/`setsockopt` call.
 /// * `$flag:path`: a flag name to set. Some examples: `libc::SO_REUSEADDR`, `libc::TCP_NODELAY`,
-///    `libc::IP_ADD_MEMBERSHIP` and others. Will be passed as the third argument (`option_name`)
-///    to the `setsockopt`/`getsockopt` call.
+///   `libc::IP_ADD_MEMBERSHIP` and others. Will be passed as the third argument (`option_name`)
+///   to the `setsockopt`/`getsockopt` call.
 /// * `$ty:ty`: type of the value that will be get/set.
 /// * `$getter:ty`: `Get` implementation; optional; only for `GetOnly` and `Both`.
 /// * `$setter:ty`: `Set` implementation; optional; only for `SetOnly` and `Both`.


### PR DESCRIPTION
## What does this PR do

Clippy cleanup:

1. doc_overindented_list_items
   
    * src/sys/aio.rs
    * src/sys/socket/addr.rs
    * src/sys/socket/sockopt.rs
    
2. macro_metavars_in_unsafe

    * src/sys/ioctl/mod.rs

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
