### PR TITLE
fix: posix_spawn returns errno on error, not -1

### DIFF
--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -370,7 +370,7 @@ pub fn posix_spawn<SA: AsRef<CStr>, SE: AsRef<CStr>>(
 ) -> Result<Pid> {
     let mut pid = 0;
 
-    let res = unsafe {
+    let ret = unsafe {
         let args_p = to_exec_array(args);
         let env_p = to_exec_array(envp);
 
@@ -384,7 +384,10 @@ pub fn posix_spawn<SA: AsRef<CStr>, SE: AsRef<CStr>>(
         )
     };
 
-    Errno::result(res)?;
+    if ret != 0 {
+        return Err(Errno::from_raw(ret));
+    }
+
     Ok(Pid::from_raw(pid))
 }
 
@@ -399,7 +402,7 @@ pub fn posix_spawnp<SA: AsRef<CStr>, SE: AsRef<CStr>>(
 ) -> Result<Pid> {
     let mut pid = 0;
 
-    let res = unsafe {
+    let ret = unsafe {
         let args_p = to_exec_array(args);
         let env_p = to_exec_array(envp);
 
@@ -413,6 +416,9 @@ pub fn posix_spawnp<SA: AsRef<CStr>, SE: AsRef<CStr>>(
         )
     };
 
-    Errno::result(res)?;
+    if ret != 0 {
+        return Err(Errno::from_raw(ret));
+    }
+
     Ok(Pid::from_raw(pid))
 }

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -1,11 +1,13 @@
-use std::ffi::CString;
-
+use super::FORK_MTX;
 use nix::spawn::{self, PosixSpawnAttr, PosixSpawnFileActions};
 use nix::sys::signal;
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use std::ffi::CString;
 
 #[test]
 fn spawn_true() {
+    let _guard = FORK_MTX.lock();
+
     let bin = &CString::new("true").unwrap();
     let args = &[
         CString::new("true").unwrap(),
@@ -32,6 +34,8 @@ fn spawn_true() {
 
 #[test]
 fn spawn_sleep() {
+    let _guard = FORK_MTX.lock();
+
     let bin = &CString::new("sleep").unwrap();
     let args = &[CString::new("sleep").unwrap(), CString::new("30").unwrap()];
     let vars: &[CString] = &[];


### PR DESCRIPTION
## What does this PR do

According to the POSIX man page:

> Otherwise, no child process shall be created, the value stored into the variable pointed to by a non-NULL pid is unspecified, and **an error number shall be returned as the function return value to indicate the error**.

`Error::result()` assumes the function returns -1 on error, so it won't work here.

Actually, this is my fault 🤦‍♂️, the implementation in PR #2007 handled this correctly, but my erroneous review comment led the PR in the wrong direction.

Also, since `posix_spawn()` uses `fork()` (can be other syscalls depending on the impl) under the hood, its tests should grab the `FORK_MTX` lock.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API

These 2 posx_spawn*() interfaces have not been released, so no changelog needed.
