### PR TITLE
test: test posix_spawn() and add negative test cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ nix = { path = ".", features = ["acct", "aio", "dir", "env", "event", "fanotify"
     "net", "personality", "poll", "pthread", "ptrace", "quota", "process", "reboot",
     "resource", "sched", "signal", "socket", "syslog", "term", "time", "ucontext", "uio",
     "user", "zerocopy"] }
-which = "5.0.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ nix = { path = ".", features = ["acct", "aio", "dir", "env", "event", "fanotify"
     "net", "personality", "poll", "pthread", "ptrace", "quota", "process", "reboot",
     "resource", "sched", "signal", "socket", "syslog", "term", "time", "ucontext", "uio",
     "user", "zerocopy"] }
+which = "7.0.1"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ nix = { path = ".", features = ["acct", "aio", "dir", "env", "event", "fanotify"
     "net", "personality", "poll", "pthread", "ptrace", "quota", "process", "reboot",
     "resource", "sched", "signal", "socket", "syslog", "term", "time", "ucontext", "uio",
     "user", "zerocopy"] }
-which = "7.0.1"
+which = "5.0.0"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dev-dependencies]
 caps = "0.5.3"

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -88,6 +88,10 @@ fn spawn_sleep() {
 }
 
 #[test]
+// `posix_spawn(path_not_exist)` succeeds under QEMU, so ignore the test. No need
+// to investigate the root cause, this test still works in native environments, which
+// is sufficient to test the binding.
+#[cfg_attr(qemu, ignore)]
 fn spawn_cmd_does_not_exist() {
     let _guard = FORK_MTX.lock();
 
@@ -167,6 +171,10 @@ fn spawnp_sleep() {
 }
 
 #[test]
+// `posix_spawnp(bin_not_exist)` succeeds under QEMU, so ignore the test. No need
+// to investigate the root cause, this test still works in native environments, which
+// is sufficient to test the binding.
+#[cfg_attr(qemu, ignore)]
 fn spawnp_cmd_does_not_exist() {
     let _guard = FORK_MTX.lock();
 

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -9,7 +9,7 @@ fn which(exe_name: &str) -> Option<std::path::PathBuf> {
     std::env::var_os("PATH").and_then(|paths| {
         std::env::split_paths(&paths)
             .filter_map(|dir| {
-                let full_path = dir.join(&exe_name);
+                let full_path = dir.join(exe_name);
                 if full_path.is_file() {
                     Some(full_path)
                 } else {

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -8,6 +8,85 @@ use std::ffi::CString;
 fn spawn_true() {
     let _guard = FORK_MTX.lock();
 
+    let bin = which::which("true").unwrap();
+    let args = &[
+        CString::new("true").unwrap(),
+        CString::new("story").unwrap(),
+    ];
+    let vars: &[CString] = &[];
+    let actions = PosixSpawnFileActions::init().unwrap();
+    let attr = PosixSpawnAttr::init().unwrap();
+
+    let pid =
+        spawn::posix_spawn(bin.as_path(), &actions, &attr, args, vars).unwrap();
+
+    let status = waitpid(pid, Some(WaitPidFlag::empty())).unwrap();
+
+    match status {
+        WaitStatus::Exited(wpid, ret) => {
+            assert_eq!(pid, wpid);
+            assert_eq!(ret, 0);
+        }
+        _ => {
+            panic!("Invalid WaitStatus");
+        }
+    };
+}
+
+#[test]
+fn spawn_sleep() {
+    let _guard = FORK_MTX.lock();
+
+    let bin = which::which("sleep").unwrap();
+    let args = &[CString::new("sleep").unwrap(), CString::new("30").unwrap()];
+    let vars: &[CString] = &[];
+    let actions = PosixSpawnFileActions::init().unwrap();
+    let attr = PosixSpawnAttr::init().unwrap();
+
+    let pid =
+        spawn::posix_spawn(bin.as_path(), &actions, &attr, args, vars).unwrap();
+
+    let status =
+        waitpid(pid, WaitPidFlag::from_bits(WaitPidFlag::WNOHANG.bits()))
+            .unwrap();
+    match status {
+        WaitStatus::StillAlive => {}
+        _ => {
+            panic!("Invalid WaitStatus");
+        }
+    };
+
+    signal::kill(pid, signal::SIGTERM).unwrap();
+
+    let status = waitpid(pid, Some(WaitPidFlag::empty())).unwrap();
+    match status {
+        WaitStatus::Signaled(wpid, wsignal, _) => {
+            assert_eq!(pid, wpid);
+            assert_eq!(wsignal, signal::SIGTERM);
+        }
+        _ => {
+            panic!("Invalid WaitStatus");
+        }
+    };
+}
+
+#[test]
+fn spawn_cmd_does_not_exist() {
+    let _guard = FORK_MTX.lock();
+
+    let args = &[CString::new("buzz").unwrap()];
+    let envs: &[CString] = &[];
+    let actions = PosixSpawnFileActions::init().unwrap();
+    let attr = PosixSpawnAttr::init().unwrap();
+
+    let bin = "2b7433c4-523b-470c-abb5-d7ee9fd295d5-fdasf";
+    let pid = spawn::posix_spawn(bin, &actions, &attr, args, envs).unwrap();
+}
+
+#[test]
+fn spawnp_true() {
+    let _guard = FORK_MTX.lock();
+
     let bin = &CString::new("true").unwrap();
     let args = &[
         CString::new("true").unwrap(),
@@ -33,7 +112,7 @@ fn spawn_true() {
 }
 
 #[test]
-fn spawn_sleep() {
+fn spawnp_sleep() {
     let _guard = FORK_MTX.lock();
 
     let bin = &CString::new("sleep").unwrap();

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -3,7 +3,7 @@ use nix::errno::Errno;
 use nix::spawn::{self, PosixSpawnAttr, PosixSpawnFileActions};
 use nix::sys::signal;
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 /// Helper function to find a binary in the $PATH
 fn which(exe_name: &str) -> Option<std::path::PathBuf> {
@@ -175,7 +175,10 @@ fn spawnp_cmd_does_not_exist() {
     let actions = PosixSpawnFileActions::init().unwrap();
     let attr = PosixSpawnAttr::init().unwrap();
 
-    let bin = c"2b7433c4-523b-470c-abb5-d7ee9fd295d5-fdasf";
+    let bin = CStr::from_bytes_with_nul(
+        "2b7433c4-523b-470c-abb5-d7ee9fd295d5-fdasf\0".as_bytes(),
+    )
+    .unwrap();
     let errno =
         spawn::posix_spawnp(bin, &actions, &attr, args, envs).unwrap_err();
     assert_eq!(errno, Errno::ENOENT);

--- a/test/test_spawn.rs
+++ b/test/test_spawn.rs
@@ -80,7 +80,7 @@ fn spawn_cmd_does_not_exist() {
     let attr = PosixSpawnAttr::init().unwrap();
 
     let bin = "2b7433c4-523b-470c-abb5-d7ee9fd295d5-fdasf";
-    let pid = spawn::posix_spawn(bin, &actions, &attr, args, envs).unwrap();
+    let _pid = spawn::posix_spawn(bin, &actions, &attr, args, envs).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do

1. Add tests for `posix_spawn()`. Before this PR, the tests only cover `posix_spawnp()`
2. Add negative tests cases (the binary to exec does not exist) for both `posix_spawn()` and `posix_spawnp()`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
