### PR TITLE
feat(ci): add OpenHarmony CI and add it to tier2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   MSRV: 1.69.0
   # Rust's Loongarch support merged in 1.71.0
   MSRV_LOONGARCH: 1.71.0
+  # Minimal Rust version to support all 3 official OpenHarmony targets as tier2
+  MSRV_OHOS: 1.78.0 
   RUSTFLAGS: -Dwarnings
 
 jobs:
@@ -247,7 +249,8 @@ jobs:
       - name: setup Rust
         uses: dtolnay/rust-toolchain@master
         with: 
-          toolchain: '${{ env.MSRV }}'
+           # Use a newer version rustc if it is OpenHarmony, remove this workaround after MSRV is newer than 1.78.0 
+          toolchain: "${{ contains(matrix.target, 'ohos')  && env.MSRV_OHOS || env.MSRV }}" 
           components: clippy
 
       - name: install targets
@@ -262,7 +265,7 @@ jobs:
 
       - name: before_cache_script
         run: rm -rf $CARGO_HOME/registry/index
-  
+
 
   redox:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,9 @@ jobs:
           - target: s390x-unknown-linux-gnu
           - target: x86_64-unknown-linux-gnux32
           - target: x86_64-unknown-netbsd
+          - target: aarch64-unknown-linux-ohos
+          - target: armv7-unknown-linux-ohos
+          - target: x86_64-unknown-linux-ohos
 
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -81,18 +81,18 @@ The following targets are supported by `nix`:
    <ul>
     <li>aarch64-apple-ios</li>
     <li>aarch64-linux-android</li>
+    <li>aarch64-unknown-linux-ohos</li>
     <li>arm-linux-androideabi</li>
     <li>arm-unknown-linux-musleabi</li>
     <li>armv7-linux-androideabi</li>
+    <li>armv7-unknown-linux-ohos</li>
     <li>i686-linux-android</li>
     <li>loongarch64-unknown-linux-gnu</li>
     <li>s390x-unknown-linux-gnu</li>
     <li>x86_64-linux-android</li>
     <li>x86_64-unknown-illumos</li>
-    <li>x86_64-unknown-netbsd</li>
-    <li>aarch64-unknown-linux-ohos</li>
-    <li>armv7-unknown-linux-ohos</li>
     <li>x86_64-unknown-linux-ohos</li>
+    <li>x86_64-unknown-netbsd</li>
    </td>
    <td>
     <li>armv7-unknown-linux-uclibceabihf</li>

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The following targets are supported by `nix`:
     <li>x86_64-linux-android</li>
     <li>x86_64-unknown-illumos</li>
     <li>x86_64-unknown-netbsd</li>
+    <li>aarch64-unknown-linux-ohos</li>
+    <li>armv7-unknown-linux-ohos</li>
+    <li>x86_64-unknown-linux-ohos</li>
    </td>
    <td>
     <li>armv7-unknown-linux-uclibceabihf</li>

--- a/changelog/2599.added.md
+++ b/changelog/2599.added.md
@@ -1,0 +1,1 @@
+Add OpenHarmony target into CI and Update documents.


### PR DESCRIPTION
## What does this PR do

Add OpenHarmony target into CI and Update documents.

The official support:  arm64,arm and x86_64, so i add three targets:
- aarch64-unknown-linux-ohos
- armv7-unknown-linux-ohos
- x86_64-unknown-linux-ohos

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
