### PR TITLE
Reexport crate::poll_timeout::PollTimeoutTryFromError;

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,7 +2,7 @@
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
 
 use crate::errno::Errno;
-pub use crate::poll_timeout::PollTimeout;
+pub use crate::poll_timeout::{PollTimeout, PollTimeoutTryFromError};
 use crate::Result;
 
 /// This is a wrapper around `libc::pollfd`.

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,5 +1,6 @@
 use crate::errno::Errno;
 pub use crate::poll_timeout::PollTimeout as EpollTimeout;
+pub use crate::poll_timeout::PollTimeoutTryFromError as EpollTimeoutTryFromError;
 use crate::Result;
 use libc::{self, c_int};
 use std::mem;


### PR DESCRIPTION
## What does this PR do

`impl TryFrom<i16> for PollTimeout` uses a custom error (`PollTimeoutTryFromError`), but the error type is not public so handling this error is not really possible. All this PR does is making the type public.

Normally something complains when you try to use private type in a public interface, not sure why is it not happening here.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
