### PR TITLE
Enable TcpMaxSeg `setsockopt` option for apple targets

### DIFF
--- a/changelog/2603.added.md
+++ b/changelog/2603.added.md
@@ -1,0 +1,1 @@
+Added the TcpMaxSeg `setsockopt` option for apple targets

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -698,7 +698,7 @@ sockopt_impl!(
     u32
 );
 cfg_if! {
-    if #[cfg(linux_android)] {
+    if #[cfg(any(linux_android, apple_targets))] {
         sockopt_impl!(
             /// The maximum segment size for outgoing TCP packets.
             TcpMaxSeg, Both, libc::IPPROTO_TCP, libc::TCP_MAXSEG, u32);


### PR DESCRIPTION
## What does this PR do

Enables the TcpMaxSeg socket option for apple targets. I've tested this on MacOS, not sure about iOS but I imagine it would work just the same.

Here's some code I used to verify that it works:
```rust
use nix::sys::socket::{getsockopt, setsockopt, sockopt::TcpMaxSeg};
use std::{io::Write, net::TcpStream};

fn main() {
    // Open a socket to somewhere
    let mut socket = TcpStream::connect(("127.0.0.1", 1234)).unwrap();
    
    // Set the MSS
    setsockopt(&socket, TcpMaxSeg, &523).unwrap();
    
    // Read the MSS
    let maxseg = getsockopt(&socket, TcpMaxSeg).unwrap();
    println!("maxseg: {maxseg}");
    
    // Send a large amount of data and observe that the segments are not bigger than 523 bytes
    socket.write_all(&[0x77; 2000]).unwrap();
}
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
