### PR TITLE
feat: Get `tcp_info` structure

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1268,6 +1268,17 @@ sockopt_impl!(
     libc::SO_EXCLBIND,
     bool
 );
+#[cfg(target_os = "linux")]
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Get tcp_info structure.
+    TcpInfo,
+    GetOnly,
+    libc::SOL_TCP,
+    libc::TCP_INFO,
+    libc::tcp_info
+);
 
 #[allow(missing_docs)]
 // Not documented by Linux!

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -569,6 +569,23 @@ fn test_ipv6_tclass() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_tcp_info() {
+    let fd = socket(
+        AddressFamily::Inet6,
+        SockType::Stream,
+        SockFlag::empty(),
+        SockProtocol::Tcp,
+    )
+    .unwrap();
+    let tcp_info = getsockopt(&fd, sockopt::TcpInfo).unwrap();
+    // Silly assert for the sake of having one in the test.
+    // There should be no retransmits because nothing is sent through the
+    // socket in the first place.
+    assert_eq!(tcp_info.tcpi_retransmits, 0);
+}
+
+#[test]
 #[cfg(target_os = "freebsd")]
 fn test_receive_timestamp() {
     let fd = socket(


### PR DESCRIPTION
Implement TCP_INFO option for getsockopt.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
