### PR TITLE
doc(socket): add a note on how to enable NONBLOCK / CLOEXEC on macOS

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -290,6 +290,9 @@ libc_bitflags! {
     /// Additional socket options
     pub struct SockFlag: c_int {
         /// Set non-blocking mode on the new socket
+        ///
+        /// Note: macOS supports `NONBLOCK` through separate call to `fcntl`,
+        /// i.e. `nix::fcntl::fcntl(fd, F_SETFL(O_NONBLOCK))`
         #[cfg(any(linux_android,
                   freebsdlike,
                   netbsdlike,

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -292,13 +292,16 @@ libc_bitflags! {
         /// Set non-blocking mode on the new socket
         ///
         /// Note: macOS supports `NONBLOCK` through separate call to `fcntl`,
-        /// i.e. `nix::fcntl::fcntl(fd, F_SETFL(O_NONBLOCK))`
+        /// e.g. `nix::fcntl::fcntl(fd, F_SETFL(O_NONBLOCK))`
         #[cfg(any(linux_android,
                   freebsdlike,
                   netbsdlike,
                   solarish))]
         SOCK_NONBLOCK;
         /// Set close-on-exec on the new descriptor
+        ///
+        /// Note: macOS supports `CLOEXEC` through separate call to `fcntl`,
+        /// e.g. `nix::fcntl::fcntl(fd, F_SETFL(O_CLOEXEC))`
         #[cfg(any(linux_android,
                   freebsdlike,
                   netbsdlike,


### PR DESCRIPTION
## What does this PR do
Adds rustdoc comment on `SockFlag` options for `NONBLOCK` and `CLOEXEC` hinting on how to achieve that functionality on macOS

See discussion in https://github.com/nix-rust/nix/pull/863

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
