### PR TITLE
Add sockopt::PeerPidfd (SO_PEERPIDFD) sockopt support to socket::sockopt

### DIFF
--- a/changelog/2620.added.md
+++ b/changelog/2620.added.md
@@ -1,0 +1,1 @@
+Add `PeerPidfd` (`SO_PEERPIDFD`) to `socket::sockopt` for Linux


### PR DESCRIPTION
## What does this PR do
The existing PeerCredentials (SO_PEERCRED) sockopt provides the PID of the process connected to a socket, but PIDs are inherently racy, leading to confused deputy problems. The pidfd mechanism solves this by using a FD to refer to a process which the kernel can keep proper track of.

This patch implements Get/Set<OwnedFd> to be able to receive a FD from getsockopt and implements sockopt::PeerPidfd (SO_PEERPIDFD) returning an OwnedFd representing the process connected to the socket.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
