### PR TITLE
sys::ptrace: adding ::syscall_info() for linux/glibc.

### DIFF
--- a/changelog/2627.added.md
+++ b/changelog/2627.added.md
@@ -1,0 +1,1 @@
+Add `ptrace::syscall_info` for linux/glibc

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -146,6 +146,8 @@ libc_enum! {
         #[cfg(all(target_os = "linux", target_env = "gnu",
                   any(target_arch = "x86", target_arch = "x86_64")))]
         PTRACE_SYSEMU_SINGLESTEP,
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        PTRACE_GET_SYSCALL_INFO,
     }
 }
 
@@ -565,6 +567,13 @@ pub fn setsiginfo(pid: Pid, sig: &siginfo_t) -> Result<()> {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
     }
+}
+
+/// Get the informations of the syscall that caused the stop, as with
+/// `ptrace(PTRACE_GET_SYSCALL_INFO, ...`.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn syscall_info(pid: Pid) -> Result<libc::ptrace_syscall_info> {
+    ptrace_get_data::<libc::ptrace_syscall_info>(Request::PTRACE_GET_SYSCALL_INFO, pid)
 }
 
 /// Sets the process as traceable, as with `ptrace(PTRACE_TRACEME, ...)`


### PR DESCRIPTION
to retrieve the very system call which stopped the process. Can be found the type of calls and their related informations. e.g. on exit we get the return value of the call.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
