### PR TITLE
Remove Copy from PollFd

### DIFF
--- a/changelog/2631.removed.md
+++ b/changelog/2631.removed.md
@@ -1,0 +1,1 @@
+Removed the `Copy` trait from `PollFd`


### PR DESCRIPTION
## What does this PR do

`PollFd` implementing `Copy` makes it easy to accidentally refer to the wrong object after putting one into an array.

This PR removes `Copy` from `PollFd`. This fixes #2630.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
