### PR TITLE
ci: downgrade libc to 0.2.171 in CI for hurd

### DIFF
--- a/.github/workflows/check_new_changelog.yml
+++ b/.github/workflows/check_new_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check_new_changelog:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check_new_changelog.yml
+++ b/.github/workflows/check_new_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check_new_changelog:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,7 @@ jobs:
   # Use cross for QEMU-based testing
   # cross needs to execute Docker, GitHub Action already has it installed
   cross:
-    # Still use 20.04 for this CI step as test `test_prctl::test_set_vma_anon_name`
-    # would fail on 22.04 and 24.04 (at least for now)
-    # https://github.com/nix-rust/nix/issues/2418
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [rustfmt, minver, macos, x86_64_linux_native_builds, rust_stable]
     strategy:
       fail-fast: false
@@ -362,6 +359,13 @@ jobs:
 
       - name: install src
         run: rustup component add rust-src
+
+      # Cargo uses the latest version of libc(without lock file), which is, at the time of writing 
+      # this, 0.2.172. And the hurd target is broken with 0.2.172: https://github.com/rust-lang/libc/issues/4421
+      # So we need to downgrade it.
+      - name: downgrade libc to 0.2.171 on hurd
+        if: ${{ matrix.target == 'i686-unknown-hurd-gnu' }}
+        run: cargo update -p libc --precise 0.2.171
 
       - name: build
         uses: ./.github/actions/build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "=0.2.171", features = ["extra_traits"] }
+libc = { version = "0.2.171", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.171", features = ["extra_traits"] }
+libc = { version = "=0.2.171", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::cast_ptr_alignment)]
 #![deny(unsafe_op_in_unsafe_fn)]
+// I found the change suggested by this rules could hurt code readability. I cannot
+// remeber every type's default value, in such cases, it forces me to open
+// the std doc to insepct the Default value, which is unnecessary with
+// `.unwrap_or(value)`.
+#![allow(clippy::unwrap_or_default)]
 
 // Re-exported external crates
 pub use libc;

--- a/test/sys/test_prctl.rs
+++ b/test/sys/test_prctl.rs
@@ -131,7 +131,12 @@ mod test_prctl {
         prctl::set_thp_disable(original).unwrap();
     }
 
+    // Ignore this test under QEMU, as it started failing after updating the Linux CI
+    // runner image, for reasons unknown.
+    //
+    // See: https://github.com/nix-rust/nix/issues/2418
     #[test]
+    #[cfg_attr(qemu, ignore)]
     fn test_set_vma_anon_name() {
         use nix::errno::Errno;
         use nix::sys::mman;


### PR DESCRIPTION
## What does this PR do

1. In our CI, pin libc to 0.2.171 on hurd to work around this issue: https://github.com/rust-lang/libc/issues/4421
2. Bump CI runner images, Ubuntu-20.04 is deprecated. 
3. Ignore test `test_prctl::test_set_vma_anon_name` under QEMU due to #2418
4. Allow `clippy::unwrap_or_default` as IMHO it is overly opinionated

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
