### PR TITLE
Fix fuchsia target triple to unbreak docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ targets = [
   "x86_64-unknown-openbsd",
   "x86_64-unknown-netbsd",
   "x86_64-unknown-dragonfly",
-  "x86_64-fuchsia",
+  "x86_64-unknown-fuchsia",
   "x86_64-unknown-redox",
   "x86_64-unknown-illumos"
 ]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following targets are supported by `nix`:
    <td>
     <li>armv7-unknown-linux-uclibceabihf</li>
     <li>powerpc64-unknown-linux-gnu</li>
-    <li>x86_64-fuchsia</li>
+    <li>x86_64-unknown-fuchsia</li>
     <li>x86_64-unknown-dragonfly</li>
     <li>x86_64-unknown-haiku</li>
     <li>x86_64-unknown-linux-gnux32</li>


### PR DESCRIPTION
## What does this PR do

Fuchsia timeline:

- **nix &lt;0.20.0**: no support for fuchsia
- **nix 0.20.0 – 0.26.1**: successful docs for `x86_64-fuchsia`
    - https://docs.rs/nix/0.20.0/x86_64-fuchsia/nix/index.html
    - https://docs.rs/nix/0.26.1/x86_64-fuchsia/nix/index.html
- Rust 1.68.0 renames `x86_64-fuchsia` to `x86_64-unknown-fuchsia`
    - https://github.com/rust-lang/rust/pull/106429
    - https://github.com/rust-lang/rust/pull/106636
- **nix 0.26.2 – 0.29.0**: no build for `x86_64-fuchsia`, but successful for everything else
    - failure: https://docs.rs/crate/nix/0.29.0/builds/1230030/x86_64-fuchsia.txt
      > adding target x86_64-fuchsia for toolchain nightly
      > running \`Command { std: CARGO_HOME="/home/cratesfyi/workspace-builder/cargo-home" RUSTUP_HOME="/home/cratesfyi/workspace-builder/rustup-home" "/home/cratesfyi/workspace-builder/cargo-home/bin/rustup" "target" "add" "--toolchain" "nightly" "x86_64-fuchsia", kill_on_drop: false }\`
      > [stderr] error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not support target 'x86_64-fuchsia'
      > [stderr] note: you can see a list of supported targets with \`rustc --print=target-list\`
      > [stderr] note: if you are adding support for a new target to rustc itself, see https://rustc-dev-guide.rust-lang.org/building/new-target.html
- Rust 1.83.0 deletes support for `x86_64-fuchsia`
    - https://github.com/rust-lang/rust/pull/130657
- **nix 0.30.0**: no docs for anything
    - https://docs.rs/crate/nix/0.30.0/builds/2054018
      > \# pre-build errors
      > command failed: exit status: 101
      >
      > error: failed to run \`rustc\` to learn about target-specific information
      >
      > Caused by:
      > process didn't exit successfully: \`/home/cratesfyi/workspace/rustup-home/toolchains/nightly-x86_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names --target x86_64-fuchsia --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg -Wwarnings\` (exit status: 1)
      > --- stderr
      > error: error loading target specification: could not find specification for target "x86_64-fuchsia"
      > |
      > = help: run \`rustc --print target-list\` for a list of built-in targets

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API