### PR TITLE
Clippy cleanup: dangerous_implicit_autorefs

### DIFF
--- a/examples/getifaddrs.rs
+++ b/examples/getifaddrs.rs
@@ -30,7 +30,7 @@ fn main() {
             .address
             .as_ref()
             .and_then(SockaddrStorage::family)
-            .map(|af| format!("{:?}", af))
+            .map(|af| format!("{af:?}"))
             .unwrap_or("".to_owned());
         match (
             &addr.address,
@@ -39,16 +39,14 @@ fn main() {
             &addr.destination,
         ) {
             (Some(a), Some(nm), Some(b), None) => {
-                println!("\t{} {} netmask {} broadcast {}", family, a, nm, b)
+                println!("\t{family} {a} netmask {nm} broadcast {b}")
             }
             (Some(a), Some(nm), None, None) => {
-                println!("\t{} {} netmask {}", family, a, nm)
+                println!("\t{family} {a} netmask {nm}")
             }
-            (Some(a), None, None, None) => println!("\t{} {}", family, a),
-            (Some(a), None, None, Some(d)) => {
-                println!("\t{} {} -> {}", family, a, d)
-            }
-            x => todo!("{:?}", x),
+            (Some(a), None, None, None) => println!("\t{family} {a}"),
+            (Some(a), None, None, Some(d)) => println!("\t{family} {a} -> {d}"),
+            x => todo!("{x:?}"),
         }
     }
 }

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -2428,7 +2428,7 @@ mod tests {
             let addr = UnixAddr::new_abstract(name.as_bytes()).unwrap();
 
             let sun_path1 =
-                unsafe { &(*addr.as_ptr()).sun_path[..addr.path_len()] };
+                unsafe { &(&(*addr.as_ptr()).sun_path)[..addr.path_len()] };
             let sun_path2 = [
                 0, 110, 105, 120, 0, 97, 98, 115, 116, 114, 97, 99, 116, 0,
                 116, 101, 115, 116,

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -200,7 +200,7 @@ pub fn test_path_to_sock_addr() {
 
     let expect: &[c_char] =
         unsafe { slice::from_raw_parts(path.as_ptr().cast(), path.len()) };
-    assert_eq!(unsafe { &(*addr.as_ptr()).sun_path[..8] }, expect);
+    assert_eq!(unsafe { &(&(*addr.as_ptr()).sun_path)[..8] }, expect);
 
     assert_eq!(addr.path(), Some(actual));
 }

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -289,11 +289,7 @@ fn test_tcp_congestion() {
     let val = getsockopt(&fd, sockopt::TcpCongestion).unwrap();
     let bytes = val.as_os_str().as_bytes();
     for b in bytes.iter() {
-        assert_ne!(
-            *b, 0,
-            "OsString should contain no embedded NULs: {:?}",
-            val
-        );
+        assert_ne!(*b, 0, "OsString should contain no embedded NULs: {val:?}");
     }
     setsockopt(&fd, sockopt::TcpCongestion, &val).unwrap();
 


### PR DESCRIPTION
## What does this PR do
Fixes a compiler warning with the latest nightly
## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
