### PR TITLE
Add support for linux rt schedule functions

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -330,6 +330,15 @@ mod sched_priority {
     pub struct SchedParam {
         pub sched_priority: c_int,
     }
+
+    impl SchedParam {
+        pub fn from_priority(priority: c_int) -> Self {
+            SchedParam {
+                sched_priority: priority,
+            }
+        }
+    }
+
     impl From<SchedParam> for libc::sched_param {
         fn from(param: SchedParam) -> Self {
             libc::sched_param {


### PR DESCRIPTION
## What does this PR do

Adds lightweight wrappers around setting and getting the scheduler and schedule parameters.

Related: https://github.com/nix-rust/nix/issues/1260

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
