### PR TITLE
Address multiple CI failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.171", features = ["extra_traits"] }
+libc = { version = "=0.2.172", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2642.removed.md
+++ b/changelog/2642.removed.md
@@ -1,0 +1,8 @@
+Removed `Eq` and `PartialEq` implementations from `SigHandler`, because they
+never worked reliably.  The suggested alternative is `matches!`.  For example:
+```
+let h: SigHandler = ...
+if matches!(h, SigHandler::SigIgn) {
+    ...
+}
+```

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -119,7 +119,7 @@ impl Dir {
     }
 
     /// Returns an iterator of `Result<Entry>` which rewinds when finished.
-    pub fn iter(&mut self) -> Iter {
+    pub fn iter(&mut self) -> Iter<'_> {
         Iter(self)
     }
 }
@@ -133,7 +133,7 @@ impl Dir {
 unsafe impl Send for Dir {}
 
 impl std::os::fd::AsFd for Dir {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         let raw_fd = self.as_raw_fd();
 
         // SAFETY:

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -753,7 +753,7 @@ pub enum FcntlArg<'a> {
     /// Acquire or release an open file description lock
     #[cfg(linux_android)]
     F_OFD_SETLK(&'a libc::flock),
-    /// Like [`F_OFD_SETLK`](FcntlArg::F_OFD_SETLK) except that if a conflicting lock is held on
+    /// Like [`F_OFD_SETLK`] except that if a conflicting lock is held on
     /// the file, then wait for that lock to be released.
     #[cfg(linux_android)]
     F_OFD_SETLKW(&'a libc::flock),

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -745,7 +745,7 @@ pub enum FcntlArg<'a> {
     F_SETFL(OFlag), // O_NONBLOCK
     /// Set or clear a file segment lock
     F_SETLK(&'a libc::flock),
-    /// Like [`F_SETLK`](FcntlArg::F_SETLK) except that if a shared or exclusive lock is blocked by
+    /// Like [`F_SETLK`] except that if a shared or exclusive lock is blocked by
     /// other locks, the process waits until the request can be satisfied.
     F_SETLKW(&'a libc::flock),
     /// Get the first lock that blocks the lock description

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -315,7 +315,7 @@ pub fn mq_remove_nonblock(mqd: &MqdT) -> Result<MqAttr> {
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "dragonfly"))]
 impl AsFd for MqdT {
     /// Borrow the underlying message queue descriptor.
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         // SAFETY: [MqdT] will only contain a valid fd by construction.
         unsafe { BorrowedFd::borrow_raw(self.0) }
     }

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -23,6 +23,7 @@
 //! [`cancel`](trait.Aio.html#method.cancel) or
 //! [`aio_cancel_all`](fn.aio_cancel_all.html), though the operating system may
 //! not support this for all filesystems and devices.
+#![allow(clippy::doc_overindented_list_items)] // It looks better this way
 #[cfg(target_os = "freebsd")]
 use std::io::{IoSlice, IoSliceMut};
 use std::{
@@ -572,8 +573,9 @@ impl<'a> AioRead<'a> {
     /// * `fd`:           File descriptor to read from
     /// * `offs`:         File offset
     /// * `buf`:          A memory buffer.  It must outlive the `AioRead`.
-    /// * `prio`:         If POSIX Prioritized IO is supported, then the operation
-    ///   will be prioritized at the process's priority level minus `prio`
+    /// * `prio`:         If POSIX Prioritized IO is supported, then the
+    ///                   operation will be prioritized at the process's
+    ///                   priority level minus `prio`.
     /// * `sigev_notify`: Determines how you will be notified of event completion.
     pub fn new(
         fd: BorrowedFd<'a>,
@@ -802,8 +804,9 @@ impl<'a> AioWrite<'a> {
     /// * `fd`:           File descriptor to write to
     /// * `offs`:         File offset
     /// * `buf`:          A memory buffer.  It must outlive the `AioWrite`.
-    /// * `prio`:         If POSIX Prioritized IO is supported, then the operation
-    ///   will be prioritized at the process's priority level minus `prio`
+    /// * `prio`:         If POSIX Prioritized IO is supported, then the
+    ///                   operation will be prioritized at the process's
+    ///                   priority level minus `prio`
     /// * `sigev_notify`: Determines how you will be notified of event completion.
     pub fn new(
         fd: BorrowedFd<'a>,

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -314,7 +314,7 @@ pub trait Aio {
     fn error(self: Pin<&mut Self>) -> Result<()>;
 
     /// Returns the underlying file descriptor associated with the operation.
-    fn fd(&self) -> BorrowedFd;
+    fn fd(&self) -> BorrowedFd<'_>;
 
     /// Does this operation currently have any in-kernel state?
     ///

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -101,7 +101,7 @@ impl EventFd {
     }
 }
 impl AsFd for EventFd {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -229,7 +229,7 @@ impl FanotifyEvent {
     /// The file descriptor of the event. If the value is `None` when reading
     /// from the fanotify group, this event is to notify that a group queue
     /// overflow occured.
-    pub fn fd(&self) -> Option<BorrowedFd> {
+    pub fn fd(&self) -> Option<BorrowedFd<'_>> {
         if self.0.fd == libc::FAN_NOFD {
             None
         } else {

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -107,7 +107,7 @@ impl<'fd> FdSet<'fd> {
     /// assert_eq!(fds, vec![4, 9]);
     /// ```
     #[inline]
-    pub fn fds(&self, highest: Option<RawFd>) -> Fds {
+    pub fn fds(&self, highest: Option<RawFd>) -> Fds<'_, '_> {
         Fds {
             set: self,
             range: 0..highest.map(|h| h as usize + 1).unwrap_or(FD_SETSIZE),

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -1035,7 +1035,7 @@ pub fn sigprocmask(how: SigmaskHow, set: Option<&SigSet>, oldset: Option<&mut Si
 ///   - If less than `-1`, the signal is sent to all processes whose
 ///     process group ID is equal to the absolute value of `pid`.
 /// * `signal` - Signal to send. If `None`, error checking is performed
-///              but no signal is actually sent.
+///   but no signal is actually sent.
 ///
 /// See Also
 /// [`kill(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html)

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -753,7 +753,7 @@ impl<'a> IntoIterator for &'a SigSet {
 }
 
 /// A signal handler.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash)]
 pub enum SigHandler {
     /// Default signal handling.
     SigDfl,

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -146,7 +146,7 @@ impl SignalFd {
 }
 
 impl AsFd for SignalFd {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -701,7 +701,7 @@ impl<S> RecvMsg<'_, '_, S> {
     /// Iterate over the valid control messages pointed to by this msghdr. If
     /// allocated space for CMSGs was too small it is not safe to iterate,
     /// instead return an `Error::ENOBUFS` error.
-    pub fn cmsgs(&self) -> Result<CmsgIterator> {
+    pub fn cmsgs(&self) -> Result<CmsgIterator<'_>> {
 
         if self.mhdr.msg_flags & MSG_CTRUNC == MSG_CTRUNC {
             return Err(Errno::ENOBUFS);

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1955,7 +1955,7 @@ pub struct SetOsString<'a> {
 
 #[cfg(any(target_os = "freebsd", linux_android, target_os = "illumos"))]
 impl<'a> Set<'a, OsString> for SetOsString<'a> {
-    fn new(val: &OsString) -> SetOsString {
+    fn new(val: &OsString) -> SetOsString<'_> {
         SetOsString {
             val: val.as_os_str(),
         }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -178,7 +178,7 @@ impl Termios {
     ///
     /// This is not part of `nix`'s public API because it requires additional work to maintain type
     /// safety.
-    pub(crate) fn get_libc_termios(&self) -> Ref<libc::termios> {
+    pub(crate) fn get_libc_termios(&self) -> Ref<'_, libc::termios> {
         {
             let mut termios = self.inner.borrow_mut();
             termios.c_iflag = self.input_flags.bits();

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -541,13 +541,14 @@ mod test_posix_fallocate {
                 assert_eq!(tmp.read(&mut data).expect("read failure"), LEN);
                 assert_eq!(&data[..], &[0u8; LEN][..]);
             }
-            Err(Errno::EINVAL) => {
-                // POSIX requires posix_fallocate to return EINVAL both for
-                // invalid arguments (i.e. len < 0) and if the operation is not
-                // supported by the file system.
-                // There's no way to tell for sure whether the file system
-                // supports posix_fallocate, so we must pass the test if it
-                // returns EINVAL.
+            Err(Errno::ENOTSUP) | Err(Errno::EINVAL) => {
+                // POSIX 1003.1-2024 Issue 8 specified ENOTSUP for "the file
+                // system does not support this operation", so Nix should accept
+                // that error code and pass the test.
+                // But older POSIX required posix_fallocate to return EINVAL
+                // both for invalid arguments (i.e. len < 0) and if the
+                // operation is not supported by the file system.  So we must
+                // also pass the test if it returns EINVAL.
             }
             _ => res.unwrap(),
         }


### PR DESCRIPTION
* Fix the `test_fcntl::test_posix_fallocate::success` test with recent ZFS
* Remove the `PartialEq` and `Eq` implementations from `SigHandler`
* Clippy cleanup: mismatched_lifetime_syntaxes
* Fix a rustdoc warning on the latest nightly
* Suppress Clippy::doc_overindented_list_items

See individual commit messages for details

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
