### PR TITLE
Conditionally const version of strlen

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -385,10 +385,8 @@ pub const unsafe fn dirent_const_time_strlen(dirent: *const libc::dirent64) -> u
     // the non-name bytes (d_type and padding) to avoid false null detection.
     // The 0x00FF_FFFF mask preserves only the 3 bytes where the name could start.
     // Branchless masking: avoids branching by using a mask that is either 0 or 0x00FF_FFFF
-    unsafe{std::hint::assert_unchecked(reclen % 8 ==0 && reclen >=24 )}; //tell the compiler is a multiple of 8 and within bounds
-    //this is safe because the kernel guarantees the above.
     //............................//special case short name check
-    let mask = 0x00FF_FFFFu64 * ((reclen ==24) as u64); // (multiply by 0 or 1)
+    let mask = 0x00FF_FFFFu64 * ((reclen ==24) as u64); // (multiply by 0 or 1) 
     // The mask is applied to the last word to isolate the relevant bytes.
     // The last word is masked to isolate the relevant bytes,
     //we're bit manipulating the last word (a byte/u64) to find the first null byte


### PR DESCRIPTION
(Firstly, I apologise, this is my first issue on a crate and I wanted to share it, please inform me of etiquette if missed!)


(I VERIFIED ALL TESTS LOCALLY BEFORE PUSHING, ALL WORKED)



## What does this PR do

This PR offers an version of strlen for filesystem operations and I believe is 

1. Constant time (thus no branching)
2. No SIMD (works on x86-64 which is a good portion of nix users)
3. No overreads from strlen.
4. Evaluable at compile time (for whatever vague reasons I don't understand is useful)
5. Faster than libc::strlen


NOTES:

I've changed functions around my the definitions in my own crate, I've exposed the function in this PR  as a new function but ideally the function could be placed wherever (it maybe too unsafe to have as a general function)

Even though this is esoteric, this is a very low level thing to optimise, I thing downstream impacts in some cases could be notable.

It needs to be heavily tested to know where it works/what needs to be modified,

I'd like to know simply if the nix maintainers would like this functionality in some form.

my comments are explained in the function definition


PROBLEMS:

Little Endianness, strange edge case versions of unix.


In my crate you can see benchmarks: 

https://github.com/alexcu2718/fdf/blob/main/const_str_benchmark.txt

(just clone it and cargo bench)


The benchmarks are pretty impressive,
```bash
EMPTY STRINGS


 strlen_by_length/const_time_swar/empty
                        time:   [994.53 ps 997.11 ps 999.71 ps]
strlen_by_length/libc_strlen/empty
                          time:   [1.6360 ns 1.6408 ns 1.6455 ns]

```

```bash
LONGSTRINGS(~128-255)

 strlen_by_length/const_time_swar/xlarge (129-255)
                       time:   [1.0687 ns 1.0719 ns 1.0750 ns]
 strlen_by_length/libc_strlen/xlarge (129-255)
                       time:   [4.2938 ns 4.3054 ns 4.3171 ns]
```
## Checklist:

- [ YES I HAVE] I have read `CONTRIBUTING.md` 
- [ YES] I have written necessary tests and rustdoc comments 
- [ ] A change log has been added if this PR modifies nix's API
