### PR TITLE
Add a timed send to match the timed receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 # Change Log
 
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Added `mq_timedsend` to `::nix::mqueue`.
+  ([#2650](https://github.com/nix-rust/nix/pull/2650))
+
 ## [0.30.1] - 2025-05-04
 
 ### Fixed

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -235,6 +235,26 @@ feature! {
         };
         Errno::result(res).map(|r| r as usize)
     }
+    /// Send a message to a message queue with a timeout
+    ///
+    /// See also ['mq_timedsend(2)'](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_send.html)
+    pub fn mq_timedsend(
+        mqdes: &MqdT,
+        message: &[u8],
+        msg_prio: u32,
+        abstime: &TimeSpec,
+    ) -> Result<()> {
+        let res = unsafe {
+            libc::mq_timedsend(
+                mqdes.0,
+                message.as_ptr().cast(),
+                message.len(),
+                msg_prio,
+                abstime.as_ref(),
+            )
+        };
+        Errno::result(res).map(drop)
+    }
 }
 
 /// Send a message to a message queue


### PR DESCRIPTION
## What does this PR do

This change adds timedsend, it  mirrors  https://github.com/nix-rust/nix/pull/1966 which added timedreceive.

I have tried to follow the pattens of the repo but as this is my first PR here I can imaging I may well have got something wrong.

I am unsure about the change log as its so soon after the last release, i looked in the history and i think this matches what should happen.