### PR TITLE
Fix the sys::test_aio::aio_fsync::error test on recent rust nightly

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -929,7 +929,7 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 ///
 /// # Errors
 ///
-/// Returns [`Error(Errno::EOPNOTSUPP)`] if `handler` is
+/// Returns [`Error(Errno::EOPNOTSUPP)`](Errno::EOPNOTSUPP) if `handler` is
 /// [`SigAction`][SigActionStruct]. Use [`sigaction`][SigActionFn] instead.
 ///
 /// `signal` also returns any error from `libc::signal`, such as when an attempt

--- a/test/sys/test_aio.rs
+++ b/test/sys/test_aio.rs
@@ -70,15 +70,11 @@ mod aio_fsync {
     #[test]
     #[cfg_attr(any(target_os = "android", target_os = "linux"), ignore)]
     fn error() {
-        use std::mem;
-
-        const INITIAL: &[u8] = b"abcdef123456";
-        // Create an invalid AioFsyncMode
-        let mode = unsafe { mem::transmute::<i32, AioFsyncMode>(666) };
-        let mut f = tempfile().unwrap();
-        f.write_all(INITIAL).unwrap();
+        let mode = AioFsyncMode::O_SYNC;
+        // Operate on an invalid file descriptor.  Should get EBADF
+        let fd = unsafe { BorrowedFd::borrow_raw(i32::MAX) };
         let mut aiof =
-            Box::pin(AioFsync::new(f.as_fd(), mode, 0, SigevNotify::SigevNone));
+            Box::pin(AioFsync::new(fd, mode, 0, SigevNotify::SigevNone));
         let err = aiof.as_mut().submit();
         err.expect_err("assertion failed");
     }


### PR DESCRIPTION
This test deliberately makes an invalid syscall.  Rust no longer allows us to even construct an invalid enum (even with `unsafe`), so alter the test to get EBADF instead of EINVAL.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
