### PR TITLE
Fix syscall_info

### DIFF
--- a/changelog/2653.fixed.md
+++ b/changelog/2653.fixed.md
@@ -1,0 +1,1 @@
+Fixed `nix::sys::ptrace::syscall_info`, which was not setting the `data` argument properly, causing garbage values to be returned.

--- a/examples/ptrace.rs
+++ b/examples/ptrace.rs
@@ -1,0 +1,39 @@
+//! Traces a child process using `ptrace`.
+//!
+//! The child issues a single `write` syscall, which is printed upon entry and exit.
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn main() {
+    let pid = unsafe { nix::unistd::fork().unwrap() };
+
+    match pid {
+        nix::unistd::ForkResult::Child => {
+            nix::sys::ptrace::traceme().unwrap();
+            nix::sys::signal::raise(nix::sys::signal::Signal::SIGCONT).unwrap();
+            println!("I'm issuing a syscall!");
+        }
+        nix::unistd::ForkResult::Parent { child } => {
+            nix::sys::wait::waitpid(Some(child), None).unwrap();
+            nix::sys::ptrace::setoptions(
+                child,
+                nix::sys::ptrace::Options::PTRACE_O_TRACESYSGOOD,
+            )
+            .unwrap();
+
+            nix::sys::ptrace::syscall(child, None).unwrap();
+            nix::sys::wait::waitpid(Some(child), None).unwrap();
+            let syscall_info = nix::sys::ptrace::syscall_info(child).unwrap();
+            println!("{syscall_info:?}");
+            assert!(syscall_info.op == libc::PTRACE_SYSCALL_INFO_ENTRY);
+
+            nix::sys::ptrace::syscall(child, None).unwrap();
+            nix::sys::wait::waitpid(Some(child), None).unwrap();
+            let syscall_info = nix::sys::ptrace::syscall_info(child).unwrap();
+            println!("{syscall_info:?}");
+            assert!(syscall_info.op == libc::PTRACE_SYSCALL_INFO_EXIT);
+        }
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+fn main() {}

--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -504,7 +504,7 @@ fn ptrace_get_data<T>(request: Request, pid: Pid) -> Result<T> {
         libc::ptrace(
             request as RequestType,
             libc::pid_t::from(pid),
-            ptr::null_mut::<T>(),
+            std::mem::size_of::<T>(),
             data.as_mut_ptr(),
         )
     };


### PR DESCRIPTION
## What does this PR do

It fixes `ptrace::syscall_info`, which is currently broken (at least on Linux 6.12.31).

See the commit message for more details.

## Reproduction

The following program panics when built against `master` and behaves correctly (i.e. it does not panic and prints valid syscall info) when built against this branch:

```rust
fn main() {
    let pid = unsafe { nix::unistd::fork().unwrap() };

    match pid {
        nix::unistd::ForkResult::Child => {
            nix::sys::ptrace::traceme().unwrap();
            nix::sys::signal::raise(nix::sys::signal::Signal::SIGCONT).unwrap();
            println!("I'm issuing a syscall!");
        }
        nix::unistd::ForkResult::Parent { child } => {
            nix::sys::wait::waitpid(Some(child), None).unwrap();
            nix::sys::ptrace::setoptions(child, nix::sys::ptrace::Options::PTRACE_O_TRACESYSGOOD)
                .unwrap();

            nix::sys::ptrace::syscall(child, None).unwrap();
            nix::sys::wait::waitpid(Some(child), None).unwrap();
            let syscall_info = nix::sys::ptrace::syscall_info(child).unwrap();
            println!("{syscall_info:?}");
            assert!(syscall_info.op == libc::PTRACE_SYSCALL_INFO_ENTRY);

            nix::sys::ptrace::syscall(child, None).unwrap();
            nix::sys::wait::waitpid(Some(child), None).unwrap();
            let syscall_info = nix::sys::ptrace::syscall_info(child).unwrap();
            println!("{syscall_info:?}");
            assert!(syscall_info.op == libc::PTRACE_SYSCALL_INFO_EXIT);
        }
    }
}
```

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
