### PR TITLE
Cast the 'addr' argument of 'madvise()' for AIX

### DIFF
--- a/changelog/2655.fixed.md
+++ b/changelog/2655.fixed.md
@@ -1,0 +1,1 @@
+Cast the 'addr' argument of 'madvise()' to '*mut u8' on AIX to match the signature in the AIX libc.


### PR DESCRIPTION
## What does this PR do

The AIX signature of `madvise()` differs from the POSIX specification, which expects `void *` as the type of the `addr` argument, whereas AIX uses `caddr_t` (i.e., `char *`). This patch casts `addr` inside the `nix` wrapper `madvise()` to smooth it out. 

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
