### PR TITLE
fix broken documentation link in

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -929,7 +929,7 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 ///
 /// # Errors
 ///
-/// Returns [`Error(Errno::EOPNOTSUPP)`] if `handler` is
+/// Returns [`Errno::ENOTSUP`] if `handler` is
 /// [`SigAction`][SigActionStruct]. Use [`sigaction`][SigActionFn] instead.
 ///
 /// `signal` also returns any error from `libc::signal`, such as when an attempt


### PR DESCRIPTION
fix broken intra-doc link from 'Error(Errno::EOPNOTSUPP)' to 'Errno::ENOTSUP' to match the actual error returned by the code and fix CI documentation build.

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
