### PR TITLE
Expose UDP GSO/GRO on android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "=0.2.172", features = ["extra_traits"] }
+libc = { version = "=0.2.175", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2666.added.md
+++ b/changelog/2666.added.md
@@ -1,0 +1,5 @@
+Added the UDP GSO/GRO socket options and CMsgs on Android. This includes the following types:
+- UdpGsoSegment
+- UdpGroSegment
+- ControlMessage::UdpGsoSegments
+- ControlMessageOwned::UdpGroSegments

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -912,7 +912,7 @@ pub enum ControlMessageOwned {
     ///
     /// `UdpGroSegment` socket option should be enabled on a socket
     /// to allow receiving GRO packets.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux_android)]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     UdpGroSegments(i32),
@@ -1087,7 +1087,7 @@ impl ControlMessageOwned {
                 let dl = unsafe { ptr::read_unaligned(p as *const libc::sockaddr_in) };
                 ControlMessageOwned::Ipv4OrigDstAddr(dl)
             },
-            #[cfg(target_os = "linux")]
+            #[cfg(linux_android)]
             #[cfg(feature = "net")]
             (libc::SOL_UDP, libc::UDP_GRO) => {
                 let gso_size: i32 = unsafe { ptr::read_unaligned(p as *const _) };
@@ -1265,7 +1265,7 @@ pub enum ControlMessage<'a> {
     /// passed through this control message.
     /// Send buffer should consist of multiple fixed-size wire payloads
     /// following one by one, and the last, possibly smaller one.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux_android)]
     #[cfg(feature = "net")]
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
     UdpGsoSegments(&'a u16),
@@ -1437,7 +1437,7 @@ impl ControlMessage<'_> {
             ControlMessage::AlgSetAeadAssoclen(len) => {
                 len as *const _ as *const u8
             },
-            #[cfg(target_os = "linux")]
+            #[cfg(linux_android)]
             #[cfg(feature = "net")]
             ControlMessage::UdpGsoSegments(gso_size) => {
                 gso_size as *const _ as *const u8
@@ -1515,7 +1515,7 @@ impl ControlMessage<'_> {
             ControlMessage::AlgSetAeadAssoclen(len) => {
                 mem::size_of_val(len)
             },
-            #[cfg(target_os = "linux")]
+            #[cfg(linux_android)]
             #[cfg(feature = "net")]
             ControlMessage::UdpGsoSegments(gso_size) => {
                 mem::size_of_val(gso_size)
@@ -1572,7 +1572,7 @@ impl ControlMessage<'_> {
             #[cfg(linux_android)]
             ControlMessage::AlgSetIv(_) | ControlMessage::AlgSetOp(_) |
                 ControlMessage::AlgSetAeadAssoclen(_) => libc::SOL_ALG,
-            #[cfg(target_os = "linux")]
+            #[cfg(linux_android)]
             #[cfg(feature = "net")]
             ControlMessage::UdpGsoSegments(_) => libc::SOL_UDP,
             #[cfg(any(linux_android, target_os = "netbsd", apple_targets))]
@@ -1624,7 +1624,7 @@ impl ControlMessage<'_> {
             ControlMessage::AlgSetAeadAssoclen(_) => {
                 libc::ALG_SET_AEAD_ASSOCLEN
             },
-            #[cfg(target_os = "linux")]
+            #[cfg(linux_android)]
             #[cfg(feature = "net")]
             ControlMessage::UdpGsoSegments(_) => {
                 libc::UDP_SEGMENT

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1120,7 +1120,7 @@ sockopt_impl!(
     libc::IP_ORIGDSTADDR,
     bool
 );
-#[cfg(target_os = "linux")]
+#[cfg(linux_android)]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
@@ -1132,7 +1132,7 @@ sockopt_impl!(
     libc::UDP_SEGMENT,
     libc::c_int
 );
-#[cfg(target_os = "linux")]
+#[cfg(linux_android)]
 #[cfg(feature = "net")]
 sockopt_impl!(
     #[cfg_attr(docsrs, doc(cfg(feature = "net")))]

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -111,7 +111,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(target_os = "linux")] {
+    if #[cfg(linux_android)] {
         #[macro_export] macro_rules! require_kernel_version {
             ($name:expr, $version_requirement:expr) => {
                 use semver::{Version, VersionReq};

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -462,7 +462,7 @@ mod recvfrom {
         assert_eq!(AddressFamily::Inet, from.unwrap().family().unwrap());
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(linux_android)]
     mod udp_offload {
         use super::*;
         use nix::sys::socket::sockopt::{UdpGroSegment, UdpGsoSegment};


### PR DESCRIPTION


## What does this PR do
Update `libc` to 0.2.175

Expose UDP generic segmentation/receive offload API on Android.
This was recently added to libc ([f6355882](https://github.com/rust-lang/libc/commit/f6355882054c91d0ed7827f35ea3d2c8b2dcfe76)).

The exposed items are:
- Socket options
  - [UdpGsoSegment](https://docs.rs/nix/0.30.1/nix/sys/socket/sockopt/struct.UdpGsoSegment.html)
  - [UdpGroSegment](https://docs.rs/nix/0.30.1/nix/sys/socket/sockopt/struct.UdpGroSegment.html)
- Control messages
  - [ControlMessage::UdpGsoSegments](https://docs.rs/nix/0.30.1/nix/sys/socket/enum.ControlMessage.html#variant.UdpGsoSegments)
  - [ControlMessageOwned::UdpGroSegments](https://docs.rs/nix/0.30.1/nix/sys/socket/enum.ControlMessageOwned.html#variant.UdpGroSegments)

I've also enabled the `udp_offload` tests on android.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
