### PR TITLE
redox: Export UDS, resource, syslog, and others

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -171,10 +171,9 @@ libc_bitflags!(
         #[cfg(linux_android)]
         O_NOATIME;
         /// Don't attach the device as the process' controlling terminal.
-        #[cfg(not(target_os = "redox"))]
         O_NOCTTY;
         /// Same as `O_NONBLOCK`.
-        #[cfg(not(any(target_os = "redox", target_os = "haiku", target_os = "cygwin")))]
+        #[cfg(not(any(target_os = "haiku", target_os = "cygwin")))]
         O_NDELAY;
         /// `open()` will fail if the given path is a symbolic link.
         O_NOFOLLOW;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -93,12 +93,7 @@ feature! {
     pub mod reboot;
 }
 
-#[cfg(not(any(
-    target_os = "redox",
-    target_os = "fuchsia",
-    solarish,
-    target_os = "haiku"
-)))]
+#[cfg(not(any(target_os = "fuchsia", solarish, target_os = "haiku")))]
 feature! {
     #![feature = "resource"]
     pub mod resource;

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -20,7 +20,8 @@ cfg_if! {
         target_os = "android",
         target_os = "aix",
         all(target_os = "linux", not(target_env = "gnu")),
-        target_os = "cygwin"
+        target_os = "cygwin",
+        target_os = "redox",
     ))]{
         use libc::rlimit;
     }
@@ -51,7 +52,8 @@ libc_enum! {
             target_os = "android",
             target_os = "aix",
             all(target_os = "linux", not(any(target_env = "gnu", target_env = "uclibc"))),
-            target_os = "cygwin"
+            target_os = "cygwin",
+            target_os = "redox",
         ), repr(i32))]
     #[non_exhaustive]
     pub enum Resource {

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -17,7 +17,7 @@ use std::ptr;
 // if the string it points to is changed, syslog() may start prepending the changed
 // string, and if the string it points to ceases to exist, the results are
 // undefined.  Most portable is to use a string constant.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "redox"))]
 pub fn openlog(
     ident: Option<&'static std::ffi::CStr>,
     logopt: LogFlags,
@@ -215,7 +215,7 @@ libc_bitflags! {
         /// which file descriptors are allocated.
         LOG_NDELAY;
         /// Write the message to standard error output as well to the system log.
-        #[cfg(not(any(solarish, target_os = "redox", target_os = "cygwin")))]
+        #[cfg(not(any(solarish, target_os = "cygwin")))]
         LOG_PERROR;
     }
 }


### PR DESCRIPTION
## What does this PR do

I exported a few supported Redox features: `resource.h`, syslog, and some `fcntl.h` constants. Some of these changes only work on `libc`'s main branch as I only recently enabled them there too which is why I'm keeping this as a draft.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
