### PR TITLE
Improve mqueue documentation and documentation example

### DIFF
--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -2,24 +2,24 @@
 //!
 //! # Example
 //!
-// no_run because a kernel module may be required.
-//! ```no_run
+//! ```
 //! # use std::ffi::CString;
 //! # use nix::mqueue::*;
 //! use nix::sys::stat::Mode;
 //!
 //! const MSG_SIZE: mq_attr_member_t = 32;
-//! let mq_name= "/a_nix_test_queue";
+//! let attr = MqAttr::new(0, 10, MSG_SIZE, 0);
+//! let mq_name= "/a_nix_doc_test_queue";
 //!
 //! let oflag0 = MQ_OFlag::O_CREAT | MQ_OFlag::O_WRONLY;
 //! let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IRGRP | Mode::S_IROTH;
-//! let mqd0 = mq_open(mq_name, oflag0, mode, None).unwrap();
+//! let mqd0 = mq_open(mq_name, oflag0, mode, Some(&attr)).unwrap();
 //! let msg_to_send = b"msg_1";
 //! mq_send(&mqd0, msg_to_send, 1).unwrap();
 //!
 //! let oflag1 = MQ_OFlag::O_CREAT | MQ_OFlag::O_RDONLY;
-//! let mqd1 = mq_open(mq_name, oflag1, mode, None).unwrap();
-//! let mut buf = [0u8; 32];
+//! let mqd1 = mq_open(mq_name, oflag1, mode, Some(&attr)).unwrap();
+//! let mut buf = [0u8; MSG_SIZE as usize];
 //! let mut prio = 0u32;
 //! let len = mq_receive(&mqd1, &mut buf, &mut prio).unwrap();
 //! assert_eq!(prio, 1);


### PR DESCRIPTION
From reading the [mqueue c implementation](https://github.com/RT-Thread/rt-thread/blob/893ae7d7ba4daecfe4732cb51db8f140dc7211ff/components/libc/posix/ipc/mqueue.c#L141) that this library wraps, it seems that we can't set `attr` to `None` when creating the mqueue `MQ_OFlag::O_CREAT`. If we do, we get an `Errno::EINVAL`. This means that the example in the documentation is incorrect. 

## What does this PR do

This PR updates the mqueue documentation example and adds some helpful documentation to explain the limits of the `MqAttr` input values.
