### PR TITLE
fix two problems in the Dir module:

### DIFF
--- a/changelog/2674.fixed.md
+++ b/changelog/2674.fixed.md
@@ -1,0 +1,3 @@
+Fixed the Dir module on NTO, Solaris, Hurd, and possibly other platforms.  The
+d_name field was not copied correctly on those platforms.  For some other
+platforms, it could be copied incorrectly for files with very long pathnames.


### PR DESCRIPTION
readdir_r does not work well on systems where {NAME_MAX} can vary.  The main reason to use it is for thread-safety.  However, POSIX 1003.1-2024 Issue 8 makes readdir_r obsolete and clarifies that readdir must be thread-safe except when concurrent calls are made to the same directory stream.  So all applications should prefer it now.  The original rationale for Nix using readdir_r[^1], in addition to thread safety, was that the Rust standard library used it.  But that is no longer the case.  So Nix should switch to plain readdir.

The second problem is that on some operating systems, libc::dirent is an
open-ended structure where the last field (d_name) has a size of 1 byte,
but additional data follow the end of the structure.  Nix currently
 relies on copying the libc::dirent structure, which can't possibly work
on those platforms.  Fix that bug by copying the d_name field to an
owned CString.


[^1]: f9ebcb7c00faf1290565630f14c93a9c7ab51e51 , from 2018

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
