### PR TITLE
Expose SEEK_DATA and SEEK_HOLE on Android

### DIFF
--- a/changelog/2676.added.md
+++ b/changelog/2676.added.md
@@ -1,0 +1,1 @@
+Add `SeekData` and `SeekHole` to `Whence` for Android

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1411,9 +1411,9 @@ pub enum Whence {
     #[cfg(any(
         apple_targets,
         freebsdlike,
+        linux_android,
         solarish,
         target_os = "hurd",
-        target_os = "linux",
     ))]
     SeekData = libc::SEEK_DATA,
     /// Specify an offset relative to the next hole in the file greater than
@@ -1424,9 +1424,9 @@ pub enum Whence {
     #[cfg(any(
         apple_targets,
         freebsdlike,
+        linux_android,
         solarish,
         target_os = "hurd",
-        target_os = "linux",
     ))]
     SeekHole = libc::SEEK_HOLE,
 }


### PR DESCRIPTION
## What does this PR do

This exposes `Whence::SeekData` and `Whence::SeekHole` on Android. These have been supported in Android itself and in the libc crate for several years.

This is the libc commit that added `SEEK_DATA` and `SEEK_HOLE` to their tests on Android: https://github.com/rust-lang/libc/commit/aa1c8ea6ba7e2b5e01f70ee6468dacd7d4588844

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
  - I don't think any changes are needed
- [x] A change log has been added if this PR modifies nix's API
