### PR TITLE
Cast the 'cap' argument of 'getgrnam_r' to 'i32' on AIX

### DIFF
--- a/changelog/2677.fixed.md
+++ b/changelog/2677.fixed.md
@@ -1,0 +1,1 @@
+Cast the 'cap' argument of 'getgrnam_r' to 'i32' on AIX to match the signature in the AIX libc


### PR DESCRIPTION
## What does this PR do
The AIX signature of `getgrnam_r(...)` differs from POSIX specification, which expects `size_t` (rust: `usize`) as the type of the `cap`/`buflen` argument, whereas AIX uses `int` (rust: `i32`). This patch casts `cap` inside the nix wrapper to avoid the mismatch

Example of compilation failure from `cargo build` output:

`error[E0308]: mismatched types
    --> /home/XXXX/.cargo/registry/src/index.crates.io-7f555b6b8ccf4919/nix-0.28.0/src/unistd.rs:3587:60`
`3587 |                 libc::getgrnam_r(name.as_ptr(), grp, cbuf, cap, res)`
`         |                 ----------------                           ^^^ expected i32, found usize`
`         |                 arguments to this function are incorrect`
`         |`
`note: function defined here`
`    --> /home/XXX/.cargo/registry/src/index.crates.io-7f555b6b8ccf4919/libc-0.2.175/src/unix/aix/mod.rs:2926:12`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
