### PR TITLE
statfs: Fix definitions for s390x musl with libc 0.2.176

### DIFF
--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -56,11 +56,10 @@ type fs_type_t = u32;
 type fs_type_t = libc::c_ulong;
 #[cfg(all(
     target_os = "linux",
-    target_arch = "s390x",
-    not(target_env = "musl")
+    target_arch = "s390x"
 ))]
 type fs_type_t = libc::c_uint;
-#[cfg(all(target_os = "linux", any(target_env = "musl", target_env = "ohos")))]
+#[cfg(all(target_os = "linux", any(target_env = "musl", target_env = "ohos"), not(target_arch = "s390x")))]
 type fs_type_t = libc::c_ulong;
 #[cfg(all(target_os = "linux", target_env = "uclibc"))]
 type fs_type_t = libc::c_int;
@@ -328,8 +327,7 @@ impl Statfs {
     /// Optimal transfer block size
     #[cfg(all(
         target_os = "linux",
-        target_arch = "s390x",
-        not(target_env = "musl")
+        target_arch = "s390x"
     ))]
     pub fn optimal_transfer_size(&self) -> u32 {
         self.0.f_bsize
@@ -338,7 +336,7 @@ impl Statfs {
     /// Optimal transfer block size
     #[cfg(any(
         target_os = "android",
-        all(target_os = "linux", target_env = "musl"),
+        all(target_os = "linux", target_env = "musl", not(target_arch = "s390x")),
         all(target_os = "linux", target_env = "ohos")
     ))]
     pub fn optimal_transfer_size(&self) -> libc::c_ulong {
@@ -387,8 +385,7 @@ impl Statfs {
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
     #[cfg(all(
         target_os = "linux",
-        target_arch = "s390x",
-        not(target_env = "musl")
+        target_arch = "s390x"
     ))]
     pub fn block_size(&self) -> u32 {
         self.0.f_bsize
@@ -396,7 +393,7 @@ impl Statfs {
 
     /// Size of a block
     // f_bsize on linux: https://github.com/torvalds/linux/blob/master/fs/nfs/super.c#L471
-    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg(all(target_os = "linux", target_env = "musl", not(target_arch = "s390x")))]
     pub fn block_size(&self) -> libc::c_ulong {
         self.0.f_bsize
     }
@@ -472,15 +469,14 @@ impl Statfs {
     /// Maximum length of filenames
     #[cfg(all(
         target_os = "linux",
-        target_arch = "s390x",
-        not(target_env = "musl")
+        target_arch = "s390x"
     ))]
     pub fn maximum_name_length(&self) -> u32 {
         self.0.f_namelen
     }
 
     /// Maximum length of filenames
-    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg(all(target_os = "linux", target_env = "musl", not(target_arch = "s390x")))]
     pub fn maximum_name_length(&self) -> libc::c_ulong {
         self.0.f_namelen
     }


### PR DESCRIPTION
## What does this PR do

This PR fixes compilation against libc 0.2.176 on `s390x-unknown-linux-musl`. libc 0.2.176 fixed the definitions of `statfs` to align them with musl, see https://github.com/rust-lang/libc/pull/4549 for the PR that fixed it.

I'm not sure why libc is currently pinned to 0.2.175, but I tested this locally against 0.2.176 on `s390x-unknown-linux-gnu` and `s390x-unknown-linux-musl` and the statfs code compiles fine for both now.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
