### PR TITLE
ptrace: Fix request type for non-GNU s390x

### DIFF
--- a/src/sys/ptrace/linux.rs
+++ b/src/sys/ptrace/linux.rs
@@ -24,8 +24,7 @@ pub type AddressType = *mut ::libc::c_void;
 use libc::user_regs_struct;
 
 cfg_if! {
-    if #[cfg(any(all(target_os = "linux", target_arch = "s390x"),
-                 all(target_os = "linux", target_env = "gnu"),
+    if #[cfg(any(all(target_os = "linux", target_env = "gnu"),
                  target_env = "uclibc"))] {
         #[doc(hidden)]
         pub type RequestType = ::libc::c_uint;


### PR DESCRIPTION
## What does this PR do

The type of the ptrace request parameter is architecture-independent in libc and only c_uint for uclibc and glibc on Linux. This fixes compilation against non-glibc s390x targets like `s390x-unknown-linux-musl`.

Ref:

```
~/libc $ rg "ptrace\(request"
src/unix/bsd/netbsdlike/openbsd/mod.rs
2009:    pub fn ptrace(request: c_int, pid: crate::pid_t, addr: caddr_t, data: c_int) -> c_int;

src/unix/bsd/freebsdlike/mod.rs
1682:    pub fn ptrace(request: c_int, pid: crate::pid_t, addr: *mut c_char, data: c_int) -> c_int;

src/unix/bsd/netbsdlike/netbsd/mod.rs
2584:    pub fn ptrace(request: c_int, pid: crate::pid_t, addr: *mut c_void, data: c_int) -> c_int;

src/unix/bsd/apple/mod.rs
5428:    pub fn ptrace(request: c_int, pid: crate::pid_t, addr: *mut c_char, data: c_int) -> c_int;

src/unix/linux_like/android/mod.rs
3633:    pub fn ptrace(request: c_int, ...) -> c_long;

src/unix/linux_like/linux/uclibc/mod.rs
443:    pub fn ptrace(request: c_uint, ...) -> c_long;

src/unix/linux_like/linux/musl/mod.rs
872:    pub fn ptrace(request: c_int, ...) -> c_long;

src/unix/linux_like/linux/gnu/mod.rs
1201:    pub fn ptrace(request: c_uint, ...) -> c_long;
```


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
