### PR TITLE
Add MS_NOSYMFOLLOW flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "=0.2.175", features = ["extra_traits"] }
+libc = { version = "=0.2.176", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2685.added.md
+++ b/changelog/2685.added.md
@@ -1,0 +1,1 @@
+Added MS_NOSYMFOLLOW flag, a mount option on linux which disallows automatic following of symlinks.

--- a/src/mount/linux.rs
+++ b/src/mount/linux.rs
@@ -21,6 +21,8 @@ libc_bitflags!(
         MS_MANDLOCK;
         /// Directory modifications are synchronous
         MS_DIRSYNC;
+        /// Do not follow symlinks
+        MS_NOSYMFOLLOW;
         /// Do not update access times
         MS_NOATIME;
         /// Do not update directory access times


### PR DESCRIPTION
## What does this PR do
Add MS_NOSYMFOLLOW (since Linux 5.10), which disallows automatic following of symlinks.

Added to rust-lang/libc in 0.2.176

See:
https://github.com/torvalds/linux/commit/dab741e0e02bd3c4f5e2e97be74b39df2523fc6e  
https://github.com/rust-lang/libc/releases/tag/0.2.176

fixes #2626 

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
