### PR TITLE
Adding unistd::setreuid() and unistd::setregid().

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1815,6 +1815,26 @@ pub fn setgid(gid: Gid) -> Result<()> {
 
     Errno::result(res).map(drop)
 }
+
+/// Set the real/effective group ID
+///
+/// See also [setregid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setregid.html)
+#[inline]
+pub fn setregid(rgid: Gid, egid: Gid) -> Result<()> {
+    let res = unsafe { libc::setregid(rgid.into(), egid.into()) };
+
+    Errno::result(res).map(drop)
+}
+
+/// Set the real/effective user ID
+///
+/// See also [setreuid(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setreuid.html)
+#[inline]
+pub fn setreuid(ruid: Uid, euid: Uid) -> Result<()> {
+    let res = unsafe { libc::setreuid(ruid.into(), euid.into()) };
+
+    Errno::result(res).map(drop)
+}
 }
 
 feature! {

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1430,3 +1430,11 @@ fn test_group_from() {
     assert_eq!(group.gid, group_id);
     assert_eq!(group.name, "wheel");
 }
+
+#[test]
+fn test_setregid_setreuid() {
+    let uid = Uid::from_raw(0);
+    let gid = Gid::from_raw(0);
+    assert_eq!(setreuid(uid, uid).err().unwrap(), Errno::EPERM);
+    assert_eq!(setregid(gid, gid).err().unwrap(), Errno::EPERM);
+}


### PR DESCRIPTION
To respectively set real and effective user id, real and effective group id.
