### PR TITLE
add tcp_info for getsockopt

### DIFF
--- a/2691.added.md
+++ b/2691.added.md
@@ -1,0 +1,1 @@
+Added TCP_INFO for `getsockopt`

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1308,6 +1308,15 @@ sockopt_impl!(
     libc::SO_ATTACH_REUSEPORT_CBPF,
     libc::sock_fprog
 );
+#[cfg(target_os = "linux")]
+sockopt_impl!(
+    /// Used to collect information about this socket.
+    TcpInfo,
+    GetOnly,
+    libc::SOL_TCP,
+    libc::TCP_INFO,
+    libc::tcp_info
+);
 
 #[allow(missing_docs)]
 // Not documented by Linux!

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1270,3 +1270,16 @@ pub fn test_so_attach_reuseport_cbpf() {
         assert_eq!(e, nix::errno::Errno::ENOPROTOOPT);
     });
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+pub fn test_so_tcp_info() {
+    let fd = socket(
+        AddressFamily::Inet6,
+        SockType::Stream,
+        SockFlag::empty(),
+        SockProtocol::Tcp,
+    )
+    .unwrap();
+    getsockopt(&fd, sockopt::TcpInfo).unwrap();
+}


### PR DESCRIPTION
## What does this PR do

Adds `TCP_INFO` for `getsockopt`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
