### PR TITLE
Pin parking_lot_core/lock_api & resolve clippy::unnecessary_unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ targets = [
 
 [dependencies]
 libc = { version = "=0.2.175", features = ["extra_traits"] }
-bitflags = "2.3.3"
+bitflags = "2.4"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }
 memoffset = { version = "0.9", optional = true }
@@ -78,6 +78,15 @@ parking_lot = "0.12"
 rand = "0.9"
 tempfile = "3.7.1"
 semver = "1.0.7"
+
+# parking_lot_core and lock_api are indirect dependencies, so they normally should
+# not appear here. However, we include them because we want Cargo to pick the exact 
+# version that we choose here when resolving dependencies. Newer versions of them 
+# require MSRV 1.71, our current MSRV is 1.69.
+parking_lot_core = "=0.9.11"
+lock_api = "=0.4.13"
+
+# To make IDE/LSP work better
 nix = { path = ".", features = ["acct", "aio", "dir", "env", "event", "fanotify",
     "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
     "net", "personality", "poll", "pthread", "ptrace", "quota", "process", "reboot",

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1041,8 +1041,10 @@ pub struct Flock<T: Flockable>(T);
 impl<T: Flockable> Drop for Flock<T> {
     fn drop(&mut self) {
         let res = Errno::result(unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) });
-        if res.is_err() && !std::thread::panicking() {
-            panic!("Failed to remove flock: {}", res.unwrap_err());
+        if let Err(e) = res {
+            if !std::thread::panicking() {
+                panic!("Failed to remove flock: {}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
## What does this PR do

This commit:

1. Pins **indirect** dependencies

   * parking_lot_core to 0.9.11
   * lock_api to 0.4.13

   by adding them to our "dev-dependencies" list. Newer versions of them
   require MSRV 1.71, which is higher than our current one 1.69.0
   
   > [parking_lot_core 0.9.12 link][1]
   > [lock_api 0.4.14 link][2]

2. Bumps bitflags to 2.4, which is required after doing 1, or we have a
   dependency conflict

3. Resolves Clippy warning ["clippy::unnecessary_unwrap"][3]

[1]: https://crates.io/crates/parking_lot_core/0.9.12
[2]: https://crates.io/crates/lock_api/0.4.14
[3]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
        not needed
- [ ] A change log has been added if this PR modifies nix's API
       not needed
