### PR TITLE
increase documentation of statfs/statvfs to prevent confusion

### DIFF
--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -662,7 +662,7 @@ impl Debug for Statfs {
 
 /// Describes a mounted file system.
 ///
-/// The result is OS-dependent.  For a portable alternative, see
+/// The result is OS-dependent.  For a platform portable alternative, see
 /// [`statvfs`](crate::sys::statvfs::statvfs).
 ///
 /// # Arguments
@@ -680,7 +680,7 @@ pub fn statfs<P: ?Sized + NixPath>(path: &P) -> Result<Statfs> {
 
 /// Describes a mounted file system.
 ///
-/// The result is OS-dependent.  For a portable alternative, see
+/// The result is OS-dependent.  For a platform portable alternative, see
 /// [`fstatvfs`](crate::sys::statvfs::fstatvfs).
 ///
 /// # Arguments


### PR DESCRIPTION
This closes #2699 by increasing the amount of documentation on fstatfs and fstatvfs to reduce confusion when writing code against these apis.

Probably could be tweaked, might be too niche or specific for top level documentation, but it would have prevented a lost day of development in practice so I thought it would be worthwhile to send a PR in regardless.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
