### PR TITLE
termios: Add definition for IUCLC

### DIFF
--- a/changelog/2702.added.md
+++ b/changelog/2702.added.md
@@ -1,0 +1,1 @@
+termios: Add definition for IUCLC to supported platforms

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -478,6 +478,14 @@ libc_bitflags! {
         ICRNL;
         IXON;
         IXOFF;
+        #[cfg(any(linux_android,
+                  target_os = "aix",
+                  target_os = "cygwin",
+                  target_os = "haiku",
+                  target_os = "hurd",
+                  target_os = "nto",
+                  solarish))]
+        IUCLC;
         #[cfg(not(target_os = "redox"))]
         IXANY;
         #[cfg(not(any(target_os = "redox", target_os = "haiku")))]


### PR DESCRIPTION
## What does this PR do

Adds `IUCLC` definition

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

---

Needs: https://github.com/rust-lang/libc/pull/4846
Related: https://github.com/uutils/coreutils/pull/9432
