### PR TITLE
termios: Add definition for XCASE

### DIFF
--- a/changelog/2703.added.md
+++ b/changelog/2703.added.md
@@ -1,0 +1,1 @@
+termios: Add definition for XCASE for supported platforms

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -697,6 +697,11 @@ libc_bitflags! {
         #[cfg(not(any(target_os = "redox", target_os = "cygwin")))]
         PENDIN;
         NOFLSH;
+        #[cfg(any(linux_android,
+                  target_os = "aix",
+                  target_os = "haiku",
+                  target_os = "nto"))]
+        XCASE;
     }
 }
 


### PR DESCRIPTION
## What does this PR do

Adds definition for `XCASE`

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

--

Needs: https://github.com/rust-lang/libc/pull/4847
Related: https://github.com/uutils/coreutils/pull/9432