### PR TITLE
fix(netbsd): remove IFF_NOTRAILERS

### DIFF
--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -66,7 +66,6 @@ libc_bitflags!(
                   solarish,
                   apple_targets,
                   target_os = "fuchsia",
-                  target_os = "netbsd",
                   target_os = "cygwin"))]
         IFF_NOTRAILERS as IflagsType;
         /// Interface manages own routes.


### PR DESCRIPTION
`libc` version 0.2.178 includes this change:

> NetBSD: Remove IFF_NOTRAILERS (https://github.com/rust-lang/libc/pull/4782)

This causes `nix` to fail to compile against NetBSD targets:

```
$ cargo check --target x86_64-unknown-netbsd
    Checking nix v0.30.1
error[E0425]: cannot find value `IFF_NOTRAILERS` in crate `libc`
```

Real world failure observed in Gitlab CI using `cargo-cross`: https://github.com/fujiapple852/trippy/actions/runs/20000766159/job/57355635047#step:7:402

This MR is similar to https://github.com/nix-rust/nix/pull/893 which removed `IFF_NOTRAILERS` from OpenBSD.

aside: I didn't add this to the `CHANGELOG.md` as there was no unreleased section.