### PR TITLE
Fix spelling mistake of occurred

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -62,7 +62,7 @@ impl<'fd> PollFd<'fd> {
         PollFlags::from_bits(self.pollfd.revents)
     }
 
-    /// Returns if any of the events of interest occured in the last call to `poll` or `ppoll`. Will
+    /// Returns if any of the events of interest occurred in the last call to `poll` or `ppoll`. Will
     /// only return `None` if the kernel provides status flags that Nix does not know about.
     ///
     /// Equivalent to `x.revents()? != PollFlags::empty()`.
@@ -72,7 +72,7 @@ impl<'fd> PollFd<'fd> {
         Some(self.revents()? != PollFlags::empty())
     }
 
-    /// Returns if all the events of interest occured in the last call to `poll` or `ppoll`. Will
+    /// Returns if all the events of interest occurred in the last call to `poll` or `ppoll`. Will
     /// only return `None` if the kernel provides status flags that Nix does not know about.
     ///
     /// Equivalent to `x.revents()? & x.events() == x.events()`.

--- a/src/sys/fanotify.rs
+++ b/src/sys/fanotify.rs
@@ -228,7 +228,7 @@ impl FanotifyEvent {
 
     /// The file descriptor of the event. If the value is `None` when reading
     /// from the fanotify group, this event is to notify that a group queue
-    /// overflow occured.
+    /// overflow occurred.
     pub fn fd(&self) -> Option<BorrowedFd<'_>> {
         if self.0.fd == libc::FAN_NOFD {
             None

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -130,7 +130,7 @@ pub struct InotifyEvent {
     /// this event comes from.
     pub wd: WatchDescriptor,
     /// Event mask. This field is a bitfield describing the exact event that
-    /// occured.
+    /// occurred.
     pub mask: AddWatchFlags,
     /// This cookie is a number that allows you to connect related events. For
     /// now only IN_MOVED_FROM and IN_MOVED_TO can be connected.


### PR DESCRIPTION
## What does this PR do

Fix the spelling mistake of `occurred`.

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
