### PR TITLE
ioctl: add support for cygwin

### DIFF
--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -4,6 +4,7 @@ use cfg_if::cfg_if;
 #[cfg(any(
     target_os = "android",
     target_os = "fuchsia",
+    target_os = "cygwin",
     target_env = "musl",
     target_env = "ohos"
 ))]
@@ -12,12 +13,14 @@ pub type ioctl_num_type = ::libc::c_int;
 #[cfg(not(any(
     target_os = "android",
     target_os = "fuchsia",
+    target_os = "cygwin",
     target_env = "musl",
     target_env = "ohos"
 )))]
 #[doc(hidden)]
 pub type ioctl_num_type = ::libc::c_ulong;
 /// The datatype used for the 3rd argument
+#[cfg(not(target_os = "cygwin"))]
 #[doc(hidden)]
 pub type ioctl_param_type = ::libc::c_ulong;
 

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -227,11 +227,21 @@
 //! ```
 use cfg_if::cfg_if;
 
-#[cfg(any(linux_android, target_os = "fuchsia", target_os = "redox"))]
+#[cfg(any(
+    linux_android,
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "cygwin"
+))]
 #[macro_use]
 mod linux;
 
-#[cfg(any(linux_android, target_os = "fuchsia", target_os = "redox"))]
+#[cfg(any(
+    linux_android,
+    target_os = "fuchsia",
+    target_os = "redox",
+    target_os = "cygwin"
+))]
 pub use self::linux::*;
 
 #[cfg(any(bsd, solarish, target_os = "haiku",))]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -40,6 +40,7 @@ feature! {
     solarish,
     target_os = "fuchsia",
     target_os = "redox",
+    target_os = "cygwin",
 ))]
 #[cfg(feature = "ioctl")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]


### PR DESCRIPTION
## What does this PR do

Enable `ioctl` support for Cygwin, based on [the Cygwin C headers](https://github.com/msys2/msys2-runtime/blob/msys2-3.6.5/winsup/cygwin/include/sys/ioctl.h)

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
