### PR TITLE
time: Add netbsdlike support for several ClockID constants

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -60,7 +60,8 @@ impl ClockId {
         linux_android,
         target_os = "emscripten",
         target_os = "freebsd",
-        target_os = "fuchsia"
+        target_os = "fuchsia",
+        target_os = "openbsd",
     ))]
     /// Starts at zero when the kernel boots and increments monotonically in SI seconds while the
     /// machine is running.
@@ -97,6 +98,7 @@ impl ClockId {
         linux_android,
         apple_targets,
         freebsdlike,
+        netbsdlike,
         target_os = "emscripten",
         target_os = "fuchsia",
         target_os = "redox",
@@ -152,13 +154,14 @@ impl ClockId {
         linux_android,
         apple_targets,
         freebsdlike,
+        netbsdlike,
         target_os = "emscripten",
         target_os = "fuchsia",
     ))]
     /// Returns the execution time of the calling thread.
     pub const CLOCK_THREAD_CPUTIME_ID: ClockId =
         ClockId(libc::CLOCK_THREAD_CPUTIME_ID);
-    #[cfg(freebsdlike)]
+    #[cfg(any(freebsdlike, target_os = "openbsd"))]
     /// Starts at zero when the kernel boots and increments monotonically in SI seconds while the
     /// machine is running.
     pub const CLOCK_UPTIME: ClockId = ClockId(libc::CLOCK_UPTIME);


### PR DESCRIPTION
### Changes

Add `netbsdlike` (netbsd, openbsd) to existing cfg conditions for the following `ClockId` constants:

- `CLOCK_BOOTTIME` (openbsd only)
- `CLOCK_PROCESS_CPUTIME_ID`
- `CLOCK_THREAD_CPUTIME_ID`
- `CLOCK_UPTIME` (openbsd only)

### Rationale

Both platforms expose these constants in their system interfaces:

- https://man.openbsd.org/clock_gettime.2
- https://man.netbsd.org/clock_gettime.2

### Notes

Some constants documented in the manuals are not included because they are currently missing from the `libc` crate. They can be added once they become available upstream, see https://github.com/rust-lang/libc/issues/5017.
