### PR TITLE
Add api to get inner WatchDescriptor id, to work with c code.

### DIFF
--- a/changelog/2718.added.md
+++ b/changelog/2718.added.md
@@ -1,1 +1,1 @@
-Add WatchDescriptor::inner_id, to get libc id of WatchDescriptor.
+Add WatchDescriptor::as_raw, to get libc id of WatchDescriptor.

--- a/src/sys/inotify.rs
+++ b/src/sys/inotify.rs
@@ -114,8 +114,8 @@ pub struct WatchDescriptor {
     wd: i32,
 }
 impl WatchDescriptor {
-    /// Inner WatchDescriptor, from libc.
-    pub fn inner_id(self) -> i32 {
+    /// Raw WatchDescriptor, from libc.
+    pub fn as_raw(self) -> i32 {
         self.wd
     }
 }


### PR DESCRIPTION
## What does this PR do
Add a fn WatchDescriptor::as_raw, to get libc id.
## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
