### PR TITLE
fix(netbsd): remove udata special casing

### DIFF
--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -91,10 +91,8 @@ impl Kqueue {
     }
 }
 
-#[cfg(any(freebsdlike, apple_targets, target_os = "openbsd"))]
+#[cfg(any(freebsdlike, apple_targets, target_os = "openbsd", target_os = "netbsd"))]
 type type_of_udata = *mut libc::c_void;
-#[cfg(target_os = "netbsd")]
-type type_of_udata = intptr_t;
 
 #[cfg(target_os = "netbsd")]
 type type_of_event_filter = u32;


### PR DESCRIPTION
## What does this PR do

Alongside https://github.com/nix-rust/nix/pull/2709, fixes NetBSD target if/when libc updates are needed, e.g., https://github.com/nix-rust/nix/pull/2715.

See libc PR https://github.com/rust-lang/libc/pull/4782, specifically commit https://github.com/rust-lang/libc/pull/4782/commits/63f40376430e3f86b895d2b73621c2e25e802858.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
