### PR TITLE
skip test::sys::test_af_alg_cipher on s390x/Linux too

### DIFF
--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -921,11 +921,21 @@ pub fn test_scm_rights() {
 
 // 1. Disable the test on emulated platforms due to not enabled support of
 //    AF_ALG in QEMU from rust cross
-// 2. Disable the test on aarch64/Linux CI because bind() fails with ENOENT
+// 2. Disable the test on aarch64/Linux, s390x/Linux, and powerpc64le/Linux
+//    because bind() fails with ENOENT:
 //    https://github.com/nix-rust/nix/issues/1352
 #[cfg(linux_android)]
 #[cfg_attr(
-    any(qemu, all(target_os = "linux", target_arch = "aarch64")),
+    any(
+        qemu,
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "s390x"),
+        all(
+            target_os = "linux",
+            target_arch = "powerpc64",
+            target_endian = "little"
+        ),
+    ),
     ignore
 )]
 #[test]


### PR DESCRIPTION
It appears that s390x-unknown-linux-gnu is also affected by issue https://github.com/nix-rust/nix/issues/1352:

```
---- sys::test_socket::test_af_alg_cipher stdout ----
thread 'sys::test_socket::test_af_alg_cipher' (1118) panicked at test/sys/test_socket.rs:961:39:
bind failed: ENOENT
```

This PR just adds the s390x/Linux configuration to the list of environments where this specific test is skipped.
