### PR TITLE
docs: minor fix in tcgetpgrp and tcsetpgrp doc comments

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -365,7 +365,7 @@ pub fn tcgetpgrp<F: std::os::fd::AsFd>(fd: F) -> Result<Pid> {
 /// Set the terminal foreground process group (see
 /// [tcsetpgrp(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html)).
 ///
-/// Set the group process id (PGID) to the foreground process group on the
+/// Set the process group id (PGID) to the foreground process group on the
 /// terminal associated to file descriptor (FD).
 #[inline]
 pub fn tcsetpgrp<F: std::os::fd::AsFd>(fd: F, pgrp: Pid) -> Result<()> {


### PR DESCRIPTION
## What does this PR do

Minor docs fix.

mistakes fixed:
* Used GPID instead of PGID in tcgetpgrp comment.
* Used 'Get' instead of 'Set' in tcsetpgrp comment.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
