### PR TITLE
Add IPV6_MULTICAST_LOOP socket option

### DIFF
--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -479,6 +479,17 @@ sockopt_impl!(
     libc::IP_MULTICAST_LOOP,
     bool
 );
+#[cfg(feature = "net")]
+sockopt_impl!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+    /// Set or read a boolean integer argument that determines whether sent
+    /// multicast packets should be looped back to the local sockets.
+    Ipv6MulticastLoop,
+    Both,
+    libc::IPPROTO_IPV6,
+    libc::IPV6_MULTICAST_LOOP,
+    bool
+);
 #[cfg(target_os = "linux")]
 #[cfg(feature = "net")]
 sockopt_impl!(


### PR DESCRIPTION
## What does this PR do
Add the IPV6_MULTICAST_LOOP sockopt

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API

I don't believe tests nor changelog is needed, since neither exist for the IPv4 option `IP_MULTICAST_LOOP`.