### PR TITLE
Add interface argument to Ipv6MembershipRequest::new

### DIFF
--- a/changelog/2736.changed.md
+++ b/changelog/2736.changed.md
@@ -1,0 +1,1 @@
+Changed the Ipv6MembershipRequest::new function to accept an interface index.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -633,10 +633,20 @@ pub struct Ipv6MembershipRequest(libc::ipv6_mreq);
 
 impl Ipv6MembershipRequest {
     /// Instantiate a new `Ipv6MembershipRequest`
-    pub const fn new(group: net::Ipv6Addr) -> Self {
+    /// If the interface argument is None, the interface index will be
+    /// specified as 0.
+    pub const fn new(group: net::Ipv6Addr, interface: Option<libc::c_uint>) -> Self {
         Ipv6MembershipRequest(libc::ipv6_mreq {
             ipv6mr_multiaddr: ipv6addr_to_libc(&group),
-            ipv6mr_interface: 0,
+            ipv6mr_interface:
+                match interface {
+                    None => 0,
+                    Some(n) => {
+                        #[cfg(target_os = "android")]
+                        let n = n as libc::c_int;
+                        n
+                    }
+                }
         })
     }
 }


### PR DESCRIPTION
This commit adds an additional argument to the
Ipv6MembershipRequest::new function that allows the user to specify the interface index for which the
membership request is associated with.

Closes #323

## What does this PR do
This PR revives the efforts of #1320 to add proper support to the IPV6_JOIN_GROUP socket option.

Devices (especially routers) have many IPv6 interfaces, and being able to specify which interfaces to join a multicast group on is critical. Specifying `0` (as is currently done) is not portable:

> If the interface index is specified as 0, the kernel chooses local interface.  For example, some kernels look up multicast group in the normal IPv6 routing table and using the resulting interface.

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
