### PR TITLE
linux ptrace: add `set_syscall_info`

### DIFF
--- a/changelog/2739.added.md
+++ b/changelog/2739.added.md
@@ -1,0 +1,1 @@
+Added set_syscall_info to ptrace on linux


### PR DESCRIPTION
## What does this PR do

Added set_syscall_info to ptrace on linux

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
