### PR TITLE
if_nameindex: add android target

### DIFF
--- a/src/net/if_.rs
+++ b/src/net/if_.rs
@@ -42,7 +42,7 @@ pub fn if_indextoname(index: c_uint) -> Result<CString> {
 libc_bitflags!(
     /// Standard interface flags, used by `getifaddrs`
     pub struct InterfaceFlags: IflagsType {
-    
+
         /// Interface is running. (see
         /// [`netdevice(7)`](https://man7.org/linux/man-pages/man7/netdevice.7.html))
         IFF_UP as IflagsType;
@@ -271,6 +271,7 @@ impl fmt::Display for InterfaceFlags {
     bsd,
     target_os = "fuchsia",
     target_os = "linux",
+    target_os = "android",
     solarish,
 ))]
 mod if_nameindex {
@@ -398,6 +399,7 @@ mod if_nameindex {
     bsd,
     target_os = "fuchsia",
     target_os = "linux",
+    target_os = "android",
     solarish,
 ))]
 pub use if_nameindex::*;


### PR DESCRIPTION
## What does this PR do
Add android target to if_nameindex(), it's supported https://cs.android.com/android/platform/superproject/+/android-latest-release:bionic/libc/include/net/if.h

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API

Since this is a minor change, I think additional comments or change log would be unnecessary.
