### PR TITLE
Simplify and optimize `inotify` and `fanotify` `read_events` APIs

### DIFF
--- a/changelog/2741.changed.md
+++ b/changelog/2741.changed.md
@@ -1,0 +1,9 @@
+In both the inotify and fanotify `read_events(...)` APIs:
+
+Remove logic with `MaybeUninit` + `ptr::copy_nonoverlapping` and use `ptr::read_unaligned`, leaving the code more concise and clean on both sides, without the redundant check using `.min()`
+
+Use `Vec::with_capacity(nread / size)` instead of allocating empty space. Useful for increasing performance in case of event bursts. Allocates space to spare, but is still more performant than allocating almost empty space
+
+In inotify `read_events`:
+
+Reduce the event name iteration window to the maximum byte size (which is `event.len`), without risking reading beyond the event name in any way and without needing to scan again using `CStr::from_ptr` and increasing perfomance


### PR DESCRIPTION
## What does this PR do

In both the inotify and fanotify `read_events(...)` APIs:

Remove logic with `MaybeUninit` + `copy_nonoverlapping` and use `ptr::read_unaligned`, leaving the code more concise and clean on both sides, without the redundant check using `.min()`

Use `Vec::with_capacity(nread / size)` instead of allocating empty space. Useful for increasing performance in case of event bursts. Allocates space to spare, but is still more performant than allocating almost empty space.

In inotify `read_events`:

Reduce the event name iteration window to the maximum byte size (which is `event.len`), without risking reading beyond the event name in any way and without needing to scan again using `CStr::from_ptr` and increasing perfomance

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
