### PR TITLE
Make sys::resource work on Solaris

### DIFF
--- a/changelog/2742.fixed.md
+++ b/changelog/2742.fixed.md
@@ -1,0 +1,1 @@
+Fixed sys::resource support on Solaris targets.

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -96,7 +96,6 @@ feature! {
 #[cfg(not(any(
     target_os = "redox",
     target_os = "fuchsia",
-    target_os = "solaris",
     target_os = "haiku"
 )))]
 feature! {

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -17,9 +17,9 @@ cfg_if! {
         use libc::{__rlimit_resource_t, rlimit};
     } else if #[cfg(any(
         bsd,
+        solarish,
         target_os = "android",
         target_os = "aix",
-        target_os = "illumos",
         all(target_os = "linux", not(target_env = "gnu")),
         target_os = "cygwin"
     ))]{
@@ -49,9 +49,9 @@ libc_enum! {
         ), repr(u32))]
     #[cfg_attr(any(
             bsd,
+            solarish,
             target_os = "android",
             target_os = "aix",
-            target_os = "illumos",
             all(target_os = "linux", not(any(target_env = "gnu", target_env = "uclibc"))),
             target_os = "cygwin"
         ), repr(i32))]


### PR DESCRIPTION
## What does this PR do
This change lets sys::resource build and work on Solaris. Tested on Solaris 11.4 (SPARC 64-bit) and Linux 6.8 (x86-64). Relevant test already exists in test/sys/test_resource.rs.

Tests run on Solaris (skipping unrelated failing tests):
RUST_BACKTRACE=1 cargo test --\
  --skip sys::socker::addr::tests::linl::solarish_tap \
  --skip sys::test_timer::alarm_fires

Tests run on Linux:
cargo test

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
