### PR TITLE
Unpin libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "=0.2.180", features = ["extra_traits"] }
+libc = { version = "0.2.181", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/changelog/2744.fixed.md
+++ b/changelog/2744.fixed.md
@@ -1,0 +1,1 @@
+The libc requirement is now `0.2.181`, rather than pinned to 0.2.180.


### PR DESCRIPTION
And raise the requirement to 0.2.181, Now that the gnux32 bug is fixed.

Fixes #2737 

## What does this PR do

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
