### PR TITLE
Check exit code in Dir::as_raw_fd

### DIFF
--- a/changelog/2747.changed.md
+++ b/changelog/2747.changed.md
@@ -1,0 +1,1 @@
+`Dir::as_raw_fd` now panics if `libc::dirfd` returns a negative value.

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -137,7 +137,9 @@ impl std::os::fd::AsFd for Dir {
 
 impl AsRawFd for Dir {
     fn as_raw_fd(&self) -> RawFd {
-        unsafe { libc::dirfd(self.0.as_ptr()) }
+        let fd = unsafe { libc::dirfd(self.0.as_ptr()) };
+        assert!(fd >= 0, "dirfd returned error: {}", Errno::last());
+        fd
     }
 }
 


### PR DESCRIPTION
## What does this PR do

`libc::dirfd` should not fail. But if does, we better do some error detection (panic) rather than quietly returning incorrect value.

Alternatively we can stop implementing `AsRawFd`.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
