### PR TITLE
unistd: add mkfifo for redox

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -812,7 +812,6 @@ pub fn mkdir<P: ?Sized + NixPath>(path: &P, mode: crate::sys::stat::Mode) -> Res
 /// }
 /// ```
 #[inline]
-#[cfg(not(target_os = "redox"))] // RedoxFS does not support fifo yet
 pub fn mkfifo<P: ?Sized + NixPath>(path: &P, mode: crate::sys::stat::Mode) -> Result<()> {
     let res = path.with_nix_path(|cstr| unsafe {
         libc::mkfifo(cstr.as_ptr(), mode.bits() as libc::mode_t)


### PR DESCRIPTION
## What does this PR do

This PR removes the `#[cfg(not(target_os = "redox"))]` gate as I think it is no longer necessary. Over in [uutils/coreutils](https://github.com/uutils/coreutils) we also use `libc::mkfifo` and it compiles on redox in our CI.