### PR TITLE
fix: sys::signal::SaFlags_t definition on redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ targets = [
 ]
 
 [dependencies]
-libc = { version = "0.2.181", features = ["extra_traits"] }
+libc = { version = "0.2.183", features = ["extra_traits"] }
 bitflags = "2.3.3"
 cfg-if = "1.0"
 pin-utils = { version = "0.1.0", optional = true }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -426,9 +426,7 @@ pub const SIGPOLL : Signal = SIGIO;
 pub const SIGUNUSED : Signal = SIGSYS;
 
 cfg_if! {
-    if #[cfg(target_os = "redox")] {
-        type SaFlags_t = libc::c_ulong;
-    } else if #[cfg(target_env = "uclibc")] {
+    if #[cfg(target_env = "uclibc")] {
         type SaFlags_t = libc::c_ulong;
     } else {
         type SaFlags_t = libc::c_int;
@@ -444,25 +442,25 @@ libc_bitflags! {
         /// When catching a [`Signal::SIGCHLD`] signal, the signal will be
         /// generated only when a child process exits, not when a child process
         /// stops.
-        SA_NOCLDSTOP;
+        SA_NOCLDSTOP as SaFlags_t;
         /// When catching a [`Signal::SIGCHLD`] signal, the system will not
         /// create zombie processes when children of the calling process exit.
         #[cfg(not(target_os = "hurd"))]
-        SA_NOCLDWAIT;
+        SA_NOCLDWAIT as SaFlags_t;
         /// Further occurrences of the delivered signal are not masked during
         /// the execution of the handler.
-        SA_NODEFER;
+        SA_NODEFER as SaFlags_t;
         /// The system will deliver the signal to the process on a signal stack,
         /// specified by each thread with sigaltstack(2).
-        SA_ONSTACK;
+        SA_ONSTACK as SaFlags_t;
         /// The handler is reset back to the default at the moment the signal is
         /// delivered.
-        SA_RESETHAND;
+        SA_RESETHAND as SaFlags_t;
         /// Requests that certain system calls restart if interrupted by this
         /// signal.  See the man page for complete details.
-        SA_RESTART;
+        SA_RESTART as SaFlags_t;
         /// This flag is controlled internally by Nix.
-        SA_SIGINFO;
+        SA_SIGINFO as SaFlags_t;
     }
 }
 


### PR DESCRIPTION
Unblock redox build

- Fix `sys::signal::SaFlags_t` definition
- Update rust crate libc to v0.2.183

Fix https://github.com/nix-rust/nix/issues/2750