### PR TITLE
fix(ci): temporarily disable armv7-unknown-linux-uclibceabihf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,9 @@ jobs:
           - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
           - target: x86_64-unknown-haiku
-          - target: armv7-unknown-linux-uclibceabihf
+          # Temporarily disable armv7-unknown-linux-uclibceabihf
+          # https://github.com/rust-lang/rust/issues/154679
+          # - target: armv7-unknown-linux-uclibceabihf
           # Disable Hurd due to 
           #     1. https://github.com/rust-lang/libc/issues/4421
           #     2. https://github.com/nix-rust/nix/pull/2635#issuecomment-2842062528


### PR DESCRIPTION
Closes https://github.com/nix-rust/nix/issues/2763

Disable a target which fails in CI due to a toolchain issue.