### PR TITLE
Revert "fix(ci): temporarily disable armv7-unknown-linux-uclibceabihf (#2764)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,9 +360,7 @@ jobs:
           - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
           - target: x86_64-unknown-haiku
-          # Temporarily disable armv7-unknown-linux-uclibceabihf
-          # https://github.com/rust-lang/rust/issues/154679
-          # - target: armv7-unknown-linux-uclibceabihf
+          - target: armv7-unknown-linux-uclibceabihf
           # Disable Hurd due to 
           #     1. https://github.com/rust-lang/libc/issues/4421
           #     2. https://github.com/nix-rust/nix/pull/2635#issuecomment-2842062528

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,9 +360,7 @@ jobs:
           - target: x86_64-unknown-dragonfly
           - target: x86_64-unknown-openbsd
           - target: x86_64-unknown-haiku
-          # Temporarily disable armv7-unknown-linux-uclibceabihf
-          # https://github.com/rust-lang/rust/issues/154679
-          # - target: armv7-unknown-linux-uclibceabihf
+          - target: armv7-unknown-linux-uclibceabihf
           - target: i686-unknown-hurd-gnu
     steps:
       - name: checkout


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/154679 was fixed.

This reverts commit d32aad9a9a27ec6cf3adda417321ebdf9128998a.
