### PR TITLE
redox: Enable getres/setres

### DIFF
--- a/changelog/2767.added.md
+++ b/changelog/2767.added.md
@@ -1,0 +1,1 @@
+Added `getres` and `setres` for Redox OS

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -39,10 +39,20 @@ feature! {
     pub use self::pivot_root::*;
 }
 
-#[cfg(any(freebsdlike, linux_android, target_os = "openbsd"))]
+#[cfg(any(
+    freebsdlike,
+    linux_android,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 pub use self::setres::*;
 
-#[cfg(any(freebsdlike, linux_android, target_os = "openbsd"))]
+#[cfg(any(
+    freebsdlike,
+    linux_android,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 pub use self::getres::*;
 
 feature! {
@@ -3225,7 +3235,12 @@ mod pivot_root {
     }
 }
 
-#[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
+#[cfg(any(
+    linux_android,
+    freebsdlike,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 mod setres {
     feature! {
     #![feature = "user"]
@@ -3270,7 +3285,12 @@ mod setres {
     }
 }
 
-#[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
+#[cfg(any(
+    linux_android,
+    freebsdlike,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 mod getres {
     feature! {
     #![feature = "user"]

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -721,7 +721,12 @@ fn test_sysconf_unsupported() {
     assert!(open_max.expect("sysconf failed").is_none())
 }
 
-#[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
+#[cfg(any(
+    linux_android,
+    freebsdlike,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 #[test]
 fn test_getresuid() {
     let resuids = getresuid().unwrap();
@@ -730,7 +735,12 @@ fn test_getresuid() {
     assert_ne!(resuids.saved.as_raw(), libc::uid_t::MAX);
 }
 
-#[cfg(any(linux_android, freebsdlike, target_os = "openbsd"))]
+#[cfg(any(
+    linux_android,
+    freebsdlike,
+    target_os = "openbsd",
+    target_os = "redox"
+))]
 #[test]
 fn test_getresgid() {
     let resgids = getresgid().unwrap();


### PR DESCRIPTION
## What does this PR do

This enables getset/setres unistd API for Redox OS. This has been added to `libc` since https://github.com/rust-lang/libc/pull/4752, and tested for months by porting rustysd to the platform.

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
