### PR TITLE
socket: support TCP_CORK option in Linux

### DIFF
--- a/changelog/2769.added.md
+++ b/changelog/2769.added.md
@@ -1,0 +1,1 @@
+Add `nix::sys::socket::sockopt:TcpCork` on Linux.

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1315,6 +1315,16 @@ sockopt_impl!(
     libc::SO_ATTACH_REUSEPORT_CBPF,
     libc::sock_fprog
 );
+#[cfg(target_os = "linux")]
+sockopt_impl!(
+    /// Enable/disable TCP corking. If enabled all queued partial frames are
+    /// sent when the option is cleared again.
+    TcpCork,
+    Both,
+    libc::IPPROTO_TCP,
+    libc::TCP_CORK,
+    bool
+);
 
 #[allow(missing_docs)]
 // Not documented by Linux!

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1271,3 +1271,21 @@ pub fn test_so_attach_reuseport_cbpf() {
         assert_eq!(e, nix::errno::Errno::ENOPROTOOPT);
     });
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_tcp_cork() {
+    let fd = socket(
+        AddressFamily::Inet,
+        SockType::Stream,
+        SockFlag::empty(),
+        SockProtocol::Tcp,
+    )
+    .unwrap();
+
+    setsockopt(&fd, sockopt::TcpCork, &true).unwrap();
+    assert!(getsockopt(&fd, sockopt::TcpCork).unwrap());
+
+    setsockopt(&fd, sockopt::TcpCork, &false).unwrap();
+    assert!(!getsockopt(&fd, sockopt::TcpCork).unwrap());
+}


### PR DESCRIPTION
Closes: #2758

## What does this PR do

Enable getting and setting the corking state of a tcp connection. See man:tcp(7).

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
