### PR TITLE
Make prctl module available on Android too.

### DIFF
--- a/changelog/2770.added.md
+++ b/changelog/2770.added.md
@@ -1,0 +1,1 @@
+Made the `sys::prctl` module available on Android the same as on other Linux targets.

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -64,7 +64,7 @@ feature! {
     pub mod personality;
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(linux_android)]
 feature! {
     #![feature = "process"]
     pub mod prctl;

--- a/test/sys/test_prctl.rs
+++ b/test/sys/test_prctl.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(linux_android)]
 #[cfg(feature = "process")]
 mod test_prctl {
     use std::ffi::CStr;


### PR DESCRIPTION
This should work just the same as on other Linux targets.

## What does this PR do

Makes the prctl module available on Android the same as on other Linux targets.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
