### PR TITLE
make vmsplice unsafe

### DIFF
--- a/changelog/2777.changed.md
+++ b/changelog/2777.changed.md
@@ -1,0 +1,1 @@
+Made `fcntl::vmsplice` an unsafe function.

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1317,8 +1317,10 @@ pub fn tee<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
 /// # Safety
 ///
 /// * The content of `iov` must not be changed until kernel has finished reading it "even after the caller process finished".
-/// If `SPLICE_F_GIFT` flag is set, the content of `iov` must never be changed
-/// and all of the pointers in `iov` are page aligned, and the lengths are multiples of a page size
+/// * If `SpliceFFlags::SPLICE_F_GIFT` is set:
+///   - The contents of `iov` must never be modified after the call.
+///   - All pointers in `iov` must be page-aligned.
+///   - All lengths must be a multiple of the system page size in bytes.
 /// **Note** Linux kernel does not have an API to know when the kernel finished using the content of RAM
 #[cfg(linux_android)]
 pub unsafe fn vmsplice<F: std::os::fd::AsFd>(

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1313,8 +1313,15 @@ pub fn tee<Fd1: std::os::fd::AsFd, Fd2: std::os::fd::AsFd>(
 ///
 /// # See Also
 /// *[`vmsplice`](https://man7.org/linux/man-pages/man2/vmsplice.2.html)
+///
+/// # Safety
+///
+/// * The content of `iov` must not be changed until kernel has finished reading it "even after the caller process finished".
+/// If `SPLICE_F_GIFT` flag is set, the content of `iov` must never be changed
+/// and all of the pointers in `iov` are page aligned, and the lengths are multiples of a page size
+/// **Note** Linux kernel does not have an API to know when the kernel finished using the content of RAM
 #[cfg(linux_android)]
-pub fn vmsplice<F: std::os::fd::AsFd>(
+pub unsafe fn vmsplice<F: std::os::fd::AsFd>(
     fd: F,
     iov: &[std::io::IoSlice<'_>],
     flags: SpliceFFlags,

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -360,7 +360,8 @@ mod linux_android {
         let buf2 = b"defghi";
         let iovecs = [IoSlice::new(&buf1[0..3]), IoSlice::new(&buf2[0..3])];
 
-        let res = vmsplice(wr, &iovecs[..], SpliceFFlags::empty()).unwrap();
+        let res = unsafe { vmsplice(wr, &iovecs[..], SpliceFFlags::empty()) }
+            .unwrap();
 
         assert_eq!(6, res);
 


### PR DESCRIPTION
## What does this PR do
make vmsplice unsafe. Closes https://github.com/nix-rust/nix/issues/2633
## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
