### PR TITLE
socket: change accept to return an OwnedFd

### DIFF
--- a/changelog/2780.changed.md
+++ b/changelog/2780.changed.md
@@ -1,1 +1,2 @@
 Change `sys::socket::accept` and `sys::socket::accept4` to return `OwnedFd` instead of `RawFd`.
+Change `sys::socket::accept` and `sys::socket::accept4` to take `AsFd` instead of `RawFd`.

--- a/changelog/2780.changed.md
+++ b/changelog/2780.changed.md
@@ -1,0 +1,1 @@
+Change `sys::socket::accept` and `sys::socket::accept4` to return `OwnedFd` instead of `RawFd`.

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -2340,8 +2340,8 @@ pub fn bind(fd: RawFd, addr: &dyn SockaddrLike) -> Result<()> {
 /// Accept a connection on a socket
 ///
 /// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html)
-pub fn accept(sockfd: RawFd) -> Result<OwnedFd> {
-    let res = unsafe { libc::accept(sockfd, ptr::null_mut(), ptr::null_mut()) };
+pub fn accept<Fd: AsFd>(sockfd: Fd) -> Result<OwnedFd> {
+    let res = unsafe { libc::accept(sockfd.as_fd().as_raw_fd(), ptr::null_mut(), ptr::null_mut()) };
 
     Errno::result(res).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })
 }
@@ -2365,9 +2365,9 @@ pub fn accept(sockfd: RawFd) -> Result<OwnedFd> {
     solarish,
     target_os = "linux",
 ))]
-pub fn accept4(sockfd: RawFd, flags: SockFlag) -> Result<OwnedFd> {
+pub fn accept4<Fd: AsFd>(sockfd: Fd, flags: SockFlag) -> Result<OwnedFd> {
     let res = unsafe {
-        libc::accept4(sockfd, ptr::null_mut(), ptr::null_mut(), flags.bits())
+        libc::accept4(sockfd.as_fd().as_raw_fd(), ptr::null_mut(), ptr::null_mut(), flags.bits())
     };
 
     Errno::result(res).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -2340,10 +2340,10 @@ pub fn bind(fd: RawFd, addr: &dyn SockaddrLike) -> Result<()> {
 /// Accept a connection on a socket
 ///
 /// [Further reading](https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html)
-pub fn accept(sockfd: RawFd) -> Result<RawFd> {
+pub fn accept(sockfd: RawFd) -> Result<OwnedFd> {
     let res = unsafe { libc::accept(sockfd, ptr::null_mut(), ptr::null_mut()) };
 
-    Errno::result(res)
+    Errno::result(res).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
 /// Accept a connection on a socket
@@ -2365,12 +2365,12 @@ pub fn accept(sockfd: RawFd) -> Result<RawFd> {
     solarish,
     target_os = "linux",
 ))]
-pub fn accept4(sockfd: RawFd, flags: SockFlag) -> Result<RawFd> {
+pub fn accept4(sockfd: RawFd, flags: SockFlag) -> Result<OwnedFd> {
     let res = unsafe {
         libc::accept4(sockfd, ptr::null_mut(), ptr::null_mut(), flags.bits())
     };
 
-    Errno::result(res)
+    Errno::result(res).map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
 /// Initiate a connection on a socket

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -992,12 +992,8 @@ pub fn test_af_alg_cipher() {
 
     // allocate buffer for encrypted data
     let mut encrypted = vec![0u8; payload_len];
-    // SAFETY:
-    // should be safe since session_socket won't be closed before the use of this borrowed one
-    let borrowed_session_socket =
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(borrowed_session_socket, &mut encrypted).expect("read encrypt");
+        read(&session_socket, &mut encrypted).expect("read encrypt");
     assert_eq!(num_bytes, payload_len);
 
     let iov = IoSlice::new(&encrypted);
@@ -1019,12 +1015,8 @@ pub fn test_af_alg_cipher() {
 
     // allocate buffer for decrypted data
     let mut decrypted = vec![0u8; payload_len];
-    // SAFETY:
-    // should be safe since session_socket won't be closed before the use of this borrowed one
-    let borrowed_session_socket =
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(borrowed_session_socket, &mut decrypted).expect("read decrypt");
+        read(&session_socket, &mut decrypted).expect("read decrypt");
 
     assert_eq!(num_bytes, payload_len);
     assert_eq!(decrypted, payload);
@@ -1112,12 +1104,8 @@ pub fn test_af_alg_aead() {
     // allocate buffer for encrypted data
     let mut encrypted =
         vec![0u8; (assoc_size as usize) + payload_len + auth_size];
-    // SAFETY:
-    // should be safe since session_socket won't be closed before the use of this borrowed one
-    let borrowed_session_socket =
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
     let num_bytes =
-        read(borrowed_session_socket, &mut encrypted).expect("read encrypt");
+        read(&session_socket, &mut encrypted).expect("read encrypt");
     assert_eq!(num_bytes, payload_len + auth_size + (assoc_size as usize));
 
     for i in 0..assoc_size {
@@ -1152,15 +1140,10 @@ pub fn test_af_alg_aead() {
     // and in the input buffer for decryption.
     // Do not block on read, as we may have fewer bytes than buffer size
 
-    // SAFETY:
-    //
-    // `session_socket` will be valid for the lifetime of this test
-    // TODO: remove this workaround when accept(2) becomes I/O-safe.
-    let borrowed_fd =
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(session_socket) };
-    fcntl(borrowed_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
+    fcntl(&session_socket, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
         .expect("fcntl non_blocking");
-    let num_bytes = read(borrowed_fd, &mut decrypted).expect("read decrypt");
+    let num_bytes =
+        read(&session_socket, &mut decrypted).expect("read decrypt");
 
     assert!(num_bytes >= payload_len + (assoc_size as usize));
     assert_eq!(
@@ -1699,9 +1682,6 @@ pub fn test_named_unixdomain() {
 
     let s3 = accept(s1.as_raw_fd()).expect("accept failed");
 
-    // SAFETY:
-    // It should be safe considering that s3 will be open within this test
-    let s3 = unsafe { std::os::fd::BorrowedFd::borrow_raw(s3) };
     let mut buf = [0; 5];
     read(s3, &mut buf).unwrap();
     thr.join().unwrap();

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -974,7 +974,7 @@ pub fn test_af_alg_cipher() {
     assert_eq!(sockaddr.alg_type().to_string_lossy(), alg_type);
 
     setsockopt(&sock, AlgSetKey::default(), &key).expect("setsockopt");
-    let session_socket = accept(sock.as_raw_fd()).expect("accept failed");
+    let session_socket = accept(&sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&libc::ALG_OP_ENCRYPT),
@@ -1083,7 +1083,7 @@ pub fn test_af_alg_aead() {
         .expect("setsockopt AlgSetAeadAuthSize");
     setsockopt(&sock, AlgSetKey::default(), &key)
         .expect("setsockopt AlgSetKey");
-    let session_socket = accept(sock.as_raw_fd()).expect("accept failed");
+    let session_socket = accept(&sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&ALG_OP_ENCRYPT),
@@ -1116,7 +1116,7 @@ pub fn test_af_alg_aead() {
 
     let iv = vec![1u8; iv_len];
 
-    let session_socket = accept(sock.as_raw_fd()).expect("accept failed");
+    let session_socket = accept(&sock).expect("accept failed");
 
     let msgs = [
         ControlMessage::AlgSetOp(&ALG_OP_DECRYPT),
@@ -1680,7 +1680,7 @@ pub fn test_named_unixdomain() {
         write(&s2, b"hello").expect("write failed");
     });
 
-    let s3 = accept(s1.as_raw_fd()).expect("accept failed");
+    let s3 = accept(&s1).expect("accept failed");
 
     let mut buf = [0; 5];
     read(s3, &mut buf).unwrap();

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -5,7 +5,9 @@ use nix::sys::socket::{
     SockProtocol, SockType,
 };
 use rand::{rng, Rng};
-use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::io::AsRawFd;
+#[cfg(linux_android)]
+use std::os::unix::io::{FromRawFd, OwnedFd};
 
 // NB: FreeBSD supports LOCAL_PEERCRED for SOCK_SEQPACKET, but OSX does not.
 #[cfg(freebsdlike)]
@@ -204,7 +206,6 @@ fn test_so_tcp_maxseg() {
     connect(ssock.as_raw_fd(), &sock_addr).unwrap();
 
     let rsess = accept(rsock.as_raw_fd()).unwrap();
-    let rsess = unsafe { OwnedFd::from_raw_fd(rsess) };
 
     cfg_if! {
         if #[cfg(apple_targets)] {

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -205,7 +205,7 @@ fn test_so_tcp_maxseg() {
 
     connect(ssock.as_raw_fd(), &sock_addr).unwrap();
 
-    let rsess = accept(rsock.as_raw_fd()).unwrap();
+    let rsess = accept(&rsock).unwrap();
 
     cfg_if! {
         if #[cfg(apple_targets)] {
@@ -904,7 +904,7 @@ fn test_ktls() {
     .unwrap();
     connect(ssock.as_raw_fd(), &sock_addr).unwrap();
 
-    let _rsess = accept(rsock.as_raw_fd()).unwrap();
+    let _rsess = accept(&rsock).unwrap();
 
     match setsockopt(&ssock, sockopt::TcpUlp::default(), b"tls") {
         Ok(()) => (),


### PR DESCRIPTION
accept(2) returns on success a new file descriptor that is not coupled with the listened socket. Thus it is safe to wrap it into an OwnedFd, which will close the socket on cleanup.

## What does this PR do

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
