### PR TITLE
epoll: use from_bits_retain to avoid panics on unknown flags

### DIFF
--- a/changelog/2783.fixed.md
+++ b/changelog/2783.fixed.md
@@ -1,0 +1,3 @@
+Fixed `EpollEvent::events()` to use `from_bits_retain` instead of
+`from_bits().unwrap()`, preventing panics when the kernel returns
+unknown epoll flags.

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -63,7 +63,7 @@ impl EpollEvent {
     }
 
     pub fn events(&self) -> EpollFlags {
-        EpollFlags::from_bits(self.event.events as c_int).unwrap()
+        EpollFlags::from_bits_retain(self.event.events as c_int)
     }
 
     pub const fn data(&self) -> u64 {


### PR DESCRIPTION
## What does this PR do

EpollEvent::events() used from_bits().unwrap(), which panics if the kernel returns flags unknown to the current bitflags definition. Use from_bits_retain to preserve all bits without panicking.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
