### PR TITLE
kqueue: use from_bits_retain to avoid panics on unknown flags

### DIFF
--- a/changelog/2784.fixed.md
+++ b/changelog/2784.fixed.md
@@ -1,0 +1,3 @@
+Fixed `KEvent::flags()` and `KEvent::fflags()` to use `from_bits_retain`
+instead of `from_bits().unwrap()`, preventing panics when the kernel
+returns unknown kqueue flags.

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -382,12 +382,12 @@ impl KEvent {
     /// Flags control what the kernel will do when this event is added with
     /// [`Kqueue::kevent`].
     pub fn flags(&self) -> EvFlags {
-        EvFlags::from_bits(self.kevent.flags).unwrap()
+        EvFlags::from_bits_retain(self.kevent.flags)
     }
 
     /// Filter-specific flags.
     pub fn fflags(&self) -> FilterFlag {
-        FilterFlag::from_bits(self.kevent.fflags).unwrap()
+        FilterFlag::from_bits_retain(self.kevent.fflags)
     }
 
     /// Filter-specific data value.


### PR DESCRIPTION
## What does this PR do

KEvent::flags() and KEvent::fflags() used from_bits().unwrap(), which panics if the kernel returns flags unknown to the current bitflags definition. Use from_bits_retain to preserve all bits without panicking.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
