### PR TITLE
chore: fix clippy warning useless_borrows_in_formatting

### DIFF
--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -1145,22 +1145,32 @@ pub fn aio_suspend(
 // Do not run this doc test on:
 //   * aarch64-unknown-linux-musl
 //   * i686-unknown-linux-musl
+//   * x86_64-unknown-linux-musl
 // because it hangs on these targets. After further debugging, we think this is
 // likely a bug of musl. Since we only test our bindings and do not intend to
 // fix the underlying libc bug, we skip this test here.
 // See this thread for the discussion of this issue:
-// https://github.com/nix-rust/nix/pull/2689#issuecomment-3419813159
+// 1. https://github.com/nix-rust/nix/pull/2689#issuecomment-3419813159
+// 2. https://github.com/nix-rust/nix/issues/2788
 #[cfg_attr(
     all(
         target_env = "musl",
-        any(target_arch = "aarch64", target_arch = "x86")
+        any(
+            target_arch = "aarch64",
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )
     ),
     doc = " ```no_run"
 )]
 #[cfg_attr(
     not(all(
         target_env = "musl",
-        any(target_arch = "aarch64", target_arch = "x86")
+        any(
+            target_arch = "aarch64",
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )
     )),
     doc = " ```"
 )]

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -247,7 +247,7 @@ fn test_readlink() {
     let tempdir = tempfile::tempdir().unwrap();
     let src = tempdir.path().join("a");
     let dst = tempdir.path().join("b");
-    println!("a: {:?}, b: {:?}", &src, &dst);
+    println!("a: {:?}, b: {:?}", src, dst);
     fs::symlink(src.as_path(), dst.as_path()).unwrap();
     let dirfd = open(tempdir.path(), OFlag::empty(), Mode::empty()).unwrap();
     let expected_dir = src.to_str().unwrap();


### PR DESCRIPTION
## What does this PR do

This commit fixes the clippy warning `useless_borrows_in_formatting`.

The doc test `sys::aio::lio_listio` was found to hang in CI on `x86_64-unknown-linux-musl`. This test has previously been observed hanging on other musl targets and was already disabled there, so disable it on `x86_64-unknown-linux-musl` as well.


## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
