### PR TITLE
cargo: Remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ description = "Rust friendly bindings to *nix APIs"
 edition     = "2021"
 version     = "0.31.2"
 rust-version = "1.69"
-authors     = ["The nix-rust Project Developers"]
 repository  = "https://github.com/nix-rust/nix"
 license     = "MIT"
 categories  = ["os::unix-apis"]


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068