### PR TITLE
chore: resolve clippy useless_borrows_in_formatting

### DIFF
--- a/test/mount/test_mount.rs
+++ b/test/mount/test_mount.rs
@@ -128,7 +128,7 @@ fn test_mount_noexec_disallows_exec() {
     assert!(
         mode.contains(Mode::S_IXUSR | Mode::S_IXGRP | Mode::S_IXOTH),
         "{:?} did not have execute permissions",
-        &test_path
+        test_path
     );
 
     // while forking and unmounting prevent other child processes


### PR DESCRIPTION
## What does this PR do


Fix another occurrence of the `useless_borrows_in_formatting` warning, found it while reviewing https://github.com/nix-rust/nix/pull/2781.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
