### PR TITLE
Enable ioctl for Haiku

### DIFF
--- a/changelog/2792.added.md
+++ b/changelog/2792.added.md
@@ -1,0 +1,1 @@
+Enable module `ioctl` for Haiku

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -39,6 +39,7 @@ feature! {
     linux_android,
     solarish,
     target_os = "fuchsia",
+    target_os = "haiku",
     target_os = "redox",
     target_os = "cygwin",
 ))]

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -18,7 +18,6 @@ mod test_aio;
 #[cfg(not(any(
     target_os = "redox",
     target_os = "fuchsia",
-    target_os = "haiku",
     target_os = "hurd",
     target_os = "cygwin"
 )))]


### PR DESCRIPTION
## What does this PR do

Haiku supports ioctl without problems. Enable the feature and basic tests.
There are no "well-behaved" ioctl on Haiku, only "bad" ones with arbitrary numbers. So the corresponding tests for ioctl numbering are not enabled.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
