### PR TITLE
Add setgroups(2) to macOS/Apple targets

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1962,7 +1962,6 @@ pub fn getgroups() -> Result<Vec<Gid>> {
 /// # try_main().unwrap();
 /// ```
 #[cfg(not(any(
-    apple_targets,
     target_os = "redox",
     target_os = "haiku"
 )))]


### PR DESCRIPTION
## What does this PR do

This is related to #2069 and https://github.com/kpcyrd/acme-redirect/pull/50, the `setgroups` api definitely exists, but it's currently not available in nix for that target, causing compile errors with some projects.

- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setgroups.2.html#//apple_ref/doc/man/2/setgroups
- https://keith.github.io/xcode-man-pages/setgroups.2.html
- https://docs.python.org/3/library/os.html#os.setgroups
- https://docs.python.org/3/library/os.html#os.getgroups

The nix commit had some information that was likely not accurate:

> "Note: This function is not available for Apple platforms. On those platforms, group membership management should be achieved via communication with the opendirectoryd service."

Quoting from @Elizafox in #2069 (which I believe to be correct):

> This is erroneous for this function. OpenDirectory is just for querying the directory. It cannot manage the groups of the process.

## Checklist:

- [ ] I have read `CONTRIBUTING.md`
- [ ] I have written necessary tests and rustdoc comments
- [ ] A change log has been added if this PR modifies nix's API
