### PR TITLE
test: only run test_af_alg_* tests when requirements are met

### DIFF
--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -142,26 +142,25 @@ cfg_if! {
     if #[cfg(linux_android)] {
         #[macro_export] macro_rules! require_kernel_module {
             ($name:expr, $module_name:expr) => {
-                let loaded = std::fs::read_to_string("/proc/modules")
+                let loaded_from_proc = std::fs::read_to_string("/proc/modules")
                     .map(|modules| {
                         modules.lines().any(|line| {
                             line.split_whitespace().next()
                                 == Some($module_name)
                         })
                     })
-                    .unwrap_or_else(|_| {
-                        let module_path =
-                            format!("/sys/module/{}", $module_name);
-                        match std::path::Path::new(&module_path).try_exists()
-                        {
-                            Ok(exists) => exists,
-                            Err(error) => {
-                                panic!(
-                                    "failed to inspect {module_path}: {error}"
-                                )
-                            }
+                    .unwrap_or(false);
+
+                let module_path = format!("/sys/module/{}", $module_name);
+                let loaded_from_sys =
+                    match std::path::Path::new(&module_path).try_exists() {
+                        Ok(exists) => exists,
+                        Err(error) => {
+                            panic!("failed to inspect {module_path}: {error}")
                         }
-                    });
+                    };
+
+                let loaded = loaded_from_proc || loaded_from_sys;
 
                 if !loaded {
                     $crate::skip!(

--- a/test/common/mod.rs
+++ b/test/common/mod.rs
@@ -137,3 +137,40 @@ cfg_if! {
         }
     }
 }
+
+cfg_if! {
+    if #[cfg(linux_android)] {
+        #[macro_export] macro_rules! require_kernel_module {
+            ($name:expr, $module_name:expr) => {
+                let loaded = std::fs::read_to_string("/proc/modules")
+                    .map(|modules| {
+                        modules.lines().any(|line| {
+                            line.split_whitespace().next()
+                                == Some($module_name)
+                        })
+                    })
+                    .unwrap_or_else(|_| {
+                        let module_path =
+                            format!("/sys/module/{}", $module_name);
+                        match std::path::Path::new(&module_path).try_exists()
+                        {
+                            Ok(exists) => exists,
+                            Err(error) => {
+                                panic!(
+                                    "failed to inspect {module_path}: {error}"
+                                )
+                            }
+                        }
+                    });
+
+                if !loaded {
+                    $crate::skip!(
+                        "Skip {} because kernel module `{}` is unavailable",
+                        stringify!($name),
+                        $module_name
+                    );
+                }
+            }
+        }
+    }
+}

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1022,10 +1022,7 @@ pub fn test_af_alg_cipher() {
     assert_eq!(decrypted, payload);
 }
 
-// Disable the test on emulated platforms due to not enabled support of AF_ALG
-// in QEMU from rust cross
 #[cfg(linux_android)]
-#[cfg_attr(qemu, ignore)]
 #[test]
 pub fn test_af_alg_aead() {
     use libc::{ALG_OP_DECRYPT, ALG_OP_ENCRYPT};
@@ -1036,17 +1033,37 @@ pub fn test_af_alg_aead() {
         ControlMessage, MsgFlags, SockFlag, SockType,
     };
     use nix::unistd::read;
+    use std::fs;
     use std::io::IoSlice;
 
-    // Travis's seccomp profile blocks AF_ALG
-    // https://docs.docker.com/engine/security/seccomp/
-    skip_if_seccomp!(test_af_alg_aead);
+    let alg_name = "gcm(aes)";
+
+    /*
+     * Skip the test if requirements are not satisfied.
+     */
+    require_kernel_module!(test_af_alg_aead, "af_alg");
+
+    let has_algorithm = fs::read_to_string("/proc/crypto")
+        .map(|crypto| {
+            crypto.lines().any(|line| {
+                if let Some((key, value)) = line.split_once(':') {
+                    key.trim() == "name" && value.trim() == alg_name
+                } else {
+                    false
+                }
+            })
+        })
+        .unwrap_or(false);
+    if !has_algorithm {
+        println!("AF_ALG algorithm {alg_name:?} unavailable, skipping test.");
+        return;
+    }
+    require_kernel_module!(test_af_alg_aead, "algif_aead");
 
     let auth_size = 4usize;
     let assoc_size = 16u32;
 
     let alg_type = "aead";
-    let alg_name = "gcm(aes)";
     // 256-bits secret key
     let key = vec![0u8; 32];
     // 12-bytes IV

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -919,25 +919,7 @@ pub fn test_scm_rights() {
     close(received_r).unwrap();
 }
 
-// 1. Disable the test on emulated platforms due to not enabled support of
-//    AF_ALG in QEMU from rust cross
-// 2. Disable the test on aarch64/Linux, s390x/Linux, and powerpc64le/Linux
-//    because bind() fails with ENOENT:
-//    https://github.com/nix-rust/nix/issues/1352
 #[cfg(linux_android)]
-#[cfg_attr(
-    any(
-        qemu,
-        all(target_os = "linux", target_arch = "aarch64"),
-        all(target_os = "linux", target_arch = "s390x"),
-        all(
-            target_os = "linux",
-            target_arch = "powerpc64",
-            target_endian = "little"
-        ),
-    ),
-    ignore
-)]
 #[test]
 pub fn test_af_alg_cipher() {
     use nix::sys::socket::sockopt::AlgSetKey;
@@ -946,10 +928,35 @@ pub fn test_af_alg_cipher() {
         ControlMessage, MsgFlags, SockFlag, SockType,
     };
     use nix::unistd::read;
+    use std::fs;
     use std::io::IoSlice;
 
     let alg_type = "skcipher";
     let alg_name = "ctr-aes-aesni";
+
+    /*
+     * Skip the test if requirements are not satisfied.
+     */
+    require_kernel_module!(test_af_alg_cipher, "af_alg");
+
+    let has_algorithm = fs::read_to_string("/proc/crypto")
+        .map(|crypto| {
+            crypto.lines().any(|line| {
+                if let Some((key, value)) = line.split_once(':') {
+                    key.trim() == "name" && value.trim() == alg_name
+                } else {
+                    false
+                }
+            })
+        })
+        .unwrap_or(false);
+    if !has_algorithm {
+        println!("AF_ALG algorithm {alg_name:?} unavailable, skipping test.");
+        return;
+    }
+
+    require_kernel_module!(test_af_alg_cipher, "algif_skcipher");
+
     // 256-bits secret key
     let key = vec![0u8; 32];
     // 16-bytes IV


### PR DESCRIPTION
## What does this PR do

Our CI runner does not provide the algif_aead kernel module, so
test_af_alg_aead fails with ENOENT when binding the AF_ALG socket.

Check the required kernel support before running the test and skip it
when the prerequisites are unavailable.

Since the test now performs runtime checks, there is no need to
unconditionally ignore it under QEMU. `skip_if_seccomp!(test_af_alg_aead)`
is also removed since we no longer use Travis.

## Checklist:

- [x] I have read `CONTRIBUTING.md`
- [x] I have written necessary tests and rustdoc comments
- [x] A change log has been added if this PR modifies nix's API
