### PR TITLE
redox: Enable SigAction and SigSet::wait

### DIFF
--- a/changelog/2798.added.md
+++ b/changelog/2798.added.md
@@ -1,0 +1,1 @@
+Enable `SigAction` and `SigSet::wait` for Redox

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -583,7 +583,6 @@ impl SigSet {
 
     /// Suspends execution of the calling thread until one of the signals in the
     /// signal mask becomes pending, and returns the accepted signal.
-    #[cfg(not(target_os = "redox"))] // RedoxFS does not yet support sigwait
     pub fn wait(&self) -> Result<Signal> {
         use std::convert::TryFrom;
 
@@ -791,7 +790,6 @@ pub enum SigHandler {
     Handler(extern "C" fn(libc::c_int)),
     /// Use the given signal-catching function, which takes in the signal, information about how
     /// the signal was generated, and a pointer to the threads `ucontext_t`.
-    #[cfg(not(target_os = "redox"))]
     SigAction(extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void))
 }
 
@@ -843,7 +841,6 @@ impl SigAction {
                     SigHandler::SigDfl => libc::SIG_DFL,
                     SigHandler::SigIgn => libc::SIG_IGN,
                     SigHandler::Handler(f) => f as *const extern "C" fn(libc::c_int) as usize,
-                    #[cfg(not(target_os = "redox"))]
                     SigHandler::SigAction(f) => f as *const extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) as usize,
                 };
             }
@@ -854,7 +851,6 @@ impl SigAction {
             let p = s.as_mut_ptr();
             install_sig(p, handler);
             (*p).sa_flags = match handler {
-                #[cfg(not(target_os = "redox"))]
                 SigHandler::SigAction(_) => (flags | SaFlags::SA_SIGINFO).bits(),
                 _ => (flags - SaFlags::SA_SIGINFO).bits(),
             };
@@ -880,7 +876,6 @@ impl SigAction {
         match self.sigaction.sa_sigaction {
             libc::SIG_DFL => SigHandler::SigDfl,
             libc::SIG_IGN => SigHandler::SigIgn,
-            #[cfg(not(target_os = "redox"))]
             p if self.flags().contains(SaFlags::SA_SIGINFO) =>
                 SigHandler::SigAction(
                 // Safe for one of two reasons:
@@ -997,6 +992,8 @@ pub unsafe fn signal(signal: Signal, handler: SigHandler) -> Result<SigHandler> 
         SigHandler::Handler(handler) => unsafe { libc::signal(signal, handler as libc::sighandler_t) },
         #[cfg(not(target_os = "redox"))]
         SigHandler::SigAction(_) => return Err(Errno::ENOTSUP),
+        #[cfg(target_os = "redox")]
+        SigHandler::SigAction(_) => return Err(Errno::EOPNOTSUPP),
     };
     Errno::result(res).map(|oldhandler| {
         match oldhandler {

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -3,7 +3,6 @@ use nix::sys::signal::*;
 use nix::unistd::*;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(not(target_os = "redox"))]
 use std::thread;
 
 #[test]
@@ -86,7 +85,6 @@ extern "C" fn test_sigaction_handler(signal: libc::c_int) {
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
 }
 
-#[cfg(not(target_os = "redox"))]
 extern "C" fn test_sigaction_action(
     _: libc::c_int,
     _: *mut libc::siginfo_t,
@@ -95,14 +93,19 @@ extern "C" fn test_sigaction_action(
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_signal_sigaction() {
     let _m = crate::SIGNAL_MTX.lock();
 
     let action_handler = SigHandler::SigAction(test_sigaction_action);
+    #[cfg(not(target_os = "redox"))]
     assert_eq!(
         unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(),
         Errno::ENOTSUP
+    );
+    #[cfg(target_os = "redox")]
+    assert_eq!(
+        unsafe { signal(Signal::SIGINT, action_handler) }.unwrap_err(),
+        Errno::EOPNOTSUPP
     );
 }
 
@@ -186,7 +189,6 @@ fn test_extend() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_thread_signal_set_mask() {
     thread::spawn(|| {
         let prev_mask = SigSet::thread_get_mask()
@@ -211,7 +213,6 @@ fn test_thread_signal_set_mask() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_thread_signal_block() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();
@@ -226,7 +227,6 @@ fn test_thread_signal_block() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_thread_signal_unblock() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();
@@ -241,7 +241,6 @@ fn test_thread_signal_unblock() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_thread_signal_swap() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();
@@ -272,7 +271,6 @@ fn test_from_and_into_iterator() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_sigaction() {
     let _m = crate::SIGNAL_MTX.lock();
     thread::spawn(|| {
@@ -319,7 +317,6 @@ fn test_sigaction() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
 fn test_sigwait() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();


### PR DESCRIPTION
## What does this PR do

This enables `SigAction` and `SigSet::wait` with relevant tests. Tested with `redoxer test --package nix --test test -- sys::test_signal`.

## Checklist:

- [X] I have read `CONTRIBUTING.md`
- [X] I have written necessary tests and rustdoc comments
- [X] A change log has been added if this PR modifies nix's API
