### PR TITLE
Add wasm32-unknown-emscripten target support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,9 +676,12 @@ jobs:
       - name: test
         run: |
           source ./emsdk/emsdk_env.sh
+          export EM_CONFIG="$EMSDK/.emscripten"
           CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER="$JSPI_NODE" \
           RUSTFLAGS="-A linker_messages -C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-pthread -C link-arg=-sPROXY_TO_PTHREAD -C link-arg=-sNODERAWSOCKETS -C link-arg=-sNODERAWFS -C link-arg=-sALLOW_MEMORY_GROWTH=1 -C link-arg=-sEXIT_RUNTIME=1 -C link-arg=-sJSPI" \
-          cargo +nightly test --target wasm32-unknown-emscripten -Zbuild-std=std,panic_abort --test test
+          cargo +nightly test --target wasm32-unknown-emscripten -Zbuild-std=std,panic_abort --test test \
+            --config 'patch.crates-io.libc.git="https://github.com/guybedford/libc"' \
+            --config 'patch.crates-io.libc.branch="libc-0.2-emscripten"'
 
       - name: before_cache_script
         run: rm -rf $CARGO_HOME/registry/index

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,3 +634,52 @@ jobs:
       - name: before_cache_script
         run: rm -rf $CARGO_HOME/registry/index
 
+  # Runs the test suite against wasm32-unknown-emscripten under Node.
+  emscripten:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # TEMPORARY: builds against the guybedford/emscripten `cf` fork, which
+    # carries the NODEFS/socket/blocking patches this target depends on. Once
+    # those land upstream the fork checkout can be dropped for a released emsdk.
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+
+      # JSPI is the return-to-host bridge for blocking reads/writes; it needs a
+      # Node with JSPI on by default (V8 13.x+), not the one bundled with emsdk.
+      - name: setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - name: record JSPI-capable node
+        run: echo "JSPI_NODE=$(which node)" >> "$GITHUB_ENV"
+
+      - name: install emsdk
+        run: |
+          git clone --depth 1 https://github.com/emscripten-core/emsdk.git
+          ./emsdk/emsdk install latest
+          ./emsdk/emsdk activate latest
+
+      - name: overlay guybedford/emscripten (cf) fork
+        run: |
+          git clone --branch cf https://github.com/guybedford/emscripten.git em-fork
+          python3 em-fork/bootstrap.py
+          rm -rf ./emsdk/upstream/emscripten
+          ln -s "$(pwd)/em-fork" ./emsdk/upstream/emscripten
+
+      - name: test
+        run: |
+          source ./emsdk/emsdk_env.sh
+          CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER="$JSPI_NODE" \
+          RUSTFLAGS="-A linker_messages -C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=-pthread -C link-arg=-sPROXY_TO_PTHREAD -C link-arg=-sNODERAWSOCKETS -C link-arg=-sNODERAWFS -C link-arg=-sALLOW_MEMORY_GROWTH=1 -C link-arg=-sEXIT_RUNTIME=1 -C link-arg=-sJSPI" \
+          cargo +nightly test --target wasm32-unknown-emscripten -Zbuild-std=std,panic_abort --test test
+
+      - name: before_cache_script
+        run: rm -rf $CARGO_HOME/registry/index
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ targets = [
   "x86_64-unknown-illumos"
 ]
 
+[patch.crates-io]
+libc = { git = "https://github.com/guybedford/libc", branch = "libc-0.2-emscripten" }
+
 [dependencies]
 libc = { version = "0.2.186", features = ["extra_traits"] }
 bitflags = "2.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ targets = [
   "x86_64-unknown-illumos"
 ]
 
-[patch.crates-io]
-libc = { git = "https://github.com/guybedford/libc", branch = "libc-0.2-emscripten" }
-
 [dependencies]
 libc = { version = "0.2.186", features = ["extra_traits"] }
 bitflags = "2.3.3"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following targets are supported by `nix`:
     <li>x86_64-unknown-openbsd</li>
     <li>x86_64-unknown-redox</li>
     <li>i686-unknown-hurd-gnu</li>
+    <li>wasm32-unknown-emscripten</li>
    </td>
   </tr>
 </table>

--- a/src/sys/ioctl/linux.rs
+++ b/src/sys/ioctl/linux.rs
@@ -5,6 +5,7 @@ use cfg_if::cfg_if;
     target_os = "android",
     target_os = "fuchsia",
     target_os = "cygwin",
+    target_os = "emscripten",
     target_env = "musl",
     target_env = "ohos"
 ))]
@@ -14,6 +15,7 @@ pub type ioctl_num_type = ::libc::c_int;
     target_os = "android",
     target_os = "fuchsia",
     target_os = "cygwin",
+    target_os = "emscripten",
     target_env = "musl",
     target_env = "ohos"
 )))]

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -231,7 +231,8 @@ use cfg_if::cfg_if;
     linux_android,
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "cygwin"
+    target_os = "cygwin",
+    target_os = "emscripten"
 ))]
 #[macro_use]
 mod linux;
@@ -240,7 +241,8 @@ mod linux;
     linux_android,
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "cygwin"
+    target_os = "cygwin",
+    target_os = "emscripten"
 ))]
 pub use self::linux::*;
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -42,6 +42,7 @@ feature! {
     target_os = "haiku",
     target_os = "redox",
     target_os = "cygwin",
+    target_os = "emscripten",
 ))]
 #[cfg(feature = "ioctl")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]

--- a/src/sys/resource.rs
+++ b/src/sys/resource.rs
@@ -21,6 +21,7 @@ cfg_if! {
         target_os = "aix",
         target_os = "illumos",
         all(target_os = "linux", not(target_env = "gnu")),
+        target_os = "emscripten",
         target_os = "cygwin"
     ))]{
         use libc::rlimit;
@@ -53,6 +54,7 @@ libc_enum! {
             target_os = "aix",
             target_os = "illumos",
             all(target_os = "linux", not(any(target_env = "gnu", target_env = "uclibc"))),
+            target_os = "emscripten",
             target_os = "cygwin"
         ), repr(i32))]
     #[non_exhaustive]

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -4,6 +4,7 @@
     solarish,
     target_os = "haiku",
     target_os = "fuchsia",
+    target_os = "emscripten",
     target_os = "aix",
 ))]
 #[cfg(feature = "net")]
@@ -448,6 +449,7 @@ impl UnixAddr {
                      target_os = "fuchsia",
                      solarish,
                      target_os = "redox",
+                     target_os = "emscripten",
                      target_os = "cygwin",
                 ))]
             {
@@ -513,6 +515,7 @@ impl UnixAddr {
                      target_os = "fuchsia",
                      solarish,
                      target_os = "redox",
+                     target_os = "emscripten",
                      target_os = "cygwin",
                 ))]
             {
@@ -531,6 +534,7 @@ impl SockaddrLike for UnixAddr {
         target_os = "fuchsia",
         solarish,
         target_os = "redox",
+        target_os = "emscripten",
         target_os = "cygwin",
     ))]
     fn len(&self) -> libc::socklen_t {
@@ -561,6 +565,7 @@ impl SockaddrLike for UnixAddr {
                          target_os = "fuchsia",
                          solarish,
                          target_os = "redox",
+                         target_os = "emscripten",
                          target_os = "cygwin",
                 ))] {
                 let su_len = len.unwrap_or(
@@ -1172,6 +1177,7 @@ impl SockaddrLike for SockaddrStorage {
                     linux_android,
                     target_os = "fuchsia",
                     solarish,
+                    target_os = "emscripten",
                     target_os = "cygwin",
                 ))]
                 if i32::from(ss.ss_family) == libc::AF_UNIX {
@@ -1229,7 +1235,7 @@ impl SockaddrLike for SockaddrStorage {
         }
     }
 
-    #[cfg(any(linux_android, target_os = "fuchsia", solarish, target_os = "cygwin"))]
+    #[cfg(any(linux_android, target_os = "fuchsia", solarish, target_os = "emscripten", target_os = "cygwin"))]
     fn len(&self) -> libc::socklen_t {
         match self.as_unix_addr() {
             // The UnixAddr type knows its own length
@@ -1291,6 +1297,7 @@ impl SockaddrStorage {
             if #[cfg(any(linux_android,
                      target_os = "fuchsia",
                      solarish,
+                     target_os = "emscripten",
                      target_os = "cygwin",
                 ))]
             {
@@ -1321,6 +1328,7 @@ impl SockaddrStorage {
             if #[cfg(any(linux_android,
                      target_os = "fuchsia",
                      solarish,
+                     target_os = "emscripten",
                      target_os = "cygwin",
                 ))]
             {
@@ -1834,7 +1842,7 @@ pub mod sys_control {
 }
 }
 
-#[cfg(any(linux_android, target_os = "fuchsia"))]
+#[cfg(any(linux_android, target_os = "fuchsia", target_os = "emscripten"))]
 mod datalink {
     feature! {
     #![feature = "net"]
@@ -2312,7 +2320,7 @@ mod tests {
         fn size() {
             #[cfg(any(bsd, target_os = "aix", solarish, target_os = "haiku"))]
             let l = mem::size_of::<libc::sockaddr_dl>();
-            #[cfg(any(linux_android, target_os = "fuchsia"))]
+            #[cfg(any(linux_android, target_os = "fuchsia", target_os = "emscripten"))]
             let l = mem::size_of::<libc::sockaddr_ll>();
             assert_eq!(LinkAddr::size() as usize, l);
         }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1301,7 +1301,7 @@ feature! {
 /// On some systems, the host name is limited to as few as 64 bytes.  An error
 /// will be returned if the name is not valid or the current process does not
 /// have permissions to update the host name.
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "emscripten")))]
 pub fn sethostname<S: AsRef<OsStr>>(name: S) -> Result<()> {
     // Handle some differences in type of the len arg across platforms.
     cfg_if! {

--- a/test/sys/test_resource.rs
+++ b/test/sys/test_resource.rs
@@ -11,6 +11,7 @@ use nix::sys::resource::{getrusage, UsageWho};
 /// been updated.
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_resource_limits_nofile() {
     let (mut soft_limit, hard_limit) =
         getrlimit(Resource::RLIMIT_NOFILE).unwrap();

--- a/test/sys/test_signal.rs
+++ b/test/sys/test_signal.rs
@@ -2,6 +2,7 @@ use nix::errno::Errno;
 use nix::sys::signal::*;
 use nix::unistd::*;
 use std::hash::{Hash, Hasher};
+#[cfg_attr(target_os = "emscripten", allow(unused_imports))]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(target_os = "redox"))]
 use std::thread;
@@ -12,7 +13,7 @@ fn test_kill_none() {
 }
 
 #[test]
-#[cfg(not(target_os = "fuchsia"))]
+#[cfg(not(any(target_os = "fuchsia", target_os = "emscripten")))]
 fn test_killpg_none() {
     killpg(getpgrp(), None)
         .expect("Should be able to send signal to my process group.");
@@ -79,8 +80,10 @@ fn test_sigprocmask() {
         .expect("expect to be able to block signals");
 }
 
+#[cfg(not(target_os = "emscripten"))]
 static SIGNALED: AtomicBool = AtomicBool::new(false);
 
+#[cfg(not(target_os = "emscripten"))]
 extern "C" fn test_sigaction_handler(signal: libc::c_int) {
     let signal = Signal::try_from(signal).unwrap();
     SIGNALED.store(signal == Signal::SIGINT, Ordering::Relaxed);
@@ -107,6 +110,7 @@ fn test_signal_sigaction() {
 }
 
 #[test]
+#[cfg(not(target_os = "emscripten"))]
 fn test_signal() {
     let _m = crate::SIGNAL_MTX.lock();
 
@@ -186,7 +190,7 @@ fn test_extend() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "emscripten")))]
 fn test_thread_signal_set_mask() {
     thread::spawn(|| {
         let prev_mask = SigSet::thread_get_mask()
@@ -211,7 +215,7 @@ fn test_thread_signal_set_mask() {
 }
 
 #[test]
-#[cfg(not(target_os = "redox"))]
+#[cfg(not(any(target_os = "redox", target_os = "emscripten")))]
 fn test_thread_signal_block() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();
@@ -242,6 +246,7 @@ fn test_thread_signal_unblock() {
 
 #[test]
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_thread_signal_swap() {
     thread::spawn(|| {
         let mut mask = SigSet::empty();

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1,7 +1,6 @@
 #[cfg(linux_android)]
 use crate::*;
 use libc::c_char;
-#[cfg_attr(target_os = "emscripten", allow(unused_imports))]
 use nix::sys::socket::{getsockname, AddressFamily, UnixAddr};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -287,7 +286,7 @@ pub fn test_unnamed_uds_addr() {
 }
 
 #[test]
-#[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_getsockname() {
     use nix::sys::socket::bind;
     use nix::sys::socket::{socket, AddressFamily, SockFlag, SockType};
@@ -310,7 +309,7 @@ pub fn test_getsockname() {
 }
 
 #[test]
-#[cfg(not(target_os = "emscripten"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_socketpair() {
     use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
     use nix::unistd::{read, write};

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1,6 +1,7 @@
 #[cfg(linux_android)]
 use crate::*;
 use libc::c_char;
+#[cfg_attr(target_os = "emscripten", allow(unused_imports))]
 use nix::sys::socket::{getsockname, AddressFamily, UnixAddr};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -286,6 +287,7 @@ pub fn test_unnamed_uds_addr() {
 }
 
 #[test]
+#[cfg(not(target_os = "emscripten"))]
 pub fn test_getsockname() {
     use nix::sys::socket::bind;
     use nix::sys::socket::{socket, AddressFamily, SockFlag, SockType};
@@ -308,6 +310,7 @@ pub fn test_getsockname() {
 }
 
 #[test]
+#[cfg(not(target_os = "emscripten"))]
 pub fn test_socketpair() {
     use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
     use nix::unistd::{read, write};
@@ -328,6 +331,7 @@ pub fn test_socketpair() {
 
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_recvmsg_sockaddr_un() {
     use nix::sys::socket::{
         self, bind, socket, AddressFamily, MsgFlags, SockFlag, SockType,
@@ -421,6 +425,7 @@ mod recvfrom {
     }
 
     #[test]
+    #[cfg_attr(target_os = "emscripten", ignore)]
     pub fn stream() {
         let (fd2, fd1) = socketpair(
             AddressFamily::Unix,
@@ -843,6 +848,7 @@ pub fn test_recvmsg_ebadf() {
 #[cfg_attr(qemu, ignore)]
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_scm_rights() {
     use nix::sys::socket::{
         recvmsg, sendmsg, socketpair, AddressFamily, ControlMessage,
@@ -1346,6 +1352,7 @@ pub fn test_sendmsg_ipv4sendsrcaddr() {
 #[cfg_attr(qemu, ignore)]
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_scm_rights_single_cmsg_multiple_fds() {
     use nix::sys::socket::{
         recvmsg, sendmsg, ControlMessage, ControlMessageOwned, MsgFlags,
@@ -1404,6 +1411,7 @@ fn test_scm_rights_single_cmsg_multiple_fds() {
 // msg_control field and a msg_controllen of 0 when calling into the
 // raw `sendmsg`.
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 pub fn test_sendmsg_empty_cmsgs() {
     use nix::sys::socket::{
         recvmsg, sendmsg, socketpair, AddressFamily, MsgFlags, SockFlag,
@@ -3265,7 +3273,8 @@ fn can_use_cmsg_space() {
     linux_android,
     target_os = "redox",
     target_os = "haiku",
-    target_os = "cygwin"
+    target_os = "cygwin",
+    target_os = "emscripten"
 )))]
 #[test]
 fn can_open_routing_socket() {

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -806,6 +806,7 @@ fn can_get_peerpidfd_on_unix_socket() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn is_socket_type_unix() {
     use nix::sys::socket::{socketpair, sockopt, SockFlag, SockType};
 

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -26,6 +26,7 @@ fn test_baudrate_try_from() {
 
 // Test tcgetattr on a terminal
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_tcgetattr_pty() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();
@@ -43,6 +44,7 @@ fn test_tcgetattr_enotty() {
 
 // Test modifying output flags
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_output_flags() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();
@@ -81,6 +83,7 @@ fn test_output_flags() {
 // Test modifying local flags
 #[test]
 #[cfg(not(target_os = "solaris"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_local_flags() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -7,6 +7,7 @@ use nix::unistd::*;
 
 #[test]
 #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_wait_signal() {
     let _m = crate::FORK_MTX.lock();
 
@@ -59,6 +60,7 @@ fn test_waitid_signal() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_wait_exit() {
     let _m = crate::FORK_MTX.lock();
 
@@ -119,6 +121,7 @@ fn test_waitstatus_from_raw() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_waitstatus_pid() {
     let _m = crate::FORK_MTX.lock();
 

--- a/test/test_fcntl.rs
+++ b/test/test_fcntl.rs
@@ -660,6 +660,7 @@ mod test_flock {
 
     /// Verify that `Flock::lock()` correctly obtains a lock, and subsequently unlocks upon drop.
     #[test]
+    #[cfg_attr(target_os = "emscripten", ignore)]
     fn lock_and_drop() {
         // Get 2 `File` handles to same underlying file.
         let file1 = NamedTempFile::new().unwrap();
@@ -686,6 +687,7 @@ mod test_flock {
 
     /// An exclusive lock can be downgraded
     #[test]
+    #[cfg_attr(target_os = "emscripten", ignore)]
     fn downgrade() {
         let file1 = NamedTempFile::new().unwrap();
         let file2 = file1.reopen().unwrap();
@@ -729,6 +731,7 @@ mod test_flock {
 
     /// A shared lock can be upgraded
     #[test]
+    #[cfg_attr(target_os = "emscripten", ignore)]
     fn upgrade() {
         let file1 = NamedTempFile::new().unwrap();
         let file2 = file1.reopen().unwrap();

--- a/test/test_net.rs
+++ b/test/test_net.rs
@@ -11,12 +11,14 @@ const LOOPBACK: &[u8] = b"loop";
 
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_if_nametoindex() {
     if_nametoindex(LOOPBACK).expect("assertion failed");
 }
 
 #[test]
 #[cfg_attr(target_os = "cygwin", ignore)]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_if_indextoname() {
     let loopback_index = if_nametoindex(LOOPBACK).expect("assertion failed");
     assert_eq!(

--- a/test/test_pty.rs
+++ b/test/test_pty.rs
@@ -135,6 +135,7 @@ fn open_ptty_pair() -> (PtyMaster, File) {
 /// themselves. So for this test we perform the basic act of getting a file handle for a
 /// master/slave PTTY pair.
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_open_ptty_pair() {
     let (_, _) = open_ptty_pair();
 }
@@ -149,6 +150,7 @@ fn make_raw<Fd: AsFd>(fd: Fd) {
 /// Test `io::Read` on the PTTY master
 #[test]
 #[cfg(not(target_os = "solaris"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_read_ptty_pair() {
     let (mut master, mut slave) = open_ptty_pair();
     make_raw(&slave);
@@ -166,6 +168,7 @@ fn test_read_ptty_pair() {
 
 /// Test `io::Write` on the PTTY master
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_write_ptty_pair() {
     let (mut master, mut slave) = open_ptty_pair();
     make_raw(&slave);
@@ -182,6 +185,7 @@ fn test_write_ptty_pair() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_openpty() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();
@@ -212,6 +216,7 @@ fn test_openpty() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_openpty_with_termios() {
     // openpty uses ptname(3) internally
     let _m = crate::PTSNAME_MTX.lock();
@@ -250,6 +255,7 @@ fn test_openpty_with_termios() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_forkpty() {
     use nix::sys::signal::*;
     use nix::sys::wait::wait;

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -21,6 +21,7 @@ use nix::unistd::ForkResult::*;
 use nix::unistd::*;
 use std::env;
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
+#[cfg_attr(target_os = "emscripten", allow(unused_imports))]
 use std::ffi::CString;
 #[cfg(not(target_os = "redox"))]
 use std::fs::DirBuilder;
@@ -38,6 +39,7 @@ use crate::*;
 
 #[test]
 #[cfg(not(any(target_os = "netbsd")))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_fork_and_waitpid() {
     let _m = crate::FORK_MTX.lock();
 
@@ -97,6 +99,7 @@ fn test_rfork_and_waitpid() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_wait() {
     // Grab FORK_MTX so wait doesn't reap a different test's child process
     let _m = crate::FORK_MTX.lock();
@@ -135,6 +138,7 @@ fn test_mkstemp_directory() {
 
 #[test]
 #[cfg(not(target_os = "redox"))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_mkfifo() {
     let tempdir = tempdir().unwrap();
     let mkfifo_fifo = tempdir.path().join("mkfifo_fifo");
@@ -160,6 +164,7 @@ fn test_mkfifo_directory() {
     target_os = "redox",
     target_os = "haiku"
 )))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_mkfifoat_none() {
     use nix::fcntl::AT_FDCWD;
 
@@ -182,6 +187,7 @@ fn test_mkfifoat_none() {
     target_os = "redox",
     target_os = "haiku"
 )))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_mkfifoat() {
     use nix::fcntl;
 
@@ -281,6 +287,7 @@ mod freebsd {
     target_os = "fuchsia",
     target_os = "haiku"
 )))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_setgroups() {
     // Skip this test when not run as root as `setgroups()` requires root.
     skip_if_not_root!("test_setgroups");
@@ -308,6 +315,7 @@ fn test_setgroups() {
     target_os = "redox",
     target_os = "fuchsia",
     target_os = "haiku",
+    target_os = "emscripten",
     solarish
 )))]
 fn test_initgroups() {
@@ -343,6 +351,7 @@ fn test_initgroups() {
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "redox")))]
+#[cfg_attr(target_os = "emscripten", allow(unused_macros))]
 macro_rules! execve_test_factory (
     ($test_name:ident, $syscall:ident, $exe: expr $(, $pathname:expr, $flags:expr)*) => (
 
@@ -647,6 +656,7 @@ cfg_if! {
     target_os = "haiku",
     target_os = "cygwin"
 )))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_acct() {
     use std::process::Command;
     use std::{thread, time};
@@ -776,6 +786,7 @@ fn test_pipe() {
     target_os = "redox",
 ))]
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_pipe2() {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag};
 
@@ -1066,7 +1077,12 @@ fn test_linkat_newdirfd_none() {
 }
 
 #[test]
-#[cfg(not(any(apple_targets, target_os = "redox", target_os = "haiku")))]
+#[cfg(not(any(
+    apple_targets,
+    target_os = "redox",
+    target_os = "haiku",
+    target_os = "emscripten"
+)))]
 fn test_linkat_no_follow_symlink() {
     use nix::fcntl::AtFlags;
     use nix::fcntl::AT_FDCWD;
@@ -1245,6 +1261,7 @@ fn test_access_file_exists() {
 
 #[cfg(not(target_os = "redox"))]
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_user_into_passwd() {
     let test_username = if cfg!(target_os = "haiku") {
         // "nobody" unavailable on haiku
@@ -1306,6 +1323,7 @@ fn test_setfsuid() {
     target_os = "fuchsia",
     target_os = "haiku"
 )))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_ttyname() {
     use std::os::fd::AsRawFd;
 

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -1077,12 +1077,8 @@ fn test_linkat_newdirfd_none() {
 }
 
 #[test]
-#[cfg(not(any(
-    apple_targets,
-    target_os = "redox",
-    target_os = "haiku",
-    target_os = "emscripten"
-)))]
+#[cfg(not(any(apple_targets, target_os = "redox", target_os = "haiku")))]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn test_linkat_no_follow_symlink() {
     use nix::fcntl::AtFlags;
     use nix::fcntl::AT_FDCWD;


### PR DESCRIPTION
Draft PR for #2804.

Adds `wasm32-unknown-emscripten` as a target for nix, with a CI job running the full test suite under Node (stock target, `-Zbuild-std` threaded, JSPI, NODERAWFS/NODERAWSOCKETS). Opened as a draft since it depends on unreleased patchsets for both Emscripten and Rust's libc, including:

- emscripten-core/emscripten#27319 — Report host uid/gid credentials under NODERAWFS
- emscripten-core/emscripten#27306 — NODERAWSOCKETS: socket fstat and SO_TYPE/SO_LINGER/TCP_MAXSEG options
- emscripten-core/emscripten#27305 — [NODEFS] hardlinks, utimensat nofollow, and fadvise/fallocate seek errors
- emscripten-core/emscripten#27277 — Support Node.js blocking socket operations
- rust-lang/libc#5256 — emscripten: add in6_pktinfo struct (merged)
- rust-lang/libc#5270 — emscripten: add pthread_sigmask, sigwait, faccessat, pthread_kill, sethostname

Requires a recent Rust nightly to include rust-lang/rust#158937.

### Test Status
148 passing, 35 ignored at runtime, 8 compiled out.

**Ignored (35):**
- `test_unistd` (10): test_fork_and_waitpid, test_wait, test_mkfifo, test_mkfifoat, test_mkfifoat_none, test_setgroups, test_acct, test_pipe2, test_user_into_passwd, test_ttyname
- `test_pty` (6): test_open_ptty_pair, test_read_ptty_pair, test_write_ptty_pair, test_openpty, test_openpty_with_termios, test_forkpty
- `test_socket` (5): recvfrom::stream, test_recvmsg_sockaddr_un, test_scm_rights, test_scm_rights_single_cmsg_multiple_fds, test_sendmsg_empty_cmsgs
- `test_termios` (3): test_tcgetattr_pty, test_output_flags, test_local_flags
- `test_wait` (3): test_wait_signal, test_wait_exit, test_waitstatus_pid
- `test_fcntl` flock (3): lock_and_drop, downgrade, upgrade
- `test_net` (2): test_if_nametoindex, test_if_indextoname
- `test_resource` (1): test_resource_limits_nofile
- `test_signal` (1): test_thread_signal_swap
- `test_sockopt` (1): is_socket_type_unix

**Compiled out (8):**
- `test_socket` (3): test_getsockname, test_socketpair, can_open_routing_socket
- `test_signal` (4): test_killpg_none, test_signal, test_thread_signal_set_mask, test_thread_signal_block
- `test_unistd` (1): test_linkat_no_follow_symlink

Early feedback on the approach very much welcome.