### PR TITLE
Remove unnecessary casts

### DIFF
--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -199,7 +199,7 @@ pub fn mq_receive(
     message: &mut [u8],
     msg_prio: &mut u32,
 ) -> Result<usize> {
-    let len = message.len() as size_t;
+    let len = message.len();
     let res = unsafe {
         libc::mq_receive(
             mqdes.0,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1927,7 +1927,7 @@ impl<'a> Set<'a, OwnedFd> for SetOwnedFd {
     fn new(val: &'a OwnedFd) -> SetOwnedFd {
         use std::os::fd::AsRawFd;
 
-        SetOwnedFd { val: val.as_raw_fd() as c_int }
+        SetOwnedFd { val: val.as_raw_fd() }
     }
 
     fn ffi_ptr(&self) -> *const c_void {


### PR DESCRIPTION
As these expressions already have the type to which they are being cast, the casts are actually redundant and can be safely deleted.

CC @nunoplopes