### PR TITLE
fix: bump cfg_aliases minimum version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ caps = "0.5.3"
 sysctl = "0.4"
 
 [build-dependencies]
-cfg_aliases = "0.2.1"
+cfg_aliases = "0.2.2"
 
 [[test]]
 name = "test"


### PR DESCRIPTION
Raise the minimum `cfg_aliases` build-dependency version to 0.2.2.

When running `cargo -Zdirect-minimal-versions`, Cargo pins `cfg_aliases` to its declared minimum version (`0.2.1`). Its `cfg_aliases!` macro expansion contains a trailing semicolon in expression position, which current Rust rejects as a hard error.

Closes https://github.com/nix-rust/nix/pull/2812