### PR TITLE
fix: compatibility with the upcoming libc release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,8 +594,6 @@ jobs:
             cargo build --target x86_64-pc-solaris --all-targets --all-features && sudo env PATH=$PATH cargo test
 
   # Test that we can build with the lowest version of all dependencies.
-  # "cargo test" doesn't work because some of our dev-dependencies, like
-  # rand, can't build with their own minimal dependencies.
   minver:
     runs-on: ubuntu-latest
     env: 
@@ -608,10 +606,13 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: setup 
-        run: cargo update -Zdirect-minimal-versions
+        run: cargo update -Zminimal-versions
 
-      - name: check
-        run: cargo check
+      - name: build
+        run: cargo build --all-targets --all-features --locked
+
+      - name: test
+        run: cargo test --all-targets --all-features --locked
 
       - name: before_cache_script
         run: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ caps = "0.5.3"
 sysctl = "0.4"
 
 [build-dependencies]
-cfg_aliases = "0.2.1"
+cfg_aliases = "0.2.2"
 
 [[test]]
 name = "test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ zerocopy = ["fs", "uio"]
 
 [dev-dependencies]
 assert-impl = "0.1"
-parking_lot = "0.12"
+parking_lot = "0.12.4"
 rand = "0.9"
 tempfile = "3.7.1"
 semver = "1.0.7"

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -7,9 +7,8 @@ use crate::Result;
 
 /// This is a wrapper around `libc::pollfd`.
 ///
-/// It's meant to be used as an argument to the [`poll`](fn.poll.html) and
-/// [`ppoll`](fn.ppoll.html) functions to specify the events of interest
-/// for a specific file descriptor.
+/// It's meant to be used as an argument to the [`poll`] and `ppoll` functions
+/// to specify the events of interest for a specific file descriptor.
 ///
 /// After a call to `poll` or `ppoll`, the events that occurred can be retrieved by calling
 /// [`revents()`](#method.revents) on the `PollFd` object from the array passed to `poll`.
@@ -34,7 +33,7 @@ impl<'fd> PollFd<'fd> {
     /// let (r, w) = pipe().unwrap();
     /// let pfd = PollFd::new(r.as_fd(), PollFlags::POLLIN);
     /// ```
-    /// These are placed in an array and passed to [`poll`] or [`ppoll`](fn.ppoll.html).
+    /// These are placed in an array and passed to [`poll`] or `ppoll`.
     // Unlike I/O functions, constructors like this must take `BorrowedFd`
     // instead of AsFd or &AsFd.  Otherwise, an `OwnedFd` argument would be
     // dropped at the end of the method, leaving the structure referencing a
@@ -176,7 +175,7 @@ libc_bitflags! {
 /// `poll` waits for one of a set of file descriptors to become ready to perform I/O.
 /// ([`poll(2)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html))
 ///
-/// `fds` contains all [`PollFd`](struct.PollFd.html) to poll.
+/// `fds` contains all [`PollFd`] to poll.
 /// The function will return as soon as any event occur for any of these `PollFd`s.
 ///
 /// The `timeout` argument specifies the number of milliseconds that `poll()`

--- a/src/sys/aio.rs
+++ b/src/sys/aio.rs
@@ -10,19 +10,18 @@
 //! platform support.  Completion
 //! notifications can optionally be delivered via
 //! [signals](../signal/enum.SigevNotify.html#variant.SigevSignal), via the
-//! [`aio_suspend`](fn.aio_suspend.html) function, or via polling.  Some
-//! platforms support other completion
-//! notifications, such as
+//! [`aio_suspend`] function, or via polling.  Some platforms support other
+//! completion notifications, such as
 //! [kevent](../signal/enum.SigevNotify.html#variant.SigevKevent).
 //!
 //! Multiple operations may be submitted in a batch with
-//! [`lio_listio`](fn.lio_listio.html), though the standard does not guarantee
-//! that they will be executed atomically.
+//! [`lio_listio`], though the standard does not guarantee that they will be
+//! executed atomically.
 //!
 //! Outstanding operations may be cancelled with
 //! [`cancel`](trait.Aio.html#method.cancel) or
-//! [`aio_cancel_all`](fn.aio_cancel_all.html), though the operating system may
-//! not support this for all filesystems and devices.
+//! [`aio_cancel_all`], though the operating system may not support this for
+//! all filesystems and devices.
 #![allow(clippy::doc_overindented_list_items)] // It looks better this way
 #[cfg(target_os = "freebsd")]
 use std::io::{IoSlice, IoSliceMut};
@@ -64,19 +63,19 @@ libc_enum! {
 }
 
 libc_enum! {
-    /// Mode for [`lio_listio`](fn.lio_listio.html)
+    /// Mode for [`lio_listio`]
     #[repr(i32)]
     pub enum LioMode {
-        /// Requests that [`lio_listio`](fn.lio_listio.html) block until all
+        /// Requests that [`lio_listio`] block until all
         /// requested operations have been completed
         LIO_WAIT,
-        /// Requests that [`lio_listio`](fn.lio_listio.html) return immediately
+        /// Requests that [`lio_listio`] return immediately
         LIO_NOWAIT,
     }
 }
 
 /// Return values for [`AioCb::cancel`](struct.AioCb.html#method.cancel) and
-/// [`aio_cancel_all`](fn.aio_cancel_all.html)
+/// [`aio_cancel_all`]
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AioCancelStat {

--- a/src/sys/ptrace/bsd.rs
+++ b/src/sys/ptrace/bsd.rs
@@ -9,7 +9,7 @@ use std::ptr;
 pub type RequestType = c_int;
 
 cfg_if! {
-    if #[cfg(any(freebsdlike, apple_targets, target_os = "openbsd"))] {
+    if #[cfg(any(freebsdlike, target_os = "macos", target_os = "openbsd"))] {
         #[doc(hidden)]
         pub type AddressType = *mut ::libc::c_char;
     } else {
@@ -26,26 +26,26 @@ libc_enum! {
         PT_TRACE_ME,
         PT_READ_I,
         PT_READ_D,
-        #[cfg(apple_targets)]
+        #[cfg(target_os = "macos")]
         PT_READ_U,
         PT_WRITE_I,
         PT_WRITE_D,
-        #[cfg(apple_targets)]
+        #[cfg(target_os = "macos")]
         PT_WRITE_U,
         PT_CONTINUE,
         PT_KILL,
-        #[cfg(any(any(freebsdlike, apple_targets),
+        #[cfg(any(any(freebsdlike, target_os = "macos"),
                   all(target_os = "openbsd", target_arch = "x86_64"),
                   all(target_os = "netbsd", any(target_arch = "x86_64",
                                                 target_arch = "powerpc"))))]
         PT_STEP,
         PT_ATTACH,
         PT_DETACH,
-        #[cfg(apple_targets)]
+        #[cfg(target_os = "macos")]
         PT_SIGEXC,
-        #[cfg(apple_targets)]
+        #[cfg(target_os = "macos")]
         PT_THUPDATE,
-        #[cfg(apple_targets)]
+        #[cfg(target_os = "macos")]
         PT_ATTACHEXC
     }
 }
@@ -149,7 +149,7 @@ pub fn kill(pid: Pid) -> Result<()> {
 /// }
 /// ```
 #[cfg(any(
-    any(freebsdlike, apple_targets),
+    any(freebsdlike, target_os = "macos"),
     all(target_os = "openbsd", target_arch = "x86_64"),
     all(
         target_os = "netbsd",

--- a/src/sys/ptrace/mod.rs
+++ b/src/sys/ptrace/mod.rs
@@ -6,8 +6,8 @@ mod linux;
 #[cfg(linux_android)]
 pub use self::linux::*;
 
-#[cfg(bsd)]
+#[cfg(any(bsd_without_apple, target_os = "macos"))]
 mod bsd;
 
-#[cfg(bsd)]
+#[cfg(any(bsd_without_apple, target_os = "macos"))]
 pub use self::bsd::*;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -942,12 +942,12 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// Installs `handler` for the given `signal`, returning the previous signal
 /// handler. `signal` should only be used following another call to `signal` or
 /// if the current handler is the default. The return value of `signal` is
-/// undefined after setting the handler with [`sigaction`][SigActionFn].
+/// undefined after setting the handler with [`sigaction`].
 ///
 /// # Safety
 ///
 /// If the pointer to the previous signal handler is invalid, undefined
-/// behavior could be invoked when casting it back to a [`SigAction`][SigActionStruct].
+/// behavior could be invoked when casting it back to a [`SigAction`].
 ///
 /// # Examples
 ///
@@ -980,15 +980,13 @@ pub unsafe fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigActi
 /// # Errors
 ///
 /// Returns [`Error(Errno::EOPNOTSUPP)`](Errno::EOPNOTSUPP) if `handler` is
-/// [`SigAction`][SigActionStruct]. Use [`sigaction`][SigActionFn] instead.
+/// [`SigAction`]. Use [`sigaction`] instead.
 ///
 /// `signal` also returns any error from `libc::signal`, such as when an attempt
 /// is made to catch a signal that cannot be caught or to ignore a signal that
 /// cannot be ignored.
 ///
 /// [`Error::UnsupportedOperation`]: ../../enum.Error.html#variant.UnsupportedOperation
-/// [SigActionStruct]: struct.SigAction.html
-/// [sigactionFn]: fn.sigaction.html
 pub unsafe fn signal(signal: Signal, handler: SigHandler) -> Result<SigHandler> {
     let signal = signal as libc::c_int;
     let res = match handler {

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -16,7 +16,7 @@ use crate::errno::Errno;
 use crate::sys::socket::addr::alg::AlgAddr;
 #[cfg(linux_android)]
 use crate::sys::socket::addr::netlink::NetlinkAddr;
-#[cfg(all(feature = "ioctl", apple_targets))]
+#[cfg(all(feature = "ioctl", target_os = "macos"))]
 use crate::sys::socket::addr::sys_control::SysControlAddr;
 use crate::{NixPath, Result};
 use cfg_if::cfg_if;
@@ -1134,7 +1134,7 @@ pub union SockaddrStorage {
     dl: LinkAddr,
     #[cfg(linux_android)]
     nl: NetlinkAddr,
-    #[cfg(all(feature = "ioctl", apple_targets))]
+    #[cfg(all(feature = "ioctl", target_os = "macos"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     sctl: SysControlAddr,
     #[cfg(feature = "net")]
@@ -1216,7 +1216,7 @@ impl SockaddrLike for SockaddrStorage {
                 libc::AF_PACKET => unsafe {
                     LinkAddr::from_raw(addr, l).map(|dl| Self { dl })
                 },
-                #[cfg(all(feature = "ioctl", apple_targets))]
+                #[cfg(all(feature = "ioctl", target_os = "macos"))]
                 libc::AF_SYSTEM => unsafe {
                     SysControlAddr::from_raw(addr, l).map(|sctl| Self { sctl })
                 },
@@ -1375,7 +1375,7 @@ impl SockaddrStorage {
     accessors! {as_netlink_addr, as_netlink_addr_mut, NetlinkAddr,
     AddressFamily::Netlink, libc::sockaddr_nl, nl}
 
-    #[cfg(all(feature = "ioctl", apple_targets))]
+    #[cfg(all(feature = "ioctl", target_os = "macos"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "ioctl")))]
     accessors! {as_sys_control_addr, as_sys_control_addr_mut, SysControlAddr,
     AddressFamily::System, libc::sockaddr_ctl, sctl}
@@ -1413,7 +1413,7 @@ impl fmt::Display for SockaddrStorage {
                 #[cfg(any(linux_android, target_os = "fuchsia"))]
                 #[cfg(feature = "net")]
                 libc::AF_PACKET => self.dl.fmt(f),
-                #[cfg(apple_targets)]
+                #[cfg(target_os = "macos")]
                 #[cfg(feature = "ioctl")]
                 libc::AF_SYSTEM => self.sctl.fmt(f),
                 libc::AF_UNIX => self.su.fmt(f),
@@ -1475,7 +1475,7 @@ impl Hash for SockaddrStorage {
                 #[cfg(any(linux_android, target_os = "fuchsia"))]
                 #[cfg(feature = "net")]
                 libc::AF_PACKET => self.dl.hash(s),
-                #[cfg(apple_targets)]
+                #[cfg(target_os = "macos")]
                 #[cfg(feature = "ioctl")]
                 libc::AF_SYSTEM => self.sctl.hash(s),
                 libc::AF_UNIX => self.su.hash(s),
@@ -1505,7 +1505,7 @@ impl PartialEq for SockaddrStorage {
                 #[cfg(any(linux_android, target_os = "fuchsia"))]
                 #[cfg(feature = "net")]
                 (libc::AF_PACKET, libc::AF_PACKET) => self.dl == other.dl,
-                #[cfg(apple_targets)]
+                #[cfg(target_os = "macos")]
                 #[cfg(feature = "ioctl")]
                 (libc::AF_SYSTEM, libc::AF_SYSTEM) => self.sctl == other.sctl,
                 (libc::AF_UNIX, libc::AF_UNIX) => self.su == other.su,
@@ -1727,7 +1727,7 @@ pub mod alg {
 
 feature! {
 #![feature = "ioctl"]
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 pub mod sys_control {
     use crate::sys::socket::addr::AddressFamily;
     use libc::{self, c_uchar};

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -62,7 +62,7 @@ pub use self::addr::{SockaddrIn, SockaddrIn6};
 pub use crate::sys::socket::addr::alg::AlgAddr;
 #[cfg(linux_android)]
 pub use crate::sys::socket::addr::netlink::NetlinkAddr;
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 #[cfg(feature = "ioctl")]
 pub use crate::sys::socket::addr::sys_control::SysControlAddr;
 #[cfg(any(linux_android, apple_targets))]
@@ -136,7 +136,7 @@ pub enum SockProtocol {
     Raw = libc::IPPROTO_RAW,
     /// Allows applications to configure and control a KEXT
     /// ([ref](https://developer.apple.com/library/content/documentation/Darwin/Conceptual/NKEConceptual/control/control.html))
-    #[cfg(apple_targets)]
+    #[cfg(target_os = "macos")]
     KextControl = libc::SYSPROTO_CONTROL,
     /// Receives routing and link updates and may be used to modify the routing tables (both IPv4 and IPv6), IP addresses, link
     // parameters, neighbor setups, queueing disciplines, traffic classes and packet classifiers

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -123,8 +123,7 @@ impl TryFrom<i32> for SockType {
     }
 }
 
-/// Constants used in [`socket`](fn.socket.html) and [`socketpair`](fn.socketpair.html)
-/// to specify the protocol to use.
+/// Constants used in [`socket`] and [`socketpair`] to specify the protocol to use.
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
@@ -1762,7 +1761,7 @@ pub fn sendmsg<S>(fd: RawFd, iov: &[IoSlice<'_>], cmsgs: &[ControlMessage],
 }
 
 
-/// An extension of `sendmsg` that allows the caller to transmit multiple
+/// An extension of [`sendmsg`] that allows the caller to transmit multiple
 /// messages on a socket using a single system call. This has performance
 /// benefits for some applications.
 ///
@@ -1776,9 +1775,6 @@ pub fn sendmsg<S>(fd: RawFd, iov: &[IoSlice<'_>], cmsgs: &[ControlMessage],
 ///
 /// # Returns
 /// `Vec` with numbers of sent bytes on each sent message.
-///
-/// # References
-/// [`sendmsg`](fn.sendmsg.html)
 #[cfg(any(linux_android, target_os = "freebsd", target_os = "netbsd"))]
 pub fn sendmmsg<'a, XS, AS, C, I, S>(
     fd: RawFd,

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -6,7 +6,7 @@ use crate::sys::time::TimeVal;
 use crate::{errno::Errno, Result};
 use cfg_if::cfg_if;
 use libc::{self, c_int, c_void, socklen_t};
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 use std::ffi::CString;
 use std::ffi::{CStr, OsStr, OsString};
 use std::mem::{self, MaybeUninit};
@@ -1297,7 +1297,7 @@ sockopt_impl!(
     libc::IPV6_DONTFRAG,
     bool
 );
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 #[cfg(feature = "net")]
 sockopt_impl!(
     /// Get the utun interface name.
@@ -2005,14 +2005,14 @@ impl<'a> Set<'a, OsString> for SetOsString<'a> {
 }
 
 /// Getter for a `CString` value.
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 #[cfg(feature = "net")]
 struct GetCString<T: AsMut<[u8]>> {
     len: socklen_t,
     val: MaybeUninit<T>,
 }
 
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 #[cfg(feature = "net")]
 impl<T: AsMut<[u8]>> Get<CString> for GetCString<T> {
     fn uninit() -> Self {

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -52,7 +52,7 @@ pub fn readv<Fd: AsFd>(fd: Fd, iov: &mut [IoSliceMut<'_>]) -> Result<usize> {
 /// Buffers in `iov` will be written in order until all buffers have been written
 /// or an error occurs. The file offset is not changed.
 ///
-/// See also: [`writev`](fn.writev.html) and [`pwrite`](fn.pwrite.html)
+/// See also: [`writev`] and [`pwrite`]
 #[cfg(not(any(target_os = "redox", target_os = "haiku", target_os = "solaris", target_os = "cygwin")))]
 pub fn pwritev<Fd: AsFd>(
     fd: Fd,
@@ -81,7 +81,7 @@ pub fn pwritev<Fd: AsFd>(
 /// no more bytes are available, or an error occurs. The file offset is not
 /// changed.
 ///
-/// See also: [`readv`](fn.readv.html) and [`pread`](fn.pread.html)
+/// See also: [`readv`] and [`pread`]
 #[cfg(not(any(target_os = "redox", target_os = "haiku", target_os = "solaris", target_os = "cygwin")))]
 // Clippy doesn't know that we need to pass iov mutably only because the
 // mutation happens after converting iov to a pointer

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -52,7 +52,7 @@ mod test_fanotify;
 mod test_inotify;
 mod test_pthread;
 
-#[cfg(any(linux_android, freebsdlike, netbsdlike, apple_targets))]
+#[cfg(any(linux_android, freebsdlike, netbsdlike, target_os = "macos"))]
 mod test_ptrace;
 #[cfg(linux_android)]
 mod test_timerfd;

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -1777,7 +1777,7 @@ pub fn test_unnamed_unixdomain_autobind() {
 }
 
 // Test creating and using named system control sockets
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 #[test]
 pub fn test_syscontrol() {
     use nix::errno::Errno;

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -952,7 +952,7 @@ fn test_ktls() {
 }
 
 #[test]
-#[cfg(apple_targets)]
+#[cfg(target_os = "macos")]
 fn test_utun_ifname() {
     skip_if_not_root!("test_utun_ifname");
 


### PR DESCRIPTION
The next `libc` release removes some invalid APIs on non-Darwin Apple targets.

Stacked on https://github.com/nix-rust/nix/pull/2825.

[All checks passed](https://github.com/nix-rust/nix/pull/2821/checks?check_run_id=105162264208) with [`libc-0.2`](https://github.com/rust-lang/libc/tree/libc-0.2) branch of libc: c17cecb4d9b1e4f6ef75b844de18bb1ae545a927
[All checks passed](https://github.com/nix-rust/nix/pull/2821/checks?check_run_id=103465140365) with current (v0.2.189) release of libc: 8580c539bfa6a0d401554d4542188f68047337ec